### PR TITLE
gpodder now properly sets the initial data for feeds

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="48"
+    android:versionCode="49"
     android:versionName="1.1">
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -140,7 +140,7 @@ public class GpodnetSyncService extends Service {
     private synchronized void processSubscriptionChanges(List<String> localSubscriptions, GpodnetSubscriptionChange changes) throws DownloadRequestException {
         for (String downloadUrl : changes.getAdded()) {
             if (!localSubscriptions.contains(downloadUrl)) {
-                Feed feed = new Feed(downloadUrl, new Date());
+                Feed feed = new Feed(downloadUrl, new Date(0));
                 DownloadRequester.getInstance().downloadFeed(this, feed);
             }
         }


### PR DESCRIPTION
Fixes a bug where GPodnetSyncService was setting the wrong date when importing new feeds.  This result in feeds not being displayed since the system thought there was nothing new.