### PR TITLE
Store information if file has embedded picture in the database

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.activity;
 
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -31,6 +32,7 @@ import java.util.List;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.NavListAdapter;
+import de.danoeh.antennapod.core.event.ProgressEvent;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.QueueEvent;
@@ -94,6 +96,8 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
 
     private CharSequence currentTitle;
     private String currentFragment;
+
+    private ProgressDialog pd;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -470,6 +474,9 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         cancelLoadTask();
         EventDistributor.getInstance().unregister(contentUpdate);
         EventBus.getDefault().unregister(this);
+        if(pd != null) {
+            pd.dismiss();
+        }
     }
 
     @Override
@@ -571,6 +578,24 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
     public void onEvent(QueueEvent event) {
         Log.d(TAG, "onEvent(" + event + ")");
         loadData();
+    }
+
+    public void onEventMainThread(ProgressEvent event) {
+        Log.d(TAG, "onEvent(" + event + ")");
+        switch(event.action) {
+            case START:
+                pd = new ProgressDialog(this);
+                pd.setMessage(event.message);
+                pd.setIndeterminate(true);
+                pd.setCancelable(false);
+                pd.show();
+                break;
+            case END:
+                if(pd != null) {
+                    pd.dismiss();
+                }
+                break;
+        }
     }
 
     private EventDistributor.EventListener contentUpdate = new EventDistributor.EventListener() {

--- a/core/src/main/java/de/danoeh/antennapod/core/event/ProgressEvent.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/event/ProgressEvent.java
@@ -1,0 +1,36 @@
+package de.danoeh.antennapod.core.event;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class ProgressEvent {
+
+    public enum Action {
+        START, END
+    }
+
+    public final Action action;
+    public final String message;
+
+    private ProgressEvent(Action action, String message) {
+        this.action = action;
+        this.message = message;
+    }
+
+    public static ProgressEvent start(String message) {
+        return new ProgressEvent(Action.START, message);
+    }
+
+    public static ProgressEvent end() {
+        return new ProgressEvent(Action.END, null);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("action", action)
+                .append("message", message)
+                .toString();
+    }
+
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -35,6 +35,8 @@ public class FeedMedia extends FeedFile implements Playable {
     private String mime_type;
     private volatile FeedItem item;
     private Date playbackCompletionDate;
+
+    // if null: unknown, will be checked
     private Boolean hasEmbeddedPicture;
 
     /* Used for loading item when restoring from parcel. */
@@ -61,6 +63,15 @@ public class FeedMedia extends FeedFile implements Playable {
         this.mime_type = mime_type;
         this.playbackCompletionDate = playbackCompletionDate == null
                 ? null : (Date) playbackCompletionDate.clone();
+    }
+
+    public FeedMedia(long id, FeedItem item, int duration, int position,
+                     long size, String mime_type, String file_url, String download_url,
+                     boolean downloaded, Date playbackCompletionDate, int played_duration,
+                     Boolean hasEmbeddedPicture) {
+        this(id, item, duration, position, size, mime_type, file_url, download_url, downloaded,
+                playbackCompletionDate, played_duration);
+        this.hasEmbeddedPicture = hasEmbeddedPicture;
     }
 
     @Override
@@ -427,6 +438,10 @@ public class FeedMedia extends FeedFile implements Playable {
         } else {
             return item.getImageUri();
         }
+    }
+
+    public void setHasEmbeddedPicture(Boolean hasEmbeddedPicture) {
+        this.hasEmbeddedPicture = hasEmbeddedPicture;
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -1143,6 +1143,7 @@ public class DownloadService extends Service {
             boolean chaptersRead = false;
             media.setDownloaded(true);
             media.setFile_url(request.getDestination());
+            media.setHasEmbeddedPicture(null);
 
             // Get duration
             MediaMetadataRetriever mmr = null;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -274,6 +274,18 @@ public final class DBReader {
             playbackCompletionDate = new Date(
                     playbackCompletionTime);
         }
+        Boolean hasEmbeddedPicture;
+        switch(cursor.getInt(cursor.getColumnIndex(PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE))) {
+            case 1:
+                hasEmbeddedPicture = Boolean.TRUE;
+                break;
+            case 0:
+                hasEmbeddedPicture = Boolean.FALSE;
+                break;
+            default:
+                hasEmbeddedPicture = null;
+                break;
+        }
 
         return new FeedMedia(
                 mediaId,
@@ -286,7 +298,8 @@ public final class DBReader {
                 cursor.getString(PodDBAdapter.KEY_DOWNLOAD_URL_INDEX),
                 cursor.getInt(PodDBAdapter.KEY_DOWNLOADED_INDEX) > 0,
                 playbackCompletionDate,
-                cursor.getInt(PodDBAdapter.KEY_PLAYED_DURATION_INDEX));
+                cursor.getInt(PodDBAdapter.KEY_PLAYED_DURATION_INDEX),
+                hasEmbeddedPicture);
     }
 
     private static Feed extractFeedFromCursorRow(PodDBAdapter adapter,

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -100,6 +100,7 @@ public class DBWriter {
                         }
                         media.setDownloaded(false);
                         media.setFile_url(null);
+                        media.setHasEmbeddedPicture(false);
                         PodDBAdapter adapter = new PodDBAdapter(context);
                         adapter.open();
                         adapter.setMedia(media);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.ClientConfig;
+import de.danoeh.antennapod.core.R;
+import de.danoeh.antennapod.core.event.ProgressEvent;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedComponent;
@@ -29,6 +31,7 @@ import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.util.LongIntMap;
 import de.danoeh.antennapod.core.util.flattr.FlattrStatus;
+import de.greenrobot.event.EventBus;
 
 ;
 
@@ -155,6 +158,8 @@ public class PodDBAdapter {
     public static final String KEY_NEXT_PAGE_LINK = "next_page_link";
     public static final String KEY_HIDE = "hide";
     public static final String KEY_LAST_UPDATE_FAILED = "last_update_failed";
+    public static final String KEY_HAS_EMBEDDED_PICTURE = "has_embedded_picture";
+
 
     // Table names
     public static final String TABLE_NAME_FEEDS = "Feeds";
@@ -209,7 +214,7 @@ public class PodDBAdapter {
             + KEY_PLAYBACK_COMPLETION_DATE + " INTEGER,"
             + KEY_FEEDITEM + " INTEGER,"
             + KEY_PLAYED_DURATION + " INTEGER,"
-            + KEY_AUTO_DOWNLOAD + " INTEGER)";
+            + KEY_HAS_EMBEDDED_PICTURE + " INTEGER)";
 
     public static final String CREATE_TABLE_DOWNLOAD_LOG = "CREATE TABLE "
             + TABLE_NAME_DOWNLOAD_LOG + " (" + TABLE_PRIMARY_KEY + KEY_FEEDFILE
@@ -516,6 +521,7 @@ public class PodDBAdapter {
         values.put(KEY_DOWNLOAD_URL, media.getDownload_url());
         values.put(KEY_DOWNLOADED, media.isDownloaded());
         values.put(KEY_FILE_URL, media.getFile_url());
+        values.put(KEY_HAS_EMBEDDED_PICTURE, media.hasEmbeddedPicture());
 
         if (media.getPlaybackCompletionDate() != null) {
             values.put(KEY_PLAYBACK_COMPLETION_DATE, media
@@ -1463,6 +1469,9 @@ public class PodDBAdapter {
      * Helper class for opening the Antennapod database.
      */
     private static class PodDBHelper extends SQLiteOpenHelper {
+
+        private Context context;
+
         /**
          * Constructor.
          *
@@ -1474,6 +1483,7 @@ public class PodDBAdapter {
         public PodDBHelper(final Context context, final String name,
                            final CursorFactory factory, final int version) {
             super(context, name, factory, version);
+            this.context = context;
         }
 
         @Override
@@ -1497,7 +1507,9 @@ public class PodDBAdapter {
         @Override
         public void onUpgrade(final SQLiteDatabase db, final int oldVersion,
                               final int newVersion) {
+            EventBus.getDefault().post(ProgressEvent.start(context.getString(R.string.progress_upgrading_database)));
             ClientConfig.storageCallbacks.onUpgrade(db, oldVersion, newVersion);
+            EventBus.getDefault().post(ProgressEvent.end());
         }
     }
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -435,6 +435,10 @@
     <string name="authentication_label">Authentication</string>
     <string name="authentication_descr">Change your username and password for this podcast and its episodes.</string>
 
+
+    <!-- Progress information -->
+    <string name="progress_upgrading_database">Upgrading the database</string>
+
     <!-- AntennaPodSP -->
 
     <string name="sp_apps_importing_feeds_msg">Importing subscriptions from single-purpose apps&#8230;</string>


### PR DESCRIPTION
We now store in the database if a media file has an embedded picture. In principle, this makes any further checking superfluous.

Migration: Already downloaded files are checked and the database is updated accordingly. While the files are processed, we show a progress dialog to the user. (This dialog will be shown in future database migration)

This branch is based on the similar hotfix.

Resolves #898