### PR TITLE
Flush BufferedOutputStream correctly

### DIFF
--- a/src/de/danoeh/antennapod/service/download/HttpDownloader.java
+++ b/src/de/danoeh/antennapod/service/download/HttpDownloader.java
@@ -63,7 +63,7 @@ public class HttpDownloader extends Downloader {
 	@Override
 	protected void download() {
 		DefaultHttpClient httpClient = null;
-		OutputStream out = null;
+		BufferedOutputStream out = null;
 		InputStream connection = null;
 		try {
 			HttpGet httpGet = new HttpGet(status.getFeedFile()
@@ -113,6 +113,7 @@ public class HttpDownloader extends Downloader {
 							if (cancelled) {
 								onCancelled();
 							} else {
+								out.flush();
 								onSuccess();
 							}
 						} else {

--- a/tests/src/de/danoeh/antennapod/test/FeedHandlerTest.java
+++ b/tests/src/de/danoeh/antennapod/test/FeedHandlerTest.java
@@ -54,7 +54,7 @@ public class FeedHandlerTest extends AndroidTestCase {
 
 		for (int i = 0; i < num_retries; i++) {
 			InputStream in = null;
-			OutputStream out = null;
+			BufferedOutputStream out = null;
 			try {
 				in = getInputStream(feed.getDownload_url());
 				assertNotNull(in);
@@ -65,6 +65,7 @@ public class FeedHandlerTest extends AndroidTestCase {
 				while ((count = in.read(buffer)) != -1) {
 					out.write(buffer, 0, count);
 				}
+				out.flush();
 				successful = true;
 			} catch (IOException e) {
 				e.printStackTrace();


### PR DESCRIPTION
This ensures that IOException due to writes are thrown in the main
code path instead of the exceptional code path.  Specifically for
HttpDownloader this ensures that IOUtils.closeQuietly does not swallow
a failed write.
