### PR TITLE
Fix for drawer layout and refreshing feeds that failed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.IconTextView;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.squareup.picasso.Picasso;
@@ -267,8 +268,12 @@ public class NavListAdapter extends BaseAdapter
 
 
         if(feed.hasLastUpdateFailed()) {
+            RelativeLayout.LayoutParams p = (RelativeLayout.LayoutParams) holder.title.getLayoutParams();
+            p.addRule(RelativeLayout.LEFT_OF, R.id.itxtvFailure);
             holder.failure.setVisibility(View.VISIBLE);
         } else {
+            RelativeLayout.LayoutParams p = (RelativeLayout.LayoutParams) holder.title.getLayoutParams();
+            p.addRule(RelativeLayout.LEFT_OF, R.id.txtvCount);
             holder.failure.setVisibility(View.GONE);
         }
         int feedUnreadItems = itemAccess.getNumberOfUnreadFeedItems(feed.getId());
@@ -277,7 +282,7 @@ public class NavListAdapter extends BaseAdapter
             holder.count.setText(String.valueOf(feedUnreadItems));
             holder.count.setTypeface(holder.title.getTypeface());
         } else {
-            holder.count.setVisibility(View.INVISIBLE);
+            holder.count.setVisibility(View.GONE);
         }
         return convertView;
     }

--- a/app/src/main/res/layout/nav_feedlistitem.xml
+++ b/app/src/main/res/layout/nav_feedlistitem.xml
@@ -5,6 +5,7 @@
                 android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/listitem_iconwithtext_height"
+                android:paddingRight="@dimen/listitem_threeline_verticalpadding"
                 tools:background="@android:color/darker_gray">
 
     <ImageView
@@ -24,30 +25,13 @@
         tools:background="@android:color/holo_green_dark"/>
 
     <TextView
-        android:id="@+id/txtvTitle"
-        android:lines="1"
-        android:ellipsize="end"
-        android:singleLine="true"
-        android:layout_centerVertical="true"
-        android:textColor="?android:attr/textColorPrimary"
-        android:textSize="@dimen/text_size_navdrawer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/listitem_iconwithtext_textleftpadding"
-        android:layout_marginRight="@dimen/listitem_icon_rightpadding"
-        android:layout_toRightOf="@id/imgvCover"
-        tools:text="Navigation feed item title"
-        tools:background="@android:color/holo_green_dark"/>
-
-    <TextView
         android:id="@+id/txtvCount"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/list_vertical_padding"
         android:lines="1"
         android:textColor="?android:attr/textColorTertiary"
         android:textSize="@dimen/text_size_navdrawer"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="@dimen/listitem_icon_rightpadding"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         tools:text="23"
@@ -58,13 +42,32 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toLeftOf="@id/txtvCount"
+        android:layout_marginLeft="@dimen/list_vertical_padding"
+        android:layout_alignWithParentIfMissing="true"
         android:lines="1"
         android:text="{fa-exclamation-circle}"
         android:textColor="@color/download_failed_red"
         android:textSize="@dimen/text_size_navdrawer"
-        android:layout_marginLeft="8dp"
         android:layout_centerVertical="true"
         tools:text="!"
         tools:background="@android:color/holo_green_dark"/>
+
+    <TextView
+        android:id="@+id/txtvTitle"
+        android:lines="1"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:layout_centerVertical="true"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="@dimen/text_size_navdrawer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/listitem_iconwithtext_textleftpadding"
+        android:layout_toRightOf="@id/imgvCover"
+        android:layout_toLeftOf="@id/itxtvFailure"
+        android:layout_alignWithParentIfMissing="true"
+        tools:text="Navigation feed item title"
+        tools:background="@android:color/holo_green_dark"/>
+
 
 </RelativeLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -308,10 +308,11 @@ public final class DBTasks {
 
     private static void refreshFeed(Context context, Feed feed, boolean loadAllPages) throws DownloadRequestException {
         Feed f;
+        Date lastUpdate = feed.hasLastUpdateFailed() ? new Date(0) : feed.getLastUpdate();
         if (feed.getPreferences() == null) {
-            f = new Feed(feed.getDownload_url(), feed.getLastUpdate(), feed.getTitle());
+            f = new Feed(feed.getDownload_url(), lastUpdate, feed.getTitle());
         } else {
-            f = new Feed(feed.getDownload_url(), feed.getLastUpdate(), feed.getTitle(),
+            f = new Feed(feed.getDownload_url(), lastUpdate, feed.getTitle(),
                     feed.getPreferences().getUsername(), feed.getPreferences().getPassword());
         }
         f.setId(feed.getId());


### PR DESCRIPTION
Forgot to make a screenshot of the layout errors. Hiding some of the elements led to elements overlapping.

Fixed:

![nav](https://cloud.githubusercontent.com/assets/6860662/7870762/973a6182-058b-11e5-9818-294520f01b63.png)

