### PR TITLE
Can understand DublinCore publication date in RSS feed

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/SyndHandler.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/SyndHandler.java
@@ -1,13 +1,22 @@
 package de.danoeh.antennapod.core.syndication.handler;
 
 import android.util.Log;
-import de.danoeh.antennapod.core.BuildConfig;
-import de.danoeh.antennapod.core.feed.Feed;
-import de.danoeh.antennapod.core.syndication.namespace.*;
-import de.danoeh.antennapod.core.syndication.namespace.atom.NSAtom;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
+
+import de.danoeh.antennapod.core.BuildConfig;
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.syndication.namespace.NSContent;
+import de.danoeh.antennapod.core.syndication.namespace.NSDublinCore;
+import de.danoeh.antennapod.core.syndication.namespace.NSITunes;
+import de.danoeh.antennapod.core.syndication.namespace.NSMedia;
+import de.danoeh.antennapod.core.syndication.namespace.NSRSS20;
+import de.danoeh.antennapod.core.syndication.namespace.NSSimpleChapters;
+import de.danoeh.antennapod.core.syndication.namespace.Namespace;
+import de.danoeh.antennapod.core.syndication.namespace.SyndElement;
+import de.danoeh.antennapod.core.syndication.namespace.atom.NSAtom;
 
 /** Superclass for all SAX Handlers which process Syndication formats */
 public class SyndHandler extends DefaultHandler {
@@ -100,7 +109,12 @@ public class SyndHandler extends DefaultHandler {
 				state.namespaces.put(uri, new NSMedia());
 				if (BuildConfig.DEBUG)
 					Log.d(TAG, "Recognized media namespace");
-			}
+			} else if (uri.equals(NSDublinCore.NSURI)
+                    && prefix.equals(NSDublinCore.NSTAG)) {
+                state.namespaces.put(uri, new NSDublinCore());
+                if (BuildConfig.DEBUG)
+                    Log.d(TAG, "Recognized DublinCore namespace");
+            }
 		}
 	}
 

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSDublinCore.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSDublinCore.java
@@ -1,0 +1,37 @@
+package de.danoeh.antennapod.core.syndication.namespace;
+
+import org.xml.sax.Attributes;
+
+import de.danoeh.antennapod.core.syndication.handler.HandlerState;
+import de.danoeh.antennapod.core.syndication.util.SyndDateUtils;
+
+public class NSDublinCore extends Namespace {
+    private static final String TAG = "NSDublinCore";
+    public static final String NSTAG = "dc";
+    public static final String NSURI = "http://purl.org/dc/elements/1.1/";
+
+    private static final String ITEM = "item";
+    private static final String DATE = "date";
+
+    @Override
+    public SyndElement handleElementStart(String localName, HandlerState state,
+                                          Attributes attributes) {
+        return new SyndElement(localName, this);
+    }
+
+    @Override
+    public void handleElementEnd(String localName, HandlerState state) {
+        if(state.getTagstack().size() >= 2
+                && state.getContentBuf() != null) {
+            String content = state.getContentBuf().toString();
+            SyndElement topElement = state.getTagstack().peek();
+            String top = topElement.getName();
+            SyndElement secondElement = state.getSecondTag();
+            String second = secondElement.getName();
+            if (top.equals(DATE) && second.equals(ITEM)) {
+                state.getCurrentItem().setPubDate(
+                        SyndDateUtils.parseISO8601Date(content));
+            }
+        }
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndDateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndDateUtils.java
@@ -28,6 +28,8 @@ public class SyndDateUtils {
      */
     public static final String RFC3339LOCAL = "yyyy-MM-dd'T'HH:mm:ssZ";
 
+    public static final String ISO8601_SHORT = "yyyy-MM-dd";
+
     private static ThreadLocal<SimpleDateFormat> RFC822Formatter = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
@@ -40,6 +42,14 @@ public class SyndDateUtils {
         @Override
         protected SimpleDateFormat initialValue() {
             return new SimpleDateFormat(RFC3339UTC, Locale.US);
+        }
+
+    };
+
+    private static ThreadLocal<SimpleDateFormat> ISO8601ShortFormatter = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat(ISO8601_SHORT, Locale.US);
         }
 
     };
@@ -121,6 +131,23 @@ public class SyndDateUtils {
 
         return result;
 
+    }
+
+    public static Date parseISO8601Date(String date) {
+        if(date.length() > ISO8601_SHORT.length()) {
+            return parseRFC3339Date(date);
+        }
+        Date result = null;
+        if(date.length() == "YYYYMMDD".length()) {
+            date = date.substring(0, 4) + "-" + date.substring(4, 6) + "-" + date.substring(6,8);
+        }
+        SimpleDateFormat format = ISO8601ShortFormatter.get();
+        try {
+            result = format.parse(date);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
I extended the SyncHandler to recognize the DublinCore namespace and it's date tag in particular
Date values are assumed to be in ISO8601 or RFC3339 format

Resolves AntennaPod/AntennaPod#610