### PR TITLE
Add option to share OPML file when exporting it

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="1030204"
-    android:versionName="1.3.2">
+    android:versionCode="1040000"
+    android:versionName="1.4.0.0">
     <!--
       Version code schema:
       "1.2.3-SNAPSHOT" -> 1020300

--- a/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
@@ -96,15 +96,14 @@ public class OpmlExportWorker extends AsyncTask<Void, Void, Void> {
             alert.setMessage(context
                     .getString(R.string.opml_export_success_sum)
                     + output.toString())
-                    .setPositiveButton(R.string.share_label, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {Uri outputUri = Uri.fromFile(output);
-                            Intent sendIntent = new Intent(Intent.ACTION_SEND);
-                            sendIntent.putExtra(Intent.EXTRA_SUBJECT, "OPML Export");
-                            sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
-                            sendIntent.setType("text/plain");
-                            context.startActivity(Intent.createChooser(sendIntent, context.getResources().getText(R.string.share_label)));
-                        }
+                    .setPositiveButton(R.string.share_label, (dialog, which) -> {
+                        Uri outputUri = Uri.fromFile(output);
+                        Intent sendIntent = new Intent(Intent.ACTION_SEND);
+                        sendIntent.putExtra(Intent.EXTRA_SUBJECT, "OPML Export");
+                        sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
+                        sendIntent.setType("text/plain");
+                        context.startActivity(Intent.createChooser(sendIntent,
+                                context.getResources().getText(R.string.share_label)));
                     });
         }
         alert.create().show();

--- a/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
@@ -96,14 +96,15 @@ public class OpmlExportWorker extends AsyncTask<Void, Void, Void> {
             alert.setMessage(context
                     .getString(R.string.opml_export_success_sum)
                     + output.toString())
-                    .setPositiveButton(R.string.share_label, (dialog, which) -> {
+                    .setPositiveButton(R.string.send_label, (dialog, which) -> {
                         Uri outputUri = Uri.fromFile(output);
                         Intent sendIntent = new Intent(Intent.ACTION_SEND);
-                        sendIntent.putExtra(Intent.EXTRA_SUBJECT, "OPML Export");
+                        sendIntent.putExtra(Intent.EXTRA_SUBJECT,
+                                context.getResources().getText(R.string.opml_export_label));
                         sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
                         sendIntent.setType("text/plain");
                         context.startActivity(Intent.createChooser(sendIntent,
-                                context.getResources().getText(R.string.share_label)));
+                                context.getResources().getText(R.string.send_label)));
                     });
         }
         alert.create().show();

--- a/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
@@ -78,24 +78,36 @@ public class OpmlExportWorker extends AsyncTask<Void, Void, Void> {
     @Override
     protected void onPostExecute(Void result) {
         progDialog.dismiss();
-        if (exception != null) {
-            AlertDialog.Builder alert = new AlertDialog.Builder(context)
-                    .setNeutralButton(android.R.string.ok,
-                            (dialog, which) -> {
+        AlertDialog.Builder alert = new AlertDialog.Builder(context)
+                .setNeutralButton(android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+
+                            @Override
+                            public void onClick(DialogInterface dialog,
+                                                int which) {
                                 dialog.dismiss();
-                            });
+                            }
+                        });
+        if (exception != null) {
             alert.setTitle(R.string.export_error_label);
             alert.setMessage(exception.getMessage());
-            alert.create().show();
-            return;
+        } else {
+            alert.setTitle(R.string.opml_export_success_title);
+            alert.setMessage(context
+                    .getString(R.string.opml_export_success_sum)
+                    + output.toString())
+                    .setPositiveButton(R.string.share_label, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {Uri outputUri = Uri.fromFile(output);
+                            Intent sendIntent = new Intent(Intent.ACTION_SEND);
+                            sendIntent.putExtra(Intent.EXTRA_SUBJECT, "OPML Export");
+                            sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
+                            sendIntent.setType("text/plain");
+                            context.startActivity(Intent.createChooser(sendIntent, context.getResources().getText(R.string.share_label)));
+                        }
+                    });
         }
-
-        Uri outputUri = Uri.fromFile(output);
-        Intent sendIntent = new Intent(Intent.ACTION_SEND);
-        sendIntent.putExtra(Intent.EXTRA_SUBJECT, "OPML Export");
-        sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
-        sendIntent.setType("text/plain");
-        context.startActivity(Intent.createChooser(sendIntent, context.getResources().getText(R.string.share_label)));
+        alert.create().show();
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
@@ -5,6 +5,8 @@ import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Log;
 
@@ -76,26 +78,24 @@ public class OpmlExportWorker extends AsyncTask<Void, Void, Void> {
     @Override
     protected void onPostExecute(Void result) {
         progDialog.dismiss();
-        AlertDialog.Builder alert = new AlertDialog.Builder(context)
-                .setNeutralButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-
-                            @Override
-                            public void onClick(DialogInterface dialog,
-                                                int which) {
-                                dialog.dismiss();
-                            }
-                        });
         if (exception != null) {
+            AlertDialog.Builder alert = new AlertDialog.Builder(context)
+                    .setNeutralButton(android.R.string.ok,
+                            (dialog, which) -> {
+                                dialog.dismiss();
+                            });
             alert.setTitle(R.string.export_error_label);
             alert.setMessage(exception.getMessage());
-        } else {
-            alert.setTitle(R.string.opml_export_success_title);
-            alert.setMessage(context
-                    .getString(R.string.opml_export_success_sum)
-                    + output.toString());
+            alert.create().show();
+            return;
         }
-        alert.create().show();
+
+        Uri outputUri = Uri.fromFile(output);
+        Intent sendIntent = new Intent(Intent.ACTION_SEND);
+        sendIntent.putExtra(Intent.EXTRA_SUBJECT, "OPML Export");
+        sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
+        sendIntent.setType("text/plain");
+        context.startActivity(Intent.createChooser(sendIntent, context.getResources().getText(R.string.share_label)));
     }
 
     @Override

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="feed_auto_download_global">Global</string>
     <string name="feed_auto_download_always">Always</string>
     <string name="feed_auto_download_never">Never</string>
+    <string name="send_label">Send...</string>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>


### PR DESCRIPTION
We had tried (but failed) to implement a robust folder selection dialog when exporting OPML (as mentioned in #314).  Here we give the option to share the exported OPML file with whatever application can support it.

If we think this is good enough we might think about closing #314.

![device-2015-09-07-204628](https://cloud.githubusercontent.com/assets/5216560/9724211/90917422-55a1-11e5-9a3c-e843eff948f1.png)
