### PR TITLE
Add git commit ID and version top the "About" screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,7 @@ task filterAbout {
         into 'src/main/assets'
         filter(ReplaceTokens, tokens: [versionname: android.defaultConfig.versionName,
                                        versioncode: android.defaultConfig.versionCode.toString(),
-                                       commit: "git rev-parse HEAD".execute().text[0..6]])
+                                       commit: "git describe".execute().text])
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,8 @@ task filterAbout {
         from 'src/main/templates/about.html'
         into 'src/main/assets'
         filter(ReplaceTokens, tokens: [versionname: android.defaultConfig.versionName,
-                                       versioncode: android.defaultConfig.versionCode.toString()])
+                                       versioncode: android.defaultConfig.versionCode.toString(),
+                                       commit: "git rev-parse HEAD".execute().text[0..6]])
     }
 }
 

--- a/app/src/main/templates/about.html
+++ b/app/src/main/templates/about.html
@@ -42,6 +42,7 @@
     <img src="logo.png" alt="Logo" width="100px" height="100px"/>
 
     <p>AntennaPod, Version @versionname@, Build @versioncode@</p>
+    <p>commit: @commit@</p>
 
     <p>Created by Daniel Oeh</p>
 


### PR DESCRIPTION
This change adds the information provided by "git describe" to the "About" screen.
This info includes the SHA1 of the commit on which this release is based, as well the the number of commits since the last release and the last release number.

Please note that AntennaPod release labels have been applies to the 'master' branch, therefore releasing snapshots from the 'develop' branch will not yield useful info other than the commit ID,
It is still useful in the sense that it provides the number of commits since the last label on the develop branch, and even if there are no more labels, the number of commit will increment for newer builds.
