### PR TITLE
Fix date format parsing

### DIFF
--- a/src/de/danoeh/antennapod/syndication/util/SyndDateUtils.java
+++ b/src/de/danoeh/antennapod/syndication/util/SyndDateUtils.java
@@ -11,8 +11,7 @@ import android.util.Log;
 public class SyndDateUtils {
 	private static final String TAG = "DateUtils";
 
-	public static final String[] RFC822DATES = { "dd MMM yyyy HH:mm:ss Z",
-			"dd MMM yy HH:mm:ss Z", };
+	public static final String[] RFC822DATES = { "dd MMM yy HH:mm:ss Z", };
 
 	/** RFC 3339 date format for UTC dates. */
 	public static final String RFC3339UTC = "yyyy-MM-dd'T'HH:mm:ss'Z'";


### PR DESCRIPTION
I came across this bug because "Waiting List" was not sorted properly. Then i realized it was a date parsing problem with some feeds.

Short year format specification works in both cases. Long year didn't. You can check docs if you want:
http://docs.oracle.com/javase/1.4.2/docs/api/java/text/SimpleDateFormat.html#applyPattern(java.lang.String)

The code has been tested with both types of year spec:
- Long format like "2013", which worked both before and after the patch. Eg: http://feeds.feedburner.com/droidcast/
- Short format like "13", which parsed nonsense timestamps (literally year 13 A.D.) before patch and now works. Eg: http://www.ivoox.com/portada-ivoox_fh.xml
