### PR TITLE
added android-test as a dependency to resolve build problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
             <type>jar</type>
         </dependency>
         <dependency>
+           <groupId>com.google.android</groupId>
+           <artifactId>android-test</artifactId>
+           <version>2.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>


### PR DESCRIPTION
As develop stands now the maven build breaks because it doesn't know about android.test.  This fixes that by adding  android-test as a dependency.
