### PR TITLE
Fix locking in GpodnetPreferences

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -426,30 +426,4 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
             }
         }, Timeout.getLargeTimeout());
     }
-
-    @FlakyTest(tolerance = 3)
-    public void testAbout() throws IOException {
-        int numViews = 0, numLinks = 0;
-        InputStream input = getActivity().getResources().getAssets().open("about.html");
-        List<String> lines = IOUtils.readLines(input);
-        input.close();
-        for(String line : lines) {
-            if(line.contains("(View)")) {
-                numViews++;
-            } else if(line.contains("(Link)")) {
-                numLinks++;
-            }
-        }
-        for(int i=0; i < numViews; i++) {
-            solo.clickOnText(solo.getString(R.string.about_pref));
-            solo.clickOnText("(View)", i);
-            solo.goBack();
-        }
-        for(int i=0; i < numLinks; i++) {
-            solo.clickOnText(solo.getString(R.string.about_pref));
-            solo.clickOnText("(Link)", i);
-            solo.goBack();
-        }
-    }
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -217,26 +216,36 @@ public class GpodnetPreferences {
 
     public static void removeRemovedFeeds(Collection<String> removed) {
         ensurePreferencesLoaded();
+        feedListLock.lock();
         removedFeeds.removeAll(removed);
         writePreference(PREF_SYNC_REMOVED, removedFeeds);
+        feedListLock.unlock();
     }
 
-    public static synchronized void enqueueEpisodeAction(GpodnetEpisodeAction action) {
+    public static void enqueueEpisodeAction(GpodnetEpisodeAction action) {
         ensurePreferencesLoaded();
+        feedListLock.lock();
         queuedEpisodeActions.add(action);
         writePreference(PREF_SYNC_EPISODE_ACTIONS, writeEpisodeActionsToString(queuedEpisodeActions));
+        feedListLock.unlock();
         GpodnetSyncService.sendSyncActionsIntent(ClientConfig.applicationCallbacks.getApplicationInstance());
     }
 
     public static List<GpodnetEpisodeAction> getQueuedEpisodeActions() {
         ensurePreferencesLoaded();
-        return Collections.unmodifiableList(queuedEpisodeActions);
+        List<GpodnetEpisodeAction> copy = new ArrayList();
+        feedListLock.lock();
+        copy.addAll(queuedEpisodeActions);
+        feedListLock.unlock();
+        return copy;
     }
 
-    public static synchronized void removeQueuedEpisodeActions(Collection<GpodnetEpisodeAction> queued) {
+    public static void removeQueuedEpisodeActions(Collection<GpodnetEpisodeAction> queued) {
         ensurePreferencesLoaded();
+        feedListLock.lock();
         queuedEpisodeActions.removeAll(queued);
         writePreference(PREF_SYNC_EPISODE_ACTIONS, writeEpisodeActionsToString(queuedEpisodeActions));
+        feedListLock.unlock();
     }
 
     /**
@@ -252,12 +261,14 @@ public class GpodnetPreferences {
         setUsername(null);
         setPassword(null);
         setDeviceID(null);
+        feedListLock.lock();
         addedFeeds.clear();
         writePreference(PREF_SYNC_ADDED, addedFeeds);
         removedFeeds.clear();
         writePreference(PREF_SYNC_REMOVED, removedFeeds);
         queuedEpisodeActions.clear();
         writePreference(PREF_SYNC_EPISODE_ACTIONS, writeEpisodeActionsToString(queuedEpisodeActions));
+        feedListLock.unlock();
         setLastSubscriptionSyncTimestamp(0);
     }
 


### PR DESCRIPTION
I noticed the following exception via Google Play

```
java.util.ConcurrentModificationException
at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
at java.util.AbstractCollection.toString(AbstractCollection.java:372)
at java.util.Collections$UnmodifiableCollection.toString(Collections.java:994)
at java.lang.StringBuilder.append(StringBuilder.java:202)
at de.danoeh.antennapod.core.service.GpodnetSyncService.syncEpisodeActions(GpodnetSyncService.java:207)
at de.danoeh.antennapod.core.service.GpodnetSyncService.sync(GpodnetSyncService.java:120)
at de.danoeh.antennapod.core.service.GpodnetSyncService.access$100(GpodnetSyncService.java:45)
at de.danoeh.antennapod.core.service.GpodnetSyncService$1.onWaitCompleted(GpodnetSyncService.java:323)
at de.danoeh.antennapod.core.service.GpodnetSyncService$WaiterThread$1.run(GpodnetSyncService.java:359)
```

When I investigated I discovered that GpodnetPreferences was very inconsistent with how it handled locking.  I believe I've improved things.

I also removed 'testAbout' because it took so long and didn't add much (though we may discover in the future that some link died).