### PR TITLE
Download Report: introduce setting to disable

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,6 +25,12 @@
             android:key="prefPersistNotify"
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="prefShowDownloadReport"
+            android:summary="@string/pref_showDownloadReport_sum"
+            android:title="@string/pref_showDownloadReport_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/queue_label">

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -44,6 +44,7 @@ public class UserPreferences implements
     public static final String PREF_HIDDEN_DRAWER_ITEMS = "prefHiddenDrawerItems";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
+    public static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
 
     // Queue
     public static final String PREF_QUEUE_ADD_TO_FRONT = "prefQueueAddToFront";
@@ -94,6 +95,7 @@ public class UserPreferences implements
     private List<String> hiddenDrawerItems;
     private int notifyPriority;
     private boolean persistNotify;
+    private boolean showDownloadReport;
 
     // Queue
     private boolean enqueueAtFront;
@@ -164,6 +166,7 @@ public class UserPreferences implements
         }
         hiddenDrawerItems = Arrays.asList(StringUtils.split(sp.getString(PREF_HIDDEN_DRAWER_ITEMS, ""), ','));
         persistNotify = sp.getBoolean(PREF_PERSISTENT_NOTIFICATION, false);
+        showDownloadReport = sp.getBoolean(PREF_SHOW_DOWNLOAD_REPORT, true);
 
         // Queue
         enqueueAtFront = sp.getBoolean(PREF_QUEUE_ADD_TO_FRONT, false);
@@ -305,6 +308,16 @@ public class UserPreferences implements
     public static boolean isPersistNotify() {
         instanceAvailable();
         return instance.persistNotify;
+    }
+
+    /**
+     * Returns true if download reports are shown
+     *
+     * @return {@code true} if download reports are shown, {@code false}  otherwise
+     */
+    public static boolean showDownloadReport() {
+        instanceAvailable();
+        return instance.showDownloadReport;
     }
 
     /**
@@ -462,6 +475,9 @@ public class UserPreferences implements
                 break;
             case PREF_PERSISTENT_NOTIFICATION:
                 persistNotify = sp.getBoolean(PREF_PERSISTENT_NOTIFICATION, false);
+                break;
+            case PREF_SHOW_DOWNLOAD_REPORT:
+                showDownloadReport = sp.getBoolean(PREF_SHOW_DOWNLOAD_REPORT, true);
                 break;
             // Queue
             case PREF_QUEUE_ADD_TO_FRONT:

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -309,7 +309,8 @@ public class DownloadService extends Service {
         Log.d(TAG, "Service shutting down");
         isRunning = false;
 
-        if (ClientConfig.downloadServiceCallbacks.shouldCreateReport()) {
+        if (ClientConfig.downloadServiceCallbacks.shouldCreateReport() &&
+                UserPreferences.showDownloadReport()) {
             updateReport();
         }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -303,6 +303,9 @@
     <string name="pref_expandNotify_sum">Always expand the notification to show playback buttons.</string>
     <string name="pref_persistNotify_title">Persistent playback controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
+    <string name="pref_showDownloadReport_title">Show Download Report</string>
+    <string name="pref_showDownloadReport_sum">If downloads fail, generate a report that shows the details of the failure.</string>
+
     <string name="pref_expand_notify_unsupport_toast">Android versions before 4.1 do not support expanded notifications.</string>
     <string name="pref_queueAddToFront_sum">Add new episodes to the front of the queue.</string>
     <string name="pref_queueAddToFront_title">Enqueue at front.</string>


### PR DESCRIPTION
Give the use the option to disable the download report.
While it is useful to see the failed downloads, if a user is subscribed
to many podcasts, most of the times a few fail, which makes the notifications rather annonying.