### PR TITLE
now always displaying both refresh and search. closes #633

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
@@ -14,7 +14,7 @@ public class MenuItemUtils extends de.danoeh.antennapod.core.menuhandler.MenuIte
 
     public static MenuItem addSearchItem(Menu menu, SearchView searchView) {
         MenuItem item = menu.add(Menu.NONE, R.id.search_item, Menu.NONE, R.string.search_label);
-        MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
+        MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_ALWAYS);
         MenuItemCompat.setActionView(item, searchView);
         return item;
     }

--- a/app/src/main/res/menu/feedlist.xml
+++ b/app/src/main/res/menu/feedlist.xml
@@ -7,7 +7,7 @@
         android:icon="?attr/navigation_refresh"
         android:menuCategory="container"
         android:title="@string/refresh_label"
-        custom:showAsAction="ifRoom">
+        custom:showAsAction="always">
     </item>
     <item
         android:id="@+id/refresh_complete_item"

--- a/app/src/main/res/menu/new_episodes.xml
+++ b/app/src/main/res/menu/new_episodes.xml
@@ -7,7 +7,7 @@
         android:id="@+id/refresh_item"
         android:title="@string/refresh_label"
         android:menuCategory="container"
-        custom:showAsAction="ifRoom"
+        custom:showAsAction="always"
         android:icon="?attr/navigation_refresh"/>
 
     <item

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -7,7 +7,7 @@
         android:id="@+id/refresh_item"
         android:title="@string/refresh_label"
         android:menuCategory="container"
-        custom:showAsAction="ifRoom"
+        custom:showAsAction="always"
         android:icon="?attr/navigation_refresh"/>
 
     <item


### PR DESCRIPTION
Now always displaying both search and refresh.  If we don't 'always' display each then the other won't be displayed. This is strange, since it appears there is plenty of room for both.  It would be interesting to know if anyone has a problem with this change in place.

resolves #633 