### PR TITLE
Display line breaks in shownotes correctly

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -14,7 +14,6 @@ import org.jsoup.select.Elements;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.ShownotesProvider;
 
@@ -59,6 +58,8 @@ public class Timeline {
     private static final Pattern TIMECODE_LINK_REGEX = Pattern.compile("antennapod://timecode/((\\d+))");
     private static final String TIMECODE_LINK = "<a class=\"timecode\" href=\"antennapod://timecode/%d\">%s</a>";
     private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(([0-9][0-9])):))?(([0-9][0-9])):(([0-9][0-9]))\\b");
+    private static final Pattern LINE_BREAK_REGEX = Pattern.compile("<br *\\/?>");
+
 
     /**
      * Applies an app-specific CSS stylesheet and adds timecode links (optional).
@@ -82,13 +83,14 @@ public class Timeline {
             return null;
         }
         if (shownotes == null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "shownotesProvider contained no shownotes. Returning empty string");
+            Log.d(TAG, "shownotesProvider contained no shownotes. Returning empty string");
             return "";
         }
 
-        // ASCII line breaks to HTML line breaks
-        shownotes = shownotes.replace("\n", "<br />");
+        // replace ASCII line breaks with HTML ones if shownotes don't contain HTML line breaks already
+        if(!LINE_BREAK_REGEX.matcher(shownotes).find()) {
+            shownotes = shownotes.replace("\n", "<br />");
+        }
 
         Document document = Jsoup.parse(shownotes);
 
@@ -100,8 +102,7 @@ public class Timeline {
         // apply timecode links
         if (addTimecodes) {
             Elements elementsWithTimeCodes = document.body().getElementsMatchingOwnText(TIMECODE_REGEX);
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Recognized " + elementsWithTimeCodes.size() + " timecodes");
+            Log.d(TAG, "Recognized " + elementsWithTimeCodes.size() + " timecodes");
             for (Element element : elementsWithTimeCodes) {
                 Matcher matcherLong = TIMECODE_REGEX.matcher(element.html());
                 StringBuffer buffer = new StringBuffer();

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -87,6 +87,9 @@ public class Timeline {
             return "";
         }
 
+        // ASCII line breaks to HTML line breaks
+        shownotes = shownotes.replace("\n", "<br />");
+
         Document document = Jsoup.parse(shownotes);
 
         // apply style
@@ -100,7 +103,7 @@ public class Timeline {
             if (BuildConfig.DEBUG)
                 Log.d(TAG, "Recognized " + elementsWithTimeCodes.size() + " timecodes");
             for (Element element : elementsWithTimeCodes) {
-                Matcher matcherLong = TIMECODE_REGEX.matcher(element.text());
+                Matcher matcherLong = TIMECODE_REGEX.matcher(element.html());
                 StringBuffer buffer = new StringBuffer();
                 while (matcherLong.find()) {
                     String h = matcherLong.group(1);


### PR DESCRIPTION
# Before and after:

## Episode view
![shownotes](https://cloud.githubusercontent.com/assets/6860662/9288977/4d3b68f6-4361-11e5-9d9c-34168f57310a.png)

## Audio Player

![shownotes2](https://cloud.githubusercontent.com/assets/6860662/9289137/73d46fda-4366-11e5-843c-ef110ecd4711.png)


Fixes #1089