### PR TITLE
Fixes "gzip finished without exhausting source" error

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -188,13 +188,17 @@ public class HttpDownloader extends Downloader {
             }
 
             Log.d(TAG, "Starting download");
-            while (!cancelled
-                    && (count = connection.read(buffer)) != -1) {
-                out.write(buffer, 0, count);
-                request.setSoFar(request.getSoFar() + count);
-                request.setProgressPercent((int) (((double) request
-                        .getSoFar() / (double) request
-                        .getSize()) * 100));
+            try {
+                while (!cancelled
+                        && (count = connection.read(buffer)) != -1) {
+                    out.write(buffer, 0, count);
+                    request.setSoFar(request.getSoFar() + count);
+                    request.setProgressPercent((int) (((double) request
+                            .getSoFar() / (double) request
+                            .getSize()) * 100));
+                }
+            } catch(IOException e) {
+                Log.e(TAG, Log.getStackTraceString(e));
             }
             if (cancelled) {
                 onCancelled();
@@ -209,6 +213,9 @@ public class HttpDownloader extends Downloader {
                                     " does not equal expected size " +
                                     request.getSize()
                     );
+                    return;
+                } else if(request.getSoFar() == 0){
+                    onFail(DownloadError.ERROR_IO_ERROR, "Download completed, but nothing was read");
                     return;
                 }
                 onSuccess();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -214,7 +214,7 @@ public class HttpDownloader extends Downloader {
                                     request.getSize()
                     );
                     return;
-                } else if(request.getSoFar() == 0){
+                } else if(request.getSize() > 0 && request.getSoFar() == 0){
                     onFail(DownloadError.ERROR_IO_ERROR, "Download completed, but nothing was read");
                     return;
                 }


### PR DESCRIPTION
Resolves #854

I can only guess what exactly goes wrong here.
My guess is that okhttp either has a bug in its un-gzip and throws an error although the data was read correctly - or the server does not comply with some standard (e.g. there is no content-length field).

Catching the exception and just continuing as if nothing happened seems to work.

Not sure if additional checks would do any good. We could check the content length if it is sent by the server, but a lot of servers seem to get that wrong (sending the content length of the unzipped data)