### PR TITLE
Adding sensor rotation per Issue #965

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -178,7 +178,7 @@
         <activity
             android:name=".activity.VideoplayerActivity"
             android:configChanges="keyboardHidden|orientation"
-            android:screenOrientation="landscape">
+            android:screenOrientation="fullSensor">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="de.danoeh.antennapod.activity.MainActivity"/>


### PR DESCRIPTION
Tested this yesterday, and it worked fine on my Android (Lollipop). Is a very minimal solution of #965. If preferred I can add a portrait-specific view so that the video player isn't stretched in a weird aspect ratio in portrait orientation.