### PR TITLE
Fixed another minor typo

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -148,8 +148,8 @@
     <string name="authentication_notification_title">Authentication required</string>
     <string name="authentication_notification_msg">The resource you requested requires a username and a password</string>
     <string name="confirm_mobile_download_dialog_title">Confirm Mobile Download</string>
-    <string name="confirm_mobile_download_dialog_message_not_in_queue">Downloading over mobile data connection is disabled in the settings.\n\nEnable temporarily or just add to queue?\n\n<small>Your choice will be remember for 10 minutes.</small></string>
-    <string name="confirm_mobile_download_dialog_message">Downloading over mobile data connection is disabled in the settings.\n\nEnable temporarily?\n\n<small>Your choice will be remember for 10 minutes.</small></string>
+    <string name="confirm_mobile_download_dialog_message_not_in_queue">"Downloading over mobile data connection" is disabled in the settings.\n\nEnable temporarily or just add to queue?\n\n<small>Your choice will be remembered for 10 minutes.</small></string>
+    <string name="confirm_mobile_download_dialog_message">"Downloading over mobile data connection" is disabled in the settings.\n\nEnable temporarily?\n\n<small>Your choice will be remembered for 10 minutes.</small></string>
     <string name="confirm_mobile_download_dialog_only_add_to_queue">Only add to Queue</string>
     <string name="confirm_mobile_download_dialog_enable_temporarily">Enable temporarily</string>
 


### PR DESCRIPTION
Also added quotes around the setting string to better parse the message. Otherwise it sounds like:

> "[This app is currently] Downloading over mobile data connection is disabled in the settings"

which seems grammatically incorrect until realizing that the first part is referring to the setting, and not an action currently being undertaken.