### PR TITLE
Properly check if we should show links share items.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -255,10 +255,20 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                         (media instanceof FeedMedia) &&
                         ((FeedMedia) media).getItem().getFlattrStatus().flattrable()
         );
-        menu.findItem(R.id.share_link_item).setVisible(
-                media != null && media.getWebsiteLink() != null);
-        menu.findItem(R.id.visit_website_item).setVisible(
-                media != null && media.getWebsiteLink() != null);
+
+        boolean hasWebsiteLink = media.getWebsiteLink() != null;
+        menu.findItem(R.id.visit_website_item).setVisible(hasWebsiteLink);
+
+        boolean isItemAndHasLink = media != null && (media instanceof FeedMedia) && ((FeedMedia) media).getItem().getLink() != null;
+        menu.findItem(R.id.share_link_item).setVisible(isItemAndHasLink);
+        menu.findItem(R.id.share_link_with_position_item).setVisible(isItemAndHasLink);
+
+        boolean isItemHasDownloadLink = media != null && (media instanceof FeedMedia) && ((FeedMedia) media).getDownload_url() != null;
+        menu.findItem(R.id.share_download_url_item).setVisible(isItemHasDownloadLink);
+        menu.findItem(R.id.share_download_url_with_position_item).setVisible(isItemHasDownloadLink);
+
+        menu.findItem(R.id.share_item).setVisible(hasWebsiteLink || isItemAndHasLink || isItemHasDownloadLink);
+
         menu.findItem(R.id.skip_episode_item).setVisible(media != null);
         boolean sleepTimerSet = controller.sleepTimerActive();
         boolean sleepTimerNotSet = controller.sleepTimerNotActive();
@@ -278,7 +288,6 @@ public abstract class MediaplayerActivity extends ActionBarActivity
             startActivity(intent);
             return true;
         } else if (media != null) {
-            FeedItem feedItem = ((FeedMedia) media).getItem();
             switch (item.getItemId()) {
                 case R.id.disable_sleeptimer_item:
                     if (controller.serviceAvailable()) {
@@ -334,20 +343,28 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                     break;
                 case R.id.support_item:
                     if (media instanceof FeedMedia) {
-                        DBTasks.flattrItemIfLoggedIn(this, feedItem);
+                        DBTasks.flattrItemIfLoggedIn(this, ((FeedMedia) media).getItem());
                     }
                     break;
                 case R.id.share_link_item:
-                    ShareUtils.shareFeedItemLink(this, feedItem);
+                    if (media instanceof FeedMedia) {
+                        ShareUtils.shareFeedItemLink(this, ((FeedMedia) media).getItem());
+                    }
                     break;
                 case R.id.share_download_url_item:
-                    ShareUtils.shareFeedItemDownloadLink(this, feedItem);
+                    if (media instanceof FeedMedia) {
+                        ShareUtils.shareFeedItemDownloadLink(this, ((FeedMedia) media).getItem());
+                    }
                     break;
                 case R.id.share_link_with_position_item:
-                    ShareUtils.shareFeedItemLink(this, feedItem, true);
+                    if (media instanceof FeedMedia) {
+                        ShareUtils.shareFeedItemLink(this, ((FeedMedia) media).getItem(), true);
+                    }
                     break;
                 case R.id.share_download_url_with_position_item:
-                    ShareUtils.shareFeedItemDownloadLink(this, feedItem, true);
+                    if (media instanceof FeedMedia) {
+                        ShareUtils.shareFeedItemDownloadLink(this, ((FeedMedia) media).getItem(), true);
+                    }
                     break;
                 case R.id.skip_episode_item:
                     sendBroadcast(new Intent(


### PR DESCRIPTION
Don't case the playable until we know it's actually a FeedMedia.

You can reproduce the error that was causing this by attempting to play a normal mp3 with AntennaPod and then trying to use the share options.

Fixes AntennaPod/AntennaPod#1111