### PR TITLE
Fix Time of Day Refresh

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBReaderTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBReaderTest.java
@@ -42,38 +42,6 @@ public class DBReaderTest extends InstrumentationTestCase {
         adapter.close();
     }
 
-    private void expiredFeedListTestHelper(long lastUpdate, long expirationTime, boolean shouldReturn) {
-        final Context context = getInstrumentation().getTargetContext();
-        Feed feed = new Feed(0, new Date(lastUpdate), "feed", "link", "descr", null,
-                null, null, null, "feed", null, null, "url", false, new FlattrStatus(), false, null, null, false);
-        feed.setItems(new ArrayList<FeedItem>());
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        adapter.setCompleteFeed(feed);
-        adapter.close();
-
-        assertTrue(feed.getId() != 0);
-        List<Feed> expiredFeeds = DBReader.getExpiredFeedsList(context, expirationTime);
-        assertNotNull(expiredFeeds);
-        if (shouldReturn) {
-            assertTrue(expiredFeeds.size() == 1);
-            assertTrue(expiredFeeds.get(0).getId() == feed.getId());
-        } else {
-            assertTrue(expiredFeeds.isEmpty());
-        }
-    }
-
-    public void testGetExpiredFeedsListShouldReturnFeed() {
-        final long expirationTime = 1000 * 60 * 60; // 1 hour
-        expiredFeedListTestHelper(System.currentTimeMillis() - expirationTime - 1, expirationTime, true);
-    }
-
-    public void testGetExpiredFeedsListShouldNotReturnFeed() {
-        final long expirationTime = 1000 * 60 * 60; // 1 hour
-        expiredFeedListTestHelper(System.currentTimeMillis() - expirationTime / 2, expirationTime, false);
-    }
-
-
     public void testGetFeedList() {
         final Context context = getInstrumentation().getTargetContext();
         List<Feed> feeds = saveFeedlist(context, 10, 0, false);

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
@@ -299,37 +299,4 @@ public class DBTasksTest extends InstrumentationTestCase {
             lastDate = item.getPubDate();
         }
     }
-
-    private void expiredFeedListTestHelper(long lastUpdate, long expirationTime, boolean shouldReturn) {
-        UserPreferences.setUpdateInterval(TimeUnit.MILLISECONDS.toHours(expirationTime));
-        Feed feed = new Feed(0, new Date(lastUpdate), "feed", "link", "descr", null,
-                null, null, null, "feed", null, null, "url", false, new FlattrStatus(), false, null, null, false);
-        feed.setItems(new ArrayList<FeedItem>());
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        adapter.setCompleteFeed(feed);
-        adapter.close();
-
-        assertTrue(feed.getId() != 0);
-        List<Feed> expiredFeeds = DBTasks.getExpiredFeeds(context);
-        assertNotNull(expiredFeeds);
-        if (shouldReturn) {
-            assertTrue(expiredFeeds.size() == 1);
-            assertTrue(expiredFeeds.get(0).getId() == feed.getId());
-        } else {
-            assertTrue(expiredFeeds.isEmpty());
-        }
-    }
-
-    @FlakyTest(tolerance = 3)
-    public void testGetExpiredFeedsTestShouldReturn() {
-        final long expirationTime = 1000 * 60 * 60;
-        expiredFeedListTestHelper(System.currentTimeMillis() - expirationTime - 1, expirationTime, true);
-    }
-
-    @FlakyTest(tolerance = 3)
-    public void testGetExpiredFeedsTestShouldNotReturn() {
-        final long expirationTime = 1000 * 60 * 60;
-        expiredFeedListTestHelper(System.currentTimeMillis() - expirationTime / 2, expirationTime, false);
-    }
 }

--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -78,7 +78,7 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
         openNavDrawer();
         solo.clickOnText(solo.getString(R.string.add_feed_label));
         solo.enterText(0, feed.getDownload_url());
-        solo.clickOnButton(0);
+        solo.clickOnButton(solo.getString(R.string.confirm_label));
         solo.waitForActivity(DefaultOnlineFeedViewActivity.class);
         solo.waitForView(R.id.butSubscribe);
         assertEquals(solo.getString(R.string.subscribe_label), solo.getButton(0).getText().toString());

--- a/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
@@ -15,7 +15,7 @@ import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 
 public class ConnectivityActionReceiver extends BroadcastReceiver {
-	private static final String TAG = "ConnectivityActionReceiver";
+	private static final String TAG = "ConnectivityActionRecvr";
 
 	@Override
 	public void onReceive(final Context context, Intent intent) {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -588,7 +588,7 @@ public class UserPreferences {
         Calendar alarm = (Calendar)now.clone();
         alarm.set(Calendar.HOUR_OF_DAY, hoursOfDay);
         alarm.set(Calendar.MINUTE, minute);
-        if(alarm.before(now)) {
+        if (alarm.before(now) || alarm.equals(now)) {
             alarm.add(Calendar.DATE, 1);
         }
         Log.d(TAG, "Alarm set for: " + alarm.toString() + " : " + alarm.getTimeInMillis());

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/FeedUpdateReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/FeedUpdateReceiver.java
@@ -20,7 +20,7 @@ public class FeedUpdateReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "Received intent");
         if (NetworkUtils.isDownloadAllowed(context)) {
-            DBTasks.refreshExpiredFeeds(context);
+            DBTasks.refreshAllFeeds(context, null);
         } else {
             Log.d(TAG, "Blocking automatic update: no wifi available / no mobile updates allowed");
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -326,6 +326,7 @@ public class DownloadService extends Service {
         unregisterReceiver(cancelDownloadReceiver);
 
         if (!newMediaFiles.isEmpty()) {
+            Log.d(TAG, "newMediaFiles exist, autodownload them");
             DBTasks.autodownloadUndownloadedItems(getApplicationContext(),
                     ArrayUtils.toPrimitive(newMediaFiles.toArray(new Long[newMediaFiles.size()])));
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -115,35 +115,6 @@ public final class DBReader {
     }
 
     /**
-     * Returns a list of 'expired Feeds', i.e. Feeds that have not been updated for a certain amount of time.
-     *
-     * @param context        A context that is used for opening a database connection.
-     * @param expirationTime Time that is used for determining whether a feed is outdated or not.
-     *                       A Feed is considered expired if 'lastUpdate < (currentTime - expirationTime)' evaluates to true.
-     * @return A list of Feeds, sorted alphabetically by their title. A Feed-object
-     * of the returned list does NOT have its list of FeedItems yet. The FeedItem-list
-     * can be loaded separately with {@link #getFeedItemList(android.content.Context, de.danoeh.antennapod.core.feed.Feed)}.
-     */
-    public static List<Feed> getExpiredFeedsList(final Context context, final long expirationTime) {
-        Log.d(TAG, String.format("getExpiredFeedsList(%d)", expirationTime));
-
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-
-        Cursor feedlistCursor = adapter.getExpiredFeedsCursor(expirationTime);
-        List<Feed> feeds = new ArrayList<Feed>(feedlistCursor.getCount());
-
-        if (feedlistCursor.moveToFirst()) {
-            do {
-                Feed feed = extractFeedFromCursorRow(adapter, feedlistCursor);
-                feeds.add(feed);
-            } while (feedlistCursor.moveToNext());
-        }
-        feedlistCursor.close();
-        return feeds;
-    }
-
-    /**
      * Takes a list of FeedItems and loads their corresponding Feed-objects from the database.
      * The feedID-attribute of a FeedItem must be set to the ID of its feed or the method will
      * not find the correct feed of an item.

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -184,50 +184,13 @@ public final class DBTasks {
                     if (ClientConfig.gpodnetCallbacks.gpodnetEnabled()) {
                         GpodnetSyncService.sendSyncIntent(context);
                     }
+                    Log.d(TAG, "refreshAllFeeds autodownload");
                     autodownloadUndownloadedItems(context);
                 }
             }.start();
         } else {
             Log.d(TAG, "Ignoring request to refresh all feeds: Refresh lock is locked");
         }
-    }
-
-    /**
-     * Used by refreshExpiredFeeds to determine which feeds should be refreshed.
-     * This method will use the value specified in the UserPreferences as the
-     * expiration time.
-     *
-     * @param context Used for DB access.
-     * @return A list of expired feeds. An empty list will be returned if there
-     * are no expired feeds.
-     */
-    public static List<Feed> getExpiredFeeds(final Context context) {
-        long millis = UserPreferences.getUpdateInterval();
-        if (millis > 0) {
-            List<Feed> feedList = DBReader.getExpiredFeedsList(context, millis);
-            if (feedList.size() > 0) {
-                refreshFeeds(context, feedList);
-            }
-            return feedList;
-        } else {
-            return new ArrayList<Feed>();
-        }
-    }
-
-    /**
-     * Refreshes expired Feeds in the list returned by the getExpiredFeedsList(Context, long) method in DBReader.
-     * The expiration date parameter is determined by the update interval specified in {@link UserPreferences}.
-     *
-     * @param context Used for DB access.
-     */
-    public static void refreshExpiredFeeds(final Context context) {
-        Log.d(TAG, "Refreshing expired feeds");
-
-        new Thread() {
-            public void run() {
-                refreshFeeds(context, getExpiredFeeds(context));
-            }
-        }.start();
     }
 
     private static void refreshFeeds(final Context context,
@@ -440,6 +403,7 @@ public final class DBTasks {
      * @return A Future that can be used for waiting for the methods completion.
      */
     public static Future<?> autodownloadUndownloadedItems(final Context context, final long... mediaIds) {
+        Log.d(TAG, "autodownloadUndownloadedItems");
         return autodownloadExec.submit(ClientConfig.dbTasksCallbacks.getAutomaticDownloadAlgorithm()
                 .autoDownloadUndownloadedItems(context, mediaIds));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -981,13 +981,6 @@ public class PodDBAdapter {
         return db.query(TABLE_NAME_FEEDS, new String[]{KEY_ID, KEY_DOWNLOAD_URL}, null, null, null, null, null);
     }
 
-    public final Cursor getExpiredFeedsCursor(long expirationTime) {
-        Cursor c = db.query(TABLE_NAME_FEEDS, FEED_SEL_STD, KEY_LASTUPDATE + " < " + String.valueOf(System.currentTimeMillis() - expirationTime),
-                null, null, null,
-                null);
-        return c;
-    }
-
     /**
      * Returns a cursor with all FeedItems of a Feed. Uses FEEDITEM_SEL_FI_SMALL
      *


### PR DESCRIPTION
Fixes a couple of problems with Time of Day automatic refreshing:
* It was getting refreshed too many times. It was using .before() to determine if it should add a day, but it also needs to use .equals(), otherwise the alarm can trigger multiple times.
* It was using refreshExpiredFeeds() which was broken since it assumed getUpdateInterval() was the only game in town (it isn't since it doesn't handle time of day updates).   getExpiredFeeds() was also using the wrong units for getUpdateInterval() (it returns hours, but getExpiredFeeds() assumed it was millis) so it was just pretty much always refreshing all the feeds anyways.

I also fixed a test that was broken with some prior changes to Add Podcast.