### PR TITLE
Display message when search returned no hits

### DIFF
--- a/src/de/danoeh/antennapod/fragment/gpodnet/PodcastListFragment.java
+++ b/src/de/danoeh/antennapod/fragment/gpodnet/PodcastListFragment.java
@@ -123,7 +123,7 @@ public abstract class PodcastListFragment extends Fragment {
             protected void onPostExecute(List<GpodnetPodcast> gpodnetPodcasts) {
                 super.onPostExecute(gpodnetPodcasts);
                 final Context context = getActivity();
-                if (context != null && gpodnetPodcasts != null) {
+                if (context != null && gpodnetPodcasts != null && gpodnetPodcasts.size() > 0) {
                     PodcastListAdapter listAdapter = new PodcastListAdapter(context, 0, gpodnetPodcasts);
                     gridView.setAdapter(listAdapter);
                     listAdapter.notifyDataSetChanged();
@@ -132,13 +132,18 @@ public abstract class PodcastListFragment extends Fragment {
                     gridView.setVisibility(View.VISIBLE);
                     txtvError.setVisibility(View.GONE);
                     butRetry.setVisibility(View.GONE);
+                } else if (context != null && gpodnetPodcasts != null) {
+                    gridView.setVisibility(View.GONE);
+                    progressBar.setVisibility(View.GONE);
+                    txtvError.setText(getString(R.string.search_status_no_results));
+                    txtvError.setVisibility(View.VISIBLE);
+                    butRetry.setVisibility(View.GONE);
                 } else if (context != null) {
                     gridView.setVisibility(View.GONE);
                     progressBar.setVisibility(View.GONE);
                     txtvError.setText(getString(R.string.error_msg_prefix) + exception.getMessage());
                     txtvError.setVisibility(View.VISIBLE);
                     butRetry.setVisibility(View.VISIBLE);
-
                 }
             }
 


### PR DESCRIPTION
If no matches are found for a search, the user is presented with an empty list. However, when using the "Search gpodder.net" functionality, when you're presented with this empty list, it's not obvious that there were really no search results and there isn't [say] a problem with your network connection.

This change explicitly tells the user that nothing was found.
