### PR TITLE
Persistent lockscreen controls when playback is paused

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -250,6 +250,8 @@
     <string name="pref_seek_delta_sum">Seek this many seconds when rewinding or fast-forwarding</string>
     <string name="pref_gpodnet_sethostname_title">Set hostname</string>
     <string name="pref_gpodnet_sethostname_use_default_host">Use default host</string>
+    <string name="pref_lockscreenPersistControls_title">Persistent Lockscreen Controls</string>
+    <string name="pref_lockscreenPersistControls_sum">Keep controls on lockscreen when playback is paused.</string>
 
     <!-- Auto-Flattr dialog -->
     <string name="auto_flattr_enable">Enable automatic flattring</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -9,6 +9,12 @@
             android:key="prefTheme"
             android:summary="@string/pref_set_theme_sum"
             android:defaultValue="0"/>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefLockscreenPersist"
+            android:summary="@string/pref_lockscreenPersistControls_sum"
+            android:title="@string/pref_lockscreenPersistControls_title"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/playback_pref">
         <CheckBoxPreference

--- a/src/de/danoeh/antennapod/preferences/UserPreferences.java
+++ b/src/de/danoeh/antennapod/preferences/UserPreferences.java
@@ -53,6 +53,7 @@ public class UserPreferences implements
     private static final String PREF_PLAYBACK_SPEED_ARRAY = "prefPlaybackSpeedArray";
     public static final String PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS = "prefPauseForFocusLoss";
     private static final String PREF_SEEK_DELTA_SECS = "prefSeekDeltaSecs";
+    private static final String PREF_LOCKSCREEN_PERSISTENT_CONTROLS = "prefLockscreenPersist";
 
     // TODO: Make this value configurable
     private static final float PREF_AUTO_FLATTR_PLAYED_DURATION_THRESHOLD_DEFAULT = 0.8f;
@@ -82,6 +83,7 @@ public class UserPreferences implements
     private boolean pauseForFocusLoss;
     private int seekDeltaSecs;
     private boolean isFreshInstall;
+    private boolean lockscreenPersist;
 
     private UserPreferences(Context context) {
         this.context = context;
@@ -138,6 +140,7 @@ public class UserPreferences implements
                 PREF_PLAYBACK_SPEED_ARRAY, null));
         pauseForFocusLoss = sp.getBoolean(PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS, false);
         seekDeltaSecs = Integer.valueOf(sp.getString(PREF_SEEK_DELTA_SECS, "30"));
+        lockscreenPersist = sp.getBoolean(PREF_LOCKSCREEN_PERSISTENT_CONTROLS, false);
     }
 
     private int readThemeValue(String valueFromPrefs) {
@@ -241,6 +244,11 @@ public class UserPreferences implements
     public static boolean isAutoFlattr() {
         instanceAvailable();
         return instance.autoFlattr;
+    }
+
+    public static boolean isLockscreenPersist() {
+        instanceAvailable();
+        return instance.lockscreenPersist;
     }
 
     /**
@@ -366,6 +374,8 @@ public class UserPreferences implements
         } else if (key.equals(PREF_AUTO_FLATTR_PLAYED_DURATION_THRESHOLD)) {
             autoFlattrPlayedDurationThreshold = sp.getFloat(PREF_AUTO_FLATTR_PLAYED_DURATION_THRESHOLD,
                     PREF_AUTO_FLATTR_PLAYED_DURATION_THRESHOLD_DEFAULT);
+        } else if (key.equals(PREF_LOCKSCREEN_PERSISTENT_CONTROLS)) {
+            lockscreenPersist = sp.getBoolean(PREF_LOCKSCREEN_PERSISTENT_CONTROLS, false);
         }
     }
 

--- a/src/de/danoeh/antennapod/service/playback/PlaybackService.java
+++ b/src/de/danoeh/antennapod/service/playback/PlaybackService.java
@@ -297,7 +297,12 @@ public class PlaybackService extends Service {
             case KeyEvent.KEYCODE_HEADSETHOOK:
             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
                 if (status == PlayerStatus.PLAYING) {
-                    mediaPlayer.pause(true, true);
+                    if (UserPreferences.isLockscreenPersist()) {
+                        mediaPlayer.pause(false, true);
+                    }
+                    else {
+                        mediaPlayer.pause(true, true);
+                    }
                 } else if (status == PlayerStatus.PAUSED || status == PlayerStatus.PREPARED) {
                     mediaPlayer.resume();
                 } else if (status == PlayerStatus.PREPARING) {
@@ -317,7 +322,12 @@ public class PlaybackService extends Service {
                 break;
             case KeyEvent.KEYCODE_MEDIA_PAUSE:
                 if (status == PlayerStatus.PLAYING) {
-                    mediaPlayer.pause(true, true);
+                    if (UserPreferences.isLockscreenPersist()) {
+                        mediaPlayer.pause(false, true);
+                    }
+                    else {
+                        mediaPlayer.pause(true, true);
+                    }
                 }
                 break;
             case KeyEvent.KEYCODE_MEDIA_NEXT:
@@ -949,7 +959,12 @@ public class PlaybackService extends Service {
      */
     private void pauseIfPauseOnDisconnect() {
         if (UserPreferences.isPauseOnHeadsetDisconnect()) {
-            mediaPlayer.pause(true, true);
+            if (UserPreferences.isLockscreenPersist()) {
+                mediaPlayer.pause(false, true);
+            }
+            else {
+                mediaPlayer.pause(true, true);
+            }
         }
     }
 


### PR DESCRIPTION
Changed the pause button and disconnected headphone use of `mediaPlayer.pause()` to pass a value of `false` for `abandonFocus` when the preference is enabled.
