### PR TITLE
Prevent calling super() with null in AspectRatioView.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/view/AspectRatioVideoView.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/AspectRatioVideoView.java
@@ -27,16 +27,21 @@ public class AspectRatioVideoView extends VideoView {
     private int mVideoHeight;
 
     public AspectRatioVideoView(Context context) {
-        this(context, null);
+        super(context);
+        init();
     }
 
     public AspectRatioVideoView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+        super(context, attrs);
+        init();
     }
 
     public AspectRatioVideoView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        init();
+    }
 
+    private void init() {
         mVideoWidth = 0;
         mVideoHeight = 0;
     }


### PR DESCRIPTION
In the AspectRatioVideoView constructor, call an init method instead of this() with null arguments.