### PR TITLE
New feature: Add Feed-specific 'Delete After Playback' override option

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
@@ -116,6 +117,8 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     private Playable writeTestPlayable(String downloadUrl, String fileUrl) {
         final Context c = getInstrumentation().getTargetContext();
         Feed f = new Feed(0, new Date(), "f", "l", "d", null, null, null, null, "i", null, null, "l", false);
+        FeedPreferences prefs = new FeedPreferences(f.getId(), false, FeedPreferences.AutoDeleteAction.NO, null, null);
+        f.setPreferences(prefs);
         f.setItems(new ArrayList<FeedItem>());
         FeedItem i = new FeedItem(0, "t", "i", "l", new Date(), FeedItem.UNPLAYED, f);
         f.getItems().add(i);

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -180,7 +180,7 @@ public abstract class OnlineFeedViewActivity extends ActionBarActivity {
         url = URLChecker.prepareURL(url);
         feed = new Feed(url, new Date(0));
         if (username != null && password != null) {
-            feed.setPreferences(new FeedPreferences(0, false, username, password));
+            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, username, password));
         }
         String fileUrl = new File(getExternalCacheDir(),
                 FileNameGenerator.generateFileName(feed.getDownload_url())).toString();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -97,7 +97,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
                     long itemId = token.getFeedItemId();
                     FeedItem item = DBReader.getFeedItem(context, itemId);
                     FeedMedia media = item.getMedia();
-                    if(media != null && media.hasAlmostEnded() && UserPreferences.isAutoDelete()) {
+                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
                         DBWriter.deleteFeedMediaOfItem(context, media.getId());
                     }
                 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -97,7 +97,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
                     long itemId = token.getFeedItemId();
                     FeedItem item = DBReader.getFeedItem(context, itemId);
                     FeedMedia media = item.getMedia();
-                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
+                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete()) {
                         DBWriter.deleteFeedMediaOfItem(context, media.getId());
                     }
                 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -431,7 +431,7 @@ public class QueueFragment extends Fragment {
                     long itemId = token.getFeedItemId();
                     FeedItem item = DBReader.getFeedItem(context, itemId);
                     FeedMedia media = item.getMedia();
-                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
+                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete()) {
                         DBWriter.deleteFeedMediaOfItem(context, media.getId());
                     }
                 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -431,7 +431,7 @@ public class QueueFragment extends Fragment {
                     long itemId = token.getFeedItemId();
                     FeedItem item = DBReader.getFeedItem(context, itemId);
                     FeedMedia media = item.getMedia();
-                    if(media != null && media.hasAlmostEnded() && UserPreferences.isAutoDelete()) {
+                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
                         DBWriter.deleteFeedMediaOfItem(context, media.getId());
                     }
                 }

--- a/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
+++ b/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
@@ -62,7 +62,7 @@ public class PlayerWidgetService extends Service {
 					DBWriter.markItemRead(this, item, true, false);
 					DBWriter.removeQueueItem(this, item, false);
 					DBWriter.addItemToPlaybackHistory(this, media);
-					if (item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
+					if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
 						Log.d(TAG, "Delete " + media.toString());
 						DBWriter.deleteFeedMediaOfItem(this, media.getId());
 					}

--- a/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
+++ b/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
@@ -62,7 +62,7 @@ public class PlayerWidgetService extends Service {
 					DBWriter.markItemRead(this, item, true, false);
 					DBWriter.removeQueueItem(this, item, false);
 					DBWriter.addItemToPlaybackHistory(this, media);
-					if (UserPreferences.isAutoDelete()) {
+					if (item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
 						Log.d(TAG, "Delete " + media.toString());
 						DBWriter.deleteFeedMediaOfItem(this, media.getId());
 					}

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -159,7 +159,38 @@
                 android:enabled="false"
                 android:textColor="?android:attr/textColorPrimary"
                 tools:background="@android:color/holo_red_light"
-                android:checked="false"/>
+                android:checked="false" />
+
+            <android.support.v7.widget.GridLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:columnCount="2"
+                app:rowCount="1">
+
+                <TextView
+                    android:id="@+id/txtvFeedAutoDelete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/auto_delete_label"
+                    app:layout_row="0"
+                    app:layout_column="0"
+                    app:layout_gravity="center_vertical"
+                    android:layout_marginRight="10dp" />
+
+                <Spinner
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:id="@+id/spnAutoDelete"
+                    android:entries="@array/spnAutoDeleteItems"
+                    android:layout_marginTop="8dp"
+                    app:layout_row="0"
+                    app:layout_column="1"
+                    android:spinnerMode="dropdown"
+                    app:layout_gravity="center"
+                    android:dropDownWidth="wrap_content"
+                    android:clickable="false" />
+            </android.support.v7.widget.GridLayout>
 
             <TextView
                 android:id="@+id/txtvAuthentication"

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -189,7 +189,7 @@
                     android:spinnerMode="dropdown"
                     app:layout_gravity="center"
                     android:dropDownWidth="wrap_content"
-                    android:clickable="false" />
+                    android:clickable="true" />
             </android.support.v7.widget.GridLayout>
 
             <TextView

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -167,7 +167,7 @@ public class Feed extends FeedFile implements FlattrThing, PicassoImageResource 
      */
     public Feed(String url, Date lastUpdate, String title, String username, String password) {
         this(url, lastUpdate, title);
-        preferences = new FeedPreferences(0, true, username, password);
+        preferences = new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL, username, password);
     }
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -11,19 +11,26 @@ public class FeedPreferences {
 
     private long feedID;
     private boolean autoDownload;
+    public enum AutoDeleteAction {
+        GLOBAL,
+        YES,
+        NO
+    }
+    private AutoDeleteAction auto_delete_action;
     private String username;
     private String password;
 
-    public FeedPreferences(long feedID, boolean autoDownload, String username, String password) {
+    public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String username, String password) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
+        this.auto_delete_action = auto_delete_action;
         this.username = username;
         this.password = password;
     }
 
 
     /**
-     * Compare another FeedPreferences with this one. The feedID and autoDownload attribute are excluded from the
+     * Compare another FeedPreferences with this one. The feedID, autoDownload and AutoDeleteAction attribute are excluded from the
      * comparison.
      *
      * @return True if the two objects are different.
@@ -41,7 +48,7 @@ public class FeedPreferences {
     }
 
     /**
-     * Update this FeedPreferences object from another one. The feedID and autoDownload attributes are excluded
+     * Update this FeedPreferences object from another one. The feedID, autoDownload and AutoDeleteAction attributes are excluded
      * from the update.
      */
     public void updateFromOther(FeedPreferences other) {
@@ -65,6 +72,28 @@ public class FeedPreferences {
 
     public void setAutoDownload(boolean autoDownload) {
         this.autoDownload = autoDownload;
+    }
+
+    public AutoDeleteAction getAutoDeleteAction() {
+        return auto_delete_action;
+    }
+
+    public void setAutoDeleteAction(AutoDeleteAction auto_delete_action) {
+        this.auto_delete_action = auto_delete_action;
+    }
+
+    public boolean getCurrentAutoDelete(boolean isAutoDelete) {
+        switch (auto_delete_action) {
+            case GLOBAL:
+                return isAutoDelete;
+
+            case YES:
+                return true;
+
+            case NO:
+                return false;
+        }
+        return false; // TODO - add exceptions here
     }
 
     public void save(Context context) {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.feed;
 import android.content.Context;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import org.apache.commons.lang3.StringUtils;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 /**
  * Contains preferences for a single feed.
@@ -82,10 +83,10 @@ public class FeedPreferences {
         this.auto_delete_action = auto_delete_action;
     }
 
-    public boolean getCurrentAutoDelete(boolean isAutoDelete) {
+    public boolean getCurrentAutoDelete() {
         switch (auto_delete_action) {
             case GLOBAL:
-                return isAutoDelete;
+                return UserPreferences.isAutoDelete();
 
             case YES:
                 return true;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -891,7 +891,7 @@ public class DownloadService extends Service {
             feed.setFile_url(request.getDestination());
             feed.setId(request.getFeedfileId());
             feed.setDownloaded(true);
-            feed.setPreferences(new FeedPreferences(0, true,
+            feed.setPreferences(new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL,
                     request.getUsername(), request.getPassword()));
             feed.setPageNr(request.getArguments().getInt(DownloadRequester.REQUEST_ARG_PAGE_NR, 0));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -584,7 +584,7 @@ public class PlaybackService extends Service {
             }
 
             // Delete episode if enabled
-            if(item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
+            if(item.getFeed().getPreferences().getCurrentAutoDelete()) {
                 DBWriter.deleteFeedMediaOfItem(PlaybackService.this, media.getId());
                 Log.d(TAG, "Episode Deleted");
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -584,7 +584,7 @@ public class PlaybackService extends Service {
             }
 
             // Delete episode if enabled
-            if(UserPreferences.isAutoDelete()) {
+            if(item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
                 DBWriter.deleteFeedMediaOfItem(PlaybackService.this, media.getId());
                 Log.d(TAG, "Episode Deleted");
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -196,7 +196,7 @@ public class PlaybackServiceMediaPlayer {
                         DBWriter.markItemRead(context, item, true, false);
                         DBWriter.removeQueueItem(context, item, false);
                         DBWriter.addItemToPlaybackHistory(context, oldMedia);
-                        if (UserPreferences.isAutoDelete()) {
+                        if (item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
                             Log.d(TAG, "Delete " + oldMedia.toString());
                             DBWriter.deleteFeedMediaOfItem(context, oldMedia.getId());
                         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -196,7 +196,7 @@ public class PlaybackServiceMediaPlayer {
                         DBWriter.markItemRead(context, item, true, false);
                         DBWriter.removeQueueItem(context, item, false);
                         DBWriter.addItemToPlaybackHistory(context, oldMedia);
-                        if (item.getFeed().getPreferences().getCurrentAutoDelete(UserPreferences.isAutoDelete())) {
+                        if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
                             Log.d(TAG, "Delete " + oldMedia.toString());
                             DBWriter.deleteFeedMediaOfItem(context, oldMedia.getId());
                         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -338,9 +338,9 @@ public final class DBReader {
         if (image != null) {
             image.setOwner(feed);
         }
-
         FeedPreferences preferences = new FeedPreferences(cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_ID),
                 cursor.getInt(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_AUTO_DOWNLOAD) > 0,
+                FeedPreferences.AutoDeleteAction.values()[cursor.getInt(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_AUTO_DELETE_ACTION)],
                 cursor.getString(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_USERNAME),
                 cursor.getString(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_PASSWORD));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -150,6 +150,7 @@ public class PodDBAdapter {
     public static final String KEY_CHAPTER_TYPE = "type";
     public static final String KEY_PLAYBACK_COMPLETION_DATE = "playback_completion_date";
     public static final String KEY_AUTO_DOWNLOAD = "auto_download";
+    public static final String KEY_AUTO_DELETE_ACTION = "auto_delete_action";
     public static final String KEY_PLAYED_DURATION = "played_duration";
     public static final String KEY_USERNAME = "username";
     public static final String KEY_PASSWORD = "password";
@@ -187,7 +188,8 @@ public class PodDBAdapter {
             + KEY_IS_PAGED + " INTEGER DEFAULT 0,"
             + KEY_NEXT_PAGE_LINK + " TEXT,"
             + KEY_HIDE + " TEXT,"
-            + KEY_LAST_UPDATE_FAILED + " INTEGER DEFAULT 0)";
+            + KEY_LAST_UPDATE_FAILED + " INTEGER DEFAULT 0,"
+            + KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0)";
 
     public static final String CREATE_TABLE_FEED_ITEMS = "CREATE TABLE "
             + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY + KEY_TITLE
@@ -283,6 +285,7 @@ public class PodDBAdapter {
             TABLE_NAME_FEEDS + "." + KEY_PASSWORD,
             TABLE_NAME_FEEDS + "." + KEY_HIDE,
             TABLE_NAME_FEEDS + "." + KEY_LAST_UPDATE_FAILED,
+            TABLE_NAME_FEEDS + "." + KEY_AUTO_DELETE_ACTION,
     };
 
     // column indices for FEED_SEL_STD
@@ -306,6 +309,7 @@ public class PodDBAdapter {
     public static final int IDX_FEED_SEL_STD_NEXT_PAGE_LINK = 17;
     public static final int IDX_FEED_SEL_PREFERENCES_USERNAME = 18;
     public static final int IDX_FEED_SEL_PREFERENCES_PASSWORD = 19;
+    public static final int IDX_FEED_SEL_PREFERENCES_AUTO_DELETE_ACTION = 22;
 
     /**
      * Select all columns from the feeditems-table except description and
@@ -461,6 +465,7 @@ public class PodDBAdapter {
         }
         ContentValues values = new ContentValues();
         values.put(KEY_AUTO_DOWNLOAD, prefs.getAutoDownload());
+        values.put(KEY_AUTO_DELETE_ACTION,prefs.getAutoDeleteAction().ordinal());
         values.put(KEY_USERNAME, prefs.getUsername());
         values.put(KEY_PASSWORD, prefs.getPassword());
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(prefs.getFeedID())});

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1477,7 +1477,7 @@ public class PodDBAdapter {
      */
     private static class PodDBHelper extends SQLiteOpenHelper {
 
-        private final static int VERSION = 17;
+        private final static int VERSION = 18;
 
         private Context context;
 
@@ -1697,6 +1697,10 @@ public class PodDBAdapter {
                         + " WHERE " + KEY_ID + " IN (" + selectNew + ")";
                 Log.d("Migration", "SQL: " + sql);
                 db.execSQL(sql);
+            }
+            if(oldVersion <= 17) {
+                db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                        + " ADD COLUMN " + PodDBAdapter.KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0");
             }
             EventBus.getDefault().post(ProgressEvent.end());
         }

--- a/core/src/main/res/values-iw-rIL/strings.xml
+++ b/core/src/main/res/values-iw-rIL/strings.xml
@@ -58,6 +58,7 @@
   <string name="close_label">סגור</string>
   <string name="retry_label">נסה שוב</string>
   <string name="auto_download_label">כלול בהורדות אוטומטיות</string>
+  <string name="auto_delete_label">מחק לאחר ההשמעה (גובר על ההגדרה הגלובלית)</string>
   <string name="parallel_downloads_suffix">\u0020הורדות במקביל</string>
   <!--'Add Feed' Activity labels-->
   <string name="feedurl_label">כתובת הזנה</string>

--- a/core/src/main/res/values-iw-rIL/strings.xml
+++ b/core/src/main/res/values-iw-rIL/strings.xml
@@ -58,8 +58,11 @@
   <string name="close_label">סגור</string>
   <string name="retry_label">נסה שוב</string>
   <string name="auto_download_label">כלול בהורדות אוטומטיות</string>
-  <string name="auto_delete_label">מחק לאחר ההשמעה (גובר על ההגדרה הגלובלית)</string>
+  <string name="auto_delete_label">מחק לאחר ההשמעה\n(גובר על ההגדרה הגלובלית)</string>
   <string name="parallel_downloads_suffix">\u0020הורדות במקביל</string>
+  <string name="feed_auto_download_global">לפי הגדרה גלובלית</string>
+  <string name="feed_auto_download_always">תמיד</string>
+  <string name="feed_auto_download_never">אף פעם</string>
   <!--'Add Feed' Activity labels-->
   <string name="feedurl_label">כתובת הזנה</string>
   <string name="etxtFeedurlHint">כתובת של הזנה או אתר אינטרנט</string>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <string-array name="spnAutoDeleteItems">
+        <item>Global</item>
+        <item>Always</item>
+        <item>Never</item>
+    </string-array>
+
     <string-array name="smart_mark_as_played_values">
         <item>0</item>
         <item>15</item>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -2,9 +2,9 @@
 <resources>
 
     <string-array name="spnAutoDeleteItems">
-        <item>Global</item>
-        <item>Always</item>
-        <item>Never</item>
+        <item>@string/feed_auto_download_global</item>
+        <item>@string/feed_auto_download_always</item>
+        <item>@string/feed_auto_download_never</item>
     </string-array>
 
     <string-array name="smart_mark_as_played_values">

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="close_label">Close</string>
     <string name="retry_label">Retry</string>
     <string name="auto_download_label">Include in auto downloads</string>
+    <string name="auto_delete_label">Auto Delete Episode\n(override global default)</string>
     <string name="parallel_downloads_suffix">\u0020parallel downloads</string>
 
     <!-- 'Add Feed' Activity labels -->

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -77,6 +77,9 @@
     <string name="auto_download_label">Include in auto downloads</string>
     <string name="auto_delete_label">Auto Delete Episode\n(override global default)</string>
     <string name="parallel_downloads_suffix">\u0020parallel downloads</string>
+    <string name="feed_auto_download_global">Global</string>
+    <string name="feed_auto_download_always">Always</string>
+    <string name="feed_auto_download_never">Never</string>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>


### PR DESCRIPTION
Let me repeat this again:
DO NOT PULL THIS AS-IS. THIS IS FOR DISCUSSION ONLY.

One of the features I still miss in AntennaPod is the ability to control the Auto Delete option *per feed*.
Some feeds are throwaway - once I hear them, I want them to be automatically delete.
Other feeds are precious and I want to keep the chapters I've downloaded.

This pull request adds a new 'Delete After Playback' spinner to the FeedInfoActivity. It has 3 states:
Default - use the global setting
Yes - delete after playback, regardless of the global settings
No - Do not delete after playback, regardless of the global settings

This is my first Android work, and I have a VERY shallow understanding of Java (I come from C/C++), so this pull request is based on googling stackoverflow and the SDK documentation.

I know for a fact that this code does NOT work yet. I ran it through the emulator and I see that my settings is not saved between invocations. I'm sending this to solicit feedback and to learn `android programming.

I also hope I didn't do anything stupid with git. There were a few commits on the main repository between the time I forked and the time I merged my changes back to create the pull request.