### PR TITLE
Changed string names relating to time units.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -480,7 +480,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                             checked = i;
                         }
                         choices[i] = String.valueOf(values[i]) + " "
-                                + getString(R.string.time_unit_seconds);
+                                + getString(R.string.time_seconds);
                     }
                     choice = values[checked];
                     AlertDialog.Builder builder = new AlertDialog.Builder(MediaplayerActivity.this);
@@ -528,7 +528,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                             checked = i;
                         }
                         choices[i] = String.valueOf(values[i]) + " "
-                                + getString(R.string.time_unit_seconds);
+                                + getString(R.string.time_seconds);
                     }
                     choice = values[checked];
                     AlertDialog.Builder builder = new AlertDialog.Builder(MediaplayerActivity.this);

--- a/app/src/main/java/de/danoeh/antennapod/dialog/TimeDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/TimeDialog.java
@@ -39,9 +39,9 @@ public abstract class TimeDialog extends Dialog {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
-        String[] spinnerContent = new String[]{context.getString(R.string.time_unit_seconds),
-                context.getString(R.string.time_unit_minutes),
-                context.getString(R.string.time_unit_hours)};
+        String[] spinnerContent = new String[]{context.getString(R.string.time_seconds),
+                context.getString(R.string.time_minutes),
+                context.getString(R.string.time_hours)};
 
         setContentView(R.layout.time_dialog);
         etxtTime = (EditText) findViewById(R.id.etxtTime);

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -36,12 +36,9 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.activity.PreferenceActivity;
 import de.danoeh.antennapod.activity.PreferenceActivityGingerbread;
 import de.danoeh.antennapod.asynctask.OpmlExportWorker;
-import de.danoeh.antennapod.core.asynctask.FlattrClickWorker;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
-import de.danoeh.antennapod.core.util.flattr.FlattrStatus;
 import de.danoeh.antennapod.core.util.flattr.FlattrUtils;
-import de.danoeh.antennapod.core.util.flattr.SimpleFlattrThing;
 import de.danoeh.antennapod.dialog.AuthenticationDialog;
 import de.danoeh.antennapod.dialog.AutoFlattrPreferenceDialog;
 import de.danoeh.antennapod.dialog.GpodnetSetHostnameDialog;
@@ -431,7 +428,7 @@ public class PreferenceController {
                 entries[x] = res.getString(R.string.pref_smart_mark_as_played_disabled);
             } else {
                 Integer v = Integer.parseInt(values[x]);
-                entries[x] = res.getQuantityString(R.plurals.time_unit_seconds, v);
+                entries[x] = res.getQuantityString(R.plurals.time_seconds_quantified, v);
             }
         }
         pref.setEntries(entries);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -111,10 +111,10 @@ public final class Converter {
 
         String result = "";
         if(h > 0) {
-            String hours = context.getResources().getQuantityString(R.plurals.time_unit_hours, h, h);
+            String hours = context.getResources().getQuantityString(R.plurals.time_hours_quantified, h, h);
             result += hours + " ";
         }
-        String minutes = context.getResources().getQuantityString(R.plurals.time_unit_minutes, m, m);
+        String minutes = context.getResources().getQuantityString(R.plurals.time_minutes_quantified, m, m);
         result += minutes;
         return result;
     }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -384,18 +384,18 @@
     <string name="sleep_timer_label">Sleep timer</string>
     <string name="time_left_label">Time left:\u0020</string>
     <string name="time_dialog_invalid_input">Invalid input, time has to be an integer</string>
-    <string name="time_unit_seconds">seconds</string>
-    <string name="time_unit_minutes">minutes</string>
-    <string name="time_unit_hours">hours</string>
-    <plurals name="time_unit_seconds">
+    <string name="time_seconds">seconds</string>
+    <string name="time_minutes">minutes</string>
+    <string name="time_hours">hours</string>
+    <plurals name="time_seconds_quantified">
         <item quantity="one">1 second</item>
         <item quantity="other">%d seconds</item>
     </plurals>
-    <plurals name="time_unit_minutes">
+    <plurals name="time_minutes_quantified">
         <item quantity="one">1 minute</item>
         <item quantity="other">%d minutes</item>
     </plurals>
-    <plurals name="time_unit_hours">
+    <plurals name="time_hours_quantified">
         <item quantity="one">1 hour</item>
         <item quantity="other">%d hours</item>
     </plurals>


### PR DESCRIPTION
Android can handle plurals and strings having the same names, but
Transifex can't.  Renamed the time_unit*'s to just time_ to make sure
we got the correct translations.