### PR TITLE
Ask for volume controls to affect media volume.

### DIFF
--- a/src/de/danoeh/antennapod/activity/FeedItemlistActivity.java
+++ b/src/de/danoeh/antennapod/activity/FeedItemlistActivity.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
+import android.media.AudioManager;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
@@ -49,6 +50,8 @@ public class FeedItemlistActivity extends SherlockFragmentActivity {
 
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 		setContentView(R.layout.feeditemlist_activity);
+
+		setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
 		manager = FeedManager.getInstance();
 		long feedId = getIntent().getLongExtra(

--- a/src/de/danoeh/antennapod/activity/ItemviewActivity.java
+++ b/src/de/danoeh/antennapod/activity/ItemviewActivity.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.activity;
 
 import java.text.DateFormat;
 
+import android.media.AudioManager;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
@@ -50,6 +51,7 @@ public class ItemviewActivity extends SherlockFragmentActivity {
 		getSupportActionBar().setDisplayShowTitleEnabled(false);
 		extractFeeditem();
 		populateUI();
+		setVolumeControlStream(AudioManager.STREAM_MUSIC);
 	}
 
 	@Override

--- a/src/de/danoeh/antennapod/activity/MainActivity.java
+++ b/src/de/danoeh/antennapod/activity/MainActivity.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import android.content.Context;
 import android.content.Intent;
+import android.media.AudioManager;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentPagerAdapter;
@@ -54,6 +55,8 @@ public class MainActivity extends SherlockFragmentActivity {
 		manager = FeedManager.getInstance();
 		requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
 		setContentView(R.layout.main);
+
+		setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
 		getSupportActionBar().setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
 

--- a/src/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/src/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PixelFormat;
+import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -147,6 +148,8 @@ public abstract class MediaplayerActivity extends SherlockFragmentActivity
 		if (AppConfig.DEBUG)
 			Log.d(TAG, "Creating Activity");
 		StorageUtils.checkStorageAvailability(this);
+
+		setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
 		orientation = getResources().getConfiguration().orientation;
 		manager = FeedManager.getInstance();


### PR DESCRIPTION
By default the volume controls on Android control the ringer volume.  It's useful to be able to adjust the media playback volume before hitting play; this does that for each activity that can start playback.
