### PR TITLE
Fixes non-working app tests, especially GUI tests

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/download/HttpDownloaderTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/download/HttpDownloaderTest.java
@@ -2,16 +2,18 @@ package de.test.antennapod.service.download;
 
 import android.test.InstrumentationTestCase;
 import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+
 import de.danoeh.antennapod.core.feed.FeedFile;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.util.DownloadError;
 import de.test.antennapod.util.service.download.HTTPBin;
-
-import java.io.File;
-import java.io.IOException;
 
 public class HttpDownloaderTest extends InstrumentationTestCase {
     private static final String TAG = "HttpDownloaderTest";
@@ -41,6 +43,7 @@ public class HttpDownloaderTest extends InstrumentationTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        UserPreferences.createInstance(getInstrumentation().getTargetContext());
         destDir = getInstrumentation().getTargetContext().getExternalFilesDir(DOWNLOAD_DIR);
         assertNotNull(destDir);
         assertTrue(destDir.exists());
@@ -90,7 +93,7 @@ public class HttpDownloaderTest extends InstrumentationTestCase {
     }
 
     public void testGzip() {
-        download("http://httpbin.org/gzip", "testGzip", true);
+        download(HTTPBin.BASE_URL + "/gzip/100", "testGzip", true);
     }
 
     public void test404() {

--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -3,12 +3,13 @@ package de.test.antennapod.ui;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.test.ActivityInstrumentationTestCase2;
-import android.view.View;
+import android.widget.ListView;
+
 import com.robotium.solo.Solo;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.DefaultOnlineFeedViewActivity;
 import de.danoeh.antennapod.activity.MainActivity;
-import de.danoeh.antennapod.activity.PreferenceActivityGingerbread;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.preferences.PreferenceController;
@@ -49,10 +50,14 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
         super.tearDown();
     }
 
+    private void openNavDrawer() {
+        solo.clickOnScreen(50, 50);
+    }
+
     public void testAddFeed() throws Exception {
         uiTestUtils.addHostedFeedData();
         final Feed feed = uiTestUtils.hostedFeeds.get(0);
-        solo.setNavigationDrawer(Solo.OPENED);
+        openNavDrawer();
         solo.clickOnText(solo.getString(R.string.add_feed_label));
         solo.enterText(0, feed.getDownload_url());
         solo.clickOnButton(0);
@@ -65,39 +70,43 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
 
     public void testClickNavDrawer() throws Exception {
         uiTestUtils.addLocalFeedData(false);
-        final View home = solo.getView(UITestUtils.HOME_VIEW);
 
         // all episodes
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.all_episodes_label));
         solo.waitForView(android.R.id.list);
         assertEquals(solo.getString(R.string.all_episodes_label), getActionbarTitle());
+
         // queue
-        solo.clickOnView(home);
+        openNavDrawer();
         solo.clickOnText(solo.getString(R.string.queue_label));
         solo.waitForView(android.R.id.list);
         assertEquals(solo.getString(R.string.queue_label), getActionbarTitle());
 
         // downloads
-        solo.clickOnView(home);
+        openNavDrawer();
         solo.clickOnText(solo.getString(R.string.downloads_label));
         solo.waitForView(android.R.id.list);
         assertEquals(solo.getString(R.string.downloads_label), getActionbarTitle());
 
         // playback history
-        solo.clickOnView(home);
+        openNavDrawer();
         solo.clickOnText(solo.getString(R.string.playback_history_label));
         solo.waitForView(android.R.id.list);
         assertEquals(solo.getString(R.string.playback_history_label), getActionbarTitle());
 
         // add podcast
-        solo.clickOnView(home);
+        openNavDrawer();
         solo.clickOnText(solo.getString(R.string.add_feed_label));
         solo.waitForView(R.id.txtvFeedurl);
         assertEquals(solo.getString(R.string.add_feed_label), getActionbarTitle());
 
         // podcasts
+        ListView list = (ListView)solo.getView(R.id.nav_list);
         for (int i = 0; i < uiTestUtils.hostedFeeds.size(); i++) {
             Feed f = uiTestUtils.hostedFeeds.get(i);
-            solo.clickOnView(home);
+            solo.clickOnScreen(50, 50); // open nav drawer
+            solo.scrollListToLine(list, i);
             solo.clickOnText(f.getTitle());
             solo.waitForView(android.R.id.list);
             assertEquals("", getActionbarTitle());
@@ -109,7 +118,7 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
     }
 
     public void testGoToPreferences() {
-        solo.setNavigationDrawer(Solo.CLOSED);
+        openNavDrawer();
         solo.clickOnMenuItem(solo.getString(R.string.settings_label));
         solo.waitForActivity(PreferenceController.getPreferenceActivity());
     }

--- a/app/src/androidTest/java/de/test/antennapod/ui/PlaybackTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PlaybackTest.java
@@ -5,7 +5,11 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.test.ActivityInstrumentationTestCase2;
 import android.widget.TextView;
+
 import com.robotium.solo.Solo;
+
+import java.util.List;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.AudioplayerActivity;
 import de.danoeh.antennapod.activity.MainActivity;
@@ -15,8 +19,6 @@ import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
-
-import java.util.List;
 
 /**
  * Test cases for starting and ending playback from the MainActivity and AudioPlayerActivity
@@ -40,6 +42,7 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
         PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getTargetContext());
         adapter.open();
         adapter.close();
+
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getInstrumentation().getTargetContext());
         prefs.edit().putBoolean(UserPreferences.PREF_UNPAUSE_ON_HEADSET_RECONNECT, false).commit();
         prefs.edit().putBoolean(UserPreferences.PREF_PAUSE_ON_HEADSET_DISCONNECT, false).commit();
@@ -59,6 +62,10 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
         super.tearDown();
     }
 
+    private void openNavDrawer() {
+        solo.clickOnScreen(50, 50);
+    }
+
     private void setContinuousPlaybackPreference(boolean value) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getInstrumentation().getTargetContext());
         prefs.edit().putBoolean(UserPreferences.PREF_FOLLOW_QUEUE, value).commit();
@@ -71,7 +78,9 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
 
     private void startLocalPlayback() {
         assertTrue(solo.waitForActivity(MainActivity.class));
-        solo.setNavigationDrawer(Solo.CLOSED);
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.all_episodes_label));
+        solo.waitForView(android.R.id.list);
         solo.clickOnView(solo.getView(R.id.butSecondaryAction));
         assertTrue(solo.waitForActivity(AudioplayerActivity.class));
         assertTrue(solo.waitForView(solo.getView(R.id.butPlay)));
@@ -79,10 +88,10 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
 
     private void startLocalPlaybackFromQueue() {
         assertTrue(solo.waitForActivity(MainActivity.class));
-        solo.clickOnView(solo.getView(UITestUtils.HOME_VIEW));
+        openNavDrawer();
         solo.clickOnText(solo.getString(R.string.queue_label));
         assertTrue(solo.waitForView(solo.getView(R.id.butSecondaryAction)));
-        solo.clickOnImageButton(0);
+        solo.clickOnImageButton(1);
         assertTrue(solo.waitForActivity(AudioplayerActivity.class));
         assertTrue(solo.waitForView(solo.getView(R.id.butPlay)));
     }
@@ -108,7 +117,7 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
         setContinuousPlaybackPreference(false);
         uiTestUtils.addLocalFeedData(true);
         List<FeedItem> queue = DBReader.getQueue(getInstrumentation().getTargetContext());
-        FeedItem second = queue.get(1);
+        FeedItem second = queue.get(0);
 
         startLocalPlaybackFromQueue();
         assertTrue(solo.waitForText(second.getTitle()));
@@ -147,4 +156,6 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
     public void testReplayEpisodeContinuousPlaybackOff() throws Exception {
         replayEpisodeCheck(false);
     }
+
+
 }

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -5,12 +5,8 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Build;
 
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.feed.*;
-import de.danoeh.antennapod.core.storage.PodDBAdapter;
-import de.test.antennapod.util.service.download.HTTPBin;
-import de.test.antennapod.util.syndication.feedgenerator.RSS2Generator;
 import junit.framework.Assert;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -22,6 +18,16 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.EventDistributor;
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedImage;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.test.antennapod.util.service.download.HTTPBin;
+import de.test.antennapod.util.syndication.feedgenerator.RSS2Generator;
 
 /**
  * Utility methods for UI tests.
@@ -174,7 +180,8 @@ public class UITestUtils {
             feed.setDownloaded(true);
             if (feed.getImage() != null) {
                 FeedImage image = feed.getImage();
-                image.setFile_url(image.getDownload_url());
+                int fileId = Integer.parseInt(StringUtils.substringAfter(image.getDownload_url(), "files/"));
+                image.setFile_url(server.accessFile(fileId).getAbsolutePath());
                 image.setDownloaded(true);
             }
             if (downloadEpisodes) {

--- a/app/src/androidTest/java/de/test/antennapod/util/service/download/HTTPBin.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/service/download/HTTPBin.java
@@ -2,14 +2,27 @@ package de.test.antennapod.util.service.download;
 
 import android.util.Base64;
 import android.util.Log;
-import de.danoeh.antennapod.BuildConfig;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URLConnection;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.zip.GZIPOutputStream;
+
+import de.danoeh.antennapod.BuildConfig;
 
 /**
  * Http server for testing purposes
@@ -264,7 +277,7 @@ public class HTTPBin extends NanoHTTPD {
 
     private Response getGzippedResponse(int size) throws IOException {
         try {
-            Thread.sleep(5000);
+            Thread.sleep(200);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -272,14 +285,15 @@ public class HTTPBin extends NanoHTTPD {
         Random random = new Random(System.currentTimeMillis());
         random.nextBytes(buffer);
 
-        ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+        ByteArrayOutputStream compressed = new ByteArrayOutputStream(buffer.length);
         GZIPOutputStream gzipOutputStream = new GZIPOutputStream(compressed);
         gzipOutputStream.write(buffer);
+        gzipOutputStream.close();
 
         InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
         Response response = new Response(Response.Status.OK, MIME_PLAIN, inputStream);
-        response.addHeader("Content-encoding", "gzip");
-        response.addHeader("Content-length", String.valueOf(compressed.size()));
+        response.addHeader("Content-Encoding", "gzip");
+        response.addHeader("Content-Length", String.valueOf(compressed.size()));
         return response;
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedImage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedImage.java
@@ -2,9 +2,9 @@ package de.danoeh.antennapod.core.feed;
 
 import android.net.Uri;
 
-import de.danoeh.antennapod.core.asynctask.PicassoImageResource;
-
 import java.io.File;
+
+import de.danoeh.antennapod.core.asynctask.PicassoImageResource;
 
 
 public class FeedImage extends FeedFile implements PicassoImageResource {
@@ -65,6 +65,8 @@ public class FeedImage extends FeedFile implements PicassoImageResource {
     public Uri getImageUri() {
         if (file_url != null && downloaded) {
             return Uri.fromFile(new File(file_url));
+        } else if(download_url != null) {
+            return Uri.parse(download_url);
         } else {
             return null;
         }


### PR DESCRIPTION
GUI tests were not working properly.

Some tests still fail from time to time.
Most seem to be related to timing issues, e.g. some activity is still running while the test runner is already reseting the environment.
If this turns out to be a serious problem, adding Thread.sleep() here and there should fix them aswell