### PR TITLE
Add '\n' to the list of illegal characters in filenames.

### DIFF
--- a/src/de/danoeh/antennapod/util/FileNameGenerator.java
+++ b/src/de/danoeh/antennapod/util/FileNameGenerator.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 public class FileNameGenerator {
 	
 	private static final char[] ILLEGAL_CHARACTERS = { '/', '\\', '?', '%',
-			'*', ':', '|', '"', '<', '>' };
+			'*', ':', '|', '"', '<', '>', '\n' };
 	static {
 		Arrays.sort(ILLEGAL_CHARACTERS);
 	}


### PR DESCRIPTION
Small fix for this bug https://github.com/danieloeh/AntennaPod/issues/68
Based on this rss-fedd http://www.echo.msk.ru/programs/dream/rss-audio.xml
