### PR TITLE
Out of bounds fix when marking an item as read

### DIFF
--- a/src/de/danoeh/antennapod/adapter/ExternalEpisodesListAdapter.java
+++ b/src/de/danoeh/antennapod/adapter/ExternalEpisodesListAdapter.java
@@ -72,7 +72,13 @@ public class ExternalEpisodesListAdapter extends BaseExpandableListAdapter {
 				return EpisodeFilter.accessEpisodeByIndex(unreadItems,
 						childPosition);
 			} else {
-				return unreadItems.get(childPosition);
+				int sz=unreadItems.size();
+				if(sz>0) {
+					if(childPosition>=sz) {
+						childPosition=sz-1;
+					}
+					return unreadItems.get(childPosition);
+				}
 			}
 		}
 		return null;
@@ -88,7 +94,11 @@ public class ExternalEpisodesListAdapter extends BaseExpandableListAdapter {
 			boolean isLastChild, View convertView, ViewGroup parent) {
 		Holder holder;
 		final FeedItem item = getChild(groupPosition, childPosition);
-
+		
+		if(item==null) {
+			return(convertView);
+		}
+		
 		if (convertView == null) {
 			holder = new Holder();
 			LayoutInflater inflater = (LayoutInflater) context


### PR DESCRIPTION
W/dalvikvm( 2470): threadid=1: thread exiting with uncaught exception (group=0x40a5d1f8)
E/AndroidRuntime( 2470): FATAL EXCEPTION: main
E/AndroidRuntime( 2470): java.lang.IndexOutOfBoundsException: Invalid index 2, size is 2
E/AndroidRuntime( 2470):    at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:251)
E/AndroidRuntime( 2470):    at java.util.ArrayList.get(ArrayList.java:304)
E/AndroidRuntime( 2470):    at java.util.Collections$SynchronizedList.get(Collections.java:537)
E/AndroidRuntime( 2470):    at de.danoeh.antennapod.adapter.ExternalEpisodesListAdapter.getChild(ExternalEpisodesListAdapter.java:79)
