### PR TITLE
Separate fast forward and rewind times

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -29,7 +29,6 @@ import com.squareup.picasso.Picasso;
 
 import org.apache.commons.lang3.StringUtils;
 
-import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.ChapterListAdapter;
 import de.danoeh.antennapod.adapter.NavListAdapter;
@@ -96,30 +95,25 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
         FragmentTransaction fT = getSupportFragmentManager().beginTransaction();
 
         if (coverFragment != null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Removing cover fragment");
+            Log.d(TAG, "Removing cover fragment");
             fT.remove(coverFragment);
         }
         if (descriptionFragment != null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Removing description fragment");
+            Log.d(TAG, "Removing description fragment");
             fT.remove(descriptionFragment);
         }
         if (chapterFragment != null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Removing chapter fragment");
+            Log.d(TAG, "Removing chapter fragment");
             fT.remove(chapterFragment);
         }
         if (currentlyShownFragment != null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Removing currently shown fragment");
+            Log.d(TAG, "Removing currently shown fragment");
             fT.remove(currentlyShownFragment);
         }
         for (int i = 0; i < detachedFragments.length; i++) {
             Fragment f = detachedFragments[i];
             if (f != null) {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Removing detached fragment");
+                Log.d(TAG, "Removing detached fragment");
                 fT.remove(f);
             }
         }
@@ -152,8 +146,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
     }
 
     private void savePreferences() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Saving preferences");
+        Log.d(TAG, "Saving preferences");
         SharedPreferences prefs = getSharedPreferences(PREFS, MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         if (currentlyShownPosition >= 0 && controller != null
@@ -180,9 +173,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         // super.onSaveInstanceState(outState); would cause crash
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "onSaveInstanceState");
-
+        Log.d(TAG, "onSaveInstanceState");
     }
 
     @Override
@@ -205,8 +196,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
      * @return true if restoreFromPrefernces changed the activity's state
      */
     private boolean restoreFromPreferences() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Restoring instance state");
+        Log.d(TAG, "Restoring instance state");
         SharedPreferences prefs = getSharedPreferences(PREFS, MODE_PRIVATE);
         int savedPosition = prefs.getInt(PREF_KEY_SELECTED_FRAGMENT_POSITION,
                 -1);
@@ -220,15 +210,10 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
             switchToFragment(savedPosition);
             return true;
         } else if (controller == null || controller.getMedia() == null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG,
-                        "Couldn't restore from preferences: controller or media was null");
+            Log.d(TAG, "Couldn't restore from preferences: controller or media was null");
         } else {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG,
-                        "Couldn't restore from preferences: savedPosition was -1 or saved identifier and playable identifier didn't match.\nsavedPosition: "
-                                + savedPosition + ", id: " + playableId
-                );
+            Log.d(TAG, "Couldn't restore from preferences: savedPosition was -1 or saved identifier and playable identifier didn't match.\nsavedPosition: "
+                                + savedPosition + ", id: " + playableId);
 
         }
         return false;
@@ -239,9 +224,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
         super.onResume();
         if (StringUtils.equals(getIntent().getAction(), Intent.ACTION_VIEW)) {
             Intent intent = getIntent();
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Received VIEW intent: "
-                        + intent.getData().getPath());
+            Log.d(TAG, "Received VIEW intent: " + intent.getData().getPath());
             ExternalMedia media = new ExternalMedia(intent.getData().getPath(),
                     MediaType.AUDIO);
             Intent launchIntent = new Intent(this, PlaybackService.class);
@@ -269,8 +252,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
 
     @Override
     protected void onAwaitingVideoSurface() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "onAwaitingVideoSurface was called in audio player -> switching to video player");
+        Log.d(TAG, "onAwaitingVideoSurface was called in audio player -> switching to video player");
         startActivity(new Intent(this, VideoplayerActivity.class));
     }
 
@@ -295,8 +277,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
      * @param pos Must be POS_COVER, POS_DESCR, or POS_CHAPTERS
      */
     private void switchToFragment(int pos) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Switching contentView to position " + pos);
+        Log.d(TAG, "Switching contentView to position " + pos);
         if (currentlyShownPosition != pos && controller != null) {
             Playable media = controller.getMedia();
             if (media != null) {
@@ -354,9 +335,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
                     lastShownPosition = currentlyShownPosition;
                     currentlyShownPosition = pos;
                     if (detachedFragments[pos] != null) {
-                        if (BuildConfig.DEBUG)
-                            Log.d(TAG, "Reattaching fragment at position "
-                                    + pos);
+                        Log.d(TAG, "Reattaching fragment at position " + pos);
                         ft.attach(detachedFragments[pos]);
                     } else {
                         ft.add(R.id.contentView, currentlyShownFragment);
@@ -630,9 +609,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
     @Override
     protected void onReloadNotification(int notificationCode) {
         if (notificationCode == PlaybackService.EXTRA_CODE_VIDEO) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG,
-                        "ReloadNotification received, switching to Videoplayer now");
+            Log.d(TAG, "ReloadNotification received, switching to Videoplayer now");
             finish();
             startActivity(new Intent(this, VideoplayerActivity.class));
 
@@ -729,8 +706,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
         @Override
         public void update(EventDistributor eventDistributor, Integer arg) {
             if ((EventDistributor.FEED_LIST_UPDATE & arg) != 0) {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Received contentUpdate Intent.");
+                Log.d(TAG, "Received contentUpdate Intent.");
                 loadData();
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -12,6 +12,8 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+
+import android.view.View;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
@@ -46,7 +48,9 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected SeekBar sbPosition;
     protected ImageButton butPlay;
     protected ImageButton butRev;
+    protected TextView txtvRev;
     protected ImageButton butFF;
+    protected TextView txtvFF;
 
     private PlaybackController newPlaybackController() {
         return new PlaybackController(this, false) {
@@ -222,7 +226,6 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected void onStop() {
         super.onStop();
         Log.d(TAG, "onStop()");
-
         if (controller != null) {
             controller.release();
         }
@@ -373,6 +376,8 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         if (controller != null) {
             int currentPosition = controller.getPosition();
             int duration = controller.getDuration();
+            Log.d(TAG, "currentPosition " + Converter
+                    .getDurationStringLong(currentPosition));
             if (currentPosition != PlaybackService.INVALID_TIME
                     && duration != PlaybackService.INVALID_TIME
                     && controller.getMedia() != null) {
@@ -381,8 +386,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                 txtvLength.setText(Converter.getDurationStringLong(duration));
                 updateProgressbarPosition(currentPosition, duration);
             } else {
-                Log.w(TAG,
-                        "Could not react to position observer update because of invalid time");
+                Log.w(TAG, "Could not react to position observer update because of invalid time");
             }
         }
     }
@@ -426,7 +430,11 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         txtvLength = (TextView) findViewById(R.id.txtvLength);
         butPlay = (ImageButton) findViewById(R.id.butPlay);
         butRev = (ImageButton) findViewById(R.id.butRev);
+        txtvRev = (TextView) findViewById(R.id.txtvRev);
+        txtvRev.setText(String.valueOf(UserPreferences.getRewindSecs()));
         butFF = (ImageButton) findViewById(R.id.butFF);
+        txtvFF = (TextView) findViewById(R.id.txtvFF);
+        txtvFF.setText(String.valueOf(UserPreferences.getFastFowardSecs()));
 
         // SEEKBAR SETUP
 
@@ -437,10 +445,100 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         butPlay.setOnClickListener(controller.newOnPlayButtonClickListener());
 
         if (butFF != null) {
-            butFF.setOnClickListener(controller.newOnFFButtonClickListener());
+            butFF.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    int curr = controller.getPosition();
+                    controller.seekTo(curr + UserPreferences.getFastFowardSecs() * 1000);
+                }
+            });
+            butFF.setOnLongClickListener(new View.OnLongClickListener() {
+
+                int choice;
+
+                @Override
+                public boolean onLongClick(View v) {
+                    int checked = 0;
+                    int rewindSecs = UserPreferences.getFastFowardSecs();
+                    final int[] values = getResources().getIntArray(R.array.seek_delta_values);
+                    final String[] choices = new String[values.length];
+                    for(int i=0; i < values.length; i++) {
+                        if (rewindSecs == values[i]) {
+                            checked = i;
+                        }
+                        choices[i] = String.valueOf(values[i]) + " "
+                                + getString(R.string.time_unit_seconds);
+                    }
+                    choice = values[checked];
+                    AlertDialog.Builder builder = new AlertDialog.Builder(MediaplayerActivity.this);
+                    builder.setTitle(R.string.pref_fast_forward);
+                    builder.setSingleChoiceItems(choices, checked,
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    choice = values[which];
+                                }
+                            });
+                    builder.setNegativeButton(R.string.cancel_label, null);
+                    builder.setPositiveButton(R.string.confirm_label, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            UserPreferences.setPrefFastForwardSecs(choice);
+                            txtvFF.setText(String.valueOf(choice));
+                        }
+                    });
+                    builder.create().show();
+                    return true;
+                }
+            });
         }
         if (butRev != null) {
-            butRev.setOnClickListener(controller.newOnRevButtonClickListener());
+            butRev.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    int curr = controller.getPosition();
+                    controller.seekTo(curr - UserPreferences.getRewindSecs() * 1000);
+                }
+            });
+            butRev.setOnLongClickListener(new View.OnLongClickListener() {
+
+                int choice;
+
+                @Override
+                public boolean onLongClick(View v) {
+                    int checked = 0;
+                    int rewindSecs = UserPreferences.getRewindSecs();
+                    final int[] values = getResources().getIntArray(R.array.seek_delta_values);
+                    final String[] choices = new String[values.length];
+                    for(int i=0; i < values.length; i++) {
+                        if (rewindSecs == values[i]) {
+                            checked = i;
+                        }
+                        choices[i] = String.valueOf(values[i]) + " "
+                                + getString(R.string.time_unit_seconds);
+                    }
+                    choice = values[checked];
+                    AlertDialog.Builder builder = new AlertDialog.Builder(MediaplayerActivity.this);
+                    builder.setTitle(R.string.pref_rewind);
+                    builder.setSingleChoiceItems(choices, checked,
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    choice = values[which];
+                                }
+                            });
+                    builder.setNegativeButton(R.string.cancel_label, null);
+                    builder.setPositiveButton(R.string.confirm_label, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            UserPreferences.setPrefRewindSecs(choice);
+                            txtvRev.setText(String.valueOf(choice));
+                        }
+                    });
+                    builder.create().show();
+                    return true;
+                }
+            });
         }
 
     }

--- a/app/src/main/res/layout/audioplayer_activity.xml
+++ b/app/src/main/res/layout/audioplayer_activity.xml
@@ -95,6 +95,18 @@
                     tools:src="@drawable/ic_fast_rewind_white_36dp"
                     tools:background="@android:color/holo_blue_dark" />
 
+                <TextView
+                    android:id="@+id/txtvRev"
+                    android:layout_width="wrap_content"
+                    android:layout_height="32dp"
+                    android:layout_alignTop="@id/butRev"
+                    android:layout_alignLeft="@id/butRev"
+                    android:layout_alignRight="@id/butRev"
+                    android:gravity="center"
+                    android:text="30"
+                    android:textSize="8dp"
+                    android:clickable="false"/>
+
                 <ImageButton
                     android:id="@+id/butFF"
                     android:layout_width="@dimen/audioplayer_playercontrols_length"
@@ -105,6 +117,18 @@
                     android:src="?attr/av_ff_big"
                     tools:src="@drawable/ic_fast_forward_white_36dp"
                     tools:background="@android:color/holo_blue_dark" />
+
+                <TextView
+                    android:id="@+id/txtvFF"
+                    android:layout_width="wrap_content"
+                    android:layout_height="32dp"
+                    android:layout_alignTop="@id/butFF"
+                    android:layout_alignLeft="@id/butFF"
+                    android:layout_alignRight="@id/butFF"
+                    android:gravity="center"
+                    android:text="30"
+                    android:textSize="8dp"
+                    android:clickable="false"/>
 
                 <Button
                     android:id="@+id/butPlaybackSpeed"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -78,14 +78,6 @@
             android:summary="@string/pref_pausePlaybackForFocusLoss_sum"
             android:title="@string/pref_pausePlaybackForFocusLoss_title" />
 
-        <ListPreference
-            android:defaultValue="30"
-            android:entries="@array/seek_delta_values"
-            android:entryValues="@array/seek_delta_values"
-            android:key="prefSeekDeltaSecs"
-            android:summary="@string/pref_seek_delta_sum"
-            android:title="@string/pref_seek_delta_title" />
-
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/network_pref">
         <ListPreference

--- a/core/src/main/java/com/aocate/media/AndroidMediaPlayer.java
+++ b/core/src/main/java/com/aocate/media/AndroidMediaPlayer.java
@@ -14,12 +14,12 @@
 
 package com.aocate.media;
 
-import java.io.IOException;
-
 import android.content.Context;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.util.Log;
+
+import java.io.IOException;
 
 public class AndroidMediaPlayer extends MediaPlayerImpl {
 	private final static String AMP_TAG = "AocateAndroidMediaPlayer";

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -460,12 +460,14 @@ public class UserPreferences implements
     }
 
     public static void setPrefFastForwardSecs(int secs) {
+        Log.d(TAG, "setPrefFastForwardSecs(" + secs +")");
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(instance.context).edit();
         editor.putInt(PREF_FAST_FORWARD_SECS, secs);
         editor.commit();
     }
 
     public static void setPrefRewindSecs(int secs) {
+        Log.d(TAG, "setPrefRewindSecs(" + secs +")");
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(instance.context).edit();
         editor.putInt(PREF_REWIND_SECS, secs);
         editor.commit();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -344,11 +344,11 @@ public class PlaybackService extends Service {
                 break;
             case KeyEvent.KEYCODE_MEDIA_NEXT:
             case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
-                mediaPlayer.seekDelta(UserPreferences.getSeekDeltaMs());
+                mediaPlayer.seekDelta(UserPreferences.getFastFowardSecs() * 1000);
                 break;
             case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
             case KeyEvent.KEYCODE_MEDIA_REWIND:
-                mediaPlayer.seekDelta(-UserPreferences.getSeekDeltaMs());
+                mediaPlayer.seekDelta(-UserPreferences.getRewindSecs() * 1000);
                 break;
             case KeyEvent.KEYCODE_MEDIA_STOP:
                 if (status == PlayerStatus.PLAYING) {
@@ -481,9 +481,8 @@ public class PlaybackService extends Service {
             }
 
             Intent statusUpdate = new Intent(ACTION_PLAYER_STATUS_CHANGED);
-            statusUpdate.putExtra(EXTRA_NEW_PLAYER_STATUS, newInfo.playerStatus.ordinal());
+            // statusUpdate.putExtra(EXTRA_NEW_PLAYER_STATUS, newInfo.playerStatus.ordinal());
             sendBroadcast(statusUpdate);
-            sendBroadcast(new Intent(ACTION_PLAYER_STATUS_CHANGED));
             updateWidget();
             refreshRemoteControlClientState(newInfo);
             bluetoothNotifyChange(newInfo, AVRCP_ACTION_PLAYER_STATUS_CHANGED);
@@ -626,7 +625,6 @@ public class PlaybackService extends Service {
             prepareImmediately = startWhenPrepared = true;
         } else {
             Log.d(TAG, "No more episodes available to play");
-
             prepareImmediately = startWhenPrepared = false;
             stopForeground(true);
             stopWidgetUpdater();
@@ -933,7 +931,6 @@ public class PlaybackService extends Service {
                 // Auto flattr
                 if (isAutoFlattrable(media) &&
                         (media.getPlayedDuration() > UserPreferences.getAutoFlattrPlayedDurationThreshold() * duration)) {
-
                     Log.d(TAG, "saveCurrentPosition: performing auto flattr since played duration " + Integer.toString(media.getPlayedDuration())
                                 + " is " + UserPreferences.getAutoFlattrPlayedDurationThreshold() * 100 + "% of file duration " + Integer.toString(duration));
                     DBTasks.flattrItemIfLoggedIn(this, item);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -19,7 +19,9 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.QueueEvent;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.playback.Playable;
+
 import de.greenrobot.event.EventBus;
+
 
 /**
  * Manages the background tasks of PlaybackSerivce, i.e.
@@ -147,9 +149,9 @@ public class PlaybackServiceTaskManager {
             positionSaverFuture = schedExecutor.scheduleWithFixedDelay(positionSaver, POSITION_SAVER_WAITING_INTERVAL,
                     POSITION_SAVER_WAITING_INTERVAL, TimeUnit.MILLISECONDS);
 
-            if (BuildConfig.DEBUG) Log.d(TAG, "Started PositionSaver");
+            Log.d(TAG, "Started PositionSaver");
         } else {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Call to startPositionSaver was ignored.");
+            Log.d(TAG, "Call to startPositionSaver was ignored.");
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -32,13 +32,11 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
@@ -174,8 +172,7 @@ public abstract class PlaybackController {
      * as the arguments of the launch intent.
      */
     private void bindToService() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Trying to connect to service");
+        Log.d(TAG, "Trying to connect to service");
         AsyncTask<Void, Void, Intent> intentLoader = new AsyncTask<Void, Void, Intent>() {
             @Override
             protected Intent doInBackground(Void... voids) {
@@ -211,8 +208,7 @@ public abstract class PlaybackController {
      * played media or null if no last played media could be found.
      */
     private Intent getPlayLastPlayedMediaIntent() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Trying to restore last played media");
+        Log.d(TAG, "Trying to restore last played media");
         SharedPreferences prefs = PreferenceManager
                 .getDefaultSharedPreferences(activity.getApplicationContext());
         long currentlyPlayingMedia = PlaybackPreferences
@@ -240,8 +236,7 @@ public abstract class PlaybackController {
                 return serviceIntent;
             }
         }
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "No last played media found");
+        Log.d(TAG, "No last played media found");
         return null;
     }
 
@@ -253,8 +248,7 @@ public abstract class PlaybackController {
                 || (positionObserverFuture != null && positionObserverFuture
                 .isDone()) || positionObserverFuture == null) {
 
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Setting up position observer");
+            Log.d(TAG, "Setting up position observer");
             positionObserver = new MediaPositionObserver();
             positionObserverFuture = schedExecutor.scheduleWithFixedDelay(
                     positionObserver, MediaPositionObserver.WAITING_INTERVALL,
@@ -266,8 +260,7 @@ public abstract class PlaybackController {
     private void cancelPositionObserver() {
         if (positionObserverFuture != null) {
             boolean result = positionObserverFuture.cancel(true);
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "PositionObserver cancelled. Result: " + result);
+            Log.d(TAG, "PositionObserver cancelled. Result: " + result);
         }
     }
 
@@ -295,8 +288,7 @@ public abstract class PlaybackController {
     protected BroadcastReceiver statusUpdate = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Received statusUpdate Intent.");
+            Log.d(TAG, "Received statusUpdate Intent.");
             if (isConnectedToPlaybackService()) {
                 PlaybackServiceMediaPlayer.PSMPInfo info = playbackService.getPSMPInfo();
                 status = info.playerStatus;
@@ -353,8 +345,7 @@ public abstract class PlaybackController {
                     }
 
                 } else {
-                    if (BuildConfig.DEBUG)
-                        Log.d(TAG, "Bad arguments. Won't handle intent");
+                    Log.d(TAG, "Bad arguments. Won't handle intent");
                 }
             } else {
                 bindToService();
@@ -425,6 +416,7 @@ public abstract class PlaybackController {
             pauseResource = R.drawable.ic_av_pause_circle_outline_80dp;
         }
 
+        Log.d(TAG, "status: " + status.toString());
         switch (status) {
 
             case ERROR:
@@ -470,6 +462,7 @@ public abstract class PlaybackController {
                 updatePlayButtonAppearance(playResource, playText);
                 break;
             case SEEKING:
+                onPositionObserverUpdate();
                 postStatusMsg(R.string.player_seeking_msg);
                 break;
             case INITIALIZED:
@@ -505,8 +498,7 @@ public abstract class PlaybackController {
      * information has to be refreshed
      */
     void queryService() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Querying service info");
+        Log.d(TAG, "Querying service info");
         if (playbackService != null) {
             status = playbackService.getStatus();
             media = playbackService.getPlayable();
@@ -611,28 +603,6 @@ public abstract class PlaybackController {
                 }
             }
 
-        };
-    }
-
-    public OnClickListener newOnRevButtonClickListener() {
-        return new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (status == PlayerStatus.PLAYING) {
-                    playbackService.seekDelta(-UserPreferences.getSeekDeltaMs());
-                }
-            }
-        };
-    }
-
-    public OnClickListener newOnFFButtonClickListener() {
-        return new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (status == PlayerStatus.PLAYING) {
-                    playbackService.seekDelta(UserPreferences.getSeekDeltaMs());
-                }
-            }
         };
     }
 

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -10,7 +10,7 @@
     </string-array>
 
 
-    <string-array name="seek_delta_values">
+    <integer-array name="seek_delta_values">
         <item>5</item>
         <item>10</item>
         <item>15</item>
@@ -18,7 +18,7 @@
         <item>30</item>
         <item>45</item>
         <item>60</item>
-    </string-array>
+    </integer-array>
 
     <string-array name="update_intervall_options">
         <item>Manual</item>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -268,8 +268,8 @@
     <string name="pref_gpodnet_setlogin_information_sum">Change the login information for your gpodder.net account.</string>
     <string name="pref_playback_speed_title">Playback Speeds</string>
     <string name="pref_playback_speed_sum">Customize the speeds available for variable speed audio playback</string>
-    <string name="pref_seek_delta_title">Seek time</string>
-    <string name="pref_seek_delta_sum">Seek this many seconds when rewinding or fast-forwarding</string>
+    <string name="pref_fast_forward">Fast forward time</string>
+    <string name="pref_rewind">Rewind time</string>
     <string name="pref_gpodnet_sethostname_title">Set hostname</string>
     <string name="pref_gpodnet_sethostname_use_default_host">Use default host</string>
     <string name="pref_expandNotify_title">Expand Notification</string>


### PR DESCRIPTION
![ff](https://cloud.githubusercontent.com/assets/6860662/7007616/f7768f40-dc8b-11e4-8773-ed7bcb829c7b.png)

Users set fast forward and rewind time separately. This is set on the audio player activity by long pressing fast forward or rewind. Small numbers above the buttons show the current values.

The former preference setting has been removed.

FF/Rev seems to cause troubles on older devices. The seekbar is not updated properly when seeking while the audio is paused - the position is updated properly.
Until now, seeking was only possible when the audio was actually playing. On newer devices, the seekbar is not updated properly in very rare cases. Most of the time, it works as intended.

Closes AntennaPod/AntennaPod#642

(For easier review, I tried to add all tedious stuff into the first commit.)