### PR TITLE
don't log messages in release mode

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -69,3 +69,13 @@
 -keep class org.apache.commons.** { *; }
 
 -dontskipnonpubliclibraryclassmembers
+
+# disable logging
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** d(...);
+    public static *** e(...);
+}


### PR DESCRIPTION
We shouldn't be logging any messages in release mode. Updated ProGuard config to remove any logging calls.