### PR TITLE
Fixes pictures disappearing in some cases

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -210,7 +210,7 @@
             android:title="@string/pref_image_cache_size_title"
             android:key="prefImageCacheSize"
             android:summary="@string/pref_image_cache_size_sum"
-            android:defaultValue="0"/>
+            android:defaultValue="100"/>
         <Preference
             android:key="prefOpmlExport"
             android:title="@string/opml_export_label"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 
 import de.danoeh.antennapod.core.ClientConfig;
+import de.danoeh.antennapod.core.service.download.AntennapodHttpClient;
 import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.NetworkUtils;
@@ -42,7 +43,7 @@ public class ApOkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
             if (internalClient == null) {
                 synchronized (Factory.class) {
                     if (internalClient == null) {
-                        internalClient = new OkHttpClient();
+                        internalClient = AntennapodHttpClient.getHttpClient();
                         internalClient.interceptors().add(new NetworkAllowanceInterceptor());
                         internalClient.interceptors().add(new BasicAuthenticationInterceptor());
                     }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -85,6 +85,8 @@ public class UserPreferences {
     private static final String PREF_FAST_FORWARD_SECS = "prefFastForwardSecs";
     private static final String PREF_REWIND_SECS = "prefRewindSecs";
     public static final String PREF_QUEUE_LOCKED = "prefQueueLocked";
+    public static final String IMAGE_CACHE_DEFAULT_VALUE = "100";
+    public static final int IMAGE_CACHE_SIZE_MINIMUM = 20;
 
     // Constants
     private static int EPISODE_CACHE_SIZE_UNLIMITED = -1;
@@ -279,9 +281,16 @@ public class UserPreferences {
     }
 
     public static int getImageCacheSize() {
-        String cacheSizeString = prefs.getString(PREF_IMAGE_CACHE_SIZE, "100");
-        int cacheSize = Integer.valueOf(cacheSizeString) * 1024 * 1024;
-        return cacheSize;
+        String cacheSizeString = prefs.getString(PREF_IMAGE_CACHE_SIZE, IMAGE_CACHE_DEFAULT_VALUE);
+        int cacheSizeInt = Integer.valueOf(cacheSizeString);
+        // if the cache size is too small the user won't get any images at all
+        // that's bad, force it back to the default.
+        if (cacheSizeInt < IMAGE_CACHE_SIZE_MINIMUM) {
+            prefs.edit().putString(PREF_IMAGE_CACHE_SIZE, IMAGE_CACHE_DEFAULT_VALUE).commit();
+            cacheSizeInt = Integer.valueOf(IMAGE_CACHE_DEFAULT_VALUE);
+        }
+        int cacheSizeMB = cacheSizeInt * 1024 * 1024;
+        return cacheSizeMB;
     }
 
     public static int getFastFowardSecs() {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -286,7 +286,7 @@ public class UserPreferences {
         // if the cache size is too small the user won't get any images at all
         // that's bad, force it back to the default.
         if (cacheSizeInt < IMAGE_CACHE_SIZE_MINIMUM) {
-            prefs.edit().putString(PREF_IMAGE_CACHE_SIZE, IMAGE_CACHE_DEFAULT_VALUE).commit();
+            prefs.edit().putString(PREF_IMAGE_CACHE_SIZE, IMAGE_CACHE_DEFAULT_VALUE).apply();
             cacheSizeInt = Integer.valueOf(IMAGE_CACHE_DEFAULT_VALUE);
         }
         int cacheSizeMB = cacheSizeInt * 1024 * 1024;


### PR DESCRIPTION
* Default value for the image cache size should be > 0
* If the image cache size is too small we force it back to default
* We should only have once instance of the HTTP client

fixes AntennaPod/AntennaPod/#1053