### PR TITLE
disable predexing to get CircleCI doing a full build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,21 @@ allprojects {
     }
 }
 
+// Disable predex if requested (we can't predex in Circle CI
+// See http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance
+// and https://circleci.com/docs/android
+project.ext.preDexLibs = !project.hasProperty('disablePreDex')
+
+subprojects {
+    project.plugins.whenPluginAdded { plugin ->
+        if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)) {
+            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+        } else if ("com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
+            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+        }
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.4'
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
 machine:
   java:
     version: oraclejdk8
+test:
+  override:
+    - ./gradlew assembleDebug -PdisablePreDex


### PR DESCRIPTION
Previously CircleCi was just doing ./gradlew test which doesn't actually try to build everything.

This will now run assembleDebug for us to give a better idea of if something works.

We still can't run tests (our tests fail on non-x86 hardware and CircleCi doesn't support x86 hardware) and we still can't assembleRelease (signing).