### PR TITLE
PlaybackHistory doesn't dim played items anymore.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -33,13 +33,17 @@ public class FeedItemlistAdapter extends BaseAdapter {
     private final Context context;
     private boolean showFeedtitle;
     private int selectedItemIndex;
+    /** true if played items should be made partially transparent */
+    private boolean makePlayedItemsTransparent;
     private final ActionButtonUtils actionButtonUtils;
 
     public static final int SELECTION_NONE = -1;
 
     public FeedItemlistAdapter(Context context,
                                ItemAccess itemAccess,
-                               ActionButtonCallback callback, boolean showFeedtitle) {
+                               ActionButtonCallback callback,
+                               boolean showFeedtitle,
+                               boolean makePlayedItemsTransparent) {
         super();
         this.callback = callback;
         this.context = context;
@@ -47,6 +51,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
         this.showFeedtitle = showFeedtitle;
         this.selectedItemIndex = SELECTION_NONE;
         this.actionButtonUtils = new ActionButtonUtils(context);
+        this.makePlayedItemsTransparent = makePlayedItemsTransparent;
     }
 
     @Override
@@ -106,7 +111,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
 
             StringBuilder buffer = new StringBuilder(item.getTitle());
             if (showFeedtitle) {
-                buffer.append("(");
+                buffer.append(" (");
                 buffer.append(item.getFeed().getTitle());
                 buffer.append(")");
             }
@@ -117,7 +122,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
             } else {
                 holder.statusUnread.setVisibility(View.INVISIBLE);
             }
-            if(item.isPlayed()) {
+            if(item.isPlayed() && makePlayedItemsTransparent) {
                 ViewHelper.setAlpha(convertView, 0.5f);
             } else {
                 ViewHelper.setAlpha(convertView, 1.0f);
@@ -180,7 +185,6 @@ public class FeedItemlistAdapter extends BaseAdapter {
             convertView.setVisibility(View.GONE);
         }
         return convertView;
-
     }
 
     private final OnClickListener butActionListener = new OnClickListener() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -428,7 +428,7 @@ public class ItemlistFragment extends ListFragment {
             setListAdapter(null);
             setupHeaderView();
             setupFooterView();
-            adapter = new FeedItemlistAdapter(getActivity(), itemAccess, new DefaultActionButtonCallback(getActivity()), false);
+            adapter = new FeedItemlistAdapter(getActivity(), itemAccess, new DefaultActionButtonCallback(getActivity()), false, true);
             setListAdapter(adapter);
             downloadObserver = new DownloadObserver(getActivity(), new Handler(), downloadObserverCallback);
             downloadObserver.onResume();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -192,7 +192,10 @@ public class PlaybackHistoryFragment extends ListFragment {
 
     private void onFragmentLoaded() {
         if (adapter == null) {
-            adapter = new FeedItemlistAdapter(getActivity(), itemAccess, new DefaultActionButtonCallback(activity.get()), true);
+            // played items shoudln't be transparent for this fragment since, *all* items
+            // in this fragment will, by definition, be played. So it serves no purpose and can make
+            // it harder to read.
+            adapter = new FeedItemlistAdapter(getActivity(), itemAccess, new DefaultActionButtonCallback(activity.get()), true, false);
             setListAdapter(adapter);
             downloadObserver = new DownloadObserver(activity.get(), new Handler(), downloadObserverCallback);
             downloadObserver.onResume();


### PR DESCRIPTION
We don't dim items in playback history if they've been played anymore.

Also adds a space before the feed title when displaying the title.

fixes AntennaPod/AntennaPod#1007