### PR TITLE
Playback speed

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -59,7 +59,27 @@
         <item>1.85</item>
         <item>1.90</item>
         <item>1.95</item>
-        <item>2.0</item>
+        <item>2.00</item>
+        <item>2.10</item>
+        <item>2.20</item>
+        <item>2.30</item>
+        <item>2.40</item>
+        <item>2.50</item>
+        <item>2.60</item>
+        <item>2.70</item>
+        <item>2.80</item>
+        <item>2.90</item>
+        <item>3.00</item>
+        <item>3.10</item>
+        <item>3.20</item>
+        <item>3.30</item>
+        <item>3.40</item>
+        <item>3.50</item>
+        <item>3.60</item>
+        <item>3.70</item>
+        <item>3.80</item>
+        <item>3.90</item>
+        <item>4.00</item>
     </string-array>
     
     <string-array name="autodl_select_networks_default_entries">

--- a/src/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/src/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -428,8 +428,7 @@ public class AudioplayerActivity extends MediaplayerActivity {
 							break;
 						}
 					}
-					UserPreferences.setPlaybackSpeed(AudioplayerActivity.this,
-							newSpeed);
+					UserPreferences.setPlaybackSpeed(newSpeed);
 					controller.setPlaybackSpeed(Float.parseFloat(newSpeed));
 				}
 			}

--- a/src/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
+++ b/src/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
@@ -85,8 +85,7 @@ public class VariableSpeedDialog {
 							}
 						}
 
-						UserPreferences.setPlaybackSpeedArray(context,
-								newSpeedValues);
+						UserPreferences.setPlaybackSpeedArray(newSpeedValues);
 
 					}
 				});


### PR DESCRIPTION
Updates to the interface for variable speed playback as described in #184.  One minor variation is that by default the speed switch is by 0.1x instead of 0.05x so that if the speed is customized, the user doesn't have to uncheck as many boxes.
