### PR TITLE
more options for episode cache size

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -32,6 +32,9 @@
     </string-array>
     <string-array name="episode_cache_size_entries">
         <item>@string/pref_episode_cache_unlimited</item>
+        <item>1</item>
+        <item>2</item>
+        <item>5</item>
         <item>10</item>
         <item>20</item>
         <item>40</item>
@@ -41,6 +44,9 @@
     </string-array>
     <string-array name="episode_cache_size_values">
         <item>-1</item>
+        <item>1</item>
+        <item>2</item>
+        <item>5</item>
         <item>10</item>
         <item>20</item>
         <item>40</item>


### PR DESCRIPTION
add 1, 2, and 5 as options for episode cache size
addresses issue #519 
