### PR TITLE
Fixes issue #249 (Cannot use Kinivo BTC450 bluetooth car kit to play after pause). 

### DIFF
--- a/src/de/danoeh/antennapod/service/PlaybackService.java
+++ b/src/de/danoeh/antennapod/service/PlaybackService.java
@@ -825,14 +825,14 @@ public class PlaybackService extends Service {
 			if (AppConfig.DEBUG)
 				Log.d(TAG, "Pausing playback.");
 			player.pause();
+			cancelPositionSaver();
+			saveCurrentPosition();
+			setStatus(PlayerStatus.PAUSED);
 			if (abandonFocus) {
 				audioManager.abandonAudioFocus(audioFocusChangeListener);
 				pausedBecauseOfTransientAudiofocusLoss = false;
 				disableSleepTimer();
 			}
-			cancelPositionSaver();
-			saveCurrentPosition();
-			setStatus(PlayerStatus.PAUSED);
 			stopWidgetUpdater();
 			stopForeground(true);
 			if (shouldStream && reinit) {


### PR DESCRIPTION
The problem was that audioManager.abandonAudioFocus() was being called
before remoteControlClient.setPlaybackState(). That seems to have
prevented the BTC450 from knowing that the audio was paused. As a
result, the BTC450 continued to send "pause" instead of "play" for
subsequent button presses. The fix just moves the call to
abandonAudioFocus() until after setPlaybackState() has been called.
