### PR TITLE
Guard use of 'media'

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -555,7 +555,7 @@ public abstract class PlaybackController {
      * Should be used by classes which implement the OnSeekBarChanged interface.
      */
     public void onSeekBarStopTrackingTouch(SeekBar seekBar, float prog) {
-        if (playbackService != null) {
+        if (playbackService != null && media != null) {
             playbackService.seekTo((int) (prog * media.getDuration()));
             setupPositionObserver();
         }


### PR DESCRIPTION
It can be null in this class, so we should make sure it isn't accessed if it is.

fixes AntennaPod/AntennaPod#972