### PR TITLE
Enable the app to be installed on a Google TV device.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <uses-feature
         android:name="android.hardware.screen.portrait"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />


### PR DESCRIPTION
The app supports all the necessary APKs for Google TV support.  While the
layouts aren't optimized for navigating around with the D-PAd the app does
work.  To enable Google TV support just need to specify that touchscreen
is not required.

Tested on the Sony 2nd gen google tv device.
