### PR TITLE
Queue: Drag handle area now 4x the size

### DIFF
--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -9,9 +9,10 @@
 
     <ImageView
         android:id="@+id/drag_handle"
-        android:layout_width="24dp"
+        android:layout_width="104dp"
         android:layout_height="match_parent"
-        android:layout_margin="8dp"
+        android:layout_marginLeft="-32dp"
+        android:layout_marginRight="-32dp"
         android:contentDescription="@string/drag_handle_content_description"
         android:scaleType="center"
         android:src="?attr/dragview_background"


### PR DESCRIPTION
Drag section reaches from left border to about half of the cover.

Before:
![before](https://cloud.githubusercontent.com/assets/6860662/6651266/ff96a8b2-ca3a-11e4-8b32-2ce7fc42c2fb.png)

After:
![after](https://cloud.githubusercontent.com/assets/6860662/6651267/04abfa8c-ca3b-11e4-8a8a-9eb95ad42ccb.png)


Resolves AntennaPod/AntennaPod#670