### PR TITLE
Protect use of menuInfo:

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -75,6 +75,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
     private DrawerLayout drawerLayout;
     private NavListAdapter navAdapter;
     private ListView navList;
+    private AdapterView.AdapterContextMenuInfo lastMenuInfo = null;
     private View navDrawer;
     private ActionBarDrawerToggle drawerToggle;
 
@@ -663,11 +664,19 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
         Feed feed = navDrawerData.feeds.get(position - navAdapter.getSubscriptionOffset());
         menu.setHeaderTitle(feed.getTitle());
         // episodes are not loaded, so we cannot check if the podcast has new or unplayed ones!
+
+        // we may need to reference this elsewhere...
+        lastMenuInfo = (AdapterView.AdapterContextMenuInfo) menuInfo;
     }
 
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         AdapterView.AdapterContextMenuInfo menuInfo = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
+
+        if(menuInfo == null) {
+            menuInfo = lastMenuInfo;
+        }
+
         if(menuInfo.targetView.getParent() instanceof ListView == false
                 || ((ListView)menuInfo.targetView.getParent()).getId() != R.id.nav_list) {
             return false;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -96,6 +96,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
     private View navDrawer;
     private ListView navList;
     private NavListAdapter navAdapter;
+    private AdapterView.AdapterContextMenuInfo lastMenuInfo = null;
 
     private ActionBarDrawerToggle drawerToggle;
 
@@ -505,11 +506,19 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         Feed feed = navDrawerData.feeds.get(position - navAdapter.getSubscriptionOffset());
         menu.setHeaderTitle(feed.getTitle());
         // episodes are not loaded, so we cannot check if the podcast has new or unplayed ones!
+
+        // we may need to reference this elsewhere...
+        lastMenuInfo = (AdapterView.AdapterContextMenuInfo) menuInfo;
     }
 
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         AdapterView.AdapterContextMenuInfo menuInfo = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
+
+        if(menuInfo == null) {
+            menuInfo = lastMenuInfo;
+        }
+
         if(menuInfo.targetView.getParent() instanceof ListView == false
                 || ((ListView)menuInfo.targetView.getParent()).getId() != R.id.nav_list) {
             return false;


### PR DESCRIPTION
fixes AntennaPod/AntennaPod#1128

Using the same pattern we're using in our fragments.