### PR TITLE
resolves NPE in QueueListAdapter

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
@@ -155,19 +155,12 @@ public class QueueListAdapter extends BaseAdapter {
         holder.butSecondary.setTag(item);
         holder.butSecondary.setOnClickListener(secondaryActionListener);
 
-        Uri feedImageUri = item.getFeed().getImageUri();
-        if (feedImageUri != null) {
-            Log.d(TAG, item.getFeed().getImageUri().toString());
-        } else {
-            Log.d(TAG, "Feed has null image uri");
-        }
-
         Glide.with(context)
                 .load(item.getImageUri())
                 .diskCacheStrategy(DiskCacheStrategy.SOURCE)
                 .fitCenter()
                 .dontAnimate()
-                .into(new CoverTarget(feedImageUri, holder.placeholder, holder.cover));
+                .into(new CoverTarget(item.getFeed().getImageUri(), holder.placeholder, holder.cover));
 
         return convertView;
     }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueListAdapter.java
@@ -155,14 +155,19 @@ public class QueueListAdapter extends BaseAdapter {
         holder.butSecondary.setTag(item);
         holder.butSecondary.setOnClickListener(secondaryActionListener);
 
-        Log.d(TAG, item.getFeed().getImageUri().toString());
+        Uri feedImageUri = item.getFeed().getImageUri();
+        if (feedImageUri != null) {
+            Log.d(TAG, item.getFeed().getImageUri().toString());
+        } else {
+            Log.d(TAG, "Feed has null image uri");
+        }
 
         Glide.with(context)
                 .load(item.getImageUri())
                 .diskCacheStrategy(DiskCacheStrategy.SOURCE)
                 .fitCenter()
                 .dontAnimate()
-                .into(new CoverTarget(item.getFeed().getImageUri(), holder.placeholder, holder.cover));
+                .into(new CoverTarget(feedImageUri, holder.placeholder, holder.cover));
 
         return convertView;
     }


### PR DESCRIPTION
This following NullPointerException showed up from the play alpha channel.

What's interesting is that it came from within a 'Log.d()' line that should have been removed by ProGuard. I suspect it just removed the call to Log.d(), but that the computation that occurs in the call still occurs.

Is it ok to pass the .load() function of Glide a null pointer?  If so, awesome. If not we'll need to fix a couple of other places.

What do you think @mfietz?

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.net.Uri.toString()' on a null object reference
at de.danoeh.antennapod.adapter.QueueListAdapter.getView(QueueListAdapter.java:158)
at com.mobeta.android.dslv.DragSortListView$AdapterWrapper.getView(DragSortListView.java:730)
at android.widget.AbsListView.obtainView(AbsListView.java:2347)
at android.widget.ListView.measureHeightOfChildren(ListView.java:1270)
at android.widget.ListView.onMeasure(ListView.java:1182)
at com.mobeta.android.dslv.DragSortListView.onMeasure(DragSortListView.java:2123)
at android.view.View.measure(View.java:17547)
at android.widget.RelativeLayout.measureChild(RelativeLayout.java:697)
at android.widget.RelativeLayout.onMeasure(RelativeLayout.java:481)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
at android.view.View.measure(View.java:17547)
at android.widget.RelativeLayout.measureChildHorizontal(RelativeLayout.java:727)
at android.widget.RelativeLayout.onMeasure(RelativeLayout.java:463)
at android.view.View.measure(View.java:17547)
at android.support.v4.widget.DrawerLayout.onMeasure(DrawerLayout.java:851)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1436)
at android.widget.LinearLayout.measureVertical(LinearLayout.java:722)
at android.widget.LinearLayout.onMeasure(LinearLayout.java:613)
at android.view.View.measure(View.java:17547)
at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
at com.android.internal.policy.impl.PhoneWindow$DecorView.onMeasure(PhoneWindow.java:2615)
at android.view.View.measure(View.java:17547)
at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:2015)
at android.view.ViewRootImpl.measureHierarchy(ViewRootImpl.java:1173)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1379)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1061)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5885)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
at android.view.Choreographer.doCallbacks(Choreographer.java:580)
at android.view.Choreographer.doFrame(Choreographer.java:550)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5254)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```