### PR TITLE
Add ability to choose OMPL import path

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
@@ -15,16 +15,23 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.*;
+import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
-import de.danoeh.antennapod.BuildConfig;
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ImageButton;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+
+import de.danoeh.antennapod.BuildConfig;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 /**
  * Let's the user choose a directory on the storage device. The selected folder
@@ -37,6 +44,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 	public static final String RESULT_SELECTED_DIR = "selected_dir";
 	public static final int RESULT_CODE_DIR_SELECTED = 1;
+    public static final String NON_EMPTY_DIRECTORY_WARNING = "warn_non_empty_directory";
 
 	private Button butConfirm;
 	private Button butCancel;
@@ -52,6 +60,8 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 	private FileObserver fileObserver;
 
+    private boolean warnNonEmptyDirectory = false;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		setTheme(UserPreferences.getTheme());
@@ -65,15 +75,18 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 		txtvSelectedFolder = (TextView) findViewById(R.id.txtvSelectedFolder);
 		listDirectories = (ListView) findViewById(R.id.directory_list);
 
-		butConfirm.setOnClickListener(new OnClickListener() {
+        if(getIntent().getExtras() != null) {
+            warnNonEmptyDirectory = getIntent().getExtras().getBoolean(NON_EMPTY_DIRECTORY_WARNING, false);
+        }
 
+		butConfirm.setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
 				if (isValidFile(selectedDir)) {
-					if (selectedDir.list().length == 0) {
-						returnSelectedFolder();
+                    if(warnNonEmptyDirectory && selectedDir.list().length > 0) {
+                        showNonEmptyDirectoryWarning();
 					} else {
-						showNonEmptyDirectoryWarning();
+                        returnSelectedFolder();
 					}
 				}
 			}

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.activity;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -11,13 +12,18 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
 import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.LangUtils;
 import de.danoeh.antennapod.core.util.StorageUtils;
-
-import java.io.*;
 
 /**
  * Lets the user start the OPML-import process from a path
@@ -25,6 +31,7 @@ import java.io.*;
 public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
     private static final String TAG = "OpmlImportFromPathActivity";
     private TextView txtvPath;
+    private Button butChoose;
     private Button butStart;
     private String importPath;
 
@@ -36,9 +43,20 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setContentView(R.layout.opml_import);
 
+        butChoose = (Button)findViewById(R.id.butChoosePath);
         txtvPath = (TextView) findViewById(R.id.txtvPath);
         butStart = (Button) findViewById(R.id.butStartImport);
 
+        butChoose.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivityForResult(
+                        new Intent(OpmlImportFromPathActivity.this,
+                                DirectoryChooserActivity.class),
+                        DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED
+                );
+            }
+        });
         butStart.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -46,13 +64,13 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
             }
 
         });
+        setImportPath();
     }
 
     @Override
     protected void onResume() {
         super.onResume();
         StorageUtils.checkStorageAvailability(this);
-        setImportPath();
     }
 
     /**
@@ -167,5 +185,18 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         dialog.create().show();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.d(TAG, "activity result: " + requestCode + " " + resultCode);
+        if (requestCode == DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED) {
+            if (resultCode == DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED) {
+                String dir = data
+                        .getStringExtra(DirectoryChooserActivity.RESULT_SELECTED_DIR);
+                Log.d(TAG, dir);
+                txtvPath.setText(dir);
+                importPath = dir.toString();
+            }
+        }
+    }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -163,9 +163,10 @@ public class PreferenceController {
 
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
-                        activity.startActivityForResult(
-                                new Intent(activity,
-                                        DirectoryChooserActivity.class),
+                        Intent intent = new Intent(activity,
+                                DirectoryChooserActivity.class);
+                        intent.putExtra(DirectoryChooserActivity.NON_EMPTY_DIRECTORY_WARNING, true);
+                        activity.startActivityForResult(intent,
                                 DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED
                         );
                         return true;

--- a/app/src/main/res/layout/opml_import.xml
+++ b/app/src/main/res/layout/opml_import.xml
@@ -4,14 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:gravity="center"
     tools:background="@android:color/darker_gray">
 
-    <TextView
-        android:layout_width="match_parent"
+    <Button
+        android:id="@+id/butChoosePath"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:layout_margin="8dp"
-        android:text="@string/opml_import_explanation"
-        tools:background="@android:color/holo_green_dark" />
+        android:text="@string/choose_data_directory" />
 
     <TextView
         android:id="@+id/txtvPath"
@@ -19,7 +21,8 @@
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         tools:text="Path"
-        tools:background="@android:color/holo_green_dark" />
+        tools:background="@android:color/holo_green_dark"
+        android:gravity="center"/>
 
     <Button
         android:id="@+id/butStartImport"


### PR DESCRIPTION
Instead of having a fixed path, the user can now choose the path to
import from via dialog. This made the rather bloated instruction text
superfluous. Some minor changes to the DirectoryChooserActivity and the
OMPL Import layout.

Resolves AntennaPod/AntennaPod#623