### PR TITLE
Use NineOldAndroid compatibility library for animations

### DIFF
--- a/assets/about.html
+++ b/assets/about.html
@@ -51,6 +51,9 @@
 		<h2>Android-ViewPagerIndicator <a href="http://viewpagerindicator.com">(Link)</a></h2>
 			by Jake Wharton, licensed under the Apache 2.0 license
 			
+		<h2>NineOldAndroids <a href="http://nineoldandroids.com">(Link)</a></h2>
+			by Jake Wharton, licensed under the Apache 2.0 license
+			
 		<h2>Apache Commons <a href="http://commons.apache.org/">(Link)</a></h2>
 			by The Apache Software Foundation, licensed under the Apache 2.0 license
 		<h2>flattr4j <a href="http://www.shredzone.org/projects/flattr4j/wiki">(Link)</a></h2>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
 			<version>0.6.1-SNAPSHOT</version>
 			<type>apklib</type>
 		</dependency>
+		<dependency>
+			<groupId>com.nineoldandroids</groupId>
+			<artifactId>library</artifactId>
+			<version>2.4.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/de/danoeh/antennapod/util/UndoBarController.java
+++ b/src/de/danoeh/antennapod/util/UndoBarController.java
@@ -16,15 +16,17 @@
 
 package de.danoeh.antennapod.util;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.text.TextUtils;
 import android.view.View;
-import android.view.ViewPropertyAnimator;
 import android.widget.TextView;
+import com.nineoldandroids.animation.Animator;
+import com.nineoldandroids.animation.AnimatorListenerAdapter;
+import com.nineoldandroids.view.ViewHelper;
+import com.nineoldandroids.view.ViewPropertyAnimator;
+import static com.nineoldandroids.view.ViewPropertyAnimator.animate;
 
 import de.danoeh.antennapod.R;
 
@@ -46,7 +48,7 @@ public class UndoBarController {
 
     public UndoBarController(View undoBarView, UndoListener undoListener) {
         mBarView = undoBarView;
-        mBarAnimator = mBarView.animate();
+        mBarAnimator = animate(mBarView);
         mUndoListener = undoListener;
 
         mMessageView = (TextView) mBarView.findViewById(R.id.undobar_message);
@@ -73,7 +75,7 @@ public class UndoBarController {
 
         mBarView.setVisibility(View.VISIBLE);
         if (immediate) {
-            mBarView.setAlpha(1);
+            ViewHelper.setAlpha(mBarView, 1);
         } else {
             mBarAnimator.cancel();
             mBarAnimator
@@ -89,7 +91,7 @@ public class UndoBarController {
         mHideHandler.removeCallbacks(mHideRunnable);
         if (immediate) {
             mBarView.setVisibility(View.GONE);
-            mBarView.setAlpha(0);
+            ViewHelper.setAlpha(mBarView, 0);
             mUndoMessage = null;
             mUndoToken = null;
 


### PR DESCRIPTION
This fixes the crashes on pre-Honeycomb devices when entering the
Organize Queue activity (Fixes #223)
