### PR TITLE
Only autodownload queued and new items

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="1030004"
-    android:versionName="1.3-RC4">
+    android:versionCode="1030005"
+    android:versionName="1.3-RC5">
     <!--
       Version code schema:
       "1.2.3-SNAPSHOT" -> 1020300

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -325,6 +325,11 @@ public class DownloadService extends Service {
         cancelNotificationUpdater();
         unregisterReceiver(cancelDownloadReceiver);
 
+        // TODO: I'm not sure this is actually needed.
+        // We could just invoke the autodownloadUndownloadeditems method
+        // and it would get everything it's supposed to.  By sending it the
+        // items in newMediaFiles we're overriding the download algorithm,
+        // which is not something we should probably do.
         if (!newMediaFiles.isEmpty()) {
             Log.d(TAG, "newMediaFiles exist, autodownload them");
             DBTasks.autodownloadUndownloadedItems(getApplicationContext(),
@@ -783,7 +788,7 @@ public class DownloadService extends Service {
                                 if(item.getPubDate() == null) {
                                     Log.d(TAG, item.toString());
                                 }
-                                if (!item.isPlayed() && item.hasMedia() && !item.getMedia().isDownloaded()) {
+                                if (item.isNew() && item.hasMedia() && !item.getMedia().isDownloaded()) {
                                     newMediaFiles.add(item.getMedia().getId());
                                 }
                             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -22,7 +22,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     private final APCleanupAlgorithm cleanupAlgorithm = new APCleanupAlgorithm();
 
     /**
-     * Looks for undownloaded episodes in the queue or list of unread items and request a download if
+     * Looks for undownloaded episodes in the queue or list of new items and request a download if
      * 1. Network is available
      * 2. The device is charging or the user allows auto download on battery
      * 3. There is free space in the episode cache
@@ -57,12 +57,12 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                         candidates = DBReader.getFeedItems(context, mediaIds);
                     } else {
                         final List<FeedItem> queue = DBReader.getQueue(context);
-                        final List<FeedItem> unreadItems = DBReader.getUnreadItemsList(context);
-                        candidates = new ArrayList<FeedItem>(queue.size() + unreadItems.size());
+                        final List<FeedItem> newItems = DBReader.getNewItemsList(context);
+                        candidates = new ArrayList<FeedItem>(queue.size() + newItems.size());
                         candidates.addAll(queue);
-                        for(FeedItem unreadItem : unreadItems) {
-                            if(candidates.contains(unreadItem) == false) {
-                                candidates.add(unreadItem);
+                        for(FeedItem newItem : newItems) {
+                            if(candidates.contains(newItem) == false) {
+                                candidates.add(newItem);
                             }
                         }
                     }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1709,7 +1709,7 @@ public class PodDBAdapter {
                 db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                         + " ADD COLUMN " + PodDBAdapter.KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0");
             }
-            if(oldVersion < 1030002) {
+            if(oldVersion < 1030005) {
                 db.execSQL("UPDATE FeedItems SET auto_download=0 WHERE " +
                         "(read=1 OR id IN (SELECT feeditem FROM FeedMedia WHERE position>0 OR downloaded=1)) " +
                         "AND id NOT IN (SELECT feeditem FROM Queue)");

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1711,7 +1711,7 @@ public class PodDBAdapter {
             }
             if(oldVersion < 1030002) {
                 db.execSQL("UPDATE FeedItems SET auto_download=0 WHERE " +
-                        "(read=1 OR id IN (SELECT id FROM FeedMedia WHERE position>0 OR downloaded=1)) " +
+                        "(read=1 OR id IN (SELECT feeditem FROM FeedMedia WHERE position>0 OR downloaded=1)) " +
                         "AND id NOT IN (SELECT feeditem FROM Queue)");
             }
             EventBus.getDefault().post(ProgressEvent.end());


### PR DESCRIPTION
After some thought and use of autodownload as it stands now, auto-downloading all unplayed episodes is just not the expected behavior for anyone.  If we autodownload all unplayed episodes then if you subscribe to a new feed all of the episodes from that feed are candidates to be autodownloaded, and they may trump other 'new' episodes from other feeds.

So, this change makes it so that only queued and new items are autodownloaded. If you want to download something else you can still click the 'Download' button and it will still be downloaded and enqueued.

As a result, I think AntennaPod/AntennaPod#1060 will probably wind up focusing on the cleanup algorithm, favorites, etc...

This also fixes a small bug that occurs when upgrading the database to set the autodownload flag to false.

refs AntennaPod/AntennaPod#1009