### PR TITLE
Add feed preference to include/exclude certain feeds from auto downloads

### DIFF
--- a/res/layout/feedinfo.xml
+++ b/res/layout/feedinfo.xml
@@ -93,6 +93,18 @@
                     android:layout_below="@id/txtvAuthor"
                     android:layout_margin="8dp"
                     android:layout_toRightOf="@id/center_divider" />
+
+                <CheckBox
+                    android:id="@+id/cbxAutoDownload"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_below="@id/txtvLanguage"
+                    android:layout_margin="8dp"
+                    android:text="@string/auto_download_label"
+                    android:enabled="false"
+                    android:textStyle="bold" />
+
             </RelativeLayout>
 
             <TextView

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="image_of_prefix">Image of:\u0020</string>
     <string name="save_username_password_label">Save username and password</string>
     <string name="close_label">Close</string>
+    <string name="auto_download_label">Include in auto downloads</string>
     
 
     <!-- 'Add Feed' Activity labels -->

--- a/src/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/src/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -7,6 +7,8 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 import de.danoeh.antennapod.AppConfig;
@@ -35,6 +37,7 @@ public class FeedInfoActivity extends ActionBarActivity {
     private TextView txtvDescription;
     private TextView txtvLanguage;
     private TextView txtvAuthor;
+    private CheckBox cbxAutoDownload;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,6 +46,13 @@ public class FeedInfoActivity extends ActionBarActivity {
         setContentView(R.layout.feedinfo);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         long feedId = getIntent().getLongExtra(EXTRA_FEED_ID, -1);
+
+        imgvCover = (ImageView) findViewById(R.id.imgvCover);
+        txtvTitle = (TextView) findViewById(R.id.txtvTitle);
+        txtvDescription = (TextView) findViewById(R.id.txtvDescription);
+        txtvLanguage = (TextView) findViewById(R.id.txtvLanguage);
+        txtvAuthor = (TextView) findViewById(R.id.txtvAuthor);
+        cbxAutoDownload = (CheckBox) findViewById(R.id.cbxAutoDownload);
 
         AsyncTask<Long, Void, Feed> loadTask = new AsyncTask<Long, Void, Feed>() {
 
@@ -53,18 +63,12 @@ public class FeedInfoActivity extends ActionBarActivity {
 
             @Override
             protected void onPostExecute(Feed result) {
-                super.onPostExecute(result);
                 if (result != null) {
                     feed = result;
                     if (AppConfig.DEBUG)
                         Log.d(TAG, "Language is " + feed.getLanguage());
                     if (AppConfig.DEBUG)
                         Log.d(TAG, "Author is " + feed.getAuthor());
-                    imgvCover = (ImageView) findViewById(R.id.imgvCover);
-                    txtvTitle = (TextView) findViewById(R.id.txtvTitle);
-                    txtvDescription = (TextView) findViewById(R.id.txtvDescription);
-                    txtvLanguage = (TextView) findViewById(R.id.txtvLanguage);
-                    txtvAuthor = (TextView) findViewById(R.id.txtvAuthor);
                     imgvCover.post(new Runnable() {
 
                         @Override
@@ -83,6 +87,17 @@ public class FeedInfoActivity extends ActionBarActivity {
                         txtvLanguage.setText(LangUtils
                                 .getLanguageString(feed.getLanguage()));
                     }
+
+                    cbxAutoDownload.setEnabled(UserPreferences.isEnableAutodownload());
+                    cbxAutoDownload.setChecked(feed.getPreferences().getAutoDownload());
+                    cbxAutoDownload.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                        @Override
+                        public void onCheckedChanged(CompoundButton compoundButton, boolean checked) {
+                            feed.getPreferences().setAutoDownload(checked);
+                            feed.savePreferences(FeedInfoActivity.this);
+                        }
+                    });
+
                     supportInvalidateOptionsMenu();
 
                 } else {

--- a/src/de/danoeh/antennapod/feed/Feed.java
+++ b/src/de/danoeh/antennapod/feed/Feed.java
@@ -1,11 +1,14 @@
 package de.danoeh.antennapod.feed;
 
+import android.content.Context;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 import de.danoeh.antennapod.preferences.UserPreferences;
+import de.danoeh.antennapod.storage.DBWriter;
 import de.danoeh.antennapod.util.EpisodeFilter;
 
 /**
@@ -45,6 +48,11 @@ public class Feed extends FeedFile {
      * Feed type, for example RSS 2 or Atom
      */
     private String type;
+
+    /**
+     * Feed preferences
+     */
+    private FeedPreferences preferences;
 
     /**
      * This constructor is used for restoring a feed from the database.
@@ -366,4 +374,15 @@ public class Feed extends FeedFile {
         this.type = type;
     }
 
+    public void setPreferences(FeedPreferences preferences) {
+        this.preferences = preferences;
+    }
+
+    public FeedPreferences getPreferences() {
+        return preferences;
+    }
+
+    public void savePreferences(Context context) {
+        DBWriter.setFeedPreferences(context, preferences);
+    }
 }

--- a/src/de/danoeh/antennapod/feed/FeedPreferences.java
+++ b/src/de/danoeh/antennapod/feed/FeedPreferences.java
@@ -1,14 +1,20 @@
 package de.danoeh.antennapod.feed;
 
+import android.content.Context;
+
+import de.danoeh.antennapod.storage.DBWriter;
+
 /**
  * Contains preferences for a single feed.
  */
 public class FeedPreferences {
 
     private long feedID;
+    private boolean autoDownload;
 
-    public FeedPreferences(long feedID) {
+    public FeedPreferences(long feedID, boolean autoDownload) {
         this.feedID = feedID;
+        this.autoDownload = autoDownload;
     }
 
     public long getFeedID() {
@@ -17,5 +23,17 @@ public class FeedPreferences {
 
     public void setFeedID(long feedID) {
         this.feedID = feedID;
+    }
+
+    public boolean getAutoDownload() {
+        return autoDownload;
+    }
+
+    public void setAutoDownload(boolean autoDownload) {
+        this.autoDownload = autoDownload;
+    }
+
+    public void save(Context context) {
+        DBWriter.setFeedPreferences(context, this);
     }
 }

--- a/src/de/danoeh/antennapod/storage/DBReader.java
+++ b/src/de/danoeh/antennapod/storage/DBReader.java
@@ -333,6 +333,11 @@ public final class DBReader {
         if (image != null) {
             image.setFeed(feed);
         }
+
+        FeedPreferences preferences = new FeedPreferences(cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_ID),
+                cursor.getInt(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_AUTO_DOWNLOAD) > 0);
+
+        feed.setPreferences(preferences);
         return feed;
     }
 
@@ -767,30 +772,5 @@ public final class DBReader {
         adapter.close();
 
         return media;
-    }
-
-    private static FeedPreferences extractFeedPreferencesFromCursorRow(final Cursor cursor) {
-        return new FeedPreferences(cursor.getLong(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_ID));
-    }
-
-    /**
-     * Loads the FeedPreferences-object of a specific Feed from the database.
-     *
-     * @param context A context that is used for opening a database connection.
-     * @param feedID  ID of the Feed.
-     * @return The FeedPreferences of the Feed with the given ID or null if the no Feed could be found.
-     */
-    public static FeedPreferences getFeedPreferencesOfFeed(final Context context, final long feedID) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-
-        Cursor prefCursor = adapter.getFeedPreferenceCursor(feedID);
-        if (prefCursor.moveToFirst()) {
-            FeedPreferences result = extractFeedPreferencesFromCursorRow(prefCursor);
-            prefCursor.close();
-            return result;
-        } else {
-            return null;
-        }
     }
 }

--- a/src/de/danoeh/antennapod/storage/DBTasks.java
+++ b/src/de/danoeh/antennapod/storage/DBTasks.java
@@ -324,12 +324,14 @@ public final class DBTasks {
         int counter = 0;
         for (FeedItem item : queue) {
             if (item.hasMedia() && !item.getMedia().isDownloaded()
-                    && !item.getMedia().isPlaying()) {
+                    && !item.getMedia().isPlaying()
+                    && item.getFeed().getPreferences().getAutoDownload()) {
                 counter++;
             }
         }
         for (FeedItem item : unreadItems) {
-            if (item.hasMedia() && !item.getMedia().isDownloaded()) {
+            if (item.hasMedia() && !item.getMedia().isDownloaded()
+                    && item.getFeed().getPreferences().getAutoDownload()) {
                 counter++;
             }
         }
@@ -375,7 +377,8 @@ public final class DBTasks {
                 for (int i = 0; i < queue.size(); i++) { // ignore playing item
                     FeedItem item = queue.get(i);
                     if (item.hasMedia() && !item.getMedia().isDownloaded()
-                            && !item.getMedia().isPlaying()) {
+                            && !item.getMedia().isPlaying()
+                            && item.getFeed().getPreferences().getAutoDownload()) {
                         itemsToDownload.add(item);
                         episodeSpaceLeft--;
                         undownloadedEpisodes--;
@@ -387,7 +390,8 @@ public final class DBTasks {
             }
             if (episodeSpaceLeft > 0 && undownloadedEpisodes > 0) {
                 for (FeedItem item : unreadItems) {
-                    if (item.hasMedia() && !item.getMedia().isDownloaded()) {
+                    if (item.hasMedia() && !item.getMedia().isDownloaded()
+                            && item.getFeed().getPreferences().getAutoDownload()) {
                         itemsToDownload.add(item);
                         episodeSpaceLeft--;
                         undownloadedEpisodes--;


### PR DESCRIPTION
I had to shift a few things around and deleted some of the FeedPreference related stuff to make things easier to work with. Having to load a feed's preferences manually was a pain, it doesn't make sense to work with the preferences without the feed, so just load the feed including its preferences in a single db operation. Apart from that, the code is the same as in the original pull request (#239).
