### PR TITLE
Empty queue command 593

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -175,6 +175,9 @@ public class QueueFragment extends Fragment {
                         DBTasks.refreshAllFeeds(getActivity(), feeds);
                     }
                     return true;
+                case R.id.clear_queue:
+                    DBWriter.clearQueue(getActivity());
+                    return true;
                 case R.id.queue_sort_alpha_asc:
                     QueueSorter.sort(getActivity(), QueueSorter.Rule.ALPHA_ASC, true);
                     return true;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -2,8 +2,8 @@ package de.danoeh.antennapod.fragment;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
@@ -30,6 +30,7 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.DefaultActionButtonCallback;
 import de.danoeh.antennapod.adapter.QueueListAdapter;
 import de.danoeh.antennapod.core.asynctask.DownloadObserver;
+import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
@@ -176,7 +177,19 @@ public class QueueFragment extends Fragment {
                     }
                     return true;
                 case R.id.clear_queue:
-                    DBWriter.clearQueue(getActivity());
+                    // make sure the user really wants to clear the queue
+                    ConfirmationDialog conDialog = new ConfirmationDialog(getActivity(),
+                            R.string.clear_queue_label,
+                            R.string.clear_queue_confirmation_msg) {
+
+                        @Override
+                        public void onConfirmButtonPressed(
+                                DialogInterface dialog) {
+                            dialog.dismiss();
+                            DBWriter.clearQueue(getActivity());
+                        }
+                    };
+                    conDialog.createNewDialog().show();
                     return true;
                 case R.id.queue_sort_alpha_asc:
                     QueueSorter.sort(getActivity(), QueueSorter.Rule.ALPHA_ASC, true);

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -11,6 +11,13 @@
         android:icon="?attr/navigation_refresh"/>
 
     <item
+        android:id="@+id/clear_queue"
+        android:title="Clear Queue"
+        android:menuCategory="container"
+        custom:showAsAction="collapseActionView"
+        android:icon="?attr/navigation_accept"/>
+
+    <item
         android:id="@+id/queue_sort"
         android:title="@string/sort">
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
     <string name="duration">Duration</string>
     <string name="ascending">Ascending</string>
     <string name="descending">Descending</string>
+    <string name="clear_queue_confirmation_msg">Please confirm that you want to clear the queue of ALL of the episodes in it</string>
 
     <!-- Flattr -->
     <string name="flattr_auth_label">Flattr sign-in</string>


### PR DESCRIPTION
Clears the users queue, while first asking for confirmation from the user.

Note that the menu option is not disabled when the queue is empty. I think this is 'ok' as this doesn't harm anything.

For issue #593.