### PR TITLE
Sleep Timer: Shake to reset, lower volume, vibrate, remember preferences

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
@@ -122,7 +122,17 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
             }
 
             @Override
+            public void onSleepTimerAlmostExpired() {
+
+            }
+
+            @Override
             public void onSleepTimerExpired() {
+
+            }
+
+            @Override
+            public void onSleepTimerReset() {
 
             }
 
@@ -170,7 +180,17 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
             }
 
             @Override
+            public void onSleepTimerAlmostExpired() {
+
+            }
+
+            @Override
             public void onSleepTimerExpired() {
+
+            }
+
+            @Override
+            public void onSleepTimerReset() {
 
             }
 
@@ -221,7 +241,7 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
         PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
         pstm.startWidgetUpdater();
         pstm.startPositionSaver();
-        pstm.setSleepTimer(100000);
+        pstm.setSleepTimer(100000, false, false);
         pstm.cancelAllTasks();
         assertFalse(pstm.isPositionSaverActive());
         assertFalse(pstm.isWidgetUpdaterActive());
@@ -241,11 +261,21 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
             }
 
             @Override
+            public void onSleepTimerAlmostExpired() {
+
+            }
+
+            @Override
             public void onSleepTimerExpired() {
                 if (countDownLatch.getCount() == 0) {
                     fail();
                 }
                 countDownLatch.countDown();
+            }
+
+            @Override
+            public void onSleepTimerReset() {
+
             }
 
             @Override
@@ -258,7 +288,7 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
 
             }
         });
-        pstm.setSleepTimer(TIME);
+        pstm.setSleepTimer(TIME, false, false);
         countDownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS);
         pstm.shutdown();
     }
@@ -275,8 +305,18 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
             }
 
             @Override
+            public void onSleepTimerAlmostExpired() {
+
+            }
+
+            @Override
             public void onSleepTimerExpired() {
                 fail("Sleeptimer expired");
+            }
+
+            @Override
+            public void onSleepTimerReset() {
+
             }
 
             @Override
@@ -289,7 +329,7 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
 
             }
         });
-        pstm.setSleepTimer(TIME);
+        pstm.setSleepTimer(TIME, false, false);
         pstm.disableSleepTimer();
         assertFalse(countDownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
         pstm.shutdown();
@@ -298,7 +338,7 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
     public void testIsSleepTimerActivePositive() {
         final Context c = getInstrumentation().getTargetContext();
         PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
-        pstm.setSleepTimer(10000);
+        pstm.setSleepTimer(10000, false, false);
         assertTrue(pstm.isSleepTimerActive());
         pstm.shutdown();
     }
@@ -306,7 +346,7 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
     public void testIsSleepTimerActiveNegative() {
         final Context c = getInstrumentation().getTargetContext();
         PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
-        pstm.setSleepTimer(10000);
+        pstm.setSleepTimer(10000, false, false);
         pstm.disableSleepTimer();
         assertFalse(pstm.isSleepTimerActive());
         pstm.shutdown();
@@ -319,7 +359,17 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
         }
 
         @Override
+        public void onSleepTimerAlmostExpired() {
+
+        }
+
+        @Override
         public void onSleepTimerExpired() {
+
+        }
+
+        @Override
+        public void onSleepTimerReset() {
 
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -31,7 +31,7 @@ import de.danoeh.antennapod.core.util.StorageUtils;
 import de.danoeh.antennapod.core.util.playback.MediaPlayerError;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
-import de.danoeh.antennapod.dialog.TimeDialog;
+import de.danoeh.antennapod.dialog.SleepTimerDialog;
 
 /**
  * Provides general features which are both needed for playing audio and video
@@ -323,13 +323,10 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                     break;
                 case R.id.set_sleeptimer_item:
                     if (controller.serviceAvailable()) {
-                        TimeDialog td = new TimeDialog(this,
-                                R.string.set_sleeptimer_label,
-                                R.string.set_sleeptimer_label) {
-
+                        SleepTimerDialog td = new SleepTimerDialog(this, 0, 0) {
                             @Override
-                            public void onTimeEntered(long millis) {
-                                controller.setSleepTimer(millis);
+                            public void onTimerSet(long millis, boolean shakeToReset, boolean vibrate) {
+                                controller.setSleepTimer(millis, shakeToReset, vibrate);
                             }
                         };
                         td.show();

--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -9,13 +9,19 @@ import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.*;
-import de.danoeh.antennapod.core.BuildConfig;
-import de.danoeh.antennapod.R;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.Toast;
 
 import java.util.concurrent.TimeUnit;
 
-public abstract class TimeDialog extends Dialog {
+import de.danoeh.antennapod.R;
+
+public abstract class SleepTimerDialog extends Dialog {
+    
     private static final String TAG = "TimeDialog";
 
     private static final int DEFAULT_SPINNER_POSITION = 1;
@@ -24,13 +30,14 @@ public abstract class TimeDialog extends Dialog {
 
     private EditText etxtTime;
     private Spinner spTimeUnit;
+    private CheckBox cbShakeToReset;
+    private CheckBox cbVibrate;
     private Button butConfirm;
     private Button butCancel;
 
-    private TimeUnit[] units = {TimeUnit.SECONDS, TimeUnit.MINUTES,
-            TimeUnit.HOURS};
+    private TimeUnit[] units = { TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS };
 
-    public TimeDialog(Context context, int titleTextId, int leftButtonTextId) {
+    public SleepTimerDialog(Context context, int titleTextId, int leftButtonTextId) {
         super(context);
         this.context = context;
     }
@@ -46,13 +53,15 @@ public abstract class TimeDialog extends Dialog {
         setContentView(R.layout.time_dialog);
         etxtTime = (EditText) findViewById(R.id.etxtTime);
         spTimeUnit = (Spinner) findViewById(R.id.spTimeUnit);
+        cbShakeToReset = (CheckBox) findViewById(R.id.cbShakeToReset);
+        cbVibrate = (CheckBox) findViewById(R.id.cbVibrate);
         butConfirm = (Button) findViewById(R.id.butConfirm);
         butCancel = (Button) findViewById(R.id.butCancel);
 
         butConfirm.setText(R.string.set_sleeptimer_label);
         butCancel.setText(R.string.cancel_label);
         setTitle(R.string.set_sleeptimer_label);
-        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<String>(
+        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(
                 this.getContext(), android.R.layout.simple_spinner_item,
                 spinnerContent);
         spinnerAdapter
@@ -72,7 +81,7 @@ public abstract class TimeDialog extends Dialog {
             public void onClick(View v) {
                 try {
                     long input = readTimeMillis();
-                    onTimeEntered(input);
+                    onTimerSet(input, cbShakeToReset.isChecked(), cbVibrate.isChecked());
                     dismiss();
                 } catch (NumberFormatException e) {
                     e.printStackTrace();
@@ -117,17 +126,15 @@ public abstract class TimeDialog extends Dialog {
 
     private void checkInputLength(int length) {
         if (length > 0) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Length is larger than 0, enabling confirm button");
+            Log.d(TAG, "Length is larger than 0, enabling confirm button");
             butConfirm.setEnabled(true);
         } else {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Length is smaller than 0, disabling confirm button");
+            Log.d(TAG, "Length is smaller than 0, disabling confirm button");
             butConfirm.setEnabled(false);
         }
     }
 
-    public abstract void onTimeEntered(long millis);
+    public abstract void onTimerSet(long millis, boolean shakeToReset, boolean vibrate);
 
     private long readTimeMillis() {
         TimeUnit selectedUnit = units[spTimeUnit.getSelectedItemPosition()];

--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.dialog;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -22,11 +23,17 @@ import de.danoeh.antennapod.R;
 
 public abstract class SleepTimerDialog extends Dialog {
     
-    private static final String TAG = "TimeDialog";
+    private static final String TAG = SleepTimerDialog.class.getSimpleName();
 
     private static final int DEFAULT_SPINNER_POSITION = 1;
 
     private Context context;
+    private String PREF_NAME = "SleepTimerDialog";
+    private String PREF_VALUE = "LastValue";
+    private String PREF_TIME_UNIT = "LastTimeUnit";
+    private String PREF_VIBRATE = "Vibrate";
+    private String PREF_SHAKE_TO_RESET = "ShakeToReset";
+    private SharedPreferences prefs;
 
     private EditText etxtTime;
     private Spinner spTimeUnit;
@@ -40,15 +47,17 @@ public abstract class SleepTimerDialog extends Dialog {
     public SleepTimerDialog(Context context, int titleTextId, int leftButtonTextId) {
         super(context);
         this.context = context;
+        prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
-        String[] spinnerContent = new String[]{context.getString(R.string.time_seconds),
+        String[] spinnerContent = new String[] {
+                context.getString(R.string.time_seconds),
                 context.getString(R.string.time_minutes),
-                context.getString(R.string.time_hours)};
+                context.getString(R.string.time_hours) };
 
         setContentView(R.layout.time_dialog);
         etxtTime = (EditText) findViewById(R.id.etxtTime);
@@ -58,60 +67,23 @@ public abstract class SleepTimerDialog extends Dialog {
         butConfirm = (Button) findViewById(R.id.butConfirm);
         butCancel = (Button) findViewById(R.id.butCancel);
 
-        butConfirm.setText(R.string.set_sleeptimer_label);
-        butCancel.setText(R.string.cancel_label);
         setTitle(R.string.set_sleeptimer_label);
-        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(
-                this.getContext(), android.R.layout.simple_spinner_item,
-                spinnerContent);
-        spinnerAdapter
-                .setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spTimeUnit.setAdapter(spinnerAdapter);
-        spTimeUnit.setSelection(DEFAULT_SPINNER_POSITION);
-        butCancel.setOnClickListener(new View.OnClickListener() {
 
-            @Override
-            public void onClick(View v) {
-                dismiss();
-            }
-        });
-        butConfirm.setOnClickListener(new View.OnClickListener() {
-
-            @Override
-            public void onClick(View v) {
-                try {
-                    long input = readTimeMillis();
-                    onTimerSet(input, cbShakeToReset.isChecked(), cbVibrate.isChecked());
-                    dismiss();
-                } catch (NumberFormatException e) {
-                    e.printStackTrace();
-                    Toast toast = Toast.makeText(context,
-                            R.string.time_dialog_invalid_input,
-                            Toast.LENGTH_LONG);
-                    toast.show();
-                }
-            }
-        });
+        etxtTime.setText(prefs.getString(PREF_VALUE, "15"));
         etxtTime.addTextChangedListener(new TextWatcher() {
-
             @Override
             public void afterTextChanged(Editable s) {
                 checkInputLength(s.length());
             }
 
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count,
-                                          int after) {
-
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
             }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before,
-                                      int count) {
-
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
             }
         });
-        checkInputLength(etxtTime.getText().length());
         etxtTime.postDelayed(new Runnable() {
             @Override
             public void run() {
@@ -120,8 +92,41 @@ public abstract class SleepTimerDialog extends Dialog {
             }
         }, 100);
 
+        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(this.getContext(),
+                android.R.layout.simple_spinner_item, spinnerContent);
+        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spTimeUnit.setAdapter(spinnerAdapter);
+        int selection = prefs.getInt(PREF_TIME_UNIT, DEFAULT_SPINNER_POSITION);
+        spTimeUnit.setSelection(selection);
 
+        cbShakeToReset.setChecked(prefs.getBoolean(PREF_SHAKE_TO_RESET, true));
+        cbVibrate.setChecked(prefs.getBoolean(PREF_VIBRATE, true));
 
+        butConfirm.setText(R.string.set_sleeptimer_label);
+        butConfirm.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    savePreferences();
+                    long input = readTimeMillis();
+                    onTimerSet(input, cbShakeToReset.isChecked(), cbVibrate.isChecked());
+                    dismiss();
+                } catch (NumberFormatException e) {
+                    e.printStackTrace();
+                    Toast toast = Toast.makeText(context, R.string.time_dialog_invalid_input,
+                            Toast.LENGTH_LONG);
+                    toast.show();
+                }
+            }
+        });
+
+        butCancel.setText(R.string.cancel_label);
+        butCancel.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dismiss();
+            }
+        });
     }
 
     private void checkInputLength(int length) {
@@ -140,6 +145,15 @@ public abstract class SleepTimerDialog extends Dialog {
         TimeUnit selectedUnit = units[spTimeUnit.getSelectedItemPosition()];
         long value = Long.valueOf(etxtTime.getText().toString());
         return selectedUnit.toMillis(value);
+    }
+
+    private void savePreferences() {
+        prefs.edit()
+                .putString(PREF_VALUE, etxtTime.getText().toString())
+                .putInt(PREF_TIME_UNIT, spTimeUnit.getSelectedItemPosition())
+                .putBoolean(PREF_SHAKE_TO_RESET, cbShakeToReset.isChecked())
+                .putBoolean(PREF_VIBRATE, cbVibrate.isChecked())
+                .apply();
     }
 
 }

--- a/app/src/main/res/layout-v14/time_dialog.xml
+++ b/app/src/main/res/layout-v14/time_dialog.xml
@@ -51,14 +51,12 @@
             <CheckBox android:id="@+id/cbShakeToReset"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:text="@string/shake_to_reset_label"
-                      android:checked="true" />
+                      android:text="@string/shake_to_reset_label"/>
 
             <CheckBox android:id="@+id/cbVibrate"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:text="@string/timer_vibration_label"
-                      android:checked="true" />
+                      android:text="@string/timer_vibration_label"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout-v14/time_dialog.xml
+++ b/app/src/main/res/layout-v14/time_dialog.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -29,6 +29,39 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
             android:layout_marginTop="8dp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textSize="16sp"
+                android:text="@string/timer_about_to_expire_label"/>
+
+            <CheckBox android:id="@+id/cbShakeToReset"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:text="@string/shake_to_reset_label"
+                      android:checked="true" />
+
+            <CheckBox android:id="@+id/cbVibrate"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:text="@string/timer_vibration_label"
+                      android:checked="true" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
     <RelativeLayout

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -33,6 +33,39 @@
     </LinearLayout>
 
     <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textSize="16sp"
+                android:text="@string/timer_about_to_expire_label"/>
+
+            <CheckBox android:id="@+id/cbShakeToReset"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:text="@string/shake_to_reset_label"
+                      android:checked="true" />
+
+            <CheckBox android:id="@+id/cbVibrate"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:text="@string/timer_vibration_label"
+                      android:checked="true" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
         style="@android:style/ButtonBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -52,14 +52,12 @@
             <CheckBox android:id="@+id/cbShakeToReset"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:text="@string/shake_to_reset_label"
-                      android:checked="true" />
+                      android:text="@string/shake_to_reset_label"/>
 
             <CheckBox android:id="@+id/cbVibrate"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:text="@string/timer_vibration_label"
-                      android:checked="true" />
+                      android:text="@string/timer_vibration_label"/>
 
         </LinearLayout>
 

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
     <application
         android:allowBackup="true"

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -19,7 +19,6 @@ import android.media.MediaMetadataRetriever;
 import android.media.MediaPlayer;
 import android.media.RemoteControlClient;
 import android.media.RemoteControlClient.MetadataEditor;
-import android.os.AsyncTask;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
@@ -33,12 +32,9 @@ import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.bumptech.glide.request.animation.GlideAnimation;
-import com.bumptech.glide.request.target.SimpleTarget;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -406,7 +402,7 @@ public class PlaybackService extends Service {
 
         @Override
         public void onSleepTimerAlmostExpired() {
-            mediaPlayer.setVolume(0.5f);
+            mediaPlayer.setVolume(0.1f);
         }
 
         @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -408,6 +408,7 @@ public class PlaybackService extends Service {
         @Override
         public void onSleepTimerExpired() {
             mediaPlayer.pause(true, true);
+            mediaPlayer.setVolume(1.0f);
             sendNotificationBroadcast(NOTIFICATION_TYPE_SLEEPTIMER_UPDATE, 0);
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -405,11 +405,20 @@ public class PlaybackService extends Service {
         }
 
         @Override
+        public void onSleepTimerAlmostExpired() {
+            mediaPlayer.setVolume(0.5f);
+        }
+
+        @Override
         public void onSleepTimerExpired() {
             mediaPlayer.pause(true, true);
             sendNotificationBroadcast(NOTIFICATION_TYPE_SLEEPTIMER_UPDATE, 0);
         }
 
+        @Override
+        public void onSleepTimerReset() {
+            mediaPlayer.setVolume(1.0f);
+        }
 
         @Override
         public void onWidgetUpdaterTick() {
@@ -652,10 +661,9 @@ public class PlaybackService extends Service {
         }
     }
 
-    public void setSleepTimer(long waitingTime) {
-        Log.d(TAG, "Setting sleep timer to " + Long.toString(waitingTime)
-                    + " milliseconds");
-        taskManager.setSleepTimer(waitingTime);
+    public void setSleepTimer(long waitingTime, boolean shakeToReset, boolean vibrate) {
+        Log.d(TAG, "Setting sleep timer to " + Long.toString(waitingTime) + " milliseconds");
+        taskManager.setSleepTimer(waitingTime, shakeToReset, vibrate);
         sendNotificationBroadcast(NOTIFICATION_TYPE_SLEEPTIMER_UPDATE, 0);
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -619,6 +619,32 @@ public class PlaybackServiceMediaPlayer {
         return retVal;
     }
 
+    /**
+     * Sets the playback speed.
+     * This method is executed on an internal executor service.
+     */
+    public void setVolume(final float volume) {
+        executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                setVolumeSync(volume);
+            }
+        });
+    }
+
+    /**
+     * Sets the playback speed.
+     * This method is executed on the caller's thread.
+     */
+    private void setVolumeSync(float volume) {
+        playerLock.lock();
+        if (media != null && media.getMediaType() == MediaType.AUDIO) {
+            mediaPlayer.setVolume(volume, volume);
+            Log.d(TAG, "Media player volume was set to " + volume);
+        }
+        playerLock.unlock();
+    }
+
     public MediaType getCurrentMediaType() {
         return mediaType;
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -350,8 +350,6 @@ public class PlaybackServiceTaskManager {
                     waitingTime -= now - lastTick;
                     lastTick = now;
 
-                    Log.d(TAG, "time left: " + waitingTime);
-
                     if(waitingTime < NOTIFICATION_THRESHOLD && !notifiedAlmostExpired) {
                         Log.d(TAG, "Sleep timer is about to expire");
                         if(vibrate) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ShakeListener.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ShakeListener.java
@@ -1,0 +1,63 @@
+package de.danoeh.antennapod.core.service.playback;
+
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.util.FloatMath;
+import android.util.Log;
+
+public class ShakeListener implements SensorEventListener
+{
+    private static final String TAG = ShakeListener.class.getSimpleName();
+
+    private Sensor mAccelerometer;
+    private SensorManager mSensorMgr;
+    private PlaybackServiceTaskManager.SleepTimer mSleepTimer;
+    private Context mContext;
+
+    public ShakeListener(Context context, PlaybackServiceTaskManager.SleepTimer sleepTimer) {
+        mContext = context;
+        mSleepTimer = sleepTimer;
+        resume();
+    }
+
+    public void resume() {
+        mSensorMgr = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
+        if (mSensorMgr == null) {
+            throw new UnsupportedOperationException("Sensors not supported");
+        }
+        mAccelerometer = mSensorMgr.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+        if (!mSensorMgr.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_UI)) { // if not supported
+            mSensorMgr.unregisterListener(this);
+            throw new UnsupportedOperationException("Accelerometer not supported");
+        }
+    }
+
+    public void pause() {
+        if (mSensorMgr != null) {
+            mSensorMgr.unregisterListener(this);
+            mSensorMgr = null;
+        }
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        float gX = event.values[0] / SensorManager.GRAVITY_EARTH;
+        float gY = event.values[1] / SensorManager.GRAVITY_EARTH;
+        float gZ = event.values[2] / SensorManager.GRAVITY_EARTH;
+
+        float gForce = FloatMath.sqrt(gX*gX + gY*gY + gZ*gZ);
+        if (gForce > 2.25f) {
+            Log.d(TAG, "Detected shake " + gForce);
+            mSleepTimer.onShake();
+        }
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        return;
+    }
+
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ShakeListener.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ShakeListener.java
@@ -24,6 +24,8 @@ public class ShakeListener implements SensorEventListener
     }
 
     public void resume() {
+        // only a precaution, the user should actually not be able to activate shake to reset
+        // when the accelerometer is not available
         mSensorMgr = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
         if (mSensorMgr == null) {
             throw new UnsupportedOperationException("Sensors not supported");

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -652,9 +652,9 @@ public abstract class PlaybackController {
         }
     }
 
-    public void setSleepTimer(long time) {
+    public void setSleepTimer(long time, boolean shakeToReset, boolean vibrate) {
         if (playbackService != null) {
-            playbackService.setSleepTimer(time);
+            playbackService.setSleepTimer(time, shakeToReset, vibrate);
         }
     }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -385,6 +385,9 @@
     <string name="sleep_timer_label">Sleep timer</string>
     <string name="time_left_label">Time left:\u0020</string>
     <string name="time_dialog_invalid_input">Invalid input, time has to be an integer</string>
+    <string name="timer_about_to_expire_label"><b>When timer is about to expire:</b></string>
+    <string name="shake_to_reset_label">Shake to reset timer</string>
+    <string name="timer_vibration_label">Vibrate</string>
     <string name="time_seconds">seconds</string>
     <string name="time_minutes">minutes</string>
     <string name="time_hours">hours</string>


### PR DESCRIPTION
# Sleep Timer Dialog

![timer](https://cloud.githubusercontent.com/assets/6860662/9154520/936d074e-3e93-11e5-965d-3232652fee59.png)

The dialog will now remember the last settings.

I know, the layouts look redundant, but I found no other way to make the dialog look this way, e.g. if you remove the outer LinearLayout, the dialog will become very narrow.

# When timer is about to expire...

10s before the timer is about to expire, users can choose to get a short 0.5s vibration, we need a new permission here. Not sure if this may have any implications on devices with no vibrator, maybe the Play Store will tell them APod is not compatible...
In any case, the audio's volume will be lower significantly. Lowering it to 10% may look much: I tried to find a balance between still being able to hear and detecting the actual volume change [1]. 10% turned out to be the best solution for me.
Shake to reset will only work in this 10 second timeframe. I took the threshold from someone else's code - maybe we have to lower it in another commit, not sure how good people are at giving their phones/tablets a good shake (acceleration!) while lying down...
If a shake is detected, the timer will be reset to 15 mins [2], the volume will be reset to 100% as a kind of audible shake detection confirmation.

# References

Resolves #247
Improvement over #466
I'm also considering closing #228. Fading out sounds nice, but is (as already said) not noticeable enough.

--
[1] Not really sure what is up with the volume setting. I don't think it is linear... when I lowered the volume to 50% or so, the volume change would not be noticeable immediately
[2] Well, I could almost bet on a FR to make this configurable. Not sure if it is worth the effort... Getting an other EditText in the dialog without messing up the layout could be harder that it looks