### PR TITLE
Return NULL instead of result when unable to load bitmap.

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/PicassoProvider.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/PicassoProvider.java
@@ -170,6 +170,12 @@ public class PicassoProvider {
                     bitmap = decodeStreamFromFile(data, fallback);
                 }
             }
+
+            if (bitmap == null) {
+                Log.e(TAG, "Could not load media");
+                return null;
+            }
+
             return new Result(bitmap, Picasso.LoadedFrom.DISK);
 
         }


### PR DESCRIPTION
There are still cases where 'bitmap' could be null.
We shouldn't return a result when that's the case.

Returnning null appears to be supported by Picasso.
(see Picasso.NetworkRequestHandler)

Fixes AntennaPod/AntennaPod#947