### PR TITLE
Must send download list when content changes

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -385,14 +385,7 @@ public class AllEpisodesFragment extends Fragment {
 
     private DownloadObserver.Callback downloadObserverCallback = new DownloadObserver.Callback() {
         @Override
-        public void onContentChanged() {
-            if (listAdapter != null) {
-                listAdapter.notifyDataSetChanged();
-            }
-        }
-
-        @Override
-        public void onDownloadDataAvailable(List<Downloader> downloaderList) {
+        public void onContentChanged(List<Downloader> downloaderList) {
             AllEpisodesFragment.this.downloaderList = downloaderList;
             if (listAdapter != null) {
                 listAdapter.notifyDataSetChanged();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -531,14 +531,7 @@ public class ItemFragment extends Fragment implements LoaderManager.LoaderCallba
     private final DownloadObserver.Callback downloadObserverCallback = new DownloadObserver.Callback() {
 
         @Override
-        public void onContentChanged() {
-            if (itemsLoaded && getActivity() != null) {
-                updateAppearance();
-            }
-        }
-
-        @Override
-        public void onDownloadDataAvailable(List<Downloader> downloaderList) {
+        public void onContentChanged(List<Downloader> downloaderList) {
             ItemFragment.this.downloaderList = downloaderList;
             if (itemsLoaded && getActivity() != null) {
                 updateAppearance();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -458,14 +458,7 @@ public class ItemlistFragment extends ListFragment {
 
     private DownloadObserver.Callback downloadObserverCallback = new DownloadObserver.Callback() {
         @Override
-        public void onContentChanged() {
-            if (adapter != null) {
-                adapter.notifyDataSetChanged();
-            }
-        }
-
-        @Override
-        public void onDownloadDataAvailable(List<Downloader> downloaderList) {
+        public void onContentChanged(List<Downloader> downloaderList) {
             ItemlistFragment.this.downloaderList = downloaderList;
             if (adapter != null) {
                 adapter.notifyDataSetChanged();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -204,14 +204,7 @@ public class PlaybackHistoryFragment extends ListFragment {
 
     private DownloadObserver.Callback downloadObserverCallback = new DownloadObserver.Callback() {
         @Override
-        public void onContentChanged() {
-            if (adapter != null) {
-                adapter.notifyDataSetChanged();
-            }
-        }
-
-        @Override
-        public void onDownloadDataAvailable(List<Downloader> downloaderList) {
+        public void onContentChanged(List<Downloader> downloaderList) {
             PlaybackHistoryFragment.this.downloaderList = downloaderList;
             if (adapter != null) {
                 adapter.notifyDataSetChanged();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -473,14 +473,7 @@ public class QueueFragment extends Fragment {
 
     private DownloadObserver.Callback downloadObserverCallback = new DownloadObserver.Callback() {
         @Override
-        public void onContentChanged() {
-            if (listAdapter != null && !blockDownloadObserverUpdate) {
-                listAdapter.notifyDataSetChanged();
-            }
-        }
-
-        @Override
-        public void onDownloadDataAvailable(List<Downloader> downloaderList) {
+        public void onContentChanged(List<Downloader> downloaderList) {
             QueueFragment.this.downloaderList = downloaderList;
             if (listAdapter != null && !blockDownloadObserverUpdate) {
                 listAdapter.notifyDataSetChanged();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.fragment;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.ListFragment;
+import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
@@ -24,7 +25,7 @@ import de.danoeh.antennapod.core.storage.DownloadRequester;
  * Displays all running downloads and provides actions to cancel them
  */
 public class RunningDownloadsFragment extends ListFragment {
-    private static final String TAG = "RunningDownloadsFragment";
+    private static final String TAG = "RunningDownloadsFrag";
 
     private DownloadObserver downloadObserver;
     private List<Downloader> downloaderList;
@@ -53,12 +54,8 @@ public class RunningDownloadsFragment extends ListFragment {
 
         downloadObserver = new DownloadObserver(getActivity(), new Handler(), new DownloadObserver.Callback() {
             @Override
-            public void onContentChanged() {
-                downloadlistAdapter.notifyDataSetChanged();
-            }
-
-            @Override
-            public void onDownloadDataAvailable(List<Downloader> downloaderList) {
+            public void onContentChanged(List<Downloader> downloaderList) {
+                Log.d(TAG, "onContentChanged: downloaderList.size() == " + downloaderList.size());
                 RunningDownloadsFragment.this.downloaderList = downloaderList;
                 downloadlistAdapter.notifyDataSetChanged();
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/DownloadObserver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/DownloadObserver.java
@@ -12,6 +12,7 @@ import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.service.download.DownloadService;
 import de.danoeh.antennapod.core.service.download.Downloader;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -85,15 +86,15 @@ public class DownloadObserver {
             if (downloadService == null) {
                 connectToDownloadService();
             }
-            callback.onContentChanged();
+            if (downloadService != null) {
+                callback.onContentChanged(downloadService.getDownloads());
+            }
             startRefresher();
         }
     };
 
     public interface Callback {
-        void onContentChanged();
-
-        void onDownloadDataAvailable(List<Downloader> downloaderList);
+        void onContentChanged(List<Downloader> downloaderList);
     }
 
     private void connectToDownloadService() {
@@ -116,7 +117,7 @@ public class DownloadObserver {
                 Log.d(TAG, "Connection to service established");
             List<Downloader> downloaderList = downloadService.getDownloads();
             if (downloaderList != null && !downloaderList.isEmpty()) {
-                callback.onDownloadDataAvailable(downloaderList);
+                callback.onContentChanged(downloaderList);
                 startRefresher();
             }
         }
@@ -156,12 +157,14 @@ public class DownloadObserver {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    callback.onContentChanged();
                     if (downloadService != null) {
                         List<Downloader> downloaderList = downloadService.getDownloads();
+                        callback.onContentChanged(downloaderList);
                         if (downloaderList == null || downloaderList.isEmpty()) {
                             Thread.currentThread().interrupt();
                         }
+                    } else {
+                        callback.onContentChanged(new ArrayList<Downloader>());
                     }
                 }
             });

--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/DownloadObserver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/DownloadObserver.java
@@ -88,6 +88,9 @@ public class DownloadObserver {
             }
             if (downloadService != null) {
                 callback.onContentChanged(downloadService.getDownloads());
+            } else {
+                // the service is gone, there are no more downloads.
+                callback.onContentChanged(new ArrayList<Downloader>());
             }
             startRefresher();
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -435,6 +435,7 @@ public class DownloadService extends Service {
                 } else {
                     Log.e(TAG, "Could not cancel download with url " + url);
                 }
+                sendBroadcast(new Intent(ACTION_DOWNLOADS_CONTENT_CHANGED));
 
             } else if (StringUtils.equals(intent.getAction(), ACTION_CANCEL_ALL_DOWNLOADS)) {
                 for (Downloader d : downloads) {
@@ -1246,6 +1247,12 @@ public class DownloadService extends Service {
     }
 
     public List<Downloader> getDownloads() {
+        if (downloads == null) {
+            // this is unusual, but it should be OK, we'll return
+            // an empty list to make it easy for people
+            return new ArrayList<Downloader>();
+        }
+
         // return a copy of downloads, but the copy doesn't need to be synchronized.
         synchronized (downloads) {
             return new ArrayList<Downloader>(downloads);


### PR DESCRIPTION
In #969 we updated DownloadService to return a copy of the list of downloads. That prevented the views from referencing data that wasn't there anymore.

However, I didn't set it to send a copy of that list every time the data changed.  Previously there was 'onDownloadDataAvailable' which would get called when the initial list was created and 'onContentChanged' which would get called whenever anything changed.  Now, there is just 'onContentChanged' and it takes the content itself.

This solves the remaining problems from #968, but it does so at a cost. Now, any time the download list changes we'll create a copy of it. When we're downloading a lot of small items (feeds for example) the list might change rapidly.  That means we'll be creating a lot of these objects, just for them to be garbage collected.

This seems to work fine on my Nexus One emulator, but I'd be curious to know if there's a better way.