### PR TITLE
Episodes with a PlaybackCompletionDate should be delete before those without.

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -41,10 +41,10 @@ public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
                 Date r = rhs.getMedia().getPlaybackCompletionDate();
 
                 if (l == null) {
-                    l = new Date(0);
+                    l = new Date();
                 }
                 if (r == null) {
-                    r = new Date(0);
+                    r = new Date();
                 }
                 return l.compareTo(r);
             }


### PR DESCRIPTION
Episodes that are not played yet (getPlaybackCompletionDate()==null) should be sorted in as now and not 1.1.1970

When sorted in as "now", these episodes are delete later in auto cleanup mode, than played once.