### PR TITLE
Add ability to select OPML export folder

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
@@ -15,16 +15,23 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.*;
+import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
-import de.danoeh.antennapod.BuildConfig;
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ImageButton;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+
+import de.danoeh.antennapod.BuildConfig;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 /**
  * Let's the user choose a directory on the storage device. The selected folder
@@ -37,6 +44,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 	public static final String RESULT_SELECTED_DIR = "selected_dir";
 	public static final int RESULT_CODE_DIR_SELECTED = 1;
+    public static final String NON_EMPTY_DIRECTORY_WARNING = "warn_non_empty_directory";
 
 	private Button butConfirm;
 	private Button butCancel;
@@ -52,6 +60,8 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 	private FileObserver fileObserver;
 
+    private boolean warnNonEmptyDirectory = false;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		setTheme(UserPreferences.getTheme());
@@ -65,15 +75,18 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 		txtvSelectedFolder = (TextView) findViewById(R.id.txtvSelectedFolder);
 		listDirectories = (ListView) findViewById(R.id.directory_list);
 
-		butConfirm.setOnClickListener(new OnClickListener() {
+        if(getIntent().getExtras() != null) {
+            warnNonEmptyDirectory = getIntent().getExtras().getBoolean(NON_EMPTY_DIRECTORY_WARNING, false);
+        }
 
+		butConfirm.setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
 				if (isValidFile(selectedDir)) {
-					if (selectedDir.list().length == 0) {
-						returnSelectedFolder();
+                    if(warnNonEmptyDirectory && selectedDir.list().length > 0) {
+                        showNonEmptyDirectoryWarning();
 					} else {
-						showNonEmptyDirectoryWarning();
+                        returnSelectedFolder();
 					}
 				}
 			}

--- a/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
@@ -5,7 +5,6 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.FileObserver;
 import android.support.v4.app.NavUtils;
 import android.support.v7.app.ActionBarActivity;
@@ -158,7 +157,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 		listDirectoriesAdapter = new ArrayAdapter<String>(this,
 				android.R.layout.simple_list_item_1, filenames);
 		listDirectories.setAdapter(listDirectoriesAdapter);
-		changeDirectory(Environment.getExternalStorageDirectory());
+        changeDirectory(UserPreferences.getDataFolder(this, null));
 	}
 
 	/**

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.activity;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -11,13 +12,18 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
 import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.LangUtils;
 import de.danoeh.antennapod.core.util.StorageUtils;
-
-import java.io.*;
 
 /**
  * Lets the user start the OPML-import process from a path
@@ -25,6 +31,7 @@ import java.io.*;
 public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
     private static final String TAG = "OpmlImportFromPathActivity";
     private TextView txtvPath;
+    private Button butChoose;
     private Button butStart;
     private String importPath;
 
@@ -36,9 +43,20 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setContentView(R.layout.opml_import);
 
+        butChoose = (Button)findViewById(R.id.butChoosePath);
         txtvPath = (TextView) findViewById(R.id.txtvPath);
         butStart = (Button) findViewById(R.id.butStartImport);
 
+        butChoose.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivityForResult(
+                        new Intent(OpmlImportFromPathActivity.this,
+                                DirectoryChooserActivity.class),
+                        DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED
+                );
+            }
+        });
         butStart.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -46,13 +64,13 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
             }
 
         });
+        setImportPath();
     }
 
     @Override
     protected void onResume() {
         super.onResume();
         StorageUtils.checkStorageAvailability(this);
-        setImportPath();
     }
 
     /**
@@ -167,5 +185,18 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         dialog.create().show();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.d(TAG, "activity result: " + requestCode + " " + resultCode);
+        if (requestCode == DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED) {
+            if (resultCode == DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED) {
+                String dir = data
+                        .getStringExtra(DirectoryChooserActivity.RESULT_SELECTED_DIR);
+                Log.d(TAG, dir);
+                txtvPath.setText(dir);
+                importPath = dir.toString();
+            }
+        }
+    }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
@@ -24,10 +24,10 @@ import de.danoeh.antennapod.core.util.LangUtils;
  */
 public class OpmlExportWorker extends AsyncTask<Void, Void, Void> {
     private static final String TAG = "OpmlExportWorker";
-    private static final String DEFAULT_OUTPUT_NAME = "antennapod-feeds.opml";
+    public static final String DEFAULT_OUTPUT_NAME = "antennapod-feeds.opml";
     public static final String EXPORT_DIR = "export/";
 
-    private Context context;
+    private final Context context;
     private File output;
 
     private ProgressDialog progDialog;

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -163,9 +163,10 @@ public class PreferenceController {
 
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
-                        activity.startActivityForResult(
-                                new Intent(activity,
-                                        DirectoryChooserActivity.class),
+                        Intent intent = new Intent(activity,
+                                DirectoryChooserActivity.class);
+                        intent.putExtra(DirectoryChooserActivity.NON_EMPTY_DIRECTORY_WARNING, true);
+                        activity.startActivityForResult(intent,
                                 DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED
                         );
                         return true;

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -61,6 +61,8 @@ public class PreferenceController {
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     private static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
 
+    private static final int REQUEST_CHOOSE_DATA_DIR = 1;
+    private static final int REQUEST_CHOOSE_OMPL_EXPORT_DIR = 2;
 
     private final PreferenceUI ui;
 
@@ -150,9 +152,12 @@ public class PreferenceController {
 
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
-                        new OpmlExportWorker(activity)
-                                .executeAsync();
-
+                        Intent intent = new Intent(activity,
+                                DirectoryChooserActivity.class);
+                        intent.putExtra(DirectoryChooserActivity.NON_EMPTY_DIRECTORY_WARNING, false);
+                        activity.startActivityForResult(intent,
+                                REQUEST_CHOOSE_OMPL_EXPORT_DIR
+                        );
                         return true;
                     }
                 }
@@ -167,7 +172,7 @@ public class PreferenceController {
                                 DirectoryChooserActivity.class);
                         intent.putExtra(DirectoryChooserActivity.NON_EMPTY_DIRECTORY_WARNING, true);
                         activity.startActivityForResult(intent,
-                                DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED
+                                REQUEST_CHOOSE_DATA_DIR
                         );
                         return true;
                     }
@@ -312,9 +317,18 @@ public class PreferenceController {
         if (resultCode == DirectoryChooserActivity.RESULT_CODE_DIR_SELECTED) {
             String dir = data
                     .getStringExtra(DirectoryChooserActivity.RESULT_SELECTED_DIR);
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Setting data folder");
-            UserPreferences.setDataFolder(dir);
+            switch(requestCode) {
+                case REQUEST_CHOOSE_DATA_DIR:
+                    if (BuildConfig.DEBUG)
+                        Log.d(TAG, "Setting data folder");
+                    UserPreferences.setDataFolder(dir);
+                    break;
+                case REQUEST_CHOOSE_OMPL_EXPORT_DIR:
+                    File path = new File(dir, OpmlExportWorker.DEFAULT_OUTPUT_NAME);
+                    new OpmlExportWorker(ui.getActivity(), path)
+                            .executeAsync();
+                    break;
+            }
         }
     }
 

--- a/app/src/main/res/layout/opml_import.xml
+++ b/app/src/main/res/layout/opml_import.xml
@@ -4,14 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:gravity="center"
     tools:background="@android:color/darker_gray">
 
-    <TextView
-        android:layout_width="match_parent"
+    <Button
+        android:id="@+id/butChoosePath"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:layout_margin="8dp"
-        android:text="@string/opml_import_explanation"
-        tools:background="@android:color/holo_green_dark" />
+        android:text="@string/choose_data_directory" />
 
     <TextView
         android:id="@+id/txtvPath"
@@ -19,7 +21,8 @@
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         tools:text="Path"
-        tools:background="@android:color/holo_green_dark" />
+        tools:background="@android:color/holo_green_dark"
+        android:gravity="center"/>
 
     <Button
         android:id="@+id/butStartImport"


### PR DESCRIPTION
Instead of exporting a OPML file to a predefined folder the user can
choose the folder (but not the filename) the file will be exported

Resolves AntennaPod/AntennaPod#260