### PR TITLE
Button text capitalized, not uppercase

### DIFF
--- a/core/src/main/res/values-v21/styles.xml
+++ b/core/src/main/res/values-v21/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.AntennaPod.Button" parent="Widget.AppCompat.Button">
+        <item name="textAllCaps">true</item>
+    </style>
+
+</resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <style name="Theme.AntennaPod.Light" parent="@style/Theme.AppCompat.Light">
         <item name="colorPrimary">@color/primary_light</item>
         <item name="colorAccent">@color/color_accent</item>
+        <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="attr/action_bar_icon_color">@color/grey600</item>
         <item name="attr/action_about">@drawable/ic_info_grey600_24dp</item>
         <item name="attr/action_search">@drawable/ic_search_grey600_24dp</item>
@@ -50,6 +51,7 @@
 
     <style name="Theme.AntennaPod.Dark" parent="@style/Theme.AppCompat">
         <item name="colorAccent">@color/color_accent</item>
+        <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="attr/action_bar_icon_color">@color/white</item>
         <item name="attr/action_about">@drawable/ic_info_white_24dp</item>
         <item name="attr/action_search">@drawable/ic_search_white_24dp</item>
@@ -99,6 +101,7 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="colorPrimary">@color/primary_light</item>
         <item name="colorAccent">@color/color_accent</item>
+        <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="attr/action_about">@drawable/ic_info_grey600_24dp</item>
         <item name="attr/action_search">@drawable/ic_search_grey600_24dp</item>
         <item name="attr/action_stream">@drawable/ic_settings_input_antenna_grey600_24dp</item>
@@ -146,6 +149,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="colorAccent">@color/color_accent</item>
+        <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="attr/action_about">@drawable/ic_info_white_24dp</item>
         <item name="attr/action_search">@drawable/ic_search_white_24dp</item>
         <item name="attr/action_stream">@drawable/ic_settings_input_antenna_white_24dp</item>
@@ -261,6 +265,10 @@
         <item name="android:textSize">@dimen/text_size_micro</item>
         <item name="android:textColor">@color/new_indicator_green</item>
         <item name="android:text">@string/new_label</item>
+    </style>
+
+    <style name="Widget.AntennaPod.Button" parent="Widget.AppCompat.Button">
+        <item name="textAllCaps">false</item>
     </style>
 
     <style name="BigBlurryBackground">


### PR DESCRIPTION
Before 'n' After

![buttons](https://cloud.githubusercontent.com/assets/6860662/9731621/4c42870c-561e-11e5-9ead-4fdbc83ff694.png)

Tested on 2.3.7, 4.1.1, 4.4.4, 5.10
