### PR TITLE
fix NPE when action has no timestamp

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -260,8 +260,10 @@ public class GpodnetSyncService extends Service {
                         GpodnetEpisodeAction mostRecent = mostRecentPlayAction.get(key);
                         if (mostRecent == null || mostRecent.getTimestamp() == null) {
                             mostRecentPlayAction.put(key, action);
-                        } else if (mostRecent.getTimestamp().before(action.getTimestamp())) {
+                        } else if (action.getTimestamp() != null && mostRecent.getTimestamp().before(action.getTimestamp())) {
                             mostRecentPlayAction.put(key, action);
+                        } else {
+                            Log.d(TAG, "No date information in action, skipping it");
                         }
                     }
                     break;


### PR DESCRIPTION
Fixes this NPE as reported on Google Play:

```
java.lang.NullPointerException
at java.util.Date.before(Date.java:178)
at de.danoeh.antennapod.core.service.GpodnetSyncService.processEpisodeActions(GpodnetSyncService.java:263)
at de.danoeh.antennapod.core.service.GpodnetSyncService.syncEpisodeActions(GpodnetSyncService.java:203)
at de.danoeh.antennapod.core.service.GpodnetSyncService.sync(GpodnetSyncService.java:120)
at de.danoeh.antennapod.core.service.GpodnetSyncService.access$100(GpodnetSyncService.java:45)
at de.danoeh.antennapod.core.service.GpodnetSyncService$1.onWaitCompleted(GpodnetSyncService.java:324)
at de.danoeh.antennapod.core.service.GpodnetSyncService$WaiterThread$1.run(GpodnetSyncService.java:360)
```