### PR TITLE
Addresses #669 and #664: play buttons in the lists

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
@@ -27,7 +27,7 @@ public class ActionButtonUtils {
 
         this.context = context;
         drawables = context.obtainStyledAttributes(new int[]{
-                R.attr.av_play, R.attr.navigation_cancel, R.attr.av_download, R.attr.borderless_button, R.attr.navigation_accept});
+                R.attr.av_play, R.attr.navigation_cancel, R.attr.av_download, R.attr.av_pause, R.attr.navigation_accept});
         labels = new int[]{R.string.play_label, R.string.cancel_download_label, R.string.download_label, R.string.mark_read_label};
     }
 
@@ -57,7 +57,7 @@ public class ActionButtonUtils {
             } else {
                 // item is not being downloaded
                 butSecondary.setVisibility(View.VISIBLE);
-                if (media.isPlaying()) {
+                if (media.isCurrentlyPlaying()) {
                     butSecondary.setImageDrawable(drawables.getDrawable(3));
                 } else {
                     butSecondary

--- a/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
@@ -27,7 +27,7 @@ public class ActionButtonUtils {
 
         this.context = context;
         drawables = context.obtainStyledAttributes(new int[]{
-                R.attr.av_play, R.attr.navigation_cancel, R.attr.av_download, R.attr.av_pause, R.attr.navigation_accept});
+                R.attr.av_play, R.attr.navigation_cancel, R.attr.av_download, R.attr.borderless_button, R.attr.navigation_accept});
         labels = new int[]{R.string.play_label, R.string.cancel_download_label, R.string.download_label, R.string.mark_read_label};
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -51,7 +51,7 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 if (item.hasMedia() && item.getMedia().isCurrentlyPlaying()) {
                     context.sendBroadcast(new Intent(PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE));
                 }
-                else if (item.hasMedia() && item.getMedia().isPlaying()) {
+                else if (item.hasMedia() && item.getMedia().isCurrentlyPaused()) {
                     context.sendBroadcast(new Intent(PlaybackService.ACTION_RESUME_PLAY_CURRENT_EPISODE));
                 }
                 else {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -46,7 +46,9 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 DownloadRequester.getInstance().cancelDownload(context, media);
                 Toast.makeText(context, R.string.download_cancelled_msg, Toast.LENGTH_SHORT).show();
             } else { // media is downloaded
-                DBTasks.playMedia(context, media, true, true, false);
+                if (item.getState() != FeedItem.State.PLAYING) {
+                    DBTasks.playMedia(context, media, false, true, false);
+                }
             }
         } else {
             if (!item.isRead()) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.content.Intent;
 import android.widget.Toast;
 
 import org.apache.commons.lang3.Validate;
@@ -9,6 +10,7 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.dialog.DownloadRequestErrorDialogCreator;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequestException;
@@ -46,7 +48,13 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 DownloadRequester.getInstance().cancelDownload(context, media);
                 Toast.makeText(context, R.string.download_cancelled_msg, Toast.LENGTH_SHORT).show();
             } else { // media is downloaded
-                if (item.getState() != FeedItem.State.PLAYING) {
+                if (item.hasMedia() && item.getMedia().isCurrentlyPlaying()) {
+                    context.sendBroadcast(new Intent(PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE));
+                }
+                else if (item.hasMedia() && item.getMedia().isPlaying()) {
+                    context.sendBroadcast(new Intent(PlaybackService.ACTION_RESUME_PLAY_CURRENT_EPISODE));
+                }
+                else {
                     DBTasks.playMedia(context, media, false, true, false);
                 }
             }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -188,8 +188,6 @@ public class FeedItemlistAdapter extends BaseAdapter {
         public void onClick(View v) {
             FeedItem item = (FeedItem) v.getTag();
             callback.onActionButtonPressed(item);
-            EventDistributor.getInstance().sendPlaybackHistoryUpdateBroadcast();
-            EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -9,6 +9,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.*;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
@@ -187,6 +188,8 @@ public class FeedItemlistAdapter extends BaseAdapter {
         public void onClick(View v) {
             FeedItem item = (FeedItem) v.getTag();
             callback.onActionButtonPressed(item);
+            EventDistributor.getInstance().sendPlaybackHistoryUpdateBroadcast();
+            EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/NewEpisodesListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NewEpisodesListAdapter.java
@@ -148,7 +148,6 @@ public class NewEpisodesListAdapter extends BaseAdapter {
         public void onClick(View v) {
             FeedItem item = (FeedItem) v.getTag();
             actionButtonCallback.onActionButtonPressed(item);
-            EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/NewEpisodesListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NewEpisodesListAdapter.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import com.squareup.picasso.Picasso;
 
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
@@ -147,6 +148,7 @@ public class NewEpisodesListAdapter extends BaseAdapter {
         public void onClick(View v) {
             FeedItem item = (FeedItem) v.getTag();
             actionButtonCallback.onActionButtonPressed(item);
+            EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import com.squareup.picasso.Picasso;
 
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
@@ -137,6 +138,7 @@ public class QueueListAdapter extends BaseAdapter {
         public void onClick(View v) {
             FeedItem item = (FeedItem) v.getTag();
             actionButtonCallback.onActionButtonPressed(item);
+            EventDistributor.getInstance().sendQueueUpdateBroadcast();
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
@@ -138,7 +138,6 @@ public class QueueListAdapter extends BaseAdapter {
         public void onClick(View v) {
             FeedItem item = (FeedItem) v.getTag();
             actionButtonCallback.onActionButtonPressed(item);
-            EventDistributor.getInstance().sendQueueUpdateBroadcast();
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -66,7 +66,8 @@ public class ItemlistFragment extends ListFragment {
     private static final int EVENTS = EventDistributor.DOWNLOAD_HANDLED
             | EventDistributor.DOWNLOAD_QUEUED
             | EventDistributor.QUEUE_UPDATE
-            | EventDistributor.UNREAD_ITEMS_UPDATE;
+            | EventDistributor.UNREAD_ITEMS_UPDATE
+            | EventDistributor.PLAYER_STATUS_UPDATE;
 
     public static final String EXTRA_SELECTED_FEEDITEM = "extra.de.danoeh.antennapod.activity.selected_feeditem";
     public static final String ARGUMENT_FEED_ID = "argument.de.danoeh.antennapod.feed_id";
@@ -295,9 +296,6 @@ public class ItemlistFragment extends ListFragment {
                     startItemLoader();
                     updateProgressBarVisibility();
                 }
-            }
-            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
-                adapter.notifyDataSetChanged();
             }
         }
     };

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -296,6 +296,9 @@ public class ItemlistFragment extends ListFragment {
                     updateProgressBarVisibility();
                 }
             }
+            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
+                adapter.notifyDataSetChanged();
+            }
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -340,6 +340,9 @@ public class NewEpisodesFragment extends Fragment {
                     getActivity().supportInvalidateOptionsMenu();
                 }
             }
+            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
+                listAdapter.notifyDataSetChanged();
+            }
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -54,7 +54,8 @@ public class NewEpisodesFragment extends Fragment {
     private static final int EVENTS = EventDistributor.DOWNLOAD_HANDLED |
             EventDistributor.DOWNLOAD_QUEUED |
             EventDistributor.QUEUE_UPDATE |
-            EventDistributor.UNREAD_ITEMS_UPDATE;
+            EventDistributor.UNREAD_ITEMS_UPDATE |
+            EventDistributor.PLAYER_STATUS_UPDATE;
 
     private static final int RECENT_EPISODES_LIMIT = 150;
     private static final String PREF_NAME = "PrefNewEpisodesFragment";
@@ -339,9 +340,6 @@ public class NewEpisodesFragment extends Fragment {
                 if (isUpdatingFeeds != updateRefreshMenuItemChecker.isRefreshing()) {
                     getActivity().supportInvalidateOptionsMenu();
                 }
-            }
-            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
-                listAdapter.notifyDataSetChanged();
             }
         }
     };

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -34,6 +34,8 @@ import de.danoeh.antennapod.menuhandler.NavDrawerActivity;
 
 public class PlaybackHistoryFragment extends ListFragment {
     private static final String TAG = "PlaybackHistoryFragment";
+    private static final int EVENTS = EventDistributor.PLAYBACK_HISTORY_UPDATE |
+            EventDistributor.PLAYER_STATUS_UPDATE;
 
     private List<FeedItem> playbackHistory;
     private QueueAccess queue;
@@ -167,12 +169,9 @@ public class PlaybackHistoryFragment extends ListFragment {
 
         @Override
         public void update(EventDistributor eventDistributor, Integer arg) {
-            if ((arg & EventDistributor.PLAYBACK_HISTORY_UPDATE) != 0) {
+            if ((arg & EVENTS) != 0) {
                 startItemLoader();
                 getActivity().supportInvalidateOptionsMenu();
-            }
-            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
-                adapter.notifyDataSetChanged();
             }
         }
     };

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -171,6 +171,9 @@ public class PlaybackHistoryFragment extends ListFragment {
                 startItemLoader();
                 getActivity().supportInvalidateOptionsMenu();
             }
+            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
+                adapter.notifyDataSetChanged();
+            }
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -56,7 +56,8 @@ public class QueueFragment extends Fragment {
     private static final String TAG = "QueueFragment";
     private static final int EVENTS = EventDistributor.DOWNLOAD_HANDLED |
             EventDistributor.DOWNLOAD_QUEUED |
-            EventDistributor.QUEUE_UPDATE;
+            EventDistributor.QUEUE_UPDATE |
+            EventDistributor.PLAYER_STATUS_UPDATE;
 
     private DragSortListView listView;
     private QueueListAdapter listAdapter;
@@ -476,9 +477,6 @@ public class QueueFragment extends Fragment {
                 if (isUpdatingFeeds != updateRefreshMenuItemChecker.isRefreshing()) {
                     getActivity().supportInvalidateOptionsMenu();
                 }
-            }
-            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
-                listAdapter.notifyDataSetChanged();
             }
         }
     };

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -477,6 +477,9 @@ public class QueueFragment extends Fragment {
                     getActivity().supportInvalidateOptionsMenu();
                 }
             }
+            if ((arg & EventDistributor.PLAYER_STATUS_UPDATE) != 0) {
+                listAdapter.notifyDataSetChanged();
+            }
         }
     };
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/EventDistributor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/EventDistributor.java
@@ -31,6 +31,7 @@ public class EventDistributor extends Observable {
 	public static final int PLAYBACK_HISTORY_UPDATE = 16;
 	public static final int DOWNLOAD_QUEUED = 32;
 	public static final int DOWNLOAD_HANDLED = 64;
+    public static final int PLAYER_STATUS_UPDATE = 128;
 
 	private Handler handler;
 	private AbstractQueue<Integer> events;
@@ -123,6 +124,10 @@ public class EventDistributor extends Observable {
 	public void sendDownloadHandledBroadcast() {
 		addEvent(DOWNLOAD_HANDLED);
 	}
+
+    public void sendPlayerStatusUpdateBroadcast() {
+        addEvent(PLAYER_STATUS_UPDATE);
+    }
 
 	public static abstract class EventListener implements Observer {
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -129,10 +129,20 @@ public class FeedMedia extends FeedFile implements Playable {
 
     /**
      * Reads playback preferences to determine whether this FeedMedia object is
-     * currently being played and the player status is playing.
+     * currently being played and the current player status is playing.
      */
     public boolean isCurrentlyPlaying() {
-        return isPlaying() && PlaybackPreferences.getPlayerStatusIsPlaying();
+        return isPlaying() &&
+                ((PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING));
+    }
+
+    /**
+     * Reads playback preferences to determine whether this FeedMedia object is
+     * currently being played and the current player status is paused.
+     */
+    public boolean isCurrentlyPaused() {
+        return isPlaying() &&
+                ((PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PAUSED));
     }
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -127,6 +127,15 @@ public class FeedMedia extends FeedFile implements Playable {
                 && PlaybackPreferences.getCurrentlyPlayingFeedMediaId() == id;
     }
 
+    /**
+     * Reads playback preferences to determine whether this FeedMedia object is
+     * currently being played and the player status is playing.
+     */
+    public boolean isCurrentlyPlaying() {
+        return isPlaying() && PlaybackPreferences.getPlayerStatusIsPlaying();
+    }
+
+
     @Override
     public int getTypeAsInt() {
         return FEEDFILETYPE_FEEDMEDIA;

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import org.apache.commons.lang3.Validate;
 
 import de.danoeh.antennapod.core.BuildConfig;
+import de.danoeh.antennapod.core.feed.EventDistributor;
 
 /**
  * Provides access to preferences set by the playback service. A private
@@ -43,6 +44,9 @@ public class PlaybackPreferences implements
 	/** True if last played media was a video. */
 	public static final String PREF_CURRENT_EPISODE_IS_VIDEO = "de.danoeh.antennapod.preferences.lastIsVideo";
 
+    /** True if player status is playing. */
+    public static final String PREF_PLAYER_STATUS_IS_PLAYING = "de.danoeh.antennapod.preferences.playerStatusIsPlaying";
+
 	/** Value of PREF_CURRENTLY_PLAYING_MEDIA if no media is playing. */
 	public static final long NO_MEDIA_PLAYING = -1;
 
@@ -51,6 +55,7 @@ public class PlaybackPreferences implements
 	private long currentlyPlayingMedia;
 	private boolean currentEpisodeIsStream;
 	private boolean currentEpisodeIsVideo;
+    private boolean playerStatusIsPlaying;
 
 	private static PlaybackPreferences instance;
 	private Context context;
@@ -87,6 +92,7 @@ public class PlaybackPreferences implements
 				NO_MEDIA_PLAYING);
 		currentEpisodeIsStream = sp.getBoolean(PREF_CURRENT_EPISODE_IS_STREAM, true);
 		currentEpisodeIsVideo = sp.getBoolean(PREF_CURRENT_EPISODE_IS_VIDEO, false);
+        playerStatusIsPlaying = sp.getBoolean(PREF_PLAYER_STATUS_IS_PLAYING, false);
 	}
 
 	@Override
@@ -109,6 +115,11 @@ public class PlaybackPreferences implements
 			currentlyPlayingFeedMediaId = sp.getLong(
 					PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID, NO_MEDIA_PLAYING);
 		}
+        else if (key.equals(PREF_PLAYER_STATUS_IS_PLAYING)) {
+            playerStatusIsPlaying = sp.getBoolean(
+                    PREF_PLAYER_STATUS_IS_PLAYING, false);
+            EventDistributor.getInstance().sendPlayerStatusUpdateBroadcast();
+        }
 	}
 
 	private static void instanceAvailable() {
@@ -142,5 +153,11 @@ public class PlaybackPreferences implements
 		instanceAvailable();
 		return instance.currentEpisodeIsVideo;
 	}
+
+    public static boolean getPlayerStatusIsPlaying() {
+        instanceAvailable();
+        return instance.playerStatusIsPlaying;
+    }
+
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
@@ -44,18 +44,27 @@ public class PlaybackPreferences implements
 	/** True if last played media was a video. */
 	public static final String PREF_CURRENT_EPISODE_IS_VIDEO = "de.danoeh.antennapod.preferences.lastIsVideo";
 
-    /** True if player status is playing. */
-    public static final String PREF_PLAYER_STATUS_IS_PLAYING = "de.danoeh.antennapod.preferences.playerStatusIsPlaying";
+    /** The current player status as int. */
+    public static final String PREF_CURRENT_PLAYER_STATUS = "de.danoeh.antennapod.preferences.currentPlayerStatus";
 
 	/** Value of PREF_CURRENTLY_PLAYING_MEDIA if no media is playing. */
 	public static final long NO_MEDIA_PLAYING = -1;
+
+    /** Value of PREF_CURRENT_PLAYER_STATUS if media player status is playing. */
+    public static final int PLAYER_STATUS_PLAYING = 1;
+
+    /** Value of PREF_CURRENT_PLAYER_STATUS if media player status is paused. */
+    public static final int PLAYER_STATUS_PAUSED = 2;
+
+    /** Value of PREF_CURRENT_PLAYER_STATUS if media player status is neither playing nor paused. */
+    public static final int PLAYER_STATUS_OTHER = 3;
 
 	private long currentlyPlayingFeedId;
 	private long currentlyPlayingFeedMediaId;
 	private long currentlyPlayingMedia;
 	private boolean currentEpisodeIsStream;
 	private boolean currentEpisodeIsVideo;
-    private boolean playerStatusIsPlaying;
+    private int currentPlayerStatus;
 
 	private static PlaybackPreferences instance;
 	private Context context;
@@ -92,7 +101,8 @@ public class PlaybackPreferences implements
 				NO_MEDIA_PLAYING);
 		currentEpisodeIsStream = sp.getBoolean(PREF_CURRENT_EPISODE_IS_STREAM, true);
 		currentEpisodeIsVideo = sp.getBoolean(PREF_CURRENT_EPISODE_IS_VIDEO, false);
-        playerStatusIsPlaying = sp.getBoolean(PREF_PLAYER_STATUS_IS_PLAYING, false);
+        currentPlayerStatus = sp.getInt(PREF_CURRENT_PLAYER_STATUS,
+                PLAYER_STATUS_OTHER);
 	}
 
 	@Override
@@ -115,9 +125,9 @@ public class PlaybackPreferences implements
 			currentlyPlayingFeedMediaId = sp.getLong(
 					PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID, NO_MEDIA_PLAYING);
 		}
-        else if (key.equals(PREF_PLAYER_STATUS_IS_PLAYING)) {
-            playerStatusIsPlaying = sp.getBoolean(
-                    PREF_PLAYER_STATUS_IS_PLAYING, false);
+        else if (key.equals(PREF_CURRENT_PLAYER_STATUS)) {
+            currentPlayerStatus = sp.getInt(PREF_CURRENT_PLAYER_STATUS,
+                    PLAYER_STATUS_OTHER);
             EventDistributor.getInstance().sendPlayerStatusUpdateBroadcast();
         }
 	}
@@ -154,9 +164,9 @@ public class PlaybackPreferences implements
 		return instance.currentEpisodeIsVideo;
 	}
 
-    public static boolean getPlayerStatusIsPlaying() {
+    public static int getCurrentPlayerStatus() {
         instanceAvailable();
-        return instance.playerStatusIsPlaying;
+        return instance.currentPlayerStatus;
     }
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -653,11 +653,26 @@ public class PlaybackService extends Service {
         editor.putLong(
                 PlaybackPreferences.PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID,
                 PlaybackPreferences.NO_MEDIA_PLAYING);
-        editor.putBoolean(
-                PlaybackPreferences.PREF_PLAYER_STATUS_IS_PLAYING, false);
+        editor.putInt(
+                PlaybackPreferences.PREF_CURRENT_PLAYER_STATUS,
+                PlaybackPreferences.PLAYER_STATUS_OTHER);
         editor.commit();
     }
 
+    private int getCurrentPlayerStatusAsInt(PlayerStatus playerStatus) {
+        int playerStatusAsInt;
+        switch (playerStatus) {
+            case PLAYING:
+                playerStatusAsInt = PlaybackPreferences.PLAYER_STATUS_PLAYING;
+                break;
+            case PAUSED:
+                playerStatusAsInt = PlaybackPreferences.PLAYER_STATUS_PAUSED;
+                break;
+            default:
+                playerStatusAsInt = PlaybackPreferences.PLAYER_STATUS_OTHER;
+        }
+        return playerStatusAsInt;
+    }
 
     private void writePlaybackPreferences() {
         if (BuildConfig.DEBUG)
@@ -668,7 +683,7 @@ public class PlaybackService extends Service {
         PlaybackServiceMediaPlayer.PSMPInfo info = mediaPlayer.getPSMPInfo();
         MediaType mediaType = mediaPlayer.getCurrentMediaType();
         boolean stream = mediaPlayer.isStreaming();
-        boolean isPlaying = (info.playerStatus == PlayerStatus.PLAYING);
+        int playerStatus = getCurrentPlayerStatusAsInt(info.playerStatus);
 
         if (info.playable != null) {
             editor.putLong(PlaybackPreferences.PREF_CURRENTLY_PLAYING_MEDIA,
@@ -705,8 +720,8 @@ public class PlaybackService extends Service {
                     PlaybackPreferences.PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID,
                     PlaybackPreferences.NO_MEDIA_PLAYING);
         }
-        editor.putBoolean(
-                PlaybackPreferences.PREF_PLAYER_STATUS_IS_PLAYING, isPlaying);
+        editor.putInt(
+                PlaybackPreferences.PREF_CURRENT_PLAYER_STATUS, playerStatus);
 
         editor.commit();
     }
@@ -718,10 +733,10 @@ public class PlaybackService extends Service {
         SharedPreferences.Editor editor = PreferenceManager
                 .getDefaultSharedPreferences(getApplicationContext()).edit();
         PlaybackServiceMediaPlayer.PSMPInfo info = mediaPlayer.getPSMPInfo();
-        boolean isPlaying = (info.playerStatus == PlayerStatus.PLAYING);
+        int playerStatus = getCurrentPlayerStatusAsInt(info.playerStatus);
 
-        editor.putBoolean(
-                PlaybackPreferences.PREF_PLAYER_STATUS_IS_PLAYING, isPlaying);
+        editor.putInt(
+                PlaybackPreferences.PREF_CURRENT_PLAYER_STATUS, playerStatus);
 
         editor.commit();
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -101,6 +101,18 @@ public class PlaybackService extends Service {
     public static final String ACTION_SKIP_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.skipCurrentEpisode";
 
     /**
+     * If the PlaybackService receives this action, it will pause playback.
+     */
+    public static final String ACTION_PAUSE_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.pausePlayCurrentEpisode";
+
+
+    /**
+     * If the PlaybackService receives this action, it will resume playback.
+     */
+    public static final String ACTION_RESUME_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.resumePlayCurrentEpisode";
+
+
+    /**
      * Used in NOTIFICATION_TYPE_RELOAD.
      */
     public static final int EXTRA_CODE_AUDIO = 1;
@@ -216,6 +228,10 @@ public class PlaybackService extends Service {
                 AudioManager.ACTION_AUDIO_BECOMING_NOISY));
         registerReceiver(skipCurrentEpisodeReceiver, new IntentFilter(
                 ACTION_SKIP_CURRENT_EPISODE));
+        registerReceiver(pausePlayCurrentEpisodeReceiver, new IntentFilter(
+                ACTION_PAUSE_PLAY_CURRENT_EPISODE));
+        registerReceiver(pauseResumeCurrentEpisodeReceiver, new IntentFilter(
+                ACTION_RESUME_PLAY_CURRENT_EPISODE));
         remoteControlClient = setupRemoteControlClient();
         taskManager = new PlaybackServiceTaskManager(this, taskManagerCallback);
         mediaPlayer = new PlaybackServiceMediaPlayer(this, mediaPlayerCallback);
@@ -427,6 +443,7 @@ public class PlaybackService extends Service {
                         // remove notifcation on pause
                         stopForeground(true);
                     }
+                    writePlayerStatusPlaybackPreferences();
 
                     break;
 
@@ -443,9 +460,11 @@ public class PlaybackService extends Service {
 
                     taskManager.startPositionSaver();
                     taskManager.startWidgetUpdater();
+                    writePlayerStatusPlaybackPreferences();
                     setupNotification(newInfo);
                     started = true;
                     break;
+
                 case ERROR:
                     writePlaybackPreferencesNoMediaPlaying();
                     break;
@@ -634,6 +653,8 @@ public class PlaybackService extends Service {
         editor.putLong(
                 PlaybackPreferences.PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID,
                 PlaybackPreferences.NO_MEDIA_PLAYING);
+        editor.putBoolean(
+                PlaybackPreferences.PREF_PLAYER_STATUS_IS_PLAYING, false);
         editor.commit();
     }
 
@@ -647,6 +668,7 @@ public class PlaybackService extends Service {
         PlaybackServiceMediaPlayer.PSMPInfo info = mediaPlayer.getPSMPInfo();
         MediaType mediaType = mediaPlayer.getCurrentMediaType();
         boolean stream = mediaPlayer.isStreaming();
+        boolean isPlaying = (info.playerStatus == PlayerStatus.PLAYING);
 
         if (info.playable != null) {
             editor.putLong(PlaybackPreferences.PREF_CURRENTLY_PLAYING_MEDIA,
@@ -683,6 +705,23 @@ public class PlaybackService extends Service {
                     PlaybackPreferences.PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID,
                     PlaybackPreferences.NO_MEDIA_PLAYING);
         }
+        editor.putBoolean(
+                PlaybackPreferences.PREF_PLAYER_STATUS_IS_PLAYING, isPlaying);
+
+        editor.commit();
+    }
+
+    private void writePlayerStatusPlaybackPreferences() {
+        if (BuildConfig.DEBUG)
+            Log.d(TAG, "Writing player status playback preferences");
+
+        SharedPreferences.Editor editor = PreferenceManager
+                .getDefaultSharedPreferences(getApplicationContext()).edit();
+        PlaybackServiceMediaPlayer.PSMPInfo info = mediaPlayer.getPSMPInfo();
+        boolean isPlaying = (info.playerStatus == PlayerStatus.PLAYING);
+
+        editor.putBoolean(
+                PlaybackPreferences.PREF_PLAYER_STATUS_IS_PLAYING, isPlaying);
 
         editor.commit();
     }
@@ -1097,6 +1136,28 @@ public class PlaybackService extends Service {
                 if (BuildConfig.DEBUG)
                     Log.d(TAG, "Received SKIP_CURRENT_EPISODE intent");
                 mediaPlayer.endPlayback();
+            }
+        }
+    };
+
+    private BroadcastReceiver pauseResumeCurrentEpisodeReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (StringUtils.equals(intent.getAction(), ACTION_RESUME_PLAY_CURRENT_EPISODE)) {
+                if (BuildConfig.DEBUG)
+                    Log.d(TAG, "Received RESUME_PLAY_CURRENT_EPISODE intent");
+                mediaPlayer.resume();
+            }
+        }
+    };
+
+    private BroadcastReceiver pausePlayCurrentEpisodeReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (StringUtils.equals(intent.getAction(), ACTION_PAUSE_PLAY_CURRENT_EPISODE)) {
+                if (BuildConfig.DEBUG)
+                    Log.d(TAG, "Received PAUSE_PLAY_CURRENT_EPISODE intent");
+                mediaPlayer.pause(false, false);
             }
         }
     };

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -179,6 +179,10 @@ public class PlaybackServiceMediaPlayer {
                 if (playerStatus == PlayerStatus.PAUSED || playerStatus == PlayerStatus.PLAYING || playerStatus == PlayerStatus.PREPARED) {
                     mediaPlayer.stop();
                 }
+                // set temporarily to pause in order to update list with current position
+                if (playerStatus == PlayerStatus.PLAYING) {
+                    setPlayerStatus(PlayerStatus.PAUSED, media);
+                }
                 setPlayerStatus(PlayerStatus.INDETERMINATE, null);
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -169,7 +169,8 @@ public class PlaybackServiceMediaPlayer {
 
 
         if (media != null) {
-            if (!forceReset && media.getIdentifier().equals(playable.getIdentifier())) {
+            if (!forceReset && media.getIdentifier().equals(playable.getIdentifier())
+                    && playerStatus == PlayerStatus.PLAYING) {
                 // episode is already playing -> ignore method call
                 if (BuildConfig.DEBUG)
                     Log.d(TAG, "Method call to playMediaObject was ignored: media file already playing.");


### PR DESCRIPTION
Direct play from the the list is now enabled. A pause button is no longer displayed in the list. It would need additional changes to get a pause button to work and to always be updated accordingly. Instead the
play button of the selected item changes to blank.