### PR TITLE
Fixed some NullPointerExceptions

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -219,7 +219,10 @@ public class AllEpisodesFragment extends Fragment {
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
         if (itemsLoaded && !MenuItemUtils.isActivityDrawerOpen((NavDrawerActivity) getActivity())) {
-            menu.findItem(R.id.mark_all_read_item).setVisible(unreadItems != null && !unreadItems.isEmpty());
+            MenuItem menuItem = menu.findItem(R.id.mark_all_read_item);
+            if (menuItem != null) {
+                menuItem.setVisible(unreadItems != null && !unreadItems.isEmpty());
+            }
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -146,7 +146,10 @@ public class PlaybackHistoryFragment extends ListFragment {
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
         if (itemsLoaded && !MenuItemUtils.isActivityDrawerOpen((NavDrawerActivity) getActivity())) {
-            menu.findItem(R.id.clear_history_item).setVisible(playbackHistory != null && !playbackHistory.isEmpty());
+            MenuItem menuItem = menu.findItem(R.id.clear_history_item);
+            if (menuItem != null) {
+                menuItem.setVisible(playbackHistory != null && !playbackHistory.isEmpty());
+            }
         }
     }
 


### PR DESCRIPTION
These were happening on some handsets when onPrepareOptionsMenu was getting called.

It is sometimes called before the menu is actually loaded, causing us to not find the
MenuItem we're looking for.

This solves the symptom, if not the cause.

After making this change the number of failures reported on Apkudo dropped from 20 devices to just 6.