### PR TITLE
Number of parallel downloads can be set in the preferences

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -95,6 +95,11 @@
             android:key="prefMobileUpdate"
             android:summary="@string/pref_mobileUpdate_sum"
             android:title="@string/pref_mobileUpdate_title"/>
+        <EditTextPreference
+            android:defaultValue="6"
+            android:inputType="number"
+            android:key="prefParallelDownloads"
+            android:title="@string/pref_parallel_downloads_title"/>
         <ListPreference
             android:defaultValue="20"
             android:entries="@array/episode_cache_size_entries"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -20,7 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import de.danoeh.antennapod.core.ApplicationCallbacks;
 import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
@@ -42,6 +41,7 @@ public class UserPreferences implements
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
     public static final String PREF_DOWNLOAD_MEDIA_ON_WIFI_ONLY = "prefDownloadMediaOnWifiOnly";
     public static final String PREF_UPDATE_INTERVAL = "prefAutoUpdateIntervall";
+    public static final String PREF_PARALLEL_DOWNLOADS = "prefParallelDownloads";
     public static final String PREF_MOBILE_UPDATE = "prefMobileUpdate";
     public static final String PREF_DISPLAY_ONLY_EPISODES = "prefDisplayOnlyEpisodes";
     public static final String PREF_AUTO_DELETE = "prefAutoDelete";
@@ -86,6 +86,7 @@ public class UserPreferences implements
     private boolean enableAutodownloadWifiFilter;
     private boolean enableAutodownloadOnBattery;
     private String[] autodownloadSelectedNetworks;
+    private int parallelDownloads;
     private int episodeCacheSize;
     private String playbackSpeed;
     private String[] playbackSpeedArray;
@@ -144,6 +145,7 @@ public class UserPreferences implements
                 PREF_ENABLE_AUTODL_WIFI_FILTER, false);
         autodownloadSelectedNetworks = StringUtils.split(
                 sp.getString(PREF_AUTODL_SELECTED_NETWORKS, ""), ',');
+        parallelDownloads = Integer.valueOf(sp.getString(PREF_PARALLEL_DOWNLOADS, "6"));
         episodeCacheSize = readEpisodeCacheSizeInternal(sp.getString(
                 PREF_EPISODE_CACHE_SIZE, "20"));
         enableAutodownload = sp.getBoolean(PREF_ENABLE_AUTODL, false);
@@ -314,6 +316,11 @@ public class UserPreferences implements
         return instance.autodownloadSelectedNetworks;
     }
 
+    public static int getParallelDownloads() {
+        instanceAvailable();
+        return instance.parallelDownloads;
+    }
+
     public static int getEpisodeCacheSizeUnlimited() {
         return EPISODE_CACHE_SIZE_UNLIMITED;
     }
@@ -399,6 +406,8 @@ public class UserPreferences implements
         } else if (key.equals(PREF_AUTODL_SELECTED_NETWORKS)) {
             autodownloadSelectedNetworks = StringUtils.split(
                     sp.getString(PREF_AUTODL_SELECTED_NETWORKS, ""), ',');
+        } else if(key.equals(PREF_PARALLEL_DOWNLOADS)) {
+            parallelDownloads = Integer.valueOf(sp.getString(PREF_PARALLEL_DOWNLOADS, "6"));
         } else if (key.equals(PREF_EPISODE_CACHE_SIZE)) {
             episodeCacheSize = readEpisodeCacheSizeInternal(sp.getString(
                     PREF_EPISODE_CACHE_SIZE, "20"));

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="close_label">Close</string>
     <string name="retry_label">Retry</string>
     <string name="auto_download_label">Include in auto downloads</string>
+    <string name="parallel_downloads_suffix">\u0020parallel downloads</string>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>
@@ -248,6 +249,7 @@
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>
     <string name="pref_automatic_download_on_battery_sum">Allow automatic download when the battery is not charging</string>
+    <string name="pref_parallel_downloads_title">Parallel downloads</string>
     <string name="pref_episode_cache_title">Episode cache</string>
     <string name="pref_theme_title_light">Light</string>
     <string name="pref_theme_title_dark">Dark</string>


### PR DESCRIPTION
Number of parallel downloads can be set in the preferences.
It is checked, that the input is reasonable (between 1 and 50 parallel downloads).

Sadly, NumberPicker is only available in API level 11 - EditText it is...

(Deleted "if (BuildConfig.DEBUG) Log.d(...)" in the download service, because it is stupid)

Resolves AntennaPod/AntennaPod#622