### PR TITLE
Use public shared podcast dir for downloads

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.storage;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Environment;
 import android.util.Log;
 import android.webkit.URLUtil;
 
@@ -209,7 +210,7 @@ public class DownloadRequester {
             if (feedmedia.getFile_url() != null) {
                 dest = new File(feedmedia.getFile_url());
             } else {
-                dest = new File(getMediafilePath(context, feedmedia),
+                dest = new File(getMediafilePath(feedmedia),
                         getMediafilename(feedmedia));
             }
             download(context, feedmedia, feed,
@@ -342,14 +343,12 @@ public class DownloadRequester {
         return "image-" + FileNameGenerator.generateFileName(filename);
     }
 
-    public synchronized String getMediafilePath(Context context, FeedMedia media)
-            throws DownloadRequestException {
-        File externalStorage = getExternalFilesDirOrThrowException(
-                context,
-                MEDIA_DOWNLOADPATH
-                        + FileNameGenerator.generateFileName(media.getItem()
-                        .getFeed().getTitle()) + "/"
-        );
+    public synchronized String getMediafilePath(FeedMedia media)
+          throws DownloadRequestException {
+        File externalStorage = getExternalPublicPodcastDir(
+            FileNameGenerator.generateFileName(media.getItem()
+              .getFeed().getTitle()) + "/"
+            );
         return externalStorage.toString();
     }
 
@@ -361,6 +360,10 @@ public class DownloadRequester {
                     "Failed to access external storage");
         }
         return result;
+    }
+
+    private File getExternalPublicPodcastDir(final String type) throws DownloadRequestException {
+        return new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PODCASTS), type);
     }
 
     private String getMediafilename(FeedMedia media) {


### PR DESCRIPTION
Fixes #599 

Uses the public podcast dir for enclosure downloads. The exist (user configurable) data dir is still used for feeds and images.

Future enhancements might include adding a second shared preference for changing the location of downloaded podcasts as well, but I think it makes sese to use the system default (where other apps will expect them to go) for the actual media files by default.