### PR TITLE
Fix issue #63

### DIFF
--- a/src/de/danoeh/antennapod/service/download/HttpDownloader.java
+++ b/src/de/danoeh/antennapod/service/download/HttpDownloader.java
@@ -40,6 +40,7 @@ public class HttpDownloader extends Downloader {
 			URL url = new URL(status.getFeedFile().getDownload_url());
 			connection = (HttpURLConnection) url.openConnection();
 			connection.setConnectTimeout(CONNECTION_TIMEOUT);
+			connection.setInstanceFollowRedirects(true);
 			int responseCode = connection.getResponseCode();
 			if (responseCode == HttpURLConnection.HTTP_OK) {
 				if (AppConfig.DEBUG) {


### PR DESCRIPTION
If an HTTP request returns an error code 301 or 302, follow redirects to the
new location.
