### PR TITLE
Convert AsyncTasks to IntentService 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,7 @@
 
         <service android:name=".asynctask.OpmlFeedQueuer" android:exported="false"/>
         <service android:name=".asynctask.OpmlExportWorker" android:exported="false"/>
+        <service android:name=".fragment.ItemDescriptionFragment$GetFeedItemService" android:exported="false"/>
 
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,7 @@
         <service android:name=".fragment.ItemDescriptionFragment$GetFeedItemService" android:exported="false"/>
         <service android:name=".activity.FeedInfoActivity$GetFeedService" android:exported="false"/>
         <service android:name=".adapter.itunes.ItunesAdapter$FetchImageService" android:exported="false"/>
+        <service android:name=".fragment.ItunesSearchFragment$SearchService" android:exported="false"/>
 
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -97,6 +97,7 @@
         </service>
 
         <service android:name=".asynctask.OpmlFeedQueuer" android:exported="false"/>
+        <service android:name=".asynctask.OpmlExportWorker" android:exported="false"/>
 
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,7 @@
         <service android:name=".asynctask.OpmlFeedQueuer" android:exported="false"/>
         <service android:name=".asynctask.OpmlExportWorker" android:exported="false"/>
         <service android:name=".fragment.ItemDescriptionFragment$GetFeedItemService" android:exported="false"/>
+        <service android:name=".activity.FeedInfoActivity$GetFeedService" android:exported="false"/>
 
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,7 @@
         <service android:name=".activity.FeedInfoActivity$GetFeedService" android:exported="false"/>
         <service android:name=".adapter.itunes.ItunesAdapter$FetchImageService" android:exported="false"/>
         <service android:name=".fragment.ItunesSearchFragment$SearchService" android:exported="false"/>
+        <service android:name=".activity.DefaultOnlineFeedViewActivity$GetFeedListService" android:exported="false"/>
 
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,6 +96,8 @@
             android:exported="false">
         </service>
 
+        <service android:name=".asynctask.OpmlFeedQueuer" android:exported="false"/>
+
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,6 +100,7 @@
         <service android:name=".asynctask.OpmlExportWorker" android:exported="false"/>
         <service android:name=".fragment.ItemDescriptionFragment$GetFeedItemService" android:exported="false"/>
         <service android:name=".activity.FeedInfoActivity$GetFeedService" android:exported="false"/>
+        <service android:name=".adapter.itunes.ItunesAdapter$FetchImageService" android:exported="false"/>
 
         <receiver android:name=".receiver.PlayerWidget">
             <intent-filter>

--- a/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
@@ -1,9 +1,13 @@
 package de.danoeh.antennapod.adapter.itunes;
 
+import android.app.IntentService;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.os.AsyncTask;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -24,6 +28,8 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 
 public class ItunesAdapter extends ArrayAdapter<ItunesAdapter.Podcast> {
+    private static final String FETCH_IMAGE_FILTER = "ItunesAdapter_receiver";
+
     /**
      * Related Context
      */
@@ -49,12 +55,7 @@ public class ItunesAdapter extends ArrayAdapter<ItunesAdapter.Podcast> {
     /**
      * Updates the given ImageView with the image in the given Podcast's imageUrl
      */
-    class FetchImageTask extends  AsyncTask<Void,Void,Bitmap>{
-        /**
-         * Current podcast
-         */
-        private final Podcast podcast;
-
+    class FetchImageReceiver extends BroadcastReceiver {
         /**
          * ImageView to be updated
          */
@@ -63,34 +64,46 @@ public class ItunesAdapter extends ArrayAdapter<ItunesAdapter.Podcast> {
         /**
          * Constructor
          *
-         * @param podcast Podcast that has the image
          * @param imageView UI image to be updated
          */
-        FetchImageTask(Podcast podcast, ImageView imageView){
-            this.podcast = podcast;
+        FetchImageReceiver(ImageView imageView){
             this.imageView = imageView;
-        }
-
-        //Get the image from the url
-        @Override
-        protected Bitmap doInBackground(Void... params) {
-            HttpClient client = new DefaultHttpClient();
-            HttpGet get = new HttpGet(podcast.imageUrl);
-            try {
-                HttpResponse response = client.execute(get);
-                return BitmapFactory.decodeStream(response.getEntity().getContent());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            return null;
         }
 
         //Set the background image for the podcast
         @Override
-        protected void onPostExecute(Bitmap img) {
-            super.onPostExecute(img);
+        public void onReceive(Context receiverContext, Intent receiverIntent) {
+            Bitmap img = (Bitmap) receiverIntent.getParcelableExtra("bitmap");
             if(img!=null) {
                 imageView.setImageBitmap(img);
+            }
+        }
+    }
+
+    public static class FetchImageService extends IntentService {
+        /**
+         * Current podcast that has the image
+         */
+        Podcast podcast;
+
+        public FetchImageService() {
+            super("FetchImageService");
+        }
+
+        //Get the image from the url
+        public void onHandleIntent(Intent intent) {
+            podcast = (Podcast) intent.getSerializableExtra("podcast");
+            HttpClient client = new DefaultHttpClient();
+            HttpGet get = new HttpGet(podcast.imageUrl);
+            try {
+                HttpResponse response = client.execute(get);
+                Intent resultIntent = new Intent(FETCH_IMAGE_FILTER);
+                resultIntent.putExtra("bitmap", BitmapFactory
+                        .decodeStream(response.getEntity().getContent()));
+                LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+                return;
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }
@@ -121,7 +134,12 @@ public class ItunesAdapter extends ArrayAdapter<ItunesAdapter.Podcast> {
         viewHolder.titleView.setText(podcast.title);
 
         //Update the empty imageView with the image from the feed
-        new FetchImageTask(podcast,viewHolder.coverView).execute();
+        FetchImageReceiver receiver = new FetchImageReceiver(viewHolder.coverView);
+        LocalBroadcastManager.getInstance(context)
+            .registerReceiver(receiver, new IntentFilter(FETCH_IMAGE_FILTER));
+        Intent fetchImage = new Intent(context, FetchImageService.class);
+        fetchImage.putExtra("podcast", podcast);
+        context.startService(fetchImage);
 
         //Feed the grid view
         return view;

--- a/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
@@ -156,7 +156,9 @@ public class ItunesAdapter extends ArrayAdapter<ItunesAdapter.Podcast> {
     /**
      * Represents an individual podcast on the iTunes Store.
      */
-    public static class Podcast { //TODO: Move this out eventually. Possibly to core.itunes.model
+    public static class Podcast implements java.io.Serializable { //TODO: Move this out eventually. Possibly to core.itunes.model
+
+        private static final long serialVersionUID = 866610209692496362L;
 
         /**
          * The name of the podcast

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
@@ -14,6 +15,7 @@ import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
+import android.support.v4.content.LocalBroadcastManager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -33,6 +35,7 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.activity.PreferenceActivity;
 import de.danoeh.antennapod.activity.PreferenceActivityGingerbread;
 import de.danoeh.antennapod.asynctask.OpmlExportWorker;
+import de.danoeh.antennapod.asynctask.OpmlExportWorker.OpmlExportWorkerReceiver;
 import de.danoeh.antennapod.core.asynctask.FlattrClickWorker;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
@@ -153,8 +156,14 @@ public class PreferenceController {
 
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
-                        new OpmlExportWorker(activity)
-                                .executeAsync();
+                        final String INTENT_FILTER = "PreferenceController_opmlExportReceiver";
+                        OpmlExportWorkerReceiver opmlExportReceiver = new OpmlExportWorkerReceiver(activity);
+                        LocalBroadcastManager.getInstance(activity)
+                            .registerReceiver(opmlExportReceiver, new IntentFilter(INTENT_FILTER));
+                        opmlExportReceiver.showProgDialog();
+                        Intent opmlExportWorker = new Intent(activity, OpmlExportWorker.class);
+                        opmlExportWorker.putExtra("INTENT_FILTER", INTENT_FILTER);
+                        activity.startService(opmlExportWorker);
 
                         return true;
                     }

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
         <service
             android:name=".service.GpodnetSyncService"
             android:enabled="true" />
+        <service
+            android:name=".util.playback.PlaybackController$GetPlayedMediaIntent"
+            android:exported="false" />
 
         <receiver
             android:name=".receiver.MediaButtonReceiver"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedComponent.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedComponent.java
@@ -5,8 +5,9 @@ package de.danoeh.antennapod.core.feed;
  *
  * @author daniel
  */
-public abstract class FeedComponent {
+public abstract class FeedComponent implements java.io.Serializable {
 
+    private static final long serialVersionUID = 4368540112109834054L;
     protected long id;
 
     public FeedComponent() {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -7,8 +7,9 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Contains preferences for a single feed.
  */
-public class FeedPreferences {
+public class FeedPreferences implements java.io.Serializable {
 
+    private static final long serialVersionUID = 4695407354058817609L;
     private long feedID;
     private boolean autoDownload;
     private String username;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -125,7 +125,7 @@ public final class DBTasks {
             }
             // Start playback Service
             Intent launchIntent = new Intent(context, PlaybackService.class);
-            launchIntent.putExtra(PlaybackService.EXTRA_PLAYABLE, media);
+            launchIntent.putExtra(PlaybackService.EXTRA_PLAYABLE, (android.os.Parcelable) media);
             launchIntent.putExtra(PlaybackService.EXTRA_START_WHEN_PREPARED,
                     startWhenPrepared);
             launchIntent.putExtra(PlaybackService.EXTRA_SHOULD_STREAM,

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrStatus.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrStatus.java
@@ -2,7 +2,9 @@ package de.danoeh.antennapod.core.util.flattr;
 
 import java.util.Calendar;
 
-public class FlattrStatus {
+public class FlattrStatus implements java.io.Serializable {
+
+	private static final long serialVersionUID = -1077957744810896350L;
 	public static final int STATUS_UNFLATTERED = 0;
 	public static final int STATUS_QUEUE = 1;
 	public static final int STATUS_FLATTRED = 2;


### PR DESCRIPTION
Hi `AntennaPod` developers, I'm a Ph.D. student and doing research on Android async programming, particularly on AsyncTask and IntentService. AsyncTask can lead to memory leak and losing task result when GUI is recreated during task running (such as orientation change). [This article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html) describes the problems very well. 

We discussed with some Android experts and they agree with this issue, and claim that AsyncTask can be considered only for short tasks (less than 1 second). However, using IntentService (or AsyncTaskLoader) can avoid such problems since their lifecycles are independent from `Activity`/`Fragment`.

In `AntennaPod `, many of the AsyncTasks are declared as non-static inner classes of `Activity`/`Fragment`. So the above issue can occur (especially for relatively long tasks).

I refactored 8 AsyncTasks in `AntennaPod ` to IntentService (in separate commits), with the help of a refactoring tool we developed. I also mark some types as `Serializable` in order to put them into Intent. Do you think using IntentService should be better in some of these 8 scenario? Do you want to merge (some) commits in this pr? Thanks.