### PR TITLE
Make 'Add to queue' the default

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.Validate;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 
 /**
@@ -27,8 +28,9 @@ public class ActionButtonUtils {
 
         this.context = context;
         drawables = context.obtainStyledAttributes(new int[]{
-                R.attr.av_play, R.attr.navigation_cancel, R.attr.av_download, R.attr.av_pause, R.attr.navigation_accept});
-        labels = new int[]{R.string.play_label, R.string.cancel_download_label, R.string.download_label, R.string.mark_read_label};
+                R.attr.av_play, R.attr.navigation_cancel, R.attr.av_download, R.attr.av_pause, R.attr.navigation_accept,
+                R.attr.content_new});
+        labels = new int[]{R.string.play_label, R.string.cancel_download_label, R.string.download_label, R.string.mark_read_label, R.string.add_to_queue_label};
     }
 
     /**
@@ -39,9 +41,16 @@ public class ActionButtonUtils {
         Validate.isTrue(butSecondary != null && item != null, "butSecondary or item was null");
 
         final FeedMedia media = item.getMedia();
+        // this logic needs to match the logic in ItemFragment.updateAppearance and
+        // DefaultActionButtonCallback.onActionButtonPressed
         if (media != null) {
             final boolean isDownloadingMedia = DownloadRequester.getInstance().isDownloadingFile(media);
-            if (!media.isDownloaded()) {
+            if (!DBTasks.isInQueue(context, item.getId())) {
+                // item isn't in the queue
+                butSecondary.setVisibility(View.VISIBLE);
+                butSecondary.setImageDrawable(drawables.getDrawable(5));
+                butSecondary.setContentDescription(context.getString(labels[4]));
+            } else if (!media.isDownloaded()) {
                 if (isDownloadingMedia) {
                     // item is being downloaded
                     butSecondary.setVisibility(View.VISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -17,7 +17,6 @@ import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequestException;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
-
 /**
  * Default implementation of an ActionButtonCallback
  */
@@ -38,7 +37,9 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
         if (item.hasMedia()) {
             final FeedMedia media = item.getMedia();
             boolean isDownloading = DownloadRequester.getInstance().isDownloadingFile(media);
-            if (!isDownloading && !media.isDownloaded()) {
+            if (!DBTasks.isInQueue(context, item.getId())) {
+                DBWriter.addQueueItem(context, item.getId());
+            } else if (!isDownloading && !media.isDownloaded()) {
                 try {
                     DBTasks.downloadFeedItems(context, item);
                     Toast.makeText(context, R.string.status_downloading_label, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -362,13 +362,15 @@ public class ItemFragment extends Fragment implements LoaderManager.LoaderCallba
             }
 
             drawables.recycle();
-        } else {if(media.getDuration() > 0) {
+        } else {
+            if(media.getDuration() > 0) {
                 txtvDuration.setText(Converter.getDurationStringLong(media.getDuration()));
             }
 
             boolean isDownloading = DownloadRequester.getInstance().isDownloadingFile(media);
             TypedArray drawables = getActivity().obtainStyledAttributes(new int[]{R.attr.av_play,
-                    R.attr.av_download, R.attr.action_stream, R.attr.content_discard, R.attr.navigation_cancel});
+                    R.attr.av_download, R.attr.action_stream, R.attr.content_discard, R.attr.navigation_cancel,
+                    R.attr.content_new});
 
             if (!media.isDownloaded()) {
                 butAction2.setCompoundDrawablesWithIntrinsicBounds(drawables.getDrawable(2), null, null, null);
@@ -378,7 +380,10 @@ public class ItemFragment extends Fragment implements LoaderManager.LoaderCallba
                 butAction2.setText(getActivity().getString(R.string.remove_episode_lable));
             }
 
-            if (isDownloading) {
+            if (!DBTasks.isInQueue(getActivity(), item.getId())) {
+                butAction1.setCompoundDrawablesWithIntrinsicBounds(drawables.getDrawable(5), null, null, null);
+                butAction1.setText(getActivity().getString(R.string.add_to_queue_label));
+            } else if (isDownloading) {
                 butAction1.setCompoundDrawablesWithIntrinsicBounds(drawables.getDrawable(4), null, null, null);
                 butAction1.setText(getActivity().getString(R.string.cancel_download_label));
             } else if (media.isDownloaded()) {


### PR DESCRIPTION
If an item isn't in the queue, then 'add' will be the first option you see (instead of 'Download').

fixes AntennaPod/AntennaPod#615