### PR TITLE
Enable Fast Forward and Rewind keys on Google TV remotes.

### DIFF
--- a/src/de/danoeh/antennapod/service/PlaybackService.java
+++ b/src/de/danoeh/antennapod/service/PlaybackService.java
@@ -432,7 +432,29 @@ public class PlaybackService extends Service {
 				pause(true, true);
 			}
 			break;
+		case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD: {
+			int currentPos = getCurrentPositionSafe();
+			int duration = getDurationSafe();
+
+			if (currentPos != INVALID_TIME && duration != INVALID_TIME) {
+				if (currentPos < duration) {
+					seek(currentPos + 10000);
+				}
+			}
+			break;
 		}
+		case KeyEvent.KEYCODE_MEDIA_REWIND: {
+			int currentPos = getCurrentPositionSafe();
+			int duration = getDurationSafe();
+
+			if (currentPos != INVALID_TIME && duration != INVALID_TIME) {
+				if (currentPos > 10000) {
+					seek(currentPos - 10000);
+				}
+			}
+			break;
+ 		  }
+		} 
 	}
 
 	/**


### PR DESCRIPTION
This enables the Fast Forward and Rewind keys on the google tv remote or any device that supports the appropriate keyboard codes.  If pressed it will jump ahead by 10 seconds or go back by 10 seconds.
