### PR TITLE
restored alignment for progress bar in episode view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="51"
+    android:versionCode="52"
     android:versionName="1.2">
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -99,8 +99,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="8dp"
                 android:layout_marginRight="8dp"
-                android:layout_toLeftOf="@id/txtvPublished"
-                android:layout_toRightOf="@id/txtvDuration"
+                android:layout_alignParentLeft="true"
+                android:layout_toLeftOf="@id/imgvInPlaylist"
                 android:max="100" />
 
         </RelativeLayout>


### PR DESCRIPTION
Put the placement of the progress bar back the way it was before #808.

I think the issue is that it can't be aligned left or right of things that aren't currently displayed. Since txtvDuration and txtvPublished are both hidden when the progress bar is displayed it doesn't get shown properly.

fixes AntennaPod…/AntennaPod#822