### PR TITLE
Check file size after download

### DIFF
--- a/src/de/danoeh/antennapod/service/download/HttpDownloader.java
+++ b/src/de/danoeh/antennapod/service/download/HttpDownloader.java
@@ -114,6 +114,15 @@ public class HttpDownloader extends Downloader {
 								onCancelled();
 							} else {
 								out.flush();
+								if (status.getSize() != DownloadStatus.SIZE_UNKNOWN &&
+										status.getSoFar() != status.getSize()) {
+									onFail(DownloadError.ERROR_IO_ERROR,
+										"Download completed but size: " +
+										status.getSoFar() +
+										" does not equal expected size " +
+										status.getSize());
+									return;
+								}
 								onSuccess();
 							}
 						} else {


### PR DESCRIPTION
This commit may address symptoms seen in #187 and #197 where
AntennaPod did not flag incomplete downloads as failed.
