### PR TITLE
Add missing resources in string.xml

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation"
+    >
 
     <!-- Activitiy titles -->
     <string name="app_name">AntennaPod</string>


### PR DESCRIPTION
Lint is complaining about untraduced strings without this patch.
