### PR TITLE
Fix issue where feed media attributes did not get updated

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -135,8 +135,8 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
         if (other.media != null) {
             if (media == null) {
                 setMedia(other.media);
-            } else if (media.compareWithOther(other)) {
-                media.updateFromOther(other);
+            } else if (media.compareWithOther(other.media)) {
+                media.updateFromOther(other.media);
             }
         }
         if (other.paymentLink != null) {


### PR DESCRIPTION
Fixes AntennaPod/AntennaPod#684

media.compareWithOther(other) is always false:
* FeedItem extends FeedComponent
* compareWithOther(FeedItem/FeedComponent) is inherited from FeedComponent, always returns false

Tested on Android 4.2.2.

Not tested on an actual feed where the file's URL changes, but the code is pretty solid.