### PR TITLE
Setting updates for a specific time of day didn't work on newer devices.

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/AlarmUpdateReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/AlarmUpdateReceiver.java
@@ -25,7 +25,7 @@ public class AlarmUpdateReceiver extends BroadcastReceiver {
 		}
         PlaybackPreferences.init(context);
         UserPreferences.init(context);
-        UserPreferences.restartUpdateAlarm();
+        UserPreferences.restartUpdateAlarm(false);
 	}
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/FeedUpdateReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/FeedUpdateReceiver.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 
@@ -23,6 +24,7 @@ public class FeedUpdateReceiver extends BroadcastReceiver {
         } else {
             Log.d(TAG, "Blocking automatic update: no wifi available / no mobile updates allowed");
         }
+        UserPreferences.restartUpdateAlarm(false);
     }
 
 }


### PR DESCRIPTION
Alarm was not being issued on devices running 5.1 (and perhaps older).

setRepeating is setInexactRepeating on API 19+, that means we can go as long as interval*2 before updates.

Switched to use 'set()' instead to get behavior that matches what users expect.  Otherwise we could go as long as 2 days between updates.