### PR TITLE
Fixes 891

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/PicassoProvider.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/PicassoProvider.java
@@ -162,6 +162,14 @@ public class PicassoProvider {
             }
 
             if (bitmap == null) {
+                // this should never, happen, but sometimes it does, so fallback
+                // check for fallback Uri
+                String fallbackParam = data.uri.getQueryParameter(PicassoImageResource.PARAM_FALLBACK);
+                if (fallbackParam != null) {
+                    Uri fallback = Uri.parse(fallbackParam);
+                    bitmap = decodeStreamFromFile(data, fallback);
+                }
+
                 Log.wtf(TAG, "THIS SHOULD NEVER EVER HAPPEN!!");
             }
             return new Result(bitmap, Picasso.LoadedFrom.DISK);

--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/PicassoProvider.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/PicassoProvider.java
@@ -169,8 +169,6 @@ public class PicassoProvider {
                     Uri fallback = Uri.parse(fallbackParam);
                     bitmap = decodeStreamFromFile(data, fallback);
                 }
-
-                Log.wtf(TAG, "THIS SHOULD NEVER EVER HAPPEN!!");
             }
             return new Result(bitmap, Picasso.LoadedFrom.DISK);
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -414,6 +414,14 @@ public class FeedMedia extends FeedFile implements Playable {
         if (hasEmbeddedPicture()) {
             Uri.Builder builder = new Uri.Builder();
             builder.scheme(SCHEME_MEDIA).encodedPath(getLocalMediaUrl());
+
+            if (item != null && item.getFeed() != null) {
+                final Uri feedImgUri = item.getFeed().getImageUri();
+                if (feedImgUri != null) {
+                    builder.appendQueryParameter(PARAM_FALLBACK, feedImgUri.toString());
+                }
+            }
+
             return builder.build();
         } else {
             return item.getImageUri();


### PR DESCRIPTION
This should resolve #891.

We suspect some podcasts have a corrupt image embedded in them. When we try to decode it that fails and then we have no bitmap to display.  Restoring the old functionality of falling back to the feed image in those cases.