### PR TITLE
Choose an OPML-file to import.

### DIFF
--- a/app/src/main/res/layout/opml_import.xml
+++ b/app/src/main/res/layout/opml_import.xml
@@ -22,6 +22,14 @@
         tools:background="@android:color/holo_green_dark" />
 
     <Button
+        android:id="@+id/butChooseImport"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_margin="8dp"
+        android:text="@string/choose_file_to_import_label" />
+
+    <Button
         android:id="@+id/butStartImport"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -286,7 +286,7 @@
 
     <!-- OPML import and export -->
     <string name="opml_import_txtv_button_lable">OPML files allow you to move your podcasts from one podcatcher to another.</string>
-    <string name="opml_import_explanation">To import an OPML file, you have to place it in the following directory and press the button below to start the import process. </string>
+    <string name="opml_import_explanation">To import an OPML file, you can either manually place it in the import directory or choose a file, then press the \'Start import\'-button. </string>
     <string name="start_import_label">Start import</string>
     <string name="opml_import_label">OPML import</string>
     <string name="opml_directory_error">ERROR!</string>


### PR DESCRIPTION
Adds a button over the 'Start import' one that opens a file manager and lets the user locate an OPML-file to import.

I've tested it on the OnePlus One running CM12 (Android 5.0.2) and the Samsung Galaxy SII GT-I9100 running OmniROM (Android 4.4.4).

EDIT: This doesn't remove the old way of importing from OMPL, but in my opinion it's kind of obsolete if this gets implemented. I could make the default importPath point to /sdcard/Android/data/de.danoeh.antennapod.debug/files/import/antennapod-feeds.opml and let the user choose a different file by clicking the text? I think that would make more sense, slim the activity down a bit, and the explanation string could be much shorter and less confusing.