### PR TITLE
set autodownload == false once an item is downloaded

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -1171,12 +1171,16 @@ public class DownloadService extends Service {
             }
 
             try {
-                if (chaptersRead) {
-                    DBWriter.setFeedItem(DownloadService.this, media.getItem()).get();
-                }
+                // we've received the media, we don't want to autodownload it again
+                FeedItem item = media.getItem();
+                item.setAutoDownload(false);
+
+                // update the db
+                DBWriter.setFeedItem(DownloadService.this, item).get();
+
                 DBWriter.setFeedMedia(DownloadService.this, media).get();
-                if (!DBTasks.isInQueue(DownloadService.this, media.getItem().getId())) {
-                    DBWriter.addQueueItem(DownloadService.this, media.getItem().getId()).get();
+                if (!DBTasks.isInQueue(DownloadService.this, item.getId())) {
+                    DBWriter.addQueueItem(DownloadService.this, item.getId()).get();
                 }
             } catch (ExecutionException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Once an item has been downloaded once, we never really want to autodownload it again, whether or not it was downloaded this time.

Should resolve the problem in #936 related to episodes being re-downloaded once they've been deleted.