### PR TITLE
use correct string for action

### DIFF
--- a/app/src/main/res/menu/feedinfo.xml
+++ b/app/src/main/res/menu/feedinfo.xml
@@ -22,7 +22,7 @@
     <item
         android:id="@+id/share_download_url_item"
         custom:showAsAction="collapseActionView"
-        android:title="@string/share_source_label">
+        android:title="@string/share_feed_url_label">
     </item>
 
 </menu>


### PR DESCRIPTION
The FeedInfo display was missing a string when you clicked the ... action.  Turns out it never got switched over to share_feed_url_label.