### PR TITLE
Cancel Auto Downloads

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -79,9 +79,9 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 DownloadRequester.getInstance().cancelDownload(context, media);
                 if(UserPreferences.isEnableAutodownload()) {
                     DBWriter.setFeedItemAutoDownload(context, media.getItem(), false);
-                    Toast.makeText(context, R.string.download_cancelled_autodownload_enabled_msg, Toast.LENGTH_LONG).show();
+                    Toast.makeText(context, R.string.download_canceled_autodownload_enabled_msg, Toast.LENGTH_LONG).show();
                 } else {
-                    Toast.makeText(context, R.string.download_cancelled_msg, Toast.LENGTH_LONG).show();
+                    Toast.makeText(context, R.string.download_canceled_msg, Toast.LENGTH_LONG).show();
                 }
             } else { // media is downloaded
                 if (item.hasMedia() && item.getMedia().isCurrentlyPlaying()) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -12,9 +12,11 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.dialog.DownloadRequestErrorDialogCreator;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.gpoddernet.model.GpodnetEpisodeAction;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
-import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -75,7 +77,12 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 }
             } else if (isDownloading) {
                 DownloadRequester.getInstance().cancelDownload(context, media);
-                Toast.makeText(context, R.string.download_cancelled_msg, Toast.LENGTH_SHORT).show();
+                if(UserPreferences.isEnableAutodownload()) {
+                    DBWriter.setFeedItemAutoDownload(context, media.getItem(), false);
+                    Toast.makeText(context, R.string.download_cancelled_autodownload_enabled_msg, Toast.LENGTH_LONG).show();
+                } else {
+                    Toast.makeText(context, R.string.download_cancelled_msg, Toast.LENGTH_LONG).show();
+                }
             } else { // media is downloaded
                 if (item.hasMedia() && item.getMedia().isCurrentlyPlaying()) {
                     context.sendBroadcast(new Intent(PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE));

--- a/app/src/main/java/de/danoeh/antennapod/config/StorageCallbacksImpl.java
+++ b/app/src/main/java/de/danoeh/antennapod/config/StorageCallbacksImpl.java
@@ -13,7 +13,7 @@ public class StorageCallbacksImpl implements StorageCallbacks {
 
     @Override
     public int getDatabaseVersion() {
-        return 14;
+        return 15;
     }
 
     @Override
@@ -123,6 +123,16 @@ public class StorageCallbacksImpl implements StorageCallbacks {
                     PodDBAdapter.KEY_FEEDITEM,
                     PodDBAdapter.KEY_LINK,
                     PodDBAdapter.KEY_CHAPTER_TYPE));
+        }
+        if(oldVersion <= 14) {
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_AUTO_DOWNLOAD + " INTEGER");
+            db.execSQL("UPDATE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
+                    + " SET " + PodDBAdapter.KEY_AUTO_DOWNLOAD + " = "
+                    + "(SELECT " + PodDBAdapter.KEY_AUTO_DOWNLOAD
+                    + " FROM " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " WHERE " + PodDBAdapter.TABLE_NAME_FEEDS + "." + PodDBAdapter.KEY_ID
+                    + " = " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_FEED + ")");
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
@@ -86,9 +86,9 @@ public class RunningDownloadsFragment extends ListFragment {
                     UserPreferences.isEnableAutodownload()) {
                 FeedMedia media = DBReader.getFeedMedia(getActivity(), downloadRequest.getFeedfileId());
                 DBWriter.setFeedItemAutoDownload(getActivity(), media.getItem(), false);
-                Toast.makeText(getActivity(), R.string.download_cancelled_autodownload_enabled_msg, Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), R.string.download_canceled_autodownload_enabled_msg, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(getActivity(), R.string.download_cancelled_msg, Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), R.string.download_canceled_msg, Toast.LENGTH_SHORT).show();
             }
         }
     };

--- a/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
@@ -5,14 +5,20 @@ import android.os.Handler;
 import android.support.v4.app.ListFragment;
 import android.view.View;
 import android.widget.ListView;
+import android.widget.Toast;
+
+import java.util.List;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.DownloadlistAdapter;
 import de.danoeh.antennapod.core.asynctask.DownloadObserver;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.Downloader;
+import de.danoeh.antennapod.core.storage.DBReader;
+import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
-
-import java.util.List;
 
 /**
  * Displays all running downloads and provides actions to cancel them
@@ -73,7 +79,17 @@ public class RunningDownloadsFragment extends ListFragment {
 
         @Override
         public void onSecondaryActionClick(Downloader downloader) {
-            DownloadRequester.getInstance().cancelDownload(getActivity(), downloader.getDownloadRequest().getSource());
+            DownloadRequest downloadRequest = downloader.getDownloadRequest();
+            DownloadRequester.getInstance().cancelDownload(getActivity(), downloadRequest.getSource());
+
+            if(downloadRequest.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA &&
+                    UserPreferences.isEnableAutodownload()) {
+                FeedMedia media = DBReader.getFeedMedia(getActivity(), downloadRequest.getFeedfileId());
+                DBWriter.setFeedItemAutoDownload(getActivity(), media.getItem(), false);
+                Toast.makeText(getActivity(), R.string.download_cancelled_autodownload_enabled_msg, Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(getActivity(), R.string.download_cancelled_msg, Toast.LENGTH_SHORT).show();
+            }
         }
     };
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -63,6 +63,8 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
     private List<Chapter> chapters;
     private FeedImage image;
 
+    private boolean autoDownload = true;
+
     public FeedItem() {
         this.read = true;
         this.flattrStatus = new FlattrStatus();
@@ -74,7 +76,7 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
      * */
     public FeedItem(long id, String title, String link, Date pubDate, String paymentLink, long feedId,
                     FlattrStatus flattrStatus, boolean hasChapters, FeedImage image, boolean read,
-                    String itemIdentifier) {
+                    String itemIdentifier, boolean autoDownload) {
         this.id = id;
         this.title = title;
         this.link = link;
@@ -86,6 +88,7 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
         this.image = image;
         this.read = read;
         this.itemIdentifier = itemIdentifier;
+        this.autoDownload = autoDownload;
     }
 
     /**
@@ -386,6 +389,22 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
 
     public boolean hasChapters() {
         return hasChapters;
+    }
+
+    public void setAutoDownload(boolean autoDownload) {
+        this.autoDownload = autoDownload;
+    }
+
+    public boolean getAutoDownload() {
+        return this.autoDownload;
+    }
+
+    public boolean isAutoDownloadable() {
+        return this.hasMedia() &&
+                false == this.getMedia().isPlaying() &&
+                false == this.getMedia().isDownloaded() &&
+                false == this.isRead() &&
+                this.getAutoDownload();
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -428,25 +428,6 @@ public final class DBTasks {
         }
     }
 
-    static int getNumberOfUndownloadedEpisodes(
-            final List<FeedItem> queue, final List<FeedItem> unreadItems) {
-        int counter = 0;
-        for (FeedItem item : queue) {
-            if (item.hasMedia() && !item.getMedia().isDownloaded()
-                    && !item.getMedia().isPlaying()
-                    && item.getFeed().getPreferences().getAutoDownload()) {
-                counter++;
-            }
-        }
-        for (FeedItem item : unreadItems) {
-            if (item.hasMedia() && !item.getMedia().isDownloaded()
-                    && item.getFeed().getPreferences().getAutoDownload()) {
-                counter++;
-            }
-        }
-        return counter;
-    }
-
     /**
      * Looks for undownloaded episodes in the queue or list of unread items and request a download if
      * 1. Network is available
@@ -599,8 +580,7 @@ public final class DBTasks {
                 newFeedsList.add(newFeed);
                 resultFeeds[feedIdx] = newFeed;
             } else {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Feed with title " + newFeed.getTitle()
+                Log.d(TAG, "Feed with title " + newFeed.getTitle()
                             + " already exists. Syncing new with existing one.");
 
                 Collections.sort(newFeed.getItems(), new FeedItemPubdateComparator());
@@ -608,21 +588,17 @@ public final class DBTasks {
                 final boolean markNewItemsAsUnread;
                 if (newFeed.getPageNr() == savedFeed.getPageNr()) {
                     if (savedFeed.compareWithOther(newFeed)) {
-                        if (BuildConfig.DEBUG)
-                            Log.d(TAG,
-                                    "Feed has updated attribute values. Updating old feed's attributes");
+                        Log.d(TAG, "Feed has updated attribute values. Updating old feed's attributes");
                         savedFeed.updateFromOther(newFeed);
                     }
                     markNewItemsAsUnread = true;
                 } else {
-                    if (BuildConfig.DEBUG)
-                        Log.d(TAG, "New feed has a higher page number. Merging without marking as unread");
+                    Log.d(TAG, "New feed has a higher page number. Merging without marking as unread");
                     markNewItemsAsUnread = false;
                     savedFeed.setNextPageLink(newFeed.getNextPageLink());
                 }
                 if (savedFeed.getPreferences().compareWithOther(newFeed.getPreferences())) {
-                    if (BuildConfig.DEBUG)
-                        Log.d(TAG, "Feed has updated preferences. Updating old feed's preferences");
+                    Log.d(TAG, "Feed has updated preferences. Updating old feed's preferences");
                     savedFeed.getPreferences().updateFromOther(newFeed.getPreferences());
                 }
                 // Look for new or updated Items
@@ -634,6 +610,7 @@ public final class DBTasks {
                         // item is new
                         final int i = idx;
                         item.setFeed(savedFeed);
+                        item.setAutoDownload(savedFeed.getPreferences().getAutoDownload());
                         savedFeed.getItems().add(i, item);
                         if (markNewItemsAsUnread) {
                             item.setRead(false);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -1039,4 +1039,28 @@ public class DBWriter {
             }
         });
     }
+
+    /**
+     * Sets the 'auto_download'-attribute of specific FeedItem.
+     *
+     * @param context A context that is used for opening a database connection.
+     * @param feedItem  FeedItem.
+     */
+    public static Future<?> setFeedItemAutoDownload(final Context context, final FeedItem feedItem,
+                                                    final boolean autoDownload) {
+        Log.d(TAG, "FeedItem[id=" + feedItem.getId() + "] SET auto_download " + autoDownload);
+        return dbExec.submit(new Runnable() {
+
+            @Override
+            public void run() {
+                final PodDBAdapter adapter = new PodDBAdapter(context);
+                adapter.open();
+                adapter.setFeedItemAutoDownload(feedItem, autoDownload);
+                adapter.close();
+
+                EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
+            }
+        });
+
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -186,7 +186,8 @@ public class PodDBAdapter {
             + KEY_MEDIA + " INTEGER," + KEY_FEED + " INTEGER,"
             + KEY_HAS_CHAPTERS + " INTEGER," + KEY_ITEM_IDENTIFIER + " TEXT,"
             + KEY_FLATTR_STATUS + " INTEGER,"
-            + KEY_IMAGE + " INTEGER)";
+            + KEY_IMAGE + " INTEGER,"
+            + KEY_AUTO_DOWNLOAD + " INTEGER)";
 
     public static final String CREATE_TABLE_FEED_IMAGES = "CREATE TABLE "
             + TABLE_NAME_FEED_IMAGES + " (" + TABLE_PRIMARY_KEY + KEY_TITLE
@@ -286,7 +287,9 @@ public class PodDBAdapter {
             TABLE_NAME_FEED_ITEMS + "." + KEY_HAS_CHAPTERS,
             TABLE_NAME_FEED_ITEMS + "." + KEY_ITEM_IDENTIFIER,
             TABLE_NAME_FEED_ITEMS + "." + KEY_FLATTR_STATUS,
-            TABLE_NAME_FEED_ITEMS + "." + KEY_IMAGE};
+            TABLE_NAME_FEED_ITEMS + "." + KEY_IMAGE,
+            TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD
+    };
 
     /**
      * Contains FEEDITEM_SEL_FI_SMALL as comma-separated list. Useful for raw queries.
@@ -696,6 +699,7 @@ public class PodDBAdapter {
         values.put(KEY_HAS_CHAPTERS, item.getChapters() != null || item.hasChapters());
         values.put(KEY_ITEM_IDENTIFIER, item.getItemIdentifier());
         values.put(KEY_FLATTR_STATUS, item.getFlattrStatus().toLong());
+        values.put(KEY_AUTO_DOWNLOAD, item.getAutoDownload());
         if (item.hasItemImage()) {
             if (item.getImage().getId() == 0) {
                 setImage(item.getImage());
@@ -785,6 +789,13 @@ public class PodDBAdapter {
                     new String[]{String.valueOf(status.getId())});
         }
         return status.getId();
+    }
+
+    public void setFeedItemAutoDownload(FeedItem feedItem, boolean autoDownload) {
+        ContentValues values = new ContentValues();
+        values.put(KEY_AUTO_DOWNLOAD, autoDownload);
+        db.update(TABLE_NAME_FEED_ITEMS, values, KEY_ID + "=?",
+                    new String[] { String.valueOf(feedItem.getId()) } );
     }
 
     public long getDownloadLogSize() {

--- a/core/src/main/res/values-az/strings.xml
+++ b/core/src/main/res/values-az/strings.xml
@@ -76,7 +76,7 @@
   <string name="download_error_connection_error">Əlaqə xətasi</string>
   <string name="download_error_unknown_host">Naməlum xost</string>
   <string name="cancel_all_downloads_label">Yükləmələrin hamısını ləğv et</string>
-  <string name="download_cancelled_msg">Yükləmə ləğv olundu</string>
+  <string name="download_canceled_msg">Yükləmə ləğv olundu</string>
   <string name="download_report_title">Yükləmə başa çatdı</string>
   <string name="download_error_malformed_url">Yanlış URL</string>
   <string name="download_error_io_error">IO xətasi</string>

--- a/core/src/main/res/values-ca/strings.xml
+++ b/core/src/main/res/values-ca/strings.xml
@@ -108,7 +108,7 @@
   <string name="download_error_unknown_host">Amfitrió desconegut</string>
   <string name="download_error_unauthorized">Error d\'autenticació</string>
   <string name="cancel_all_downloads_label">Cancel·la totes les baixades</string>
-  <string name="download_cancelled_msg">S\'ha cancel·lat la baixada</string>
+  <string name="download_canceled_msg">S\'ha cancel·lat la baixada</string>
   <string name="download_report_title">Baixades completades</string>
   <string name="download_error_malformed_url">URL mal formatada</string>
   <string name="download_error_io_error">Error d\'E/S</string>

--- a/core/src/main/res/values-cs-rCZ/strings.xml
+++ b/core/src/main/res/values-cs-rCZ/strings.xml
@@ -108,7 +108,7 @@
   <string name="download_error_unknown_host">Neznámý host</string>
   <string name="download_error_unauthorized">Chyba přihlášení</string>
   <string name="cancel_all_downloads_label">Zrušit všechna stahování</string>
-  <string name="download_cancelled_msg">Stahování zrušeno</string>
+  <string name="download_canceled_msg">Stahování zrušeno</string>
   <string name="download_report_title">Všechna stahování dokončena</string>
   <string name="download_error_malformed_url">Chybné URL</string>
   <string name="download_error_io_error">IO chyba</string>

--- a/core/src/main/res/values-da/strings.xml
+++ b/core/src/main/res/values-da/strings.xml
@@ -108,7 +108,7 @@
   <string name="download_error_unknown_host">Ukendt vært</string>
   <string name="download_error_unauthorized">Godkendelses fejl</string>
   <string name="cancel_all_downloads_label">Annuller alle downloads</string>
-  <string name="download_cancelled_msg">Download afbrudt</string>
+  <string name="download_canceled_msg">Download afbrudt</string>
   <string name="download_report_title">Downloads afsluttet</string>
   <string name="download_error_malformed_url">Misdannet URL</string>
   <string name="download_error_io_error">IO fejl</string>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Unbekannter Host</string>
   <string name="download_error_unauthorized">Authentifizierungsfehler</string>
   <string name="cancel_all_downloads_label">Alle Downloads abbrechen</string>
-  <string name="download_cancelled_msg">Download abgebrochen</string>
+  <string name="download_canceled_msg">Download abgebrochen</string>
   <string name="download_report_title">Download abgeschlossen</string>
   <string name="download_error_malformed_url">Fehler in URL</string>
   <string name="download_error_io_error">E/A Error</string>

--- a/core/src/main/res/values-es-rES/strings.xml
+++ b/core/src/main/res/values-es-rES/strings.xml
@@ -72,7 +72,7 @@
   <string name="download_error_connection_error">Error de conexión</string>
   <string name="download_error_unknown_host">Host desconocido</string>
   <string name="cancel_all_downloads_label">Cancelar todas las descargas</string>
-  <string name="download_cancelled_msg">Descarga cancelada</string>
+  <string name="download_canceled_msg">Descarga cancelada</string>
   <string name="download_report_title">Descargas completadas</string>
   <string name="download_error_malformed_url">URL malformada</string>
   <string name="download_error_io_error">Error de E/S</string>

--- a/core/src/main/res/values-es/strings.xml
+++ b/core/src/main/res/values-es/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Host desconocido</string>
   <string name="download_error_unauthorized">Error de autenticación</string>
   <string name="cancel_all_downloads_label">Cancelar todas las descargas</string>
-  <string name="download_cancelled_msg">Descarga cancelada</string>
+  <string name="download_canceled_msg">Descarga cancelada</string>
   <string name="download_report_title">Descargas completadas</string>
   <string name="download_error_malformed_url">URL con formato incorrecto</string>
   <string name="download_error_io_error">Error de E/S</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Hôte inconnu</string>
   <string name="download_error_unauthorized">Erreur d\'authentification</string>
   <string name="cancel_all_downloads_label">Annuler tous les téléchargements</string>
-  <string name="download_cancelled_msg">Téléchargement annulé</string>
+  <string name="download_canceled_msg">Téléchargement annulé</string>
   <string name="download_report_title">Téléchargements terminés</string>
   <string name="download_error_malformed_url">URL incorrecte</string>
   <string name="download_error_io_error">Erreur d\'E/S</string>

--- a/core/src/main/res/values-hi-rIN/strings.xml
+++ b/core/src/main/res/values-hi-rIN/strings.xml
@@ -91,7 +91,7 @@
   <string name="download_error_connection_error">कनेक्शन त्रुटि</string>
   <string name="download_error_unknown_host">अज्ञात होस्ट</string>
   <string name="cancel_all_downloads_label">सभी डाउनलोड रद्द  करें</string>
-  <string name="download_cancelled_msg">डाउनलोड रद्द</string>
+  <string name="download_canceled_msg">डाउनलोड रद्द</string>
   <string name="download_report_title">डाउनलोड पूरा हो गया है</string>
   <string name="download_error_malformed_url">गलत URL</string>
   <string name="download_error_io_error">आईओ त्रुटि</string>

--- a/core/src/main/res/values-it-rIT/strings.xml
+++ b/core/src/main/res/values-it-rIT/strings.xml
@@ -109,7 +109,7 @@
   <string name="download_error_unknown_host">Host sconosciuto</string>
   <string name="download_error_unauthorized">Errore di autenticazione</string>
   <string name="cancel_all_downloads_label">Annulla tutti i download</string>
-  <string name="download_cancelled_msg">Download annullato</string>
+  <string name="download_canceled_msg">Download annullato</string>
   <string name="download_report_title">Download completati</string>
   <string name="download_error_malformed_url">URL malformato</string>
   <string name="download_error_io_error">Errore IO</string>

--- a/core/src/main/res/values-iw-rIL/strings.xml
+++ b/core/src/main/res/values-iw-rIL/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">שרת לא ידוע</string>
   <string name="download_error_unauthorized">שגיאת אימות</string>
   <string name="cancel_all_downloads_label">בטל את כל ההורדות</string>
-  <string name="download_cancelled_msg">הורדה בוטלה</string>
+  <string name="download_canceled_msg">הורדה בוטלה</string>
   <string name="download_report_title">הורדות הושלמו</string>
   <string name="download_error_malformed_url">כתובת אתר שגויה</string>
   <string name="download_error_io_error">שגיאת קלט פלט</string>

--- a/core/src/main/res/values-ja/strings.xml
+++ b/core/src/main/res/values-ja/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">ホスト不明</string>
   <string name="download_error_unauthorized">認証エラー</string>
   <string name="cancel_all_downloads_label">すべてのダウンロードをキャンセル</string>
-  <string name="download_cancelled_msg">ダウンロードをキャンセルしました</string>
+  <string name="download_canceled_msg">ダウンロードをキャンセルしました</string>
   <string name="download_report_title">ダウンロードが完了しました</string>
   <string name="download_error_malformed_url">不正な形式のURL</string>
   <string name="download_error_io_error">IOエラー</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">알 수 없는 호스트</string>
   <string name="download_error_unauthorized">인증 오류</string>
   <string name="cancel_all_downloads_label">모든 다운로드 취소</string>
-  <string name="download_cancelled_msg">다운로드 취소됨</string>
+  <string name="download_canceled_msg">다운로드 취소됨</string>
   <string name="download_report_title">다운로드 마침</string>
   <string name="download_error_malformed_url">URL 형식 틀림</string>
   <string name="download_error_io_error">입출력 오류</string>

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -86,7 +86,7 @@
   <string name="download_error_unknown_host">Onbekende host</string>
   <string name="download_error_unauthorized">Authenticatie fout</string>
   <string name="cancel_all_downloads_label">Alle downloads annuleren</string>
-  <string name="download_cancelled_msg">Download geannuleerd</string>
+  <string name="download_canceled_msg">Download geannuleerd</string>
   <string name="download_report_title">Downloads afgerond</string>
   <string name="download_error_malformed_url">Misvormde URL</string>
   <string name="download_error_io_error">IO fout</string>

--- a/core/src/main/res/values-pl-rPL/strings.xml
+++ b/core/src/main/res/values-pl-rPL/strings.xml
@@ -108,7 +108,7 @@
   <string name="download_error_unknown_host">Nieznany host</string>
   <string name="download_error_unauthorized">Błąd autoryzacji</string>
   <string name="cancel_all_downloads_label">Anuluj wszystkie pobierania</string>
-  <string name="download_cancelled_msg">Pobieranie anulowane</string>
+  <string name="download_canceled_msg">Pobieranie anulowane</string>
   <string name="download_report_title">Pobieranie ukończone</string>
   <string name="download_error_malformed_url">Niepoprawny adres</string>
   <string name="download_error_io_error">Błąd wejścia/wyjścia</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -85,7 +85,7 @@
   <string name="download_error_connection_error">Erro de conexão</string>
   <string name="download_error_unknown_host">Host desconhecido</string>
   <string name="cancel_all_downloads_label">Cancelar todos os downloads</string>
-  <string name="download_cancelled_msg">Download cancelado</string>
+  <string name="download_canceled_msg">Download cancelado</string>
   <string name="download_report_title">Downloads finalizados</string>
   <string name="download_error_malformed_url">URL inválida</string>
   <string name="download_error_io_error">Erro de IO</string>

--- a/core/src/main/res/values-pt/strings.xml
+++ b/core/src/main/res/values-pt/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Servidor desconhecido</string>
   <string name="download_error_unauthorized">Erro de autenticação</string>
   <string name="cancel_all_downloads_label">Cancelar transferências</string>
-  <string name="download_cancelled_msg">Transferência cancelada</string>
+  <string name="download_canceled_msg">Transferência cancelada</string>
   <string name="download_report_title">Transferências terminadas</string>
   <string name="download_error_malformed_url">URL inválido</string>
   <string name="download_error_io_error">Erro I/O</string>

--- a/core/src/main/res/values-ro-rRO/strings.xml
+++ b/core/src/main/res/values-ro-rRO/strings.xml
@@ -80,7 +80,7 @@
   <string name="download_error_connection_error">Eroare de conexiune</string>
   <string name="download_error_unknown_host">Host necunoscut</string>
   <string name="cancel_all_downloads_label">Anulează toate descărcările</string>
-  <string name="download_cancelled_msg">Descărcare anulată</string>
+  <string name="download_canceled_msg">Descărcare anulată</string>
   <string name="download_report_title">Descărcări terminate</string>
   <string name="download_error_malformed_url">URL malformat</string>
   <string name="download_error_io_error">Eroare IO</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Неизвестный узел</string>
   <string name="download_error_unauthorized">Ошибка авторизации</string>
   <string name="cancel_all_downloads_label">Отменить все загрузки</string>
-  <string name="download_cancelled_msg">Загрузка отменена</string>
+  <string name="download_canceled_msg">Загрузка отменена</string>
   <string name="download_report_title">Загрузки завершены</string>
   <string name="download_error_malformed_url">Неправильный адрес</string>
   <string name="download_error_io_error">Ошибка ввода-вывода</string>

--- a/core/src/main/res/values-sv-rSE/strings.xml
+++ b/core/src/main/res/values-sv-rSE/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Okänd värd</string>
   <string name="download_error_unauthorized">Autentiseringsproblem</string>
   <string name="cancel_all_downloads_label">Avbryt alla nedladdningar</string>
-  <string name="download_cancelled_msg">Nedladdning avbruten</string>
+  <string name="download_canceled_msg">Nedladdning avbruten</string>
   <string name="download_report_title">Nedladdningar färdiga</string>
   <string name="download_error_malformed_url">Felaktig webbadress</string>
   <string name="download_error_io_error">IO fel</string>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Bilinmeyen sunucu</string>
   <string name="download_error_unauthorized">Yetkilendirme hatası</string>
   <string name="cancel_all_downloads_label">Bütün indirmeleri iptal et</string>
-  <string name="download_cancelled_msg">İndirme iptal edildi</string>
+  <string name="download_canceled_msg">İndirme iptal edildi</string>
   <string name="download_report_title">İndirme tamamlandı</string>
   <string name="download_error_malformed_url">Bozuk URL</string>
   <string name="download_error_io_error">G/Ç Hatası</string>

--- a/core/src/main/res/values-uk-rUA/strings.xml
+++ b/core/src/main/res/values-uk-rUA/strings.xml
@@ -112,7 +112,7 @@
   <string name="download_error_unknown_host">Невідомий host</string>
   <string name="download_error_unauthorized">Помилка автентифікації</string>
   <string name="cancel_all_downloads_label">Скасувати всі завантаження</string>
-  <string name="download_cancelled_msg">Відмінено завантаження</string>
+  <string name="download_canceled_msg">Відмінено завантаження</string>
   <string name="download_report_title">Завантажили</string>
   <string name="download_error_malformed_url">Невірний URL</string>
   <string name="download_error_io_error">Помилка IO</string>

--- a/core/src/main/res/values-zh-rCN/strings.xml
+++ b/core/src/main/res/values-zh-rCN/strings.xml
@@ -103,7 +103,7 @@
   <string name="download_error_unknown_host">未知主机</string>
   <string name="download_error_unauthorized">认证错误</string>
   <string name="cancel_all_downloads_label">取消所有下载</string>
-  <string name="download_cancelled_msg">已取消下载</string>
+  <string name="download_canceled_msg">已取消下载</string>
   <string name="download_report_title">下载完成</string>
   <string name="download_error_malformed_url">畸形 URL</string>
   <string name="download_error_io_error">IO 错误</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -128,8 +128,8 @@
     <string name="download_error_unknown_host">Unknown host</string>
     <string name="download_error_unauthorized">Authentication error</string>
     <string name="cancel_all_downloads_label">Cancel all downloads</string>
-    <string name="download_cancelled_msg">Download cancelled</string>
-    <string name="download_cancelled_autodownload_enabled_msg">Download cancelled\nDisabled <i>Auto Download</i> for this item</string>
+    <string name="download_canceled_msg">Download canceled</string>
+    <string name="download_canceled_autodownload_enabled_msg">Download canceled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="download_report_content_title">Download report</string>
     <string name="download_error_malformed_url">Malformed URL</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="download_error_unauthorized">Authentication error</string>
     <string name="cancel_all_downloads_label">Cancel all downloads</string>
     <string name="download_cancelled_msg">Download cancelled</string>
+    <string name="download_cancelled_autodownload_enabled_msg">Download cancelled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="download_report_content_title">Download report</string>
     <string name="download_error_malformed_url">Malformed URL</string>


### PR DESCRIPTION
* Creates a new field boolean auto_download field in the DB's FeedItem model (default: true).
* When the user cancels a (manual or automatic) download, this field is set to false.
* Migration: The value for existing FeedItems is read from the Feed's auto_download field.
* Refactoring of the Auto Download algorithm. When IDs are provided, don't read all  items that are queued or unread and filter by ID, pull items with an acceptable ID from the database directly.

Resolves #760 