### PR TITLE
Let user change data folder if current one is not available

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
@@ -15,16 +15,23 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.*;
+import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
-import de.danoeh.antennapod.BuildConfig;
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ImageButton;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+
+import de.danoeh.antennapod.BuildConfig;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 /**
  * Let's the user choose a directory on the storage device. The selected folder
@@ -88,7 +95,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 							@Override
 							public void onClick(DialogInterface dialog,
-									int which) {
+												int which) {
 								dialog.dismiss();
 							}
 						});
@@ -97,7 +104,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 							@Override
 							public void onClick(DialogInterface dialog,
-									int which) {
+												int which) {
 								dialog.dismiss();
 								returnSelectedFolder();
 							}
@@ -119,7 +126,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 			@Override
 			public void onItemClick(AdapterView<?> adapter, View view,
-					int position, long id) {
+									int position, long id) {
 				if (BuildConfig.DEBUG)
 					Log.d(TAG, "Selected index: " + position);
 				if (filesInDir != null && position >= 0
@@ -145,7 +152,13 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 		listDirectoriesAdapter = new ArrayAdapter<String>(this,
 				android.R.layout.simple_list_item_1, filenames);
 		listDirectories.setAdapter(listDirectoriesAdapter);
-		changeDirectory(Environment.getExternalStorageDirectory());
+
+		File external = Environment.getExternalStorageDirectory();
+		if(external != null && external.exists() && external.canRead() && external.canWrite()) {
+			changeDirectory(external);
+		} else {
+			changeDirectory(getFilesDir());
+		}
 	}
 
 	/**

--- a/app/src/main/res/layout/storage_error.xml
+++ b/app/src/main/res/layout/storage_error.xml
@@ -1,25 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:gravity="center">
 
     <ImageView
         android:id="@+id/imageView1"
         android:contentDescription="@string/external_storage_error_msg"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:layout_margin="16dp"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_margin="8dp"
         android:src="@android:drawable/stat_notify_sdcard_usb" />
 
     <TextView
         android:id="@+id/textView1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/imageView1"
-        android:layout_centerHorizontal="true"
         android:layout_margin="8dp"
+        android:gravity="center"
         android:text="@string/external_storage_error_msg" />
 
-</RelativeLayout>
+    <Button
+        android:id="@+id/btnSetDataFolder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/choose_data_directory"/>
+
+</LinearLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
@@ -8,7 +8,6 @@ import android.util.Log;
 
 import java.io.File;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 
@@ -23,8 +22,7 @@ public class StorageUtils {
         if (dir != null) {
             return dir.exists() && dir.canRead() && dir.canWrite();
         } else {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Storage not available: data folder is null");
+            Log.d(TAG, "Storage not available: data folder is null");
             return false;
         }
     }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
     <string name="error_label">Error</string>
     <string name="error_msg_prefix">An error occurred:</string>
     <string name="refresh_label">Refresh</string>
-    <string name="external_storage_error_msg">No external storage is available. Please make sure that external storage is mounted so that the app can work properly.</string>
+    <string name="external_storage_error_msg">The data folder is not available. Please make sure that external storage is mounted or choose another data folder so that the app can work properly.</string>
     <string name="chapters_label">Chapters</string>
     <string name="shownotes_label">Shownotes</string>
     <string name="description_label">Description</string>


### PR DESCRIPTION
![muh](https://cloud.githubusercontent.com/assets/6860662/8395650/da7f075e-1d7d-11e5-9121-7bf30d13b78c.png)

The button will open the usual choose data folder preference dialog. On older devices, clicking the navigational up will lead to a crash, of course.
Of this is not the first start, the user will experience pictures not being displayed and media files not being found, because the folder they ought to be in is not there. [1]

This only gives the user the opportunity to change the app to a useable state again (or, if this is the first start, choose a directory because our choice of the external folder as a default didn't work)

Resolves #975

[1] Checking the database and bringing it to a consistent state (file not readable/not existent -> downloaded=0; fix local paths) should be done when the *move data folder* feature is implemented.