### PR TITLE
Fixes Queue not opening, small podcasts images not scaling up and long URL not wrapping

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -92,8 +92,8 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
 
     private ActionBarDrawerToggle drawerToggle;
 
-    private CharSequence drawerTitle;
     private CharSequence currentTitle;
+    private String currentFragment;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -107,7 +107,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         setSupportActionBar(toolbar);
         getSupportActionBar().setElevation(3.0f);
 
-        drawerTitle = currentTitle = getTitle();
+        currentTitle = getTitle();
 
         drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         navList = (ListView) findViewById(R.id.nav_list);
@@ -173,6 +173,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
     }
 
     private void saveLastNavFragment(String tag) {
+        Log.d(TAG, "saveLastNavFragment(tag: " + tag +")");
         SharedPreferences prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE);
         SharedPreferences.Editor edit = prefs.edit();
         if(tag != null) {
@@ -180,12 +181,15 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         } else {
             edit.remove(PREF_LAST_FRAGMENT_TAG);
         }
+        currentFragment = tag;
         edit.commit();
     }
 
     private String getLastNavFragment() {
         SharedPreferences prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE);
-        return prefs.getString(PREF_LAST_FRAGMENT_TAG, QueueFragment.TAG);
+        String lastFragment = prefs.getString(PREF_LAST_FRAGMENT_TAG, QueueFragment.TAG);
+        Log.d(TAG, "getLastNavFragment() -> " + lastFragment);
+        return lastFragment;
     }
 
     private void checkFirstLaunch() {
@@ -251,6 +255,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
     }
 
     public void loadFragment(int index, Bundle args) {
+        Log.d(TAG, "loadFragment(index: " + index + ", args: " + args +")");
         if (index < navAdapter.getSubscriptionOffset()) {
             String tag = navAdapter.getTags().get(index);
             loadFragment(tag, args);
@@ -261,7 +266,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
     }
 
     public void loadFragment(final String tag, Bundle args) {
-        Log.d(TAG, "loadFragment(\"" + tag + "\", " + args + ")");
+        Log.d(TAG, "loadFragment(tag: " + tag + ", args: " + args + ")");
         Fragment fragment = null;
         switch (tag) {
             case QueueFragment.TAG:
@@ -543,10 +548,10 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
                 navAdapter.notifyDataSetChanged();
 
                 String lastFragment = getLastNavFragment();
-                if(!ArrayUtils.contains(NAV_DRAWER_TAGS, lastFragment)) {
+                if(currentFragment != lastFragment &&
+                        !ArrayUtils.contains(NAV_DRAWER_TAGS, lastFragment)) {
                     long feedId = Long.valueOf(lastFragment);
                     loadFeedFragmentById(feedId);
-                    saveLastNavFragment(null);
                 }
 
                 if (handleIntent) {

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -13,7 +13,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
-        android:scaleType="centerInside"
+        android:scaleType="fitCenter"
         tools:src="@android:drawable/sym_def_app_icon" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -20,8 +20,8 @@
         <ImageView
             android:id="@+id/imgvCover"
             android:contentDescription="@string/cover_label"
-            android:layout_width="70dp"
-            android:layout_height="70dp"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             tools:src="@drawable/ic_stat_antenna_default"
@@ -33,7 +33,9 @@
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
             android:layout_marginLeft="8dp"
+            android:layout_alignTop="@id/imgvCover"
             android:layout_toRightOf="@id/imgvCover"
+            android:layout_alignBottom="@id/imgvCover"
             style="@style/AntennaPod.TextView.Heading"
             tools:text="Feed title"
             tools:background="@android:color/holo_green_dark"/>
@@ -52,7 +54,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:scrollbarStyle="outsideInset"
+        android:scrollbarStyle="outsideOverlay"
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
         android:paddingBottom="8dp">
@@ -119,7 +121,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginRight="8dp"
-                    android:layout_marginBottom="8dp"
                     app:layout_row="2"
                     app:layout_column="0"
                     android:lines="1"
@@ -129,10 +130,13 @@
 
                 <TextView
                     android:id="@+id/txtvUrl"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:paddingBottom="4dp"
                     app:layout_row="2"
                     app:layout_column="1"
+                    app:layout_gravity="fill"
+                    android:maxLines="4"
                     tools:text="http://www.example.com/feed"
                     tools:background="@android:color/holo_green_dark"/>
 


### PR DESCRIPTION
# Queue not opening

I start with the tricky bit: When the main activity is restarted or resumed, we open the last fragment the user opened. Until now, this was read and deleted (set null). When coming back from another activity (audio player), the last fragment would else (when not nulled) be read (this would be the same as the current one) and the current fragment would be loaded again (my emulator shows some sort of short flashing).

Setting the last fragment to null had the following consequence: Coming back from the audio activity, the last fragment would be read and set to null. Opening the other activity and going back would query the last fragment again, this time the preference would be null and the default value Queue would be returned. The app now believes the current fragment to be the queue and not open the queue when trying to do so via drawer. So far, so confusing...

To fix this, the main activity now stores the current fragment in a new string variable, the last fragment is no longer forgotten (nulled). When the last fragment is read, we now check if the last fragment is the current fragment (this can only be the case if the activity is resumed). If they are the same, there is nothing to be done.

Resolved #919 

# Scaling up a small cover 
![small_cover](https://cloud.githubusercontent.com/assets/6860662/8271363/adc6042a-1813-11e5-867c-738d73d5896b.png)

Resolves #921

# Long URL getting wrapping
![long_url](https://cloud.githubusercontent.com/assets/6860662/8271362/ab58e388-1813-11e5-8075-66697e0bf384.png)

Resolves #923