### PR TITLE
Support library downgrade after crashes

### DIFF
--- a/library/drag-sort-listview/build.gradle
+++ b/library/drag-sort-listview/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 21
     buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 22
+        targetSdkVersion 21
         versionCode 4
         versionName "0.6.1"
     }
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:22.0.0'
+    compile 'com.android.support:support-v4:21.0.3'
 }


### PR DESCRIPTION
Tested on emulator running 2.3.7, could not provoke a crash.