### PR TITLE
NUM_LENGTH should be 1024 for accurate download progess display

### DIFF
--- a/src/de/danoeh/antennapod/util/Converter.java
+++ b/src/de/danoeh/antennapod/util/Converter.java
@@ -21,7 +21,7 @@ public final class Converter {
     /** Indicates that the value is in the Gigabyte range.*/
     private static final int GB_RANGE = 3;
     /** Determines the length of the number for best readability.*/
-    private static final int NUM_LENGTH = 1000;
+    private static final int NUM_LENGTH = 1024;
     
     
     private static final int HOURS_MIL = 3600000;


### PR DESCRIPTION
unless NUM_LENGTH is 1024, the displayed size is 0KB or 0MB etc. for growing ranges below the respective boundary i.e. 1000-1023, 1024000-1048575
