### PR TITLE
Fix cropped dialog buttons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'io.reactivex:rxandroid:1.0.1'
     compile 'com.joanzapata.iconify:android-iconify-fontawesome:2.0.3'
+    compile 'com.afollestad:material-dialogs:0.7.8.0'
+
 
     compile project(':core')
     compile project(':library:drag-sort-listview')


### PR DESCRIPTION
![cropped](https://cloud.githubusercontent.com/assets/6860662/9770152/c395e8ec-572e-11e5-9863-56362537472d.png)

Left: Button is cropped. On smaller displays, one of the buttons might not be shown at all.
Right: Stacked buttons according to https://www.google.com/design/spec/components/dialogs.html

The dialog will also have this material look on older devices.

I was going to use the library for some of the preference dialogs for material design, anyway.
There are one major and one minor newer versions of the library, but they already target v23.

An alternative would be to insert manual wrapping into the button labels ("Set*\n*Interval")
Downside: All of the strings would probably have to be revised. In some cases (German...), it might be pretty hard to find a good wrapping that works on all the different display sizes and resolutions