### PR TITLE
Allow auto downloading of queued but played episodes

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -403,7 +403,6 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
         return this.hasMedia() &&
                 false == this.getMedia().isPlaying() &&
                 false == this.getMedia().isDownloaded() &&
-                false == this.isRead() &&
                 this.getAutoDownload();
     }
 


### PR DESCRIPTION
Resolves #839

This is only used by the auto download algorithm. Auto download candidates are items in the queue and unplayed items. For the later, the removed criteria is always true.
Episodes in the queue should be auto downloaded regardless if they are played or not.