### PR TITLE
Update copyright year to 2014

### DIFF
--- a/assets/about.html
+++ b/assets/about.html
@@ -43,7 +43,7 @@
 
     <p>AntennaPod, Version 0.9.9.0</p>
 
-    <p>Copyright © 2012 Daniel Oeh</p>
+    <p>Copyright © 2014 Daniel Oeh</p>
 
     <p>Licensed under the MIT License <a href="LICENSE.html">(View)</a></p>
 </div>


### PR DESCRIPTION
Seeing 2012 made me wonder if the app was stale the first time I opened the about page.  Users should feel great about an app with this much development activity.
