### PR TITLE
Mark all as unplayed, download all unplayed, enqueue all unplayed

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
@@ -768,7 +768,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             assertTrue(item.getId() != 0);
         }
 
-        DBWriter.markFeedRead(context, feed.getId()).get(TIMEOUT, TimeUnit.SECONDS);
+        DBWriter.markFeedRead(context, feed.getId(), true).get(TIMEOUT, TimeUnit.SECONDS);
         List<FeedItem> loadedItems = DBReader.getFeedItemList(context, feed);
         for (FeedItem item : loadedItems) {
             assertTrue(item.isRead());

--- a/app/src/main/res/menu/feedlist.xml
+++ b/app/src/main/res/menu/feedlist.xml
@@ -36,6 +36,24 @@
         android:title="@string/mark_all_read_label"
         custom:showAsAction="collapseActionView">
     </item>
+    <item
+        android:id="@+id/mark_all_unread_item"
+        android:menuCategory="container"
+        android:title="@string/mark_all_unread_label"
+        custom:showAsAction="collapseActionView">
+    </item>
+    <item
+        android:id="@+id/download_all_unplayed_item"
+        android:menuCategory="container"
+        android:title="@string/download_all_unplayed_label"
+        custom:showAsAction="collapseActionView">
+    </item>
+    <item
+        android:id="@+id/enqueue_all_unplayed_item"
+        android:menuCategory="container"
+        android:title="@string/enqueue_all_unplayed_label"
+        custom:showAsAction="collapseActionView">
+    </item>
 
     <item
         android:id="@+id/support_item"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -170,12 +170,27 @@ public class Feed extends FeedFile implements FlattrThing, PicassoImageResource 
         preferences = new FeedPreferences(0, true, username, password);
     }
 
+    /**
+     * Returns true if at least one item in the itemlist is unread.
+     *
+     */
+    public boolean hasPlayedItems() {
+        for (FeedItem item : items) {
+            if (item.getState() == FeedItem.State.READ) {
+                if (item.getMedia() != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 
     /**
      * Returns true if at least one item in the itemlist is unread.
      *
      */
-    public boolean hasNewItems() {
+    public boolean hasUnplayedItems() {
         for (FeedItem item : items) {
             if (item.getState() == FeedItem.State.UNREAD) {
                 if (item.getMedia() != null) {
@@ -362,6 +377,16 @@ public class Feed extends FeedFile implements FlattrThing, PicassoImageResource 
 
     public List<FeedItem> getItems() {
         return items;
+    }
+
+    public List<FeedItem> getUnplayedItems() {
+        List<FeedItem> result = new ArrayList<FeedItem>();
+        for(FeedItem item : items) {
+            if(false == item.isRead()) {
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public void setItems(List<FeedItem> list) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -646,7 +646,7 @@ public class DBWriter {
      * @param context A context that is used for opening a database connection.
      * @param feedId  ID of the Feed.
      */
-    public static Future<?> markFeedRead(final Context context, final long feedId) {
+    public static Future<?> markFeedRead(final Context context, final long feedId, final boolean read) {
         return dbExec.submit(new Runnable() {
 
             @Override
@@ -661,7 +661,7 @@ public class DBWriter {
                     itemCursor.moveToNext();
                 }
                 itemCursor.close();
-                adapter.setFeedItemRead(true, itemIds);
+                adapter.setFeedItemRead(read, itemIds);
                 adapter.close();
 
                 EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -84,6 +84,12 @@
     <string name="mark_all_read_msg">Marked all Episodes as played</string>
     <string name="mark_all_read_confirmation_msg">Please confirm that you want to mark all episodes as being played.</string>
     <string name="mark_all_read_feed_confirmation_msg">Please confirm that you want to mark all episodes in this feed as being played.</string>
+    <string name="mark_all_unread_label">Mark all as unplayed</string>
+    <string name="mark_all_unread_confirmation_msg">Please confirm that you want to mark all episodes as being unplayed.</string>
+    <string name="download_all_unplayed_label">Download all unplayed</string>
+    <string name="download_all_unplayed_confirmation_msg">Please confirm that you want to download all unplayed episodes.</string>
+    <string name="enqueue_all_unplayed_label">Add all unplayed to Queue</string>
+    <string name="enqueue_all_unplayed_confirmation_msg">Please confirm that you want to add all unplayed episodes to the Queue.</string>
     <string name="show_info_label">Show information</string>
     <string name="remove_feed_label">Remove Podcast</string>
     <string name="share_label">Share...</string>


### PR DESCRIPTION
In the feed view, you can now:
* Mark all as unplayed
* Download all unplayed
* Enqueue all unplayed

All of these will show a confirmation dialog just as "mark all as played" does.

This PR started with adding the ability to enqueue and download all unplayed episodes. Just downloading/enqueuing all episodes regardless of their play state seemed unreasonable to me.

When a new podcast/feed is added, all but one episodes are marked as played. To download/enqueue all episodes of a newly subscribed podcast, it became necessary to be able to undo this default behavior and mark all episodes as unplayed. 

![new](https://cloud.githubusercontent.com/assets/6860662/8307056/ced9ab4e-19bc-11e5-8376-ef19df967d32.png)

Resolves #871
Partially resolves #520