### PR TITLE
Retro-actively disable auto download for older episodes

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1477,7 +1477,7 @@ public class PodDBAdapter {
      */
     private static class PodDBHelper extends SQLiteOpenHelper {
 
-        private final static int VERSION = 18;
+        private final static int VERSION = 1030002;
 
         private Context context;
 
@@ -1701,6 +1701,11 @@ public class PodDBAdapter {
             if(oldVersion <= 17) {
                 db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                         + " ADD COLUMN " + PodDBAdapter.KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0");
+            }
+            if(oldVersion < 1030002) {
+                db.execSQL("UPDATE FeedItems SET auto_download=0 WHERE " +
+                        "(read=1 OR id IN (SELECT id FROM FeedMedia WHERE position>0 OR downloaded=1)) " +
+                        "AND id NOT IN (SELECT feeditem FROM Queue)");
             }
             EventBus.getDefault().post(ProgressEvent.end());
         }


### PR DESCRIPTION
Problem: Per default, auto downloading was enabled for all episodes when it was introduced. Now, some users complain that (older) episodes are downloaded twice (or again).

Solution: We disable auto downloading for all episodes that are marked as played, have a position > 0 (partially played) or are currently downloaded (all actions, that would disable auto downloading now).
We exclude episodes that are currently in the queue.

Possible new issues: There might be users that performed an action that automatically disabled auto downloading (like downloading or playing) and manually re-activated auto downloading. These users will lose their manual change.

Fixes #1009

Also changed: The DB version now reflects the app's code version. This will make it a lot easier to see when database migrations were performed.

Why I did not use variables in the SQL you ask? My reasoning: I know the tables and columns names for that particular version upgrade. When someone changes these constants in the future, this person will break the migration. IMHO it makes sense to not use variables here.