### PR TITLE
create PreferenceController before the main fragment

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -60,10 +60,13 @@ public class PreferenceActivity extends ActionBarActivity {
         root.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
         setContentView(root);
+
+        // we need to create the PreferenceController before the MainFragment
+        // since the MainFragment depends on the preferenceController already being created
+        preferenceController = new PreferenceController(preferenceUI);
+
         prefFragment = new MainFragment();
         getFragmentManager().beginTransaction().replace(R.id.content, prefFragment).commit();
-
-        preferenceController = new PreferenceController(preferenceUI);
     }
 
     @Override


### PR DESCRIPTION
Attempting to resolve this crash that appeared in Google Play:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{de.danoeh.antennapod/de.danoeh.antennapod.activity.PreferenceActivity}: java.lang.NullPointerException: Attempt to read from field 'de.danoeh.antennapod.preferences.PreferenceController de.danoeh.antennapod.activity.PreferenceActivity.preferenceController' on a null object reference
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2306)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2368)
at android.app.ActivityThread.access$800(ActivityThread.java:149)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1284)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5292)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:908)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:703)
Caused by: java.lang.NullPointerException: Attempt to read from field 'de.danoeh.antennapod.preferences.PreferenceController de.danoeh.antennapod.activity.PreferenceActivity.preferenceController' on a null object reference
at de.danoeh.antennapod.activity.PreferenceActivity.access$200(PreferenceActivity.java:25)
at de.danoeh.antennapod.activity.PreferenceActivity$MainFragment.onCreate(PreferenceActivity.java:99)
at android.app.Fragment.performCreate(Fragment.java:2040)
at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:863)
at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1067)
at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1049)
at android.app.FragmentManagerImpl.dispatchCreate(FragmentManager.java:1864)
at android.app.Activity.onCreate(Activity.java:949)
at android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:255)
at android.support.v7.app.ActionBarActivity.onCreate(ActionBarActivity.java:122)
at de.danoeh.antennapod.activity.PreferenceActivity.onCreate(PreferenceActivity.java:49)
at android.app.Activity.performCreate(Activity.java:6020)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1105)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2259)
... 10 more
```