### PR TITLE
Remove Flattr this App button

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -52,7 +52,6 @@ import de.danoeh.antennapod.dialog.VariableSpeedDialog;
  */
 public class PreferenceController {
     private static final String TAG = "PreferenceController";
-    public static final String PREF_FLATTR_THIS_APP = "prefFlattrThisApp";
     public static final String PREF_FLATTR_SETTINGS = "prefFlattrSettings";
     public static final String PREF_FLATTR_AUTH = "pref_flattr_authenticate";
     public static final String PREF_FLATTR_REVOKE = "prefRevokeAccess";
@@ -107,23 +106,6 @@ public class PreferenceController {
                     }
             );
         }
-
-        ui.findPreference(PreferenceController.PREF_FLATTR_THIS_APP).setOnPreferenceClickListener(
-                new Preference.OnPreferenceClickListener() {
-
-                    @Override
-                    public boolean onPreferenceClick(Preference preference) {
-                        new FlattrClickWorker(activity,
-                                new SimpleFlattrThing(activity.getString(R.string.app_name),
-                                        FlattrUtils.APP_URL,
-                                        new FlattrStatus(FlattrStatus.STATUS_QUEUE)
-                                )
-                        ).executeAsync();
-
-                        return true;
-                    }
-                }
-        );
 
         ui.findPreference(PreferenceController.PREF_FLATTR_REVOKE).setOnPreferenceClickListener(
                 new Preference.OnPreferenceClickListener() {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -205,11 +205,6 @@
             android:title="@string/choose_data_directory"
             android:key="prefChooseDataDir"/>
         <Preference
-            android:key="prefFlattrThisApp"
-            android:summary="@string/pref_flattr_this_app_sum"
-            android:title="@string/pref_flattr_this_app_title">
-        </Preference>
-        <Preference
             android:key="prefOpmlExport"
             android:title="@string/opml_export_label"/>
         <Preference

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -274,11 +274,7 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
     public void setContentEncoded(String contentEncoded) {
         this.contentEncoded = contentEncoded;
     }
-
-    public void setFlattrStatus(FlattrStatus status) {
-        this.flattrStatus = status;
-    }
-
+    
     public FlattrStatus getFlattrStatus() {
         return flattrStatus;
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
@@ -42,8 +42,6 @@ public class FlattrUtils {
 
     private static final String PREF_ACCESS_TOKEN = "de.danoeh.antennapod.preference.flattrAccessToken";
 
-    // Flattr URL for this app.
-    public static final String APP_URL = "http://antennapod.com";
     // Human-readable flattr-page.
     public static final String APP_LINK = "https://flattr.com/thing/745609/";
     public static final String APP_THING_ID = "745609";

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
@@ -42,10 +42,6 @@ public class FlattrUtils {
 
     private static final String PREF_ACCESS_TOKEN = "de.danoeh.antennapod.preference.flattrAccessToken";
 
-    // Human-readable flattr-page.
-    public static final String APP_LINK = "https://flattr.com/thing/745609/";
-    public static final String APP_THING_ID = "745609";
-
     private static volatile AccessToken cachedToken;
 
     private static AndroidAuthenticator createAuthenticator() {
@@ -106,18 +102,6 @@ public class FlattrUtils {
     public static void deleteToken() {
         Log.d(TAG, "Deleting flattr token");
         storeToken(null);
-    }
-
-    public static Thing getAppThing(Context context) {
-        FlattrService fs = FlattrServiceCreator.getService(retrieveToken());
-        try {
-            Thing thing = fs.getThing(Thing.withId(APP_THING_ID));
-            return thing;
-        } catch (FlattrException e) {
-            e.printStackTrace();
-            showErrorDialog(context, e.getMessage());
-            return null;
-        }
     }
 
     public static void clickUrl(Context context, String url)
@@ -241,37 +225,6 @@ public class FlattrUtils {
             Uri uri = Uri.parse(url);
             context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
         }
-    }
-
-    public static void showForbiddenDialog(final Context context,
-                                           final String url) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.action_forbidden_title);
-        builder.setMessage(R.string.action_forbidden_msg);
-        builder.setPositiveButton(R.string.authenticate_now_label,
-                new OnClickListener() {
-
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        context.startActivity(
-                                ClientConfig.flattrCallbacks.getFlattrAuthenticationActivityIntent(context));
-                    }
-
-                }
-        );
-        builder.setNegativeButton(R.string.visit_website_label,
-                new OnClickListener() {
-
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        Uri uri = Uri.parse(url);
-                        context.startActivity(new Intent(Intent.ACTION_VIEW,
-                                uri));
-                    }
-
-                }
-        );
-        builder.create().show();
     }
 
     public static void showErrorDialog(final Context context, final String msg) {


### PR DESCRIPTION
It turns out supporting 'flattring this app' is too complicated.

While we appreciate everyone that wants to support development, finding a way to properly and equitably manage the funds would take significant time away from actually working on AntennaPod.

We still support flattring feeds.

The best way people can support AntennaPod is by joining the alpha test and reporting bugs before the app goes to production.