### PR TITLE
Fix testPauseForInterruptions

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -231,7 +231,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
                 return pauseForFocusLoss != UserPreferences.shouldPauseForFocusLoss();
             }
         }, Timeout.getLargeTimeout());
-        solo.clickOnText(solo.getString(R.string.pref_auto_delete_title));
+        solo.clickOnText(solo.getString(R.string.pref_pausePlaybackForFocusLoss_title));
         solo.waitForCondition(new Condition() {
             @Override
             public boolean isSatisfied() {


### PR DESCRIPTION
testPauseForInterruptions was failing, looking for the Auto Delete string.

It should have been looking for the pause playback string.