### PR TITLE
Upgrade ActionbarSherlock and ViewPager to latest maven central versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
 		</dependency>
 		<dependency>
 			<groupId>com.actionbarsherlock</groupId>
-			<artifactId>library</artifactId>
-			<version>4.1.0</version>
+			<artifactId>actionbarsherlock</artifactId>
+			<version>4.3.1</version>
 			<type>apklib</type>
 		</dependency>
 		<dependency>
 			<groupId>com.viewpagerindicator</groupId>
 			<artifactId>library</artifactId>
-			<version>2.3.1</version>
+			<version>2.4.1</version>
 			<type>apklib</type>
 		</dependency>
 		<dependency>

--- a/res/values-land/styles.xml
+++ b/res/values-land/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="Theme.MediaPlayer" parent="@style/Theme.Sherlock.Light.ForceOverflow">
-        	<item name="android:windowActionBarOverlay">true</item>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.MediaPlayer" parent="@style/Theme.Sherlock.Light">
+        	<item name="android:windowActionBarOverlay" tools:ignore="NewApi">true</item>
     </style>
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.AntennaPod.Light" parent="@style/Theme.Sherlock.Light.ForceOverflow">
+    <style name="Theme.AntennaPod.Light" parent="@style/Theme.Sherlock.Light">
         <item name="vpiTabPageIndicatorStyle">@style/AntennaPod.LightTabPageIndicator</item>
         <item name="attr/action_about">@drawable/action_about</item>
         <item name="attr/action_search">@drawable/action_search</item>
@@ -51,7 +51,7 @@
         <item name="android:textColor">@color/black</item>
     </style>
 
-    <style name="Theme.AntennaPod.Dark" parent="@style/Theme.Sherlock.ForceOverflow">
+    <style name="Theme.AntennaPod.Dark" parent="@style/Theme.Sherlock.Light">
         <item name="vpiTabPageIndicatorStyle">@style/AntennaPod.DarkTabPageIndicator</item>
         <item name="attr/action_about">@drawable/action_about_dark</item>
         <item name="attr/action_search">@drawable/action_search_dark</item>
@@ -102,9 +102,9 @@
       <item name="android:orientation">horizontal</item>
       <item name="android:background">@drawable/undobar</item>
       <item name="android:clickable">true</item>
-      <item name="android:showDividers">middle</item>
+      <item name="android:showDividers" tools:ignore="NewApi">middle</item>
       <item name="android:divider">@drawable/undobar_divider</item>
-      <item name="android:dividerPadding">10dp</item>
+      <item name="android:dividerPadding" tools:ignore="NewApi">10dp</item>
     </style>
     <style name="UndoBarMessage">
       <item name="android:layout_width">0dp</item>
@@ -125,7 +125,7 @@
       <item name="android:drawableLeft">@drawable/ic_undobar_undo</item>
       <item name="android:drawablePadding">12dp</item>
       <item name="android:textAppearance">?android:textAppearanceSmall</item>
-      <item name="android:textAllCaps">true</item>
+      <item name="android:textAllCaps" tools:ignore="NewApi">true</item>
       <item name="android:textStyle">bold</item>
       <item name="android:textColor">#fff</item>
       <item name="android:text">@string/undo</item>


### PR DESCRIPTION
- Pull ActionbarSherlock and ViewPager apklibs from maven central.
- Upgrade AntennaPod to use latest version of ActionbarSherlock
- ForceOverflow theme no longer available in ActionbarSherlock

This makes it a bit easier to build AntennaPod locally instead of having to pull in sub modules.   The drag-sort-listview apk project doesn't seem to be maintained by the author any more, so you may want to host your own maven repo with this module and add the repository to the build.  In order to get this submodule to work, it's maven plugin version needed to be upgraded to 3.6.0.  I have that maintained in the following branch.

https://github.com/kingargyle/drag-sort-listview/tree/upgrade-to-3.6.0

If you hae the drag-sort-listview deployed locally already there build branch linked above isn't needed.
