### PR TITLE
Correct audio player cover scaling

### DIFF
--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -13,7 +13,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
-        android:scaleType="centerCrop"
+        android:scaleType="centerInside"
         tools:src="@android:drawable/sym_def_app_icon" />
 
 </RelativeLayout>


### PR DESCRIPTION
The former scaling would scale the image so that width and height of
the cover would be at least as large as the view. Now, the covers
dimensions will be equal or less than the dimensions of the cover view.

Fixes AntennaPod/AntennaPod#621