### PR TITLE
Remove needless leading and trailing spaces in feed or episode title

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -119,13 +119,14 @@ public class NSRSS20 extends Namespace {
 				    state.getCurrentItem().setItemIdentifier(content);
                 }
 			} else if (top.equals(TITLE)) {
+				String title = content.trim();
 				if (second.equals(ITEM)) {
-					state.getCurrentItem().setTitle(content);
+					state.getCurrentItem().setTitle(title);
 				} else if (second.equals(CHANNEL)) {
-					state.getFeed().setTitle(content);
+					state.getFeed().setTitle(title);
 				} else if (second.equals(IMAGE) && third != null
 						&& third.equals(CHANNEL)) {
-					state.getFeed().getImage().setTitle(content);
+					state.getFeed().getImage().setTitle(title);
 				}
 			} else if (top.equals(LINK)) {
 				if (second.equals(CHANNEL)) {


### PR DESCRIPTION
Feed: http://echo.msk.ru/programs/speakrus/rss-audio.xml

Before

![before](https://cloud.githubusercontent.com/assets/6860662/9575814/d7784926-4fd2-11e5-9480-f7802500ece4.png)


After

![after](https://cloud.githubusercontent.com/assets/6860662/9575816/da965f94-4fd2-11e5-8dbe-aaf4e8c7320a.png)

Fixes #1153