### PR TITLE
Handle malformed URLs

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -2,6 +2,8 @@ package de.danoeh.antennapod.activity;
 
 import android.content.ClipData;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
@@ -30,6 +32,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequestException;
+import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LangUtils;
 import de.danoeh.antennapod.menuhandler.FeedMenuHandler;
 
@@ -205,7 +208,8 @@ public class FeedInfoActivity extends ActionBarActivity {
         menu.findItem(R.id.support_item).setVisible(
                 feed != null && feed.getPaymentLink() != null);
         menu.findItem(R.id.share_link_item).setVisible(feed != null && feed.getLink() != null);
-        menu.findItem(R.id.visit_website_item).setVisible(feed != null && feed.getLink() != null);
+        menu.findItem(R.id.visit_website_item).setVisible(feed != null && feed.getLink() != null &&
+                IntentUtils.isCallable(this, new Intent(Intent.ACTION_VIEW, Uri.parse(feed.getLink()))));
         return true;
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
@@ -2,7 +2,6 @@ package de.danoeh.antennapod.activity;
 
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -18,11 +17,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.List;
 
-import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LangUtils;
 import de.danoeh.antennapod.core.util.StorageUtils;
 
@@ -72,38 +70,33 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
                 int nextOption = 1;
         intentPickAction = new Intent(Intent.ACTION_PICK);
         intentPickAction.setData(Uri.parse("file://"));
-        List<ResolveInfo> intentActivities = getPackageManager()
-                        .queryIntentActivities(intentPickAction, CHOOSE_OPML_FILE);
-        if(intentActivities.size() == 0) {
-                intentPickAction.setData(null);
-                intentActivities = getPackageManager()
-                                .queryIntentActivities(intentPickAction, CHOOSE_OPML_FILE);
-                if(intentActivities.size() == 0) {
-                        txtvHeaderExplanation1.setVisibility(View.GONE);
-                        txtvExplanation1.setVisibility(View.GONE);
-                        findViewById(R.id.divider1).setVisibility(View.GONE);
-                        butChooseFilesystem.setVisibility(View.GONE);
-                    }
+
+        if(false == IntentUtils.isCallable(getApplicationContext(), intentPickAction)) {
+            intentPickAction.setData(null);
+            if(false == IntentUtils.isCallable(getApplicationContext(), intentPickAction)) {
+                txtvHeaderExplanation1.setVisibility(View.GONE);
+                txtvExplanation1.setVisibility(View.GONE);
+                findViewById(R.id.divider1).setVisibility(View.GONE);
+                butChooseFilesystem.setVisibility(View.GONE);
             }
+        }
         if(txtvExplanation1.getVisibility() == View.VISIBLE) {
-                txtvHeaderExplanation1.setText("Option " + nextOption);
-                nextOption++;
-            }
+            txtvHeaderExplanation1.setText("Option " + nextOption);
+            nextOption++;
+        }
 
         intentGetContentAction = new Intent(Intent.ACTION_GET_CONTENT);
         intentGetContentAction.addCategory(Intent.CATEGORY_OPENABLE);
         intentGetContentAction.setType("*/*");
-        intentActivities = getPackageManager()
-                        .queryIntentActivities(intentGetContentAction, CHOOSE_OPML_FILE);
-        if(intentActivities.size() == 0) {
-                txtvHeaderExplanation2.setVisibility(View.GONE);
-                txtvExplanation2.setVisibility(View.GONE);
-                findViewById(R.id.divider2).setVisibility(View.GONE);
-                butChooseExternal.setVisibility(View.GONE);
-            } else {
-                txtvHeaderExplanation2.setText("Option " + nextOption);
-                nextOption++;
-            }
+        if(false == IntentUtils.isCallable(getApplicationContext(), intentGetContentAction)) {
+            txtvHeaderExplanation2.setVisibility(View.GONE);
+            txtvExplanation2.setVisibility(View.GONE);
+            findViewById(R.id.divider2).setVisibility(View.GONE);
+            butChooseExternal.setVisibility(View.GONE);
+        } else {
+            txtvHeaderExplanation2.setText("Option " + nextOption);
+            nextOption++;
+        }
 
         txtvHeaderExplanation3.setText("Option " + nextOption);
     }
@@ -137,7 +130,7 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         try {
             mReader = new InputStreamReader(new FileInputStream(file),
                 LangUtils.UTF_8);
-            if (BuildConfig.DEBUG) Log.d(TAG, "Parsing " + file.toString());
+            Log.d(TAG, "Parsing " + file.toString());
             startImport(mReader);
         } catch (FileNotFoundException e) {
             Log.d(TAG, "File not found which really should be there");

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -341,7 +341,7 @@ public class AllEpisodesFragment extends Fragment {
         }
 
         contextMenu = menu;
-        FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, queuedItemsIds);
+        FeedItemMenuHandler.onPrepareMenu(getActivity(), contextMenuInterface, item, true, queuedItemsIds);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -25,12 +25,12 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
 
-import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.ShareUtils;
 import de.danoeh.antennapod.core.util.ShownotesProvider;
 import de.danoeh.antennapod.core.util.playback.Playable;
@@ -104,8 +104,7 @@ public class ItemDescriptionFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Creating view");
+        Log.d(TAG, "Creating view");
         webvDescription = new WebView(getActivity());
         if (UserPreferences.getTheme() == R.style.Theme_AntennaPod_Dark) {
             if (Build.VERSION.SDK_INT >= 11
@@ -141,8 +140,7 @@ public class ItemDescriptionFragment extends Fragment {
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Page finished");
+                Log.d(TAG, "Page finished");
                 // Restoring the scroll position might not always work
                 view.postDelayed(new Runnable() {
 
@@ -163,15 +161,13 @@ public class ItemDescriptionFragment extends Fragment {
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Fragment attached");
+        Log.d(TAG, "Fragment attached");
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Fragment detached");
+        Log.d(TAG, "Fragment detached");
         if (webViewLoader != null) {
             webViewLoader.cancel(true);
         }
@@ -180,8 +176,7 @@ public class ItemDescriptionFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Fragment destroyed");
+        Log.d(TAG, "Fragment destroyed");
         if (webViewLoader != null) {
             webViewLoader.cancel(true);
         }
@@ -195,8 +190,7 @@ public class ItemDescriptionFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Creating fragment");
+        Log.d(TAG, "Creating fragment");
         Bundle args = getArguments();
         saveState = args.getBoolean(ARG_SAVE_STATE, false);
         highlightTimecodes = args.getBoolean(ARG_HIGHLIGHT_TIMECODES, false);
@@ -258,11 +252,7 @@ public class ItemDescriptionFragment extends Fragment {
             WebView.HitTestResult r = webvDescription.getHitTestResult();
             if (r != null
                     && r.getType() == WebView.HitTestResult.SRC_ANCHOR_TYPE) {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG,
-                            "Link of webview was long-pressed. Extra: "
-                                    + r.getExtra()
-                    );
+                Log.d(TAG, "Link of webview was long-pressed. Extra: " + r.getExtra());
                 selectedURL = r.getExtra();
                 webvDescription.showContextMenu();
                 return true;
@@ -281,8 +271,10 @@ public class ItemDescriptionFragment extends Fragment {
             switch (item.getItemId()) {
                 case R.id.open_in_browser_item:
                     Uri uri = Uri.parse(selectedURL);
-                    getActivity()
-                            .startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                    final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                    if(IntentUtils.isCallable(getActivity(), intent)) {
+                        getActivity().startActivity(intent);
+                    }
                     break;
                 case R.id.share_url_item:
                     ShareUtils.shareLink(getActivity(), selectedURL);
@@ -331,8 +323,12 @@ public class ItemDescriptionFragment extends Fragment {
                         R.string.go_to_position_label);
                 menu.setHeaderTitle(Converter.getDurationStringLong(Timeline.getTimecodeLinkTime(selectedURL)));
             } else {
-                menu.add(Menu.NONE, R.id.open_in_browser_item, Menu.NONE,
-                        R.string.open_in_browser_label);
+                Uri uri = Uri.parse(selectedURL);
+                final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                if(IntentUtils.isCallable(getActivity(), intent)) {
+                    menu.add(Menu.NONE, R.id.open_in_browser_item, Menu.NONE,
+                            R.string.open_in_browser_label);
+                }
                 menu.add(Menu.NONE, R.id.copy_url_item, Menu.NONE,
                         R.string.copy_url_label);
                 menu.add(Menu.NONE, R.id.share_url_item, Menu.NONE,
@@ -358,8 +354,7 @@ public class ItemDescriptionFragment extends Fragment {
                 // /webvDescription.loadData(url, "text/html", "utf-8");
                 webvDescription.loadDataWithBaseURL(null, data, "text/html",
                         "utf-8", "about:blank");
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Webview loaded");
+                Log.d(TAG, "Webview loaded");
                 webViewLoader = null;
             }
 
@@ -370,8 +365,7 @@ public class ItemDescriptionFragment extends Fragment {
 
             @Override
             protected Void doInBackground(Void... params) {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Loading Webview");
+                Log.d(TAG, "Loading Webview");
                 try {
                     Activity activity = getActivity();
                     if (activity != null) {
@@ -397,24 +391,17 @@ public class ItemDescriptionFragment extends Fragment {
 
     private void savePreference() {
         if (saveState) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Saving preferences");
+            Log.d(TAG, "Saving preferences");
             SharedPreferences prefs = getActivity().getSharedPreferences(PREF,
                     Activity.MODE_PRIVATE);
             SharedPreferences.Editor editor = prefs.edit();
             if (media != null && webvDescription != null) {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG,
-                            "Saving scroll position: "
-                                    + webvDescription.getScrollY()
-                    );
+                Log.d(TAG, "Saving scroll position: " + webvDescription.getScrollY());
                 editor.putInt(PREF_SCROLL_Y, webvDescription.getScrollY());
                 editor.putString(PREF_PLAYABLE_ID, media.getIdentifier()
                         .toString());
             } else {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG,
-                            "savePreferences was called while media or webview was null");
+                Log.d(TAG, "savePreferences was called while media or webview was null");
                 editor.putInt(PREF_SCROLL_Y, -1);
                 editor.putString(PREF_PLAYABLE_ID, "");
             }
@@ -424,8 +411,7 @@ public class ItemDescriptionFragment extends Fragment {
 
     private boolean restoreFromPreference() {
         if (saveState) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Restoring from preferences");
+            Log.d(TAG, "Restoring from preferences");
             Activity activity = getActivity();
             if (activity != null) {
                 SharedPreferences prefs = activity.getSharedPreferences(
@@ -435,8 +421,7 @@ public class ItemDescriptionFragment extends Fragment {
                 if (scrollY != -1 && media != null
                         && id.equals(media.getIdentifier().toString())
                         && webvDescription != null) {
-                    if (BuildConfig.DEBUG)
-                        Log.d(TAG, "Restored scroll Position: " + scrollY);
+                    Log.d(TAG, "Restored scroll Position: " + scrollY);
                     webvDescription.scrollTo(webvDescription.getScrollX(),
                             scrollY);
                     return true;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -302,7 +302,7 @@ public class ItemlistFragment extends ListFragment {
         }
 
         contextMenu = menu;
-        FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, queuedItemsIds);
+        FeedItemMenuHandler.onPrepareMenu(getActivity(), contextMenuInterface, item, true, queuedItemsIds);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -329,7 +329,7 @@ public class QueueFragment extends Fragment {
         for(FeedItem queueItem : queue) {
             queueIds.add(queueItem.getId());
         }
-        FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, queueIds);
+        FeedItemMenuHandler.onPrepareMenu(getActivity(), contextMenuInterface, item, true, queueIds);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,6 +21,7 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequestException;
+import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.ShareUtils;
 
 /**
@@ -83,7 +85,13 @@ public class FeedMenuHandler {
                 break;
             case R.id.visit_website_item:
                 Uri uri = Uri.parse(selectedFeed.getLink());
-                context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                if(IntentUtils.isCallable(context, intent)) {
+                    context.startActivity(intent);
+                } else {
+                    Toast.makeText(context, context.getString(R.string.download_error_malformed_url),
+                            Toast.LENGTH_SHORT);
+                }
                 break;
             case R.id.support_item:
                 DBTasks.flattrFeedIfLoggedIn(context, selectedFeed);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/IntentUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/IntentUtils.java
@@ -1,0 +1,18 @@
+package de.danoeh.antennapod.core.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+
+import java.util.List;
+
+public class IntentUtils {
+
+    public static boolean isCallable(final Context context, final Intent intent) {
+        List<ResolveInfo> list = context.getPackageManager().queryIntentActivities(intent,
+                PackageManager.MATCH_DEFAULT_ONLY);
+        return list.size() > 0;
+    }
+
+}


### PR DESCRIPTION
New utility class IntentUtils that checks if there is actually an activity (app) that handles the intent. When a URL is malformed or has no target activity, it is no longer propose to open it.

The episode fragment now also got its own long click context menu.

Fixes #880