### PR TITLE
Return when playing external media

### DIFF
--- a/src/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/src/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -155,6 +155,9 @@ public class AudioplayerActivity extends MediaplayerActivity {
 
 	@Override
 	protected void onPause() {
+        // return to calling activity (i.e. a calling file manager will not directly jump to this activity again when it is opened the next time)
+        finish();
+
 		savePreferences();
 		resetFragmentView();
 		super.onPause();


### PR DESCRIPTION
Actually this is only about commit d72c2e9, not sure where I can change the merge request target from danieloeh:master to danieloeh:develop... 

I made the experience with both filemanagers I use (OI FileManager and the cyanogenmod filemanager app), that AntennaPod (and other apps) don't disconnect and return to the filemanager.

What I mean is this: open mp3 file in the filemanager -> launches AudioPlayerActivity, switch back to homescreen (music is playing in the background), launch filemanager -> I land in the AudioPlayerActivity, while for me the expected behaviour upon launching the filemanager would be to end up in the filemanager activity.

This change remedies the issue. I am not sure if there might be any unintended side-effects, I haven't observed any upon testing though.