### PR TITLE
Fix url path get encoded twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,6 @@ You can use the [AntennaPod Google Group](https://groups.google.com/forum/#!foru
 
 Bug reports and feature requests can be submitted [here](https://github.com/danieloeh/AntennaPod/issues/new) (please read the [instructions](https://github.com/danieloeh/AntennaPod/blob/master/CONTRIBUTING.md) on how to report a bug and how to submit a feature request first!).
 
-
-## Nightly Builds
-
-There are APKs available for every branch that is actively worked on. Please note that these might be very unstable versions of the app, which can break your current installation. Install them at your own risk!
-
-Click [here](https://www.dropbox.com/sh/45vgg13bmh8jmhp/uZ_3KJIi5K) to get to the nightly builds folder.
-    
 ## License
 
 AntennaPod is licensed under the MIT License. You can find the license text in the LICENSE file.


### PR DESCRIPTION
Hey Daniel,

i had an problem to download files embedded in the feed were the url is already urlencoded. 

Reproduce the Problem:
1. add a new Podcast the "Android Developers Backstage" Podcast from gpodder.net
2. try to download an episode from this podcast
3. the Download failed with a 404

The Problem is in [src/de/danoeh/antennapod/service/download/HttpDownloader.java#L32](https://github.com/danieloeh/AntennaPod/blob/master/src/de/danoeh/antennapod/service/download/HttpDownloader.java#L32)

You first create an URL and after that you are creating an URI with all the components of this created URL. By using the multi-argument constructor URI the path of the URL get urlencoded again.
See http://stackoverflow.com/questions/4858108/url-to-uri-encoding-changes-a-3d-to-253d for details

regards,
David
