### PR TITLE
Bug fix for trying to set speed/pitch when media is null.

### DIFF
--- a/src/de/danoeh/antennapod/service/PlaybackService.java
+++ b/src/de/danoeh/antennapod/service/PlaybackService.java
@@ -1524,21 +1524,21 @@ public class PlaybackService extends Service {
 	}
 
 	public boolean canSetSpeed() {
-		if (media.getMediaType() == MediaType.AUDIO) {
+		if (media != null && media.getMediaType() == MediaType.AUDIO) {
 			return ((AudioPlayer) player).canSetSpeed();
 		}
 		return false;
 	}
 
 	public boolean canSetPitch() {
-		if (media.getMediaType() == MediaType.AUDIO) {
+		if (media != null && media.getMediaType() == MediaType.AUDIO) {
 			return ((AudioPlayer) player).canSetPitch();
 		}
 		return false;
 	}
 
 	public void setSpeed(double speed) {
-		if (media.getMediaType() == MediaType.AUDIO) {
+		if (media != null && media.getMediaType() == MediaType.AUDIO) {
 			AudioPlayer audioPlayer = (AudioPlayer) player;
 			if (audioPlayer.canSetSpeed()) {
 				audioPlayer.setPlaybackSpeed((float) speed);
@@ -1551,7 +1551,7 @@ public class PlaybackService extends Service {
 	}
 
 	public void setPitch(double pitch) {
-		if (media.getMediaType() == MediaType.AUDIO) {
+		if (media != null && media.getMediaType() == MediaType.AUDIO) {
 			AudioPlayer audioPlayer = (AudioPlayer) player;
 			if (audioPlayer.canSetPitch()) {
 				audioPlayer.setPlaybackPitch((float) pitch);


### PR DESCRIPTION
When a new track starts, it will attempt to set speed when media is still null, resulting in a null pointer exception.  This checks for the null pointer.
