### PR TITLE
gpoddernet: do not crash on unknown remote actions

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/model/GpodnetEpisodeAction.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/model/GpodnetEpisodeAction.java
@@ -93,7 +93,12 @@ public class GpodnetEpisodeAction {
         if(StringUtils.isEmpty(podcast) || StringUtils.isEmpty(episode) || StringUtils.isEmpty(actionString)) {
             return null;
         }
-        GpodnetEpisodeAction.Action action = GpodnetEpisodeAction.Action.valueOf(actionString.toUpperCase());
+        GpodnetEpisodeAction.Action action;
+        try {
+            action = GpodnetEpisodeAction.Action.valueOf(actionString.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
         String deviceId = object.optString("device", "");
         GpodnetEpisodeAction.Builder builder = new GpodnetEpisodeAction.Builder(podcast, episode, action)
                 .deviceId(deviceId);


### PR DESCRIPTION
**UNTESTED!  I don't have a working build setup.  Please verify before merging.**

According to [1] and my own episode actions feed, "action":"flattr" is a
valid action.  Future-proof the episode actions code by ignoring actions
that we don't know and care about.

This fixes the

    java.lang.IllegalArgumentException: FLATTR is not a constant

exception when fetching the episode actions list.

[1]: https://gpoddernet.readthedocs.org/en/latest/api/reference/events.html