### PR TITLE
Parse podcast duration correctly even with trailing whitespace

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
@@ -50,7 +50,7 @@ public class NSITunes extends Namespace {
         if (localName.equals(AUTHOR)) {
             state.getFeed().setAuthor(state.getContentBuf().toString());
         } else if (localName.equals(DURATION)) {
-            String[] parts = state.getContentBuf().toString().split(":");
+            String[] parts = state.getContentBuf().toString().trim().split(":");
             try {
                 int duration = 0;
                 if (parts.length == 2) {


### PR DESCRIPTION
The Skeptoid podcast (available on gpodder.net) currently has a specific
episode (titled "Skeptoid #437: Tube Amplifiers") that contains the XML
itunes:duration14:57 /itunes:duration which AntennaPod fails
to parse (and instead hits a java.lang.NumberFormatException which
it prints to stderr every time the refresh button is pressed).
The duration for that particular episode is not correctly showed in
the UI, although the duration for other Skeptoid episodes show up
just fine.
