### PR TITLE
Gpodder synchronization fixes

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
@@ -11,7 +11,20 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.*;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.ViewFlipper;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
 import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
@@ -21,11 +34,6 @@ import de.danoeh.antennapod.core.gpoddernet.model.GpodnetDevice;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.GpodnetSyncService;
-
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Guides the user through the authentication process

--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/model/GpodnetEpisodeAction.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/model/GpodnetEpisodeAction.java
@@ -258,7 +258,7 @@ public class GpodnetEpisodeAction {
         private int total = -1;
 
         public Builder(FeedItem item, Action action) {
-            this(item.getFeed().getDownload_url(), item.getItemIdentifier(), action);
+            this(item.getFeed().getDownload_url(), item.getMedia().getDownload_url(), action);
         }
 
         public Builder(String podcast, String episode, Action action) {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
@@ -173,7 +173,7 @@ public class GpodnetPreferences {
             writePreference(PREF_SYNC_REMOVED, removedFeeds);
         }
         feedListLock.unlock();
-        GpodnetSyncService.sendSyncIntent(ClientConfig.applicationCallbacks.getApplicationInstance());
+        GpodnetSyncService.sendSyncSubscriptionsIntent(ClientConfig.applicationCallbacks.getApplicationInstance());
     }
 
     public static void addRemovedFeed(String feed) {
@@ -186,7 +186,7 @@ public class GpodnetPreferences {
             writePreference(PREF_SYNC_ADDED, addedFeeds);
         }
         feedListLock.unlock();
-        GpodnetSyncService.sendSyncIntent(ClientConfig.applicationCallbacks.getApplicationInstance());
+        GpodnetSyncService.sendSyncSubscriptionsIntent(ClientConfig.applicationCallbacks.getApplicationInstance());
     }
 
     public static Set<String> getAddedFeedsCopy() {
@@ -225,6 +225,7 @@ public class GpodnetPreferences {
         ensurePreferencesLoaded();
         queuedEpisodeActions.add(action);
         writePreference(PREF_SYNC_EPISODE_ACTIONS, writeEpisodeActionsToString(queuedEpisodeActions));
+        GpodnetSyncService.sendSyncActionsIntent(ClientConfig.applicationCallbacks.getApplicationInstance());
     }
 
     public static List<GpodnetEpisodeAction> getQueuedEpisodeActions() {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -171,10 +171,10 @@ public final class DBTasks {
                     isRefreshing.set(false);
 
                     if (FlattrUtils.hasToken()) {
-                        if (BuildConfig.DEBUG) Log.d(TAG, "Flattring all pending things.");
+                        Log.d(TAG, "Flattring all pending things.");
                         new FlattrClickWorker(context).executeAsync(); // flattr pending things
 
-                        if (BuildConfig.DEBUG) Log.d(TAG, "Fetching flattr status.");
+                        Log.d(TAG, "Fetching flattr status.");
                         new FlattrStatusFetcher(context).start();
 
                     }
@@ -185,9 +185,7 @@ public final class DBTasks {
                 }
             }.start();
         } else {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG,
-                        "Ignoring request to refresh all feeds: Refresh lock is locked");
+            Log.d(TAG, "Ignoring request to refresh all feeds: Refresh lock is locked");
         }
     }
 


### PR DESCRIPTION
[Interesting stuff is in the second commit]

Changes 'n' Fixes:
* Episode actions are sent immediately (not only on feed refresh)
* Fixed episode identifier
* Local changes overwrite remote changes: If gpodder sends a podcast unsubscribe, but the local changes include subscribing to that podcast, we go with the local information.<br>Reasoning: Subscriptions are sync immediately after adding/removing, our local data is most likely more recent