### PR TITLE
Fixes bug with undo toast.

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/QueueEvent.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/QueueEvent.java
@@ -8,7 +8,7 @@ import java.util.List;
 public class QueueEvent {
 
     public enum Action {
-        ADDED, ADDED_ITEMS, REMOVED, CLEARED, DELETED_MEDIA, SORTED
+        ADDED, ADDED_ITEMS, REMOVED, CLEARED, DELETED_MEDIA, SORTED, MOVED
     }
 
     public final Action action;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -608,8 +608,7 @@ public class DBWriter {
 
                 adapter.setQueue(queue);
                 if (broadcastUpdate) {
-                    EventBus.getDefault().post(new QueueEvent(QueueEvent.Action.REMOVED, item));
-                    EventBus.getDefault().post(new QueueEvent(QueueEvent.Action.ADDED, item, to));
+                    EventBus.getDefault().post(new QueueEvent(QueueEvent.Action.MOVED, item, to));
                 }
 
             }


### PR DESCRIPTION
After adding EventBus whenever you move an episode or attempt to swip to remove
(but don't actually remove) the undo toast for removing an episode would be
displayed.  This is now resolved.