### PR TITLE
Proposal for new version code schema

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,8 +121,7 @@ task filterAbout {
         from 'src/main/templates/about.html'
         into 'src/main/assets'
         filter(ReplaceTokens, tokens: [versionname: android.defaultConfig.versionName,
-                                       versioncode: android.defaultConfig.versionCode.toString(),
-                                       commit: "git describe".execute().text])
+                                       commit: "git rev-parse --short HEAD".execute().text])
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="61"
-    android:versionName="1.3">
+    android:versionCode="1030001"
+    android:versionName="1.3-RC1">
+    <!--
+      Version code schema:
+      "1.2.3-SNAPSHOT" -> 1020300
+      "1.2.3-RC4"      -> 1020304
+      "1.2.3[-RELEASE] -> 1020399
+    -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/app/src/main/templates/about.html
+++ b/app/src/main/templates/about.html
@@ -41,8 +41,8 @@
 <div id="header" align="center">
     <img src="logo.png" alt="Logo" width="100px" height="100px"/>
 
-    <p>AntennaPod, Version @versionname@, Build @versioncode@</p>
-    <p>commit: @commit@</p>
+    <p>AntennaPod, Version @versionname@</p>
+    <p>Commit: @commit@</p>
 
     <p>Created by Daniel Oeh</p>
 


### PR DESCRIPTION
Version code schema:
* "1.2.3-SNAPSHOT" -> 1020300
* "1.2.3-RC4" -> 1020304
* "1.2.3[-RELEASE] -> 1020399

The version name will include more information (RCx) - About no longer shows the version code, only the version name and the most current (short) commit hash.