### PR TITLE
Reorganize episode cache size values

### DIFF
--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -39,30 +39,24 @@
         <item>12</item>
         <item>24</item>
     </string-array>
+
     <string-array name="episode_cache_size_entries">
-        <item>@string/pref_episode_cache_unlimited</item>
-        <item>1</item>
-        <item>2</item>
         <item>5</item>
         <item>10</item>
-        <item>20</item>
-        <item>40</item>
-        <item>60</item>
-        <item>80</item>
+        <item>25</item>
+        <item>50</item>
         <item>100</item>
+        <item>@string/pref_episode_cache_unlimited</item>
     </string-array>
     <string-array name="episode_cache_size_values">
-        <item>-1</item>
-        <item>1</item>
-        <item>2</item>
         <item>5</item>
         <item>10</item>
-        <item>20</item>
-        <item>40</item>
-        <item>60</item>
-        <item>80</item>
+        <item>25</item>
+        <item>50</item>
         <item>100</item>
+        <item>-1</item>
     </string-array>
+
     <string-array name="playback_speed_values">
         <item>0.5</item>
         <item>0.6</item>


### PR DESCRIPTION
At first, I tried 5,10,20,30,50,100,unlimited - tested it on a virtual Google Nexus One running 2.3.7, too many values to fit on one screen.
Went with 5,10,25,50,100,unlimited. Still has scroll bar, but at least all values appear without scrolling.

![ec](https://cloud.githubusercontent.com/assets/6860662/7272365/9c3848e2-e8ea-11e4-87d8-4d3e77eb04e2.png)
