### PR TITLE
Refactor database access

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/AntennaPodTestRunner.java
+++ b/app/src/androidTest/java/de/test/antennapod/AntennaPodTestRunner.java
@@ -2,6 +2,7 @@ package de.test.antennapod;
 
 import android.test.InstrumentationTestRunner;
 import android.test.suitebuilder.TestSuiteBuilder;
+
 import junit.framework.TestSuite;
 
 public class AntennaPodTestRunner extends InstrumentationTestRunner {
@@ -13,4 +14,5 @@ public class AntennaPodTestRunner extends InstrumentationTestRunner {
                 .excludePackages("de.test.antennapod.gpodnet")
                 .build();
     }
+
 }

--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -1,7 +1,6 @@
 package de.test.antennapod.service.playback;
 
 import android.content.Context;
-import android.media.RemoteControlClient;
 import android.test.InstrumentationTestCase;
 
 import junit.framework.AssertionFailedError;
@@ -45,7 +44,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        PodDBAdapter.deleteDatabase(getInstrumentation().getTargetContext());
+        PodDBAdapter.deleteDatabase();
         httpServer.stop();
     }
 
@@ -54,16 +53,16 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         super.setUp();
         assertionError = null;
 
-        final Context context = getInstrumentation().getTargetContext();
-        context.deleteDatabase(PodDBAdapter.DATABASE_NAME);
-        // make sure database is created
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.close();
 
         httpServer = new HTTPBin();
         httpServer.start();
 
+        final Context context = getInstrumentation().getTargetContext();
         File cacheDir = context.getExternalFilesDir("testFiles");
         if (cacheDir == null)
             cacheDir = context.getExternalFilesDir("testFiles");
@@ -119,12 +118,12 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         Feed f = new Feed(0, new Date(), "f", "l", "d", null, null, null, null, "i", null, null, "l", false);
         FeedPreferences prefs = new FeedPreferences(f.getId(), false, FeedPreferences.AutoDeleteAction.NO, null, null);
         f.setPreferences(prefs);
-        f.setItems(new ArrayList<FeedItem>());
+        f.setItems(new ArrayList<>());
         FeedItem i = new FeedItem(0, "t", "i", "l", new Date(), FeedItem.UNPLAYED, f);
         f.getItems().add(i);
         FeedMedia media = new FeedMedia(0, i, 0, 0, 0, "audio/wav", fileUrl, downloadUrl, fileUrl != null, null, 0);
         i.setMedia(media);
-        PodDBAdapter adapter = new PodDBAdapter(c);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(f);
         assertTrue(media.getId() != 0);

--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
@@ -26,16 +26,16 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        assertTrue(PodDBAdapter.deleteDatabase(getInstrumentation().getTargetContext()));
+        PodDBAdapter.deleteDatabase();
     }
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        final Context context = getInstrumentation().getTargetContext();
-        context.deleteDatabase(PodDBAdapter.DATABASE_NAME);
-        // make sure database is created
-        PodDBAdapter adapter = new PodDBAdapter(context);
+
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.close();
     }
@@ -49,11 +49,11 @@ public class PlaybackServiceTaskManagerTest extends InstrumentationTestCase {
         final Context c = getInstrumentation().getTargetContext();
         final int NUM_ITEMS = 10;
         Feed f = new Feed(0, new Date(), "title", "link", "d", null, null, null, null, "id", null, "null", "url", false);
-        f.setItems(new ArrayList<FeedItem>());
+        f.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS; i++) {
             f.getItems().add(new FeedItem(0, pref + i, pref + i, "link", new Date(), FeedItem.PLAYED, f));
         }
-        PodDBAdapter adapter = new PodDBAdapter(c);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(f);
         adapter.setQueue(f.getItems());

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
@@ -21,7 +20,6 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
-import de.danoeh.antennapod.core.util.flattr.FlattrStatus;
 
 import static de.test.antennapod.storage.DBTestUtils.saveFeedlist;
 
@@ -40,7 +38,8 @@ public class DBTasksTest extends InstrumentationTestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        assertTrue(PodDBAdapter.deleteDatabase(context));
+
+        assertTrue(PodDBAdapter.deleteDatabase());
 
         for (File f : destFolder.listFiles()) {
             assertTrue(f.delete());
@@ -58,9 +57,9 @@ public class DBTasksTest extends InstrumentationTestCase {
         assertTrue(destFolder.exists());
         assertTrue(destFolder.canWrite());
 
-        context.deleteDatabase(PodDBAdapter.DATABASE_NAME);
-        // make sure database is created
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.close();
 
@@ -76,9 +75,9 @@ public class DBTasksTest extends InstrumentationTestCase {
         final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
 
         Feed feed = new Feed("url", new Date(), "title");
-        List<FeedItem> items = new ArrayList<FeedItem>();
+        List<FeedItem> items = new ArrayList<>();
         feed.setItems(items);
-        List<File> files = new ArrayList<File>();
+        List<File> files = new ArrayList<>();
         for (int i = 0; i < NUM_ITEMS; i++) {
             FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
 
@@ -89,7 +88,7 @@ public class DBTasksTest extends InstrumentationTestCase {
             items.add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -128,7 +127,7 @@ public class DBTasksTest extends InstrumentationTestCase {
             items.add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -149,9 +148,9 @@ public class DBTasksTest extends InstrumentationTestCase {
         final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
 
         Feed feed = new Feed("url", new Date(), "title");
-        List<FeedItem> items = new ArrayList<FeedItem>();
+        List<FeedItem> items = new ArrayList<>();
         feed.setItems(items);
-        List<File> files = new ArrayList<File>();
+        List<File> files = new ArrayList<>();
         for (int i = 0; i < NUM_ITEMS; i++) {
             FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
 
@@ -163,7 +162,7 @@ public class DBTasksTest extends InstrumentationTestCase {
             items.add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.setQueue(items);
@@ -188,14 +187,14 @@ public class DBTasksTest extends InstrumentationTestCase {
     @FlakyTest(tolerance = 3)
     public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue_withFeedsWithNoMedia() throws IOException {
         // add feed with no enclosures so that item ID != media ID
-        saveFeedlist(context, 1, 10, false);
+        saveFeedlist(1, 10, false);
 
         // add candidate for performAutoCleanup
-        List<Feed> feeds = saveFeedlist(context, 1, 1, true);
+        List<Feed> feeds = saveFeedlist(1, 1, true);
         FeedMedia m = feeds.get(0).getItems().get(0).getMedia();
         m.setDownloaded(true);
         m.setFile_url("file");
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setMedia(m);
         adapter.close();
@@ -208,7 +207,7 @@ public class DBTasksTest extends InstrumentationTestCase {
         final int NUM_ITEMS = 10;
 
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS; i++) {
             feed.getItems().add(new FeedItem(0, "item " + i, "id " + i, "link " + i, new Date(), FeedItem.UNPLAYED, feed));
         }
@@ -228,8 +227,8 @@ public class DBTasksTest extends InstrumentationTestCase {
         Feed feed1 = new Feed("url1", new Date(), "title");
         Feed feed2 = new Feed("url2", new Date(), "title");
 
-        feed1.setItems(new ArrayList<FeedItem>());
-        feed2.setItems(new ArrayList<FeedItem>());
+        feed1.setItems(new ArrayList<>());
+        feed2.setItems(new ArrayList<>());
 
         Feed savedFeed1 = DBTasks.updateFeed(context, feed1)[0];
         Feed savedFeed2 = DBTasks.updateFeed(context, feed2)[0];
@@ -242,11 +241,11 @@ public class DBTasksTest extends InstrumentationTestCase {
         final int NUM_ITEMS_NEW = 10;
 
         final Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS_OLD; i++) {
             feed.getItems().add(new FeedItem(0, "item " + i, "id " + i, "link " + i, new Date(i), FeedItem.PLAYED, feed));
         }
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -271,7 +270,7 @@ public class DBTasksTest extends InstrumentationTestCase {
 
         updatedFeedTest(newFeed, feedID, itemIDs, NUM_ITEMS_OLD, NUM_ITEMS_NEW);
 
-        final Feed feedFromDB = DBReader.getFeed(context, newFeed.getId());
+        final Feed feedFromDB = DBReader.getFeed(newFeed.getId());
         assertNotNull(feedFromDB);
         assertTrue(feedFromDB.getId() == newFeed.getId());
         updatedFeedTest(feedFromDB, feedID, itemIDs, NUM_ITEMS_OLD, NUM_ITEMS_NEW);

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
@@ -1,7 +1,5 @@
 package de.test.antennapod.storage;
 
-import android.content.Context;
-
 import junit.framework.Assert;
 
 import java.util.ArrayList;
@@ -26,14 +24,14 @@ public class DBTestUtils {
     /**
      * Use this method when tests don't involve chapters.
      */
-    public static List<Feed> saveFeedlist(Context context, int numFeeds, int numItems, boolean withMedia) {
-        return saveFeedlist(context, numFeeds, numItems, withMedia, false, 0);
+    public static List<Feed> saveFeedlist(int numFeeds, int numItems, boolean withMedia) {
+        return saveFeedlist(numFeeds, numItems, withMedia, false, 0);
     }
 
     /**
      * Use this method when tests involve chapters.
      */
-    public static List<Feed> saveFeedlist(Context context, int numFeeds, int numItems, boolean withMedia,
+    public static List<Feed> saveFeedlist(int numFeeds, int numItems, boolean withMedia,
                                           boolean withChapters, int numChapters) {
         if (numFeeds <= 0) {
             throw new IllegalArgumentException("numFeeds<=0");
@@ -42,13 +40,13 @@ public class DBTestUtils {
             throw new IllegalArgumentException("numItems<0");
         }
 
-        List<Feed> feeds = new ArrayList<Feed>();
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        List<Feed> feeds = new ArrayList<>();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         for (int i = 0; i < numFeeds; i++) {
             Feed f = new Feed(0, new Date(), "feed " + i, "link" + i, "descr", null, null,
                     null, null, "id" + i, null, null, "url" + i, false, new FlattrStatus(), false, null, null, false);
-            f.setItems(new ArrayList<FeedItem>());
+            f.setItems(new ArrayList<>());
             for (int j = 0; j < numItems; j++) {
                 FeedItem item = new FeedItem(0, "item " + j, "id" + j, "link" + j, new Date(),
                         FeedItem.PLAYED, f, withChapters);

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
@@ -29,6 +29,7 @@ import de.danoeh.antennapod.core.storage.PodDBAdapter;
  * Test class for DBWriter
  */
 public class DBWriterTest extends InstrumentationTestCase {
+
     private static final String TAG = "DBWriterTest";
     private static final String TEST_FOLDER = "testDBWriter";
     private static final long TIMEOUT = 5L;
@@ -36,9 +37,10 @@ public class DBWriterTest extends InstrumentationTestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        final Context context = getInstrumentation().getTargetContext();
-        assertTrue(PodDBAdapter.deleteDatabase(getInstrumentation().getTargetContext()));
 
+        assertTrue(PodDBAdapter.deleteDatabase());
+
+        final Context context = getInstrumentation().getTargetContext();
         File testDir = context.getExternalFilesDir(TEST_FOLDER);
         assertNotNull(testDir);
         for (File f : testDir.listFiles()) {
@@ -49,10 +51,10 @@ public class DBWriterTest extends InstrumentationTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        final Context context = getInstrumentation().getTargetContext();
-        context.deleteDatabase(PodDBAdapter.DATABASE_NAME);
-        // make sure database is created
-        PodDBAdapter adapter = new PodDBAdapter(context);
+
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.close();
     }
@@ -63,7 +65,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertTrue(dest.createNewFile());
 
         Feed feed = new Feed("url", new Date(), "title");
-        List<FeedItem> items = new ArrayList<FeedItem>();
+        List<FeedItem> items = new ArrayList<>();
         feed.setItems(items);
         FeedItem item = new FeedItem(0, "Item", "Item", "url", new Date(), FeedItem.PLAYED, feed);
 
@@ -72,7 +74,7 @@ public class DBWriterTest extends InstrumentationTestCase {
 
         items.add(item);
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getTargetContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -80,7 +82,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertTrue(item.getId() != 0);
 
         DBWriter.deleteFeedMediaOfItem(getInstrumentation().getTargetContext(), media.getId()).get();
-        media = DBReader.getFeedMedia(getInstrumentation().getTargetContext(), media.getId());
+        media = DBReader.getFeedMedia(media.getId());
         assertNotNull(media);
         assertFalse(dest.exists());
         assertFalse(media.isDownloaded());
@@ -92,7 +94,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertNotNull(destFolder);
 
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
 
         // create Feed image
         File imgFile = new File(destFolder, "image");
@@ -118,7 +120,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             item.getChapters().add(new SimpleChapter(0, "item " + i, item, "example.com"));
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -139,7 +141,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             assertFalse(f.exists());
         }
 
-        adapter = new PodDBAdapter(getInstrumentation().getContext());
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor c = adapter.getFeedCursor(feed.getId());
         assertEquals(0, c.getCount());
@@ -164,7 +166,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertNotNull(destFolder);
 
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
 
         feed.setImage(null);
 
@@ -182,7 +184,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             item.setMedia(media);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -200,7 +202,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             assertFalse(f.exists());
         }
 
-        adapter = new PodDBAdapter(getInstrumentation().getContext());
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor c = adapter.getFeedCursor(feed.getId());
         assertTrue(c.getCount() == 0);
@@ -229,7 +231,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         image.setOwner(feed);
         feed.setImage(image);
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -242,7 +244,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         // check if files still exist
         assertFalse(imgFile.exists());
 
-        adapter = new PodDBAdapter(getInstrumentation().getContext());
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor c = adapter.getFeedCursor(feed.getId());
         assertTrue(c.getCount() == 0);
@@ -257,7 +259,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertNotNull(destFolder);
 
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
 
         // create Feed image
         File imgFile = new File(destFolder, "image");
@@ -273,7 +275,7 @@ public class DBWriterTest extends InstrumentationTestCase {
 
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -289,7 +291,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         // check if files still exist
         assertFalse(imgFile.exists());
 
-        adapter = new PodDBAdapter(getInstrumentation().getContext());
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor c = adapter.getFeedCursor(feed.getId());
         assertTrue(c.getCount() == 0);
@@ -309,7 +311,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertNotNull(destFolder);
 
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
 
         // create Feed image
         File imgFile = new File(destFolder, "image");
@@ -327,7 +329,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             item.setImage(itemImage);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -344,7 +346,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         // check if files still exist
         assertFalse(imgFile.exists());
 
-        adapter = new PodDBAdapter(getInstrumentation().getContext());
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor c = adapter.getFeedCursor(feed.getId());
         assertTrue(c.getCount() == 0);
@@ -367,7 +369,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertNotNull(destFolder);
 
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
 
         // create Feed image
         File imgFile = new File(destFolder, "image");
@@ -388,7 +390,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             item.setMedia(media);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -460,7 +462,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             item.setMedia(media);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getContext());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -474,7 +476,7 @@ public class DBWriterTest extends InstrumentationTestCase {
 
         DBWriter.deleteFeed(getInstrumentation().getTargetContext(), feed.getId()).get(TIMEOUT, TimeUnit.SECONDS);
 
-        adapter = new PodDBAdapter(getInstrumentation().getContext());
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor c = adapter.getFeedCursor(feed.getId());
         assertTrue(c.getCount() == 0);
@@ -500,7 +502,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         FeedMedia media = new FeedMedia(0, item, 10, 0, 1, "mime", null, "url", false, playbackCompletionDate, 0);
         feed.getItems().add(item);
         item.setMedia(media);
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -509,13 +511,11 @@ public class DBWriterTest extends InstrumentationTestCase {
     }
 
     public void testAddItemToPlaybackHistoryNotPlayedYet() throws ExecutionException, InterruptedException {
-        final Context context = getInstrumentation().getTargetContext();
-
         FeedMedia media = playbackHistorySetup(null);
-        DBWriter.addItemToPlaybackHistory(context, media).get();
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        DBWriter.addItemToPlaybackHistory(media).get();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        media = DBReader.getFeedMedia(context, media.getId());
+        media = DBReader.getFeedMedia(media.getId());
         adapter.close();
 
         assertNotNull(media);
@@ -524,13 +524,12 @@ public class DBWriterTest extends InstrumentationTestCase {
 
     public void testAddItemToPlaybackHistoryAlreadyPlayed() throws ExecutionException, InterruptedException {
         final long OLD_DATE = 0;
-        final Context context = getInstrumentation().getTargetContext();
 
         FeedMedia media = playbackHistorySetup(new Date(OLD_DATE));
-        DBWriter.addItemToPlaybackHistory(getInstrumentation().getTargetContext(), media).get();
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        DBWriter.addItemToPlaybackHistory(media).get();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        media = DBReader.getFeedMedia(context, media.getId());
+        media = DBReader.getFeedMedia(media.getId());
         adapter.close();
 
         assertNotNull(media);
@@ -541,13 +540,13 @@ public class DBWriterTest extends InstrumentationTestCase {
     private Feed queueTestSetupMultipleItems(final int NUM_ITEMS) throws InterruptedException, ExecutionException, TimeoutException {
         final Context context = getInstrumentation().getTargetContext();
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS; i++) {
             FeedItem item = new FeedItem(0, "title " + i, "id " + i, "link " + i, new Date(), FeedItem.PLAYED, feed);
             feed.getItems().add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -568,11 +567,11 @@ public class DBWriterTest extends InstrumentationTestCase {
     public void testAddQueueItemSingleItem() throws InterruptedException, ExecutionException, TimeoutException {
         final Context context = getInstrumentation().getTargetContext();
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
         feed.getItems().add(item);
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -580,7 +579,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertTrue(item.getId() != 0);
         DBWriter.addQueueItem(context, item.getId()).get(TIMEOUT, TimeUnit.SECONDS);
 
-        adapter = new PodDBAdapter(context);
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor cursor = adapter.getQueueIDCursor();
         assertTrue(cursor.moveToFirst());
@@ -592,11 +591,11 @@ public class DBWriterTest extends InstrumentationTestCase {
     public void testAddQueueItemSingleItemAlreadyInQueue() throws InterruptedException, ExecutionException, TimeoutException {
         final Context context = getInstrumentation().getTargetContext();
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
         feed.getItems().add(item);
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -604,7 +603,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         assertTrue(item.getId() != 0);
         DBWriter.addQueueItem(context, item.getId()).get(TIMEOUT, TimeUnit.SECONDS);
 
-        adapter = new PodDBAdapter(context);
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor cursor = adapter.getQueueIDCursor();
         assertTrue(cursor.moveToFirst());
@@ -613,7 +612,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         adapter.close();
 
         DBWriter.addQueueItem(context, item.getId()).get(TIMEOUT, TimeUnit.SECONDS);
-        adapter = new PodDBAdapter(context);
+        adapter = PodDBAdapter.getInstance();
         adapter.open();
         cursor = adapter.getQueueIDCursor();
         assertTrue(cursor.moveToFirst());
@@ -628,7 +627,7 @@ public class DBWriterTest extends InstrumentationTestCase {
         final int NUM_ITEMS = 10;
 
         Feed feed = queueTestSetupMultipleItems(NUM_ITEMS);
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor cursor = adapter.getQueueIDCursor();
         assertTrue(cursor.moveToFirst());
@@ -642,12 +641,11 @@ public class DBWriterTest extends InstrumentationTestCase {
     }
 
     public void testClearQueue() throws InterruptedException, ExecutionException, TimeoutException {
-        final Context context = getInstrumentation().getTargetContext();
         final int NUM_ITEMS = 10;
 
         Feed feed = queueTestSetupMultipleItems(NUM_ITEMS);
-        DBWriter.clearQueue(context).get(TIMEOUT, TimeUnit.SECONDS);
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        DBWriter.clearQueue().get(TIMEOUT, TimeUnit.SECONDS);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor cursor = adapter.getQueueIDCursor();
         assertFalse(cursor.moveToFirst());
@@ -659,13 +657,13 @@ public class DBWriterTest extends InstrumentationTestCase {
         final int NUM_ITEMS = 10;
         final Context context = getInstrumentation().getTargetContext();
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS; i++) {
             FeedItem item = new FeedItem(0, "title " + i, "id " + i, "link " + i, new Date(), FeedItem.PLAYED, feed);
             feed.getItems().add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -675,13 +673,13 @@ public class DBWriterTest extends InstrumentationTestCase {
         }
         for (int removeIndex = 0; removeIndex < NUM_ITEMS; removeIndex++) {
             final FeedItem item = feed.getItems().get(removeIndex);
-            adapter = new PodDBAdapter(context);
+            adapter = PodDBAdapter.getInstance();
             adapter.open();
             adapter.setQueue(feed.getItems());
             adapter.close();
 
             DBWriter.removeQueueItem(context, item, false).get(TIMEOUT, TimeUnit.SECONDS);
-            adapter = new PodDBAdapter(context);
+            adapter = PodDBAdapter.getInstance();
             adapter.open();
             Cursor queue = adapter.getQueueIDCursor();
             assertTrue(queue.getCount() == NUM_ITEMS - 1);
@@ -703,15 +701,14 @@ public class DBWriterTest extends InstrumentationTestCase {
 
     public void testMoveQueueItem() throws InterruptedException, ExecutionException, TimeoutException {
         final int NUM_ITEMS = 10;
-        final Context context = getInstrumentation().getTargetContext();
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS; i++) {
             FeedItem item = new FeedItem(0, "title " + i, "id " + i, "link " + i, new Date(), FeedItem.PLAYED, feed);
             feed.getItems().add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -727,13 +724,13 @@ public class DBWriterTest extends InstrumentationTestCase {
                 Log.d(TAG, String.format("testMoveQueueItem: From=%d, To=%d", from, to));
                 final long fromID = feed.getItems().get(from).getId();
 
-                adapter = new PodDBAdapter(context);
+                adapter = PodDBAdapter.getInstance();
                 adapter.open();
                 adapter.setQueue(feed.getItems());
                 adapter.close();
 
-                DBWriter.moveQueueItem(context, from, to, false).get(TIMEOUT, TimeUnit.SECONDS);
-                adapter = new PodDBAdapter(context);
+                DBWriter.moveQueueItem(from, to, false).get(TIMEOUT, TimeUnit.SECONDS);
+                adapter = PodDBAdapter.getInstance();
                 adapter.open();
                 Cursor queue = adapter.getQueueIDCursor();
                 assertTrue(queue.getCount() == NUM_ITEMS);
@@ -749,7 +746,6 @@ public class DBWriterTest extends InstrumentationTestCase {
     }
 
     public void testMarkFeedRead() throws InterruptedException, ExecutionException, TimeoutException {
-        final Context context = getInstrumentation().getTargetContext();
         final int NUM_ITEMS = 10;
         Feed feed = new Feed("url", new Date(), "title");
         feed.setItems(new ArrayList<FeedItem>());
@@ -758,7 +754,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             feed.getItems().add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -768,24 +764,23 @@ public class DBWriterTest extends InstrumentationTestCase {
             assertTrue(item.getId() != 0);
         }
 
-        DBWriter.markFeedRead(context, feed.getId()).get(TIMEOUT, TimeUnit.SECONDS);
-        List<FeedItem> loadedItems = DBReader.getFeedItemList(context, feed);
+        DBWriter.markFeedRead(feed.getId()).get(TIMEOUT, TimeUnit.SECONDS);
+        List<FeedItem> loadedItems = DBReader.getFeedItemList(feed);
         for (FeedItem item : loadedItems) {
             assertTrue(item.isPlayed());
         }
     }
 
     public void testMarkAllItemsReadSameFeed() throws InterruptedException, ExecutionException, TimeoutException {
-        final Context context = getInstrumentation().getTargetContext();
         final int NUM_ITEMS = 10;
         Feed feed = new Feed("url", new Date(), "title");
-        feed.setItems(new ArrayList<FeedItem>());
+        feed.setItems(new ArrayList<>());
         for (int i = 0; i < NUM_ITEMS; i++) {
             FeedItem item = new FeedItem(0, "title " + i, "id " + i, "link " + i, new Date(), FeedItem.UNPLAYED, feed);
             feed.getItems().add(item);
         }
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setCompleteFeed(feed);
         adapter.close();
@@ -795,8 +790,8 @@ public class DBWriterTest extends InstrumentationTestCase {
             assertTrue(item.getId() != 0);
         }
 
-        DBWriter.markAllItemsRead(context).get(TIMEOUT, TimeUnit.SECONDS);
-        List<FeedItem> loadedItems = DBReader.getFeedItemList(context, feed);
+        DBWriter.markAllItemsRead().get(TIMEOUT, TimeUnit.SECONDS);
+        List<FeedItem> loadedItems = DBReader.getFeedItemList(feed);
         for (FeedItem item : loadedItems) {
             assertTrue(item.isPlayed());
         }

--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -44,8 +44,10 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
         solo = new Solo(getInstrumentation(), getActivity());
         uiTestUtils = new UITestUtils(getInstrumentation().getTargetContext());
         uiTestUtils.setup();
-        // create database
-        PodDBAdapter adapter = new PodDBAdapter(getInstrumentation().getTargetContext());
+
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.close();
 
@@ -59,7 +61,7 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
         uiTestUtils.tearDown();
         solo.finishOpenedActivities();
 
-        PodDBAdapter.deleteDatabase(getInstrumentation().getTargetContext());
+        PodDBAdapter.deleteDatabase();
 
         // reset preferences
         prefs.edit().clear().commit();

--- a/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
+++ b/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
@@ -9,6 +9,7 @@ import com.joanzapata.iconify.fonts.FontAwesomeModule;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.spa.SPAUtil;
 
@@ -40,6 +41,7 @@ public class PodcastApp extends Application {
 		singleton = this;
 		LOGICAL_DENSITY = getResources().getDisplayMetrics().density;
 
+		PodDBAdapter.init(this);
 		UpdateManager.init(this);
 		UserPreferences.init(this);
 		PlaybackPreferences.init(this);

--- a/app/src/main/java/de/danoeh/antennapod/UpdateManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/UpdateManager.java
@@ -65,9 +65,9 @@ public class UpdateManager {
             // from now on, Glide will handle caching images
             new Thread() {
                 public void run() {
-                    List<Feed> feeds = DBReader.getFeedList(context);
+                    List<Feed> feeds = DBReader.getFeedList();
                     for (Feed podcast : feeds) {
-                        List<FeedItem> episodes = DBReader.getFeedItemList(context, podcast);
+                        List<FeedItem> episodes = DBReader.getFeedItemList(podcast);
                         for (FeedItem episode : episodes) {
                             FeedImage image = episode.getImage();
                             if (image != null && image.isDownloaded() && image.getFile_url() != null) {
@@ -76,7 +76,7 @@ public class UpdateManager {
                                     imageFile.delete();
                                 }
                                 image.setFile_url(null); // calls setDownloaded(false)
-                                DBWriter.setFeedImage(context, image);
+                                DBWriter.setFeedImage(image);
                             }
                         }
                     }

--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -26,7 +26,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.joanzapata.iconify.Iconify;
 
 import de.danoeh.antennapod.R;
@@ -111,7 +110,7 @@ public class FeedInfoActivity extends ActionBarActivity {
 
             @Override
             protected Feed doInBackground(Long... params) {
-                return DBReader.getFeed(FeedInfoActivity.this, params[0]);
+                return DBReader.getFeed(params[0]);
             }
 
             @Override
@@ -239,7 +238,7 @@ public class FeedInfoActivity extends ActionBarActivity {
                 prefs.setPassword(etxtPassword.getText().toString());
             }
             if (authInfoChanged || autoDeleteChanged) {
-                DBWriter.setFeedPreferences(this, prefs);
+                DBWriter.setFeedPreferences(prefs);
             }
             authInfoChanged = false;
             autoDeleteChanged = false;
@@ -299,7 +298,7 @@ public class FeedInfoActivity extends ActionBarActivity {
 
         @Override
         public  void onConfirmButtonPressed(DialogInterface dialog) {
-            DBWriter.setFeedsItemsAutoDownload(context, feed, autoDownload);
+            DBWriter.setFeedsItemsAutoDownload(feed, autoDownload);
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -109,7 +109,7 @@ public class OnlineFeedViewActivity extends ActionBarActivity {
         @Override
         public void update(EventDistributor eventDistributor, Integer arg) {
             if ((arg & EventDistributor.FEED_LIST_UPDATE) != 0) {
-                updater = Observable.defer(() -> Observable.just(DBReader.getFeedList(OnlineFeedViewActivity.this)))
+                updater = Observable.defer(() -> Observable.just(DBReader.getFeedList()))
                         .subscribeOn(Schedulers.newThread())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(feeds -> {
@@ -263,7 +263,7 @@ public class OnlineFeedViewActivity extends ActionBarActivity {
         download = Observable.create(new Observable.OnSubscribe<DownloadStatus>() {
                     @Override
                     public void call(Subscriber<? super DownloadStatus> subscriber) {
-                        feeds = DBReader.getFeedList(OnlineFeedViewActivity.this);
+                        feeds = DBReader.getFeedList();
                         downloader = new HttpDownloader(request);
                         downloader.call();
                         Log.d(TAG, "Download was completed");

--- a/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ActionButtonUtils.java
@@ -64,7 +64,7 @@ public class ActionButtonUtils {
                     butSecondary.setContentDescription(context.getString(labels[1]));
                 } else {
                     // item is not downloaded and not being downloaded
-                    LongList queueIds = DBReader.getQueueIDList(context);
+                    LongList queueIds = DBReader.getQueueIDList();
                     if(DefaultActionButtonCallback.userAllowedMobileDownloads() ||
                             !DefaultActionButtonCallback.userChoseAddToQueue() || queueIds.contains(item.getId())) {
                         butSecondary.setVisibility(View.VISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -57,7 +57,7 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
             final FeedMedia media = item.getMedia();
             boolean isDownloading = DownloadRequester.getInstance().isDownloadingFile(media);
             if (!isDownloading && !media.isDownloaded()) {
-                LongList queueIds = DBReader.getQueueIDList(context);
+                LongList queueIds = DBReader.getQueueIDList();
                 if (NetworkUtils.isDownloadAllowed() || userAllowedMobileDownloads()) {
                     try {
                         DBTasks.downloadFeedItems(context, item);
@@ -75,7 +75,7 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
             } else if (isDownloading) {
                 DownloadRequester.getInstance().cancelDownload(context, media);
                 if(UserPreferences.isEnableAutodownload()) {
-                    DBWriter.setFeedItemAutoDownload(context, media.getItem(), false);
+                    DBWriter.setFeedItemAutoDownload(media.getItem(), false);
                     Toast.makeText(context, R.string.download_canceled_autodownload_enabled_msg, Toast.LENGTH_LONG).show();
                 } else {
                     Toast.makeText(context, R.string.download_canceled_msg, Toast.LENGTH_LONG).show();
@@ -93,7 +93,7 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
             }
         } else {
             if (!item.isPlayed()) {
-                DBWriter.markItemPlayed(context, item, FeedItem.PLAYED, true);
+                DBWriter.markItemPlayed(item, FeedItem.PLAYED, true);
             }
         }
     }
@@ -117,7 +117,7 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                                 }
                             }
                         });
-        LongList queueIds = DBReader.getQueueIDList(context);
+        LongList queueIds = DBReader.getQueueIDList();
         if(!queueIds.contains(item.getId())) {
             builder.setNeutralButton(context.getText(R.string.confirm_mobile_download_dialog_only_add_to_queue),
                     new DialogInterface.OnClickListener() {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
@@ -123,7 +123,7 @@ public class DownloadLogAdapter extends BaseAdapter {
 		public void onClick(View v) {
 			ButtonHolder holder = (ButtonHolder) v.getTag();
 			if(holder.typeId == Feed.FEEDFILETYPE_FEED) {
-				Feed feed = DBReader.getFeed(context, holder.id);
+				Feed feed = DBReader.getFeed(holder.id);
 				if (feed != null) {
 					feed.setLastUpdate(new Date(0)); // force refresh
 					try {
@@ -135,7 +135,7 @@ public class DownloadLogAdapter extends BaseAdapter {
 					Log.wtf(TAG, "Could not find feed for feed id: " + holder.id);
 				}
 			} else if(holder.typeId == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
-				FeedMedia media = DBReader.getFeedMedia(context, holder.id);
+				FeedMedia media = DBReader.getFeedMedia(holder.id);
 				try {
 					DBTasks.downloadFeedItems(context, media.getItem());
 					Toast.makeText(context, R.string.status_downloading_label, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/OpmlExportWorker.java
@@ -59,7 +59,7 @@ public class OpmlExportWorker extends AsyncTask<Void, Void, Void> {
         OutputStreamWriter writer = null;
         try {
             writer = new OutputStreamWriter(new FileOutputStream(output), LangUtils.UTF_8);
-            opmlWriter.writeDocument(DBReader.getFeedList(context), writer);
+            opmlWriter.writeDocument(DBReader.getFeedList(), writer);
         } catch (IOException e) {
             e.printStackTrace();
             exception = e;

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -372,12 +372,12 @@ public class EpisodesApplyActionFragment extends Fragment {
     }
 
     private void markedCheckedPlayed() {
-        DBWriter.markItemPlayed(getActivity(), FeedItem.PLAYED, checkedIds.toArray());
+        DBWriter.markItemPlayed(FeedItem.PLAYED, checkedIds.toArray());
         close();
     }
 
     private void markedCheckedUnplayed() {
-        DBWriter.markItemPlayed(getActivity(), FeedItem.UNPLAYED, checkedIds.toArray());
+        DBWriter.markItemPlayed(FeedItem.UNPLAYED, checkedIds.toArray());
         close();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -38,6 +38,7 @@ import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.QueueEvent;
 import de.danoeh.antennapod.core.service.download.DownloadService;
 import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.storage.DBReader;
@@ -57,6 +58,7 @@ public class AllEpisodesFragment extends Fragment {
     public static final String TAG = "AllEpisodesFragment";
 
     private static final int EVENTS = EventDistributor.DOWNLOAD_HANDLED |
+            EventDistributor.FEED_LIST_UPDATE |
             EventDistributor.DOWNLOAD_QUEUED |
             EventDistributor.UNREAD_ITEMS_UPDATE |
             EventDistributor.PLAYER_STATUS_UPDATE;
@@ -251,7 +253,7 @@ public class AllEpisodesFragment extends Fragment {
                         public void onConfirmButtonPressed(
                                 DialogInterface dialog) {
                             dialog.dismiss();
-                            DBWriter.markAllItemsRead(getActivity());
+                            DBWriter.markAllItemsRead();
                             Toast.makeText(getActivity(), R.string.mark_all_read_msg, Toast.LENGTH_SHORT).show();
                         }
                     };
@@ -485,14 +487,14 @@ public class AllEpisodesFragment extends Fragment {
             if (context != null) {
                 if(showOnlyNewEpisodes) {
                     return new Object[] {
-                            DBReader.getNewItemsList(context),
-                            DBReader.getQueueIDList(context),
+                            DBReader.getNewItemsList(),
+                            DBReader.getQueueIDList(),
                             null // see ItemAccess.isNew
                     };
                 } else {
                     return new Object[]{
-                            DBReader.getRecentlyPublishedEpisodes(context, RECENT_EPISODES_LIMIT),
-                            DBReader.getQueueIDList(context)
+                            DBReader.getRecentlyPublishedEpisodes(RECENT_EPISODES_LIMIT),
+                            DBReader.getQueueIDList()
                     };
                 }
             } else {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -179,7 +179,7 @@ public class CompletedDownloadsFragment extends ListFragment {
         protected List<FeedItem> doInBackground(Void... params) {
             Context context = getActivity();
             if (context != null) {
-                return DBReader.getDownloadedItems(context);
+                return DBReader.getDownloadedItems();
             }
             return Collections.emptyList();
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/DownloadLogFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/DownloadLogFragment.java
@@ -142,7 +142,7 @@ public class DownloadLogFragment extends ListFragment {
         if (!super.onOptionsItemSelected(item)) {
             switch (item.getItemId()) {
                 case R.id.clear_history_item:
-                    DBWriter.clearDownloadLog(getActivity());
+                    DBWriter.clearDownloadLog();
                     return true;
                 default:
                     return false;
@@ -170,7 +170,7 @@ public class DownloadLogFragment extends ListFragment {
         protected List<DownloadStatus> doInBackground(Void... params) {
             Context context = getActivity();
             if (context != null) {
-                return DBReader.getDownloadLog(context);
+                return DBReader.getDownloadLog();
             }
             return null;
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -210,7 +210,7 @@ public class ItemDescriptionFragment extends Fragment {
 
                 @Override
                 protected FeedItem doInBackground(Void... voids) {
-                    return DBReader.getFeedItem(getActivity(), getArguments().getLong(ARG_FEEDITEM_ID));
+                    return DBReader.getFeedItem(getArguments().getLong(ARG_FEEDITEM_ID));
                 }
 
                 @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -36,7 +36,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import java.util.List;
 
@@ -497,12 +496,12 @@ public class ItemFragment extends Fragment implements LoaderManager.LoaderCallba
         return new DBTaskLoader<Pair<FeedItem,LongList>>(getActivity()) {
             @Override
             public Pair<FeedItem,LongList> loadInBackground() {
-                FeedItem data1 = DBReader.getFeedItem(getContext(), itemID);
+                FeedItem data1 = DBReader.getFeedItem(itemID);
                 if (data1 != null) {
                     Timeline t = new Timeline(getActivity(), data1);
                     webviewData = t.processShownotes(false);
                 }
-                LongList data2 = DBReader.getQueueIDList(getContext());
+                LongList data2 = DBReader.getQueueIDList();
                 return Pair.create(data1, data2);
             }
         };

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -630,12 +630,12 @@ public class ItemlistFragment extends ListFragment {
             long feedID = params[0];
             Context context = getActivity();
             if (context != null) {
-                Feed feed = DBReader.getFeed(context, feedID);
+                Feed feed = DBReader.getFeed(feedID);
                 if(feed != null && feed.getItemFilter() != null) {
                     FeedItemFilter filter = feed.getItemFilter();
                     feed.setItems(filter.filter(context, feed.getItems()));
                 }
-                LongList queuedItemsIds = DBReader.getQueueIDList(context);
+                LongList queuedItemsIds = DBReader.getQueueIDList();
                 return new Object[] { feed, queuedItemsIds };
             } else {
                 return null;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -73,7 +73,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
                 FeedItem item = (FeedItem) listView.getAdapter().getItem(which);
                 // we're marking it as unplayed since the user didn't actually play it
                 // but they don't want it considered 'NEW' anymore
-                DBWriter.markItemPlayed(getActivity(), FeedItem.UNPLAYED, item.getId());
+                DBWriter.markItemPlayed(FeedItem.UNPLAYED, item.getId());
                 undoBarController.showUndoBar(false,
                         getString(R.string.marked_as_read_label), new FeedItemUndoToken(item,
                                 which)
@@ -89,14 +89,14 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
             public void onUndo(FeedItemUndoToken token) {
                 if (token != null) {
                     long itemId = token.getFeedItemId();
-                    DBWriter.markItemPlayed(context, FeedItem.NEW, itemId);
+                    DBWriter.markItemPlayed(FeedItem.NEW, itemId);
                 }
             }
             @Override
             public void onHide(FeedItemUndoToken token) {
                 if (token != null && context != null) {
                     long itemId = token.getFeedItemId();
-                    FeedItem item = DBReader.getFeedItem(context, itemId);
+                    FeedItem item = DBReader.getFeedItem(itemId);
                     FeedMedia media = item.getMedia();
                     if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete()) {
                         DBWriter.deleteFeedMediaOfItem(context, media.getId());

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -164,7 +164,7 @@ public class PlaybackHistoryFragment extends ListFragment {
         if (!super.onOptionsItemSelected(item)) {
             switch (item.getItemId()) {
                 case R.id.clear_history_item:
-                    DBWriter.clearPlaybackHistory(getActivity());
+                    DBWriter.clearPlaybackHistory();
                     return true;
                 default:
                     return false;
@@ -267,9 +267,9 @@ public class PlaybackHistoryFragment extends ListFragment {
         protected Pair<List<FeedItem>,LongList> doInBackground(Void... params) {
             Context context = activity.get();
             if (context != null) {
-                List<FeedItem> history = DBReader.getPlaybackHistory(context);
-                LongList queue = DBReader.getQueueIDList(context);
-                DBReader.loadFeedDataOfFeedItemlist(context, history);
+                List<FeedItem> history = DBReader.getPlaybackHistory();
+                LongList queue = DBReader.getQueueIDList();
+                DBReader.loadFeedDataOfFeedItemlist(history);
                 return Pair.create(history, queue);
             } else {
                 return null;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -269,7 +269,7 @@ public class QueueFragment extends Fragment {
                         public void onConfirmButtonPressed(
                                 DialogInterface dialog) {
                             dialog.dismiss();
-                            DBWriter.clearQueue(getActivity());
+                            DBWriter.clearQueue();
                         }
                     };
                     conDialog.createNewDialog().show();
@@ -402,7 +402,7 @@ public class QueueFragment extends Fragment {
                 final FeedItem item = queue.remove(from);
                 queue.add(to, item);
                 listAdapter.notifyDataSetChanged();
-                DBWriter.moveQueueItem(getActivity(), from, to, true);
+                DBWriter.moveQueueItem(from, to, true);
             }
 
             @Override
@@ -432,10 +432,12 @@ public class QueueFragment extends Fragment {
             public void onHide(FeedItemUndoToken token) {
                 if (token != null && context != null) {
                     long itemId = token.getFeedItemId();
-                    FeedItem item = DBReader.getFeedItem(context, itemId);
-                    FeedMedia media = item.getMedia();
-                    if(media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete()) {
-                        DBWriter.deleteFeedMediaOfItem(context, media.getId());
+                    FeedItem item = DBReader.getFeedItem(itemId);
+                    if(item != null) {
+                        FeedMedia media = item.getMedia();
+                        if (media != null && media.hasAlmostEnded() && item.getFeed().getPreferences().getCurrentAutoDelete()) {
+                            DBWriter.deleteFeedMediaOfItem(context, media.getId());
+                        }
                     }
                 }
             }
@@ -608,7 +610,7 @@ public class QueueFragment extends Fragment {
         protected List<FeedItem> doInBackground(Void... params) {
             Context context = activity.get();
             if (context != null) {
-                return DBReader.getQueue(context);
+                return DBReader.getQueue();
             }
             return null;
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
@@ -81,8 +81,8 @@ public class RunningDownloadsFragment extends ListFragment {
 
             if(downloadRequest.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA &&
                     UserPreferences.isEnableAutodownload()) {
-                FeedMedia media = DBReader.getFeedMedia(getActivity(), downloadRequest.getFeedfileId());
-                DBWriter.setFeedItemAutoDownload(getActivity(), media.getItem(), false);
+                FeedMedia media = DBReader.getFeedMedia(downloadRequest.getFeedfileId());
+                DBWriter.setFeedItemAutoDownload(media.getItem(), false);
                 Toast.makeText(getActivity(), R.string.download_canceled_autodownload_enabled_msg, Toast.LENGTH_SHORT).show();
             } else {
                 Toast.makeText(getActivity(), R.string.download_canceled_msg, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -155,7 +155,7 @@ public class FeedItemMenuHandler {
                 break;
             case R.id.mark_read_item:
                 selectedItem.setPlayed(true);
-                DBWriter.markItemPlayed(context, selectedItem, FeedItem.PLAYED, false);
+                DBWriter.markItemPlayed(selectedItem, FeedItem.PLAYED, false);
                 if(GpodnetPreferences.loggedIn()) {
                     FeedMedia media = selectedItem.getMedia();
                     // not all items have media, Gpodder only cares about those that do
@@ -173,7 +173,7 @@ public class FeedItemMenuHandler {
                 break;
             case R.id.mark_unread_item:
                 selectedItem.setPlayed(false);
-                DBWriter.markItemPlayed(context, selectedItem, FeedItem.UNPLAYED, false);
+                DBWriter.markItemPlayed(selectedItem, FeedItem.UNPLAYED, false);
                 if(GpodnetPreferences.loggedIn()) {
                     GpodnetEpisodeAction actionNew = new GpodnetEpisodeAction.Builder(selectedItem, Action.NEW)
                             .currentDeviceId()
@@ -183,10 +183,10 @@ public class FeedItemMenuHandler {
                 }
                 break;
             case R.id.move_to_top_item:
-                DBWriter.moveQueueItemToTop(context, selectedItem.getId(), true);
+                DBWriter.moveQueueItemToTop(selectedItem.getId(), true);
                 return true;
             case R.id.move_to_bottom_item:
-                DBWriter.moveQueueItemToBottom(context, selectedItem.getId(), true);
+                DBWriter.moveQueueItemToBottom(selectedItem.getId(), true);
             case R.id.add_to_queue_item:
                 DBWriter.addQueueItem(context, selectedItem.getId());
                 break;
@@ -195,15 +195,15 @@ public class FeedItemMenuHandler {
                 break;
             case R.id.reset_position:
                 selectedItem.getMedia().setPosition(0);
-                DBWriter.markItemPlayed(context, selectedItem, FeedItem.UNPLAYED, true);
+                DBWriter.markItemPlayed(selectedItem, FeedItem.UNPLAYED, true);
                 break;
             case R.id.activate_auto_download:
                 selectedItem.setAutoDownload(true);
-                DBWriter.setFeedItemAutoDownload(context, selectedItem, true);
+                DBWriter.setFeedItemAutoDownload(selectedItem, true);
                 break;
             case R.id.deactivate_auto_download:
                 selectedItem.setAutoDownload(false);
-                DBWriter.setFeedItemAutoDownload(context, selectedItem, false);
+                DBWriter.setFeedItemAutoDownload(selectedItem, false);
                 break;
             case R.id.visit_website_item:
                 Uri uri = Uri.parse(selectedItem.getLink());

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
@@ -78,7 +78,7 @@ public class FeedMenuHandler {
                     public void onConfirmButtonPressed(
                             DialogInterface dialog) {
                         dialog.dismiss();
-                        DBWriter.markFeedRead(context, selectedFeed.getId());
+                        DBWriter.markFeedRead(selectedFeed.getId());
                     }
                 };
                 conDialog.createNewDialog().show();
@@ -138,7 +138,7 @@ public class FeedMenuHandler {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 feed.setHiddenItemProperties(hidden.toArray(new String[hidden.size()]));
-                DBWriter.setFeedItemsFilter(context, feed.getId(), hidden);
+                DBWriter.setFeedItemsFilter(feed.getId(), hidden);
             }
         });
         builder.setNegativeButton(R.string.cancel_label, null);

--- a/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
+++ b/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
@@ -58,9 +58,9 @@ public class PlayerWidgetService extends Service {
 				if (media.hasAlmostEnded()) {
 					Log.d(TAG, "smart mark as read");
 					FeedItem item = media.getItem();
-					DBWriter.markItemPlayed(this, item, FeedItem.PLAYED, false);
+					DBWriter.markItemPlayed(item, FeedItem.PLAYED, false);
 					DBWriter.removeQueueItem(this, item, false);
-					DBWriter.addItemToPlaybackHistory(this, media);
+					DBWriter.addItemToPlaybackHistory(media);
 					if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
 						Log.d(TAG, "Delete " + media.toString());
 						DBWriter.deleteFeedMediaOfItem(this, media.getId());

--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/FlattrClickWorker.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/FlattrClickWorker.java
@@ -94,7 +94,7 @@ public class FlattrClickWorker extends AsyncTask<Void, Integer, FlattrClickWorke
             return ExitCode.NO_NETWORK;
         }
 
-        final List<FlattrThing> flattrQueue = DBReader.getFlattrQueue(context);
+        final List<FlattrThing> flattrQueue = DBReader.getFlattrQueue();
         if (extraFlattrThing != null) {
             flattrQueue.add(extraFlattrThing);
         } else if (flattrQueue.size() == 1) {

--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/FlattrStatusFetcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/FlattrStatusFetcher.java
@@ -32,7 +32,7 @@ public class FlattrStatusFetcher extends Thread {
 
         try {
             List<Flattr> flattredThings = FlattrUtils.retrieveFlattredThings();
-            DBWriter.setFlattredStatus(context, flattredThings).get();
+            DBWriter.setFlattredStatus(flattredThings).get();
         } catch (FlattrException e) {
             e.printStackTrace();
             Log.d(TAG, "flattrQueue exception retrieving list with flattred items " + e.getMessage());

--- a/core/src/main/java/de/danoeh/antennapod/core/backup/OpmlBackupAgent.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/backup/OpmlBackupAgent.java
@@ -89,7 +89,7 @@ public class OpmlBackupAgent extends BackupAgentHelper {
 
             try {
                 // Write OPML
-                new OpmlWriter().writeDocument(DBReader.getFeedList(mContext), writer);
+                new OpmlWriter().writeDocument(DBReader.getFeedList(), writer);
 
                 // Compare checksum of new and old file to see if we need to perform a backup at all
                 if (digester != null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
@@ -1,5 +1,9 @@
 package de.danoeh.antennapod.core.feed;
 
+import android.database.Cursor;
+
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
 public abstract class Chapter extends FeedComponent {
 
 	/** Defines starting point in milliseconds. */
@@ -21,6 +25,33 @@ public abstract class Chapter extends FeedComponent {
 		this.title = title;
 		this.link = link;
 	}
+
+	public static Chapter fromCursor(Cursor cursor, FeedItem item) {
+		int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
+		int indexStart = cursor.getColumnIndex(PodDBAdapter.KEY_START);
+		int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
+		int indexChapterType = cursor.getColumnIndex(PodDBAdapter.KEY_CHAPTER_TYPE);
+
+		String title = cursor.getString(indexTitle);
+		long start = cursor.getLong(indexStart);
+		String link = cursor.getString(indexLink);
+		int chapterType = cursor.getInt(indexChapterType);
+
+		Chapter chapter = null;
+		switch (chapterType) {
+			case SimpleChapter.CHAPTERTYPE_SIMPLECHAPTER:
+				chapter = new SimpleChapter(start, title, item, link);
+				break;
+			case ID3Chapter.CHAPTERTYPE_ID3CHAPTER:
+				chapter = new ID3Chapter(start, title, item, link);
+				break;
+			case VorbisCommentChapter.CHAPTERTYPE_VORBISCOMMENT_CHAPTER:
+				chapter = new VorbisCommentChapter(start, title, item, link);
+				break;
+		}
+		return chapter;
+	}
+
 
 	public abstract int getChapterType();
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.core.feed;
 
 import android.content.Context;
+import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 
@@ -12,6 +13,7 @@ import java.util.List;
 
 import de.danoeh.antennapod.core.asynctask.ImageResource;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.flattr.FlattrStatus;
 import de.danoeh.antennapod.core.util.flattr.FlattrThing;
 
@@ -170,11 +172,60 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
         preferences = new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL, username, password);
     }
 
+    public static Feed fromCursor(Cursor cursor) {
+        int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
+        int indexLastUpdate = cursor.getColumnIndex(PodDBAdapter.KEY_LASTUPDATE);
+        int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
+        int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
+        int indexDescription = cursor.getColumnIndex(PodDBAdapter.KEY_DESCRIPTION);
+        int indexPaymentLink = cursor.getColumnIndex(PodDBAdapter.KEY_PAYMENT_LINK);
+        int indexAuthor = cursor.getColumnIndex(PodDBAdapter.KEY_AUTHOR);
+        int indexLanguage = cursor.getColumnIndex(PodDBAdapter.KEY_LANGUAGE);
+        int indexType = cursor.getColumnIndex(PodDBAdapter.KEY_TYPE);
+        int indexFeedIdentifier = cursor.getColumnIndex(PodDBAdapter.KEY_FEED_IDENTIFIER);
+        int indexFileUrl = cursor.getColumnIndex(PodDBAdapter.KEY_FILE_URL);
+        int indexDownloadUrl = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOAD_URL);
+        int indexDownloaded = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOADED);
+        int indexFlattrStatus = cursor.getColumnIndex(PodDBAdapter.KEY_FLATTR_STATUS);
+        int indexIsPaged = cursor.getColumnIndex(PodDBAdapter.KEY_IS_PAGED);
+        int indexNextPageLink = cursor.getColumnIndex(PodDBAdapter.KEY_NEXT_PAGE_LINK);
+        int indexHide = cursor.getColumnIndex(PodDBAdapter.KEY_HIDE);
+        int indexLastUpdateFailed = cursor.getColumnIndex(PodDBAdapter.KEY_LAST_UPDATE_FAILED);
 
-    /**
-     * Returns true if at least one item in the itemlist is unread.
-     *
-     */
+        Date lastUpdate = new Date(cursor.getLong(indexLastUpdate));
+
+        Feed feed = new Feed(
+                cursor.getLong(indexId),
+                lastUpdate,
+                cursor.getString(indexTitle),
+                cursor.getString(indexLink),
+                cursor.getString(indexDescription),
+                cursor.getString(indexPaymentLink),
+                cursor.getString(indexAuthor),
+                cursor.getString(indexLanguage),
+                cursor.getString(indexType),
+                cursor.getString(indexFeedIdentifier),
+                null,
+                cursor.getString(indexFileUrl),
+                cursor.getString(indexDownloadUrl),
+                cursor.getInt(indexDownloaded) > 0,
+                new FlattrStatus(cursor.getLong(indexFlattrStatus)),
+                cursor.getInt(indexIsPaged) > 0,
+                cursor.getString(indexNextPageLink),
+                cursor.getString(indexHide),
+                cursor.getInt(indexLastUpdateFailed) > 0
+        );
+
+        FeedPreferences preferences = FeedPreferences.fromCursor(cursor);
+        feed.setPreferences(preferences);
+        return feed;
+    }
+
+
+        /**
+         * Returns true if at least one item in the itemlist is unread.
+         *
+         */
     public boolean hasNewItems() {
         for (FeedItem item : items) {
             if (item.isNew()) {
@@ -444,7 +495,7 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
     }
 
     public void savePreferences(Context context) {
-        DBWriter.setFeedPreferences(context, preferences);
+        DBWriter.setFeedPreferences(preferences);
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedImage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedImage.java
@@ -1,10 +1,12 @@
 package de.danoeh.antennapod.core.feed;
 
+import android.database.Cursor;
 import android.net.Uri;
 
 import java.io.File;
 
 import de.danoeh.antennapod.core.asynctask.ImageResource;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 
 public class FeedImage extends FeedFile implements ImageResource {
@@ -30,6 +32,23 @@ public class FeedImage extends FeedFile implements ImageResource {
     public FeedImage() {
         super();
     }
+
+	public static FeedImage fromCursor(Cursor cursor) {
+		int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
+		int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
+		int indexFileUrl = cursor.getColumnIndex(PodDBAdapter.KEY_FILE_URL);
+		int indexDownloadUrl = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOAD_URL);
+		int indexDownloaded = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOADED);
+
+		return new FeedImage(
+				cursor.getLong(indexId),
+				cursor.getString(indexTitle),
+				cursor.getString(indexFileUrl),
+				cursor.getString(indexDownloadUrl),
+				cursor.getInt(indexDownloaded) > 0
+		);
+	}
+
 
 	@Override
 	public String getHumanReadableIdentifier() {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItemFilter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItemFilter.java
@@ -64,7 +64,7 @@ public class FeedItemFilter {
             if(hideUnplayed && false == item.isPlayed()) continue;
             if(hidePaused && item.getState() == FeedItem.State.IN_PROGRESS) continue;
             if(hidePlayed && item.isPlayed()) continue;
-            boolean isQueued = DBReader.getQueueIDList(context).contains(item.getId());
+            boolean isQueued = DBReader.getQueueIDList().contains(item.getId());
             if(hideQueued && isQueued) continue;
             if(hideNotQueued && false == isQueued) continue;
             boolean isDownloaded = item.getMedia() != null && item.getMedia().isDownloaded();

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -1,9 +1,13 @@
 package de.danoeh.antennapod.core.feed;
 
 import android.content.Context;
-import de.danoeh.antennapod.core.storage.DBWriter;
+import android.database.Cursor;
+
 import org.apache.commons.lang3.StringUtils;
+
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 /**
  * Contains preferences for a single feed.
@@ -28,6 +32,23 @@ public class FeedPreferences {
         this.username = username;
         this.password = password;
     }
+
+    public static FeedPreferences fromCursor(Cursor cursor) {
+        int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
+        int indexAutoDownload = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DOWNLOAD);
+        int indexAutoDeleteAction = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DELETE_ACTION);
+        int indexUsername = cursor.getColumnIndex(PodDBAdapter.KEY_USERNAME);
+        int indexPassword = cursor.getColumnIndex(PodDBAdapter.KEY_PASSWORD);
+
+        long feedId = cursor.getLong(indexId);
+        boolean autoDownload = cursor.getInt(indexAutoDownload) > 0;
+        int autoDeleteActionIndex = cursor.getInt(indexAutoDeleteAction);
+        AutoDeleteAction autoDeleteAction = AutoDeleteAction.values()[autoDeleteActionIndex];
+        String username = cursor.getString(indexUsername);
+        String password = cursor.getString(indexPassword);
+        return new FeedPreferences(feedId, autoDownload, autoDeleteAction, username, password);
+    }
+
 
 
     /**
@@ -98,7 +119,7 @@ public class FeedPreferences {
     }
 
     public void save(Context context) {
-        DBWriter.setFeedPreferences(context, this);
+        DBWriter.setFeedPreferences(this);
     }
 
     public String getUsername() {

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -108,7 +108,7 @@ public class ApOkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
             com.squareup.okhttp.Request request = chain.request();
             String url = request.urlString();
             Context context = ClientConfig.applicationCallbacks.getApplicationInstance();
-            String authentication = DBReader.getImageAuthentication(context, url);
+            String authentication = DBReader.getImageAuthentication(url);
 
             if(TextUtils.isEmpty(authentication)) {
                 Log.d(TAG, "no credentials for '" + url + "'");

--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -126,7 +126,7 @@ public class GpodnetSyncService extends Service {
     private synchronized void syncSubscriptionChanges() {
         final long timestamp = GpodnetPreferences.getLastSubscriptionSyncTimestamp();
         try {
-            final List<String> localSubscriptions = DBReader.getFeedListDownloadUrls(this);
+            final List<String> localSubscriptions = DBReader.getFeedListDownloadUrls();
             Collection<String> localAdded = GpodnetPreferences.getAddedFeedsCopy();
             Collection<String> localRemoved = GpodnetPreferences.getRemovedFeedsCopy();
             GpodnetService service = tryLogin();
@@ -242,9 +242,9 @@ public class GpodnetSyncService extends Service {
         for (GpodnetEpisodeAction action : remoteActions) {
             switch (action.getAction()) {
                 case NEW:
-                    FeedItem newItem = DBReader.getFeedItem(this, action.getPodcast(), action.getEpisode());
+                    FeedItem newItem = DBReader.getFeedItem(action.getPodcast(), action.getEpisode());
                     if(newItem != null) {
-                        DBWriter.markItemPlayed(this, newItem, FeedItem.UNPLAYED, true);
+                        DBWriter.markItemPlayed(newItem, FeedItem.UNPLAYED, true);
                     } else {
                         Log.i(TAG, "Unknown feed item: " + action);
                     }
@@ -273,14 +273,14 @@ public class GpodnetSyncService extends Service {
             }
         }
         for (GpodnetEpisodeAction action : mostRecentPlayAction.values()) {
-            FeedItem playItem = DBReader.getFeedItem(this, action.getPodcast(), action.getEpisode());
+            FeedItem playItem = DBReader.getFeedItem(action.getPodcast(), action.getEpisode());
             if (playItem != null) {
                 FeedMedia media = playItem.getMedia();
                 media.setPosition(action.getPosition() * 1000);
-                DBWriter.setFeedMedia(this, media);
+                DBWriter.setFeedMedia(media);
                 if(playItem.getMedia().hasAlmostEnded()) {
-                    DBWriter.markItemPlayed(this, playItem, FeedItem.PLAYED, true);
-                    DBWriter.addItemToPlaybackHistory(this, playItem.getMedia());
+                    DBWriter.markItemPlayed(playItem, FeedItem.PLAYED, true);
+                    DBWriter.addItemToPlaybackHistory(playItem.getMedia());
                 }
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadStatus.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadStatus.java
@@ -1,11 +1,14 @@
 package de.danoeh.antennapod.core.service.download;
 
+import android.database.Cursor;
+
 import org.apache.commons.lang3.Validate;
 
-import de.danoeh.antennapod.core.feed.FeedFile;
-import de.danoeh.antennapod.core.util.DownloadError;
-
 import java.util.Date;
+
+import de.danoeh.antennapod.core.feed.FeedFile;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.danoeh.antennapod.core.util.DownloadError;
 
 /** Contains status attributes for one download */
 public class DownloadStatus {
@@ -99,6 +102,30 @@ public class DownloadStatus {
 		this.successful = successful;
 		this.completionDate = new Date();
 		this.reasonDetailed = reasonDetailed;
+	}
+
+	public static DownloadStatus fromCursor(Cursor cursor) {
+		int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
+		int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOADSTATUS_TITLE);
+		int indexFeedFile = cursor.getColumnIndex(PodDBAdapter.KEY_FEEDFILE);
+		int indexFileFileType = cursor.getColumnIndex(PodDBAdapter.KEY_FEEDFILETYPE);
+		int indexSuccessful = cursor.getColumnIndex(PodDBAdapter.KEY_SUCCESSFUL);
+		int indexReason = cursor.getColumnIndex(PodDBAdapter.KEY_REASON);
+		int indexCompletionDate = cursor.getColumnIndex(PodDBAdapter.KEY_COMPLETION_DATE);
+		int indexReasonDetailed = cursor.getColumnIndex(PodDBAdapter.KEY_REASON_DETAILED);
+
+		long id = cursor.getLong(indexId);
+		String title = cursor.getString(indexTitle);
+		long feedfileId = cursor.getLong(indexFeedFile);
+		int feedfileType = cursor.getInt(indexFileFileType);
+		boolean successful = cursor.getInt(indexSuccessful) > 0;
+		int reason = cursor.getInt(indexReason);
+		Date completionDate = new Date(cursor.getLong(indexCompletionDate));
+		String reasonDetailed = cursor.getString(indexReasonDetailed);
+
+		return new DownloadStatus(id, title, feedfileId,
+				feedfileType, successful, DownloadError.fromCode(reason), completionDate,
+				reasonDetailed);
 	}
 
 	@Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -564,7 +564,7 @@ public class PlaybackService extends Service {
         if (playable instanceof FeedMedia) {
             FeedMedia media = (FeedMedia) playable;
             FeedItem item = media.getItem();
-            DBWriter.markItemPlayed(PlaybackService.this, item, FeedItem.PLAYED, true);
+            DBWriter.markItemPlayed(item, FeedItem.PLAYED, true);
 
             try {
                 final List<FeedItem> queue = taskManager.getQueue();
@@ -577,7 +577,7 @@ public class PlaybackService extends Service {
             if (isInQueue) {
                 DBWriter.removeQueueItem(PlaybackService.this, item, true);
             }
-            DBWriter.addItemToPlaybackHistory(PlaybackService.this, media);
+            DBWriter.addItemToPlaybackHistory(media);
 
             // auto-flattr if enabled
             if (isAutoFlattrable(media) && UserPreferences.getAutoFlattrPlayedDurationThreshold() == 1.0f) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -201,9 +201,9 @@ public class PlaybackServiceMediaPlayer {
                     if(oldMedia.hasAlmostEnded()) {
                         Log.d(TAG, "smart mark as read");
                         FeedItem item = oldMedia.getItem();
-                        DBWriter.markItemPlayed(context, item, FeedItem.PLAYED, false);
+                        DBWriter.markItemPlayed(item, FeedItem.PLAYED, false);
                         DBWriter.removeQueueItem(context, item, false);
-                        DBWriter.addItemToPlaybackHistory(context, oldMedia);
+                        DBWriter.addItemToPlaybackHistory(oldMedia);
                         if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
                             Log.d(TAG, "Delete " + oldMedia.toString());
                             DBWriter.deleteFeedMediaOfItem(context, oldMedia.getId());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -100,7 +100,7 @@ public class PlaybackServiceTaskManager {
             queueFuture = schedExecutor.submit(new Callable<List<FeedItem>>() {
                 @Override
                 public List<FeedItem> call() throws Exception {
-                    return DBReader.getQueue(context);
+                    return DBReader.getQueue();
                 }
             });
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -5,7 +5,6 @@ import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -18,13 +17,14 @@ import de.danoeh.antennapod.core.util.LongList;
  * Implementation of the EpisodeCleanupAlgorithm interface used by AntennaPod.
  */
 public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+
     private static final String TAG = "APCleanupAlgorithm";
 
     @Override
     public int performCleanup(Context context, Integer episodeNumber) {
-        List<FeedItem> candidates = new ArrayList<FeedItem>();
-        List<FeedItem> downloadedItems = DBReader.getDownloadedItems(context);
-        LongList queue = DBReader.getQueueIDList(context);
+        List<FeedItem> candidates = new ArrayList<>();
+        List<FeedItem> downloadedItems = DBReader.getDownloadedItems();
+        LongList queue = DBReader.getQueueIDList();
         List<FeedItem> delete;
         for (FeedItem item : downloadedItems) {
             if (item.hasMedia() && item.getMedia().isDownloaded()
@@ -34,20 +34,17 @@ public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
 
         }
 
-        Collections.sort(candidates, new Comparator<FeedItem>() {
-            @Override
-            public int compare(FeedItem lhs, FeedItem rhs) {
-                Date l = lhs.getMedia().getPlaybackCompletionDate();
-                Date r = rhs.getMedia().getPlaybackCompletionDate();
+        Collections.sort(candidates, (lhs, rhs) -> {
+            Date l = lhs.getMedia().getPlaybackCompletionDate();
+            Date r = rhs.getMedia().getPlaybackCompletionDate();
 
-                if (l == null) {
-                    l = new Date();
-                }
-                if (r == null) {
-                    r = new Date();
-                }
-                return l.compareTo(r);
+            if (l == null) {
+                l = new Date();
             }
+            if (r == null) {
+                r = new Date();
+            }
+            return l.compareTo(r);
         });
 
         if (candidates.size() > episodeNumber) {
@@ -75,22 +72,21 @@ public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
     }
 
     @Override
-    public Integer getDefaultCleanupParameter(Context context) {
-        return getPerformAutoCleanupArgs(context, 0);
+    public Integer getDefaultCleanupParameter() {
+        return getPerformAutoCleanupArgs(0);
     }
 
     @Override
-    public Integer getPerformCleanupParameter(Context context, List<FeedItem> items) {
-        return getPerformAutoCleanupArgs(context, items.size());
+    public Integer getPerformCleanupParameter(List<FeedItem> items) {
+        return getPerformAutoCleanupArgs(items.size());
     }
 
-    static int getPerformAutoCleanupArgs(Context context,
-                                         final int episodeNumber) {
+    static int getPerformAutoCleanupArgs(final int episodeNumber) {
         if (episodeNumber >= 0
                 && UserPreferences.getEpisodeCacheSize() != UserPreferences
                 .getEpisodeCacheSizeUnlimited()) {
             int downloadedEpisodes = DBReader
-                    .getNumberOfDownloadedEpisodes(context);
+                    .getNumberOfDownloadedEpisodes();
             if (downloadedEpisodes + episodeNumber >= UserPreferences
                     .getEpisodeCacheSize()) {
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -51,8 +51,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                     Log.d(TAG, "Performing auto-dl of undownloaded episodes");
 
                     List<FeedItem> candidates;
-                    final List<FeedItem> queue = DBReader.getQueue(context);
-                    final List<FeedItem> newItems = DBReader.getNewItemsList(context);
+                    final List<FeedItem> queue = DBReader.getQueue();
+                    final List<FeedItem> newItems = DBReader.getNewItemsList();
                     candidates = new ArrayList<FeedItem>(queue.size() + newItems.size());
                     candidates.addAll(queue);
                     for(FeedItem newItem : newItems) {
@@ -71,9 +71,9 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                     }
 
                     int autoDownloadableEpisodes = candidates.size();
-                    int downloadedEpisodes = DBReader.getNumberOfDownloadedEpisodes(context);
+                    int downloadedEpisodes = DBReader.getNumberOfDownloadedEpisodes();
                     int deletedEpisodes = cleanupAlgorithm.performCleanup(context,
-                            APCleanupAlgorithm.getPerformAutoCleanupArgs(context, autoDownloadableEpisodes));
+                            APCleanupAlgorithm.getPerformAutoCleanupArgs(autoDownloadableEpisodes));
                     boolean cacheIsUnlimited = UserPreferences.getEpisodeCacheSize() == UserPreferences
                             .getEpisodeCacheSizeUnlimited();
                     int episodeCacheSize = UserPreferences.getEpisodeCacheSize();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.core.storage;
 
-import android.content.Context;
 import android.database.Cursor;
 import android.util.Log;
 
@@ -9,10 +8,8 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedImage;
@@ -24,13 +21,11 @@ import de.danoeh.antennapod.core.feed.SimpleChapter;
 import de.danoeh.antennapod.core.feed.VorbisCommentChapter;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
-import de.danoeh.antennapod.core.util.DownloadError;
 import de.danoeh.antennapod.core.util.LongIntMap;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.comparator.DownloadStatusComparator;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 import de.danoeh.antennapod.core.util.comparator.PlaybackCompletionDateComparator;
-import de.danoeh.antennapod.core.util.flattr.FlattrStatus;
 import de.danoeh.antennapod.core.util.flattr.FlattrThing;
 
 /**
@@ -40,15 +35,16 @@ import de.danoeh.antennapod.core.util.flattr.FlattrThing;
  * This class will use the {@link de.danoeh.antennapod.core.feed.EventDistributor} to notify listeners about changes in the database.
  */
 public final class DBReader {
+
     private static final String TAG = "DBReader";
 
     /**
-     * Maximum size of the list returned by {@link #getPlaybackHistory(android.content.Context)}.
+     * Maximum size of the list returned by {@link #getPlaybackHistory()}.
      */
     public static final int PLAYBACK_HISTORY_SIZE = 50;
 
     /**
-     * Maximum size of the list returned by {@link #getDownloadLog(android.content.Context)}.
+     * Maximum size of the list returned by {@link #getDownloadLog()}.
      */
     public static final int DOWNLOAD_LOG_SIZE = 200;
 
@@ -59,16 +55,14 @@ public final class DBReader {
     /**
      * Returns a list of Feeds, sorted alphabetically by their title.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of Feeds, sorted alphabetically by their title. A Feed-object
      * of the returned list does NOT have its list of FeedItems yet. The FeedItem-list
-     * can be loaded separately with {@link #getFeedItemList(android.content.Context, de.danoeh.antennapod.core.feed.Feed)}.
+     * can be loaded separately with {@link #getFeedItemList(Feed)}.
      */
-    public static List<Feed> getFeedList(final Context context) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Extracting Feedlist");
+    public static List<Feed> getFeedList() {
+        Log.d(TAG, "Extracting Feedlist");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         List<Feed> result = getFeedList(adapter);
         adapter.close();
@@ -76,11 +70,8 @@ public final class DBReader {
     }
 
     private static List<Feed> getFeedList(PodDBAdapter adapter) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Extracting Feedlist");
-
         Cursor feedlistCursor = adapter.getAllFeedsCursor();
-        List<Feed> feeds = new ArrayList<Feed>(feedlistCursor.getCount());
+        List<Feed> feeds = new ArrayList<>(feedlistCursor.getCount());
 
         if (feedlistCursor.moveToFirst()) {
             do {
@@ -95,12 +86,11 @@ public final class DBReader {
     /**
      * Returns a list with the download URLs of all feeds.
      *
-     * @param context A context that is used for opening the database connection.
      * @return A list of Strings with the download URLs of all feeds.
      */
-    public static List<String> getFeedListDownloadUrls(final Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        List<String> result = new ArrayList<String>();
+    public static List<String> getFeedListDownloadUrls() {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        List<String> result = new ArrayList<>();
         adapter.open();
         Cursor feeds = adapter.getFeedCursorDownloadUrls();
         if (feeds.moveToFirst()) {
@@ -119,12 +109,10 @@ public final class DBReader {
      * The feedID-attribute of a FeedItem must be set to the ID of its feed or the method will
      * not find the correct feed of an item.
      *
-     * @param context A context that is used for opening a database connection.
      * @param items   The FeedItems whose Feed-objects should be loaded.
      */
-    public static void loadFeedDataOfFeedItemlist(Context context,
-                                                  List<FeedItem> items) {
-        List<Feed> feeds = getFeedList(context);
+    public static void loadFeedDataOfFeedItemlist(List<FeedItem> items) {
+        List<Feed> feeds = getFeedList();
         for (FeedItem item : items) {
             for (Feed feed : feeds) {
                 if (feed.getId() == item.getFeedId()) {
@@ -140,18 +128,16 @@ public final class DBReader {
 
     /**
      * Loads the list of FeedItems for a certain Feed-object. This method should NOT be used if the FeedItems are not
-     * used. In order to get information ABOUT the list of FeedItems, consider using {@link #getFeedStatisticsList(android.content.Context)} instead.
+     * used. In order to get information ABOUT the list of FeedItems, consider using {@link #getFeedStatisticsList()} instead.
      *
-     * @param context A context that is used for opening a database connection.
      * @param feed    The Feed whose items should be loaded
      * @return A list with the FeedItems of the Feed. The Feed-attribute of the FeedItems will already be set correctly.
      * The method does NOT change the items-attribute of the feed.
      */
-    public static List<FeedItem> getFeedItemList(Context context,
-                                                 final Feed feed) {
+    public static List<FeedItem> getFeedItemList(final Feed feed) {
         Log.d(TAG, "Extracting Feeditems of feed " + feed.getTitle());
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
         Cursor itemlistCursor = adapter.getAllItemsOfFeedCursor(feed);
@@ -170,8 +156,8 @@ public final class DBReader {
         return items;
     }
 
-    static List<FeedItem> extractItemlistFromCursor(Context context, Cursor itemlistCursor) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static List<FeedItem> extractItemlistFromCursor(Cursor itemlistCursor) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         List<FeedItem> result = extractItemlistFromCursor(adapter, itemlistCursor);
         adapter.close();
@@ -180,31 +166,20 @@ public final class DBReader {
 
     private static List<FeedItem> extractItemlistFromCursor(
             PodDBAdapter adapter, Cursor itemlistCursor) {
-        ArrayList<String> itemIds = new ArrayList<String>();
-        List<FeedItem> items = new ArrayList<FeedItem>(
-                itemlistCursor.getCount());
+        ArrayList<String> itemIds = new ArrayList<>();
+        List<FeedItem> items = new ArrayList<>(itemlistCursor.getCount());
 
         if (itemlistCursor.moveToFirst()) {
             do {
-                long imageIndex = itemlistCursor.getLong(PodDBAdapter.IDX_FI_SMALL_IMAGE);
+                int indexImage = itemlistCursor.getColumnIndex(PodDBAdapter.KEY_IMAGE);
+                long imageId = itemlistCursor.getLong(indexImage);
                 FeedImage image = null;
-                if (imageIndex != 0) {
-                    image = getFeedImage(adapter, imageIndex);
+                if (imageId != 0) {
+                    image = getFeedImage(adapter, imageId);
                 }
 
-                FeedItem item = new FeedItem(itemlistCursor.getLong(PodDBAdapter.IDX_FI_SMALL_ID),
-                        itemlistCursor.getString(PodDBAdapter.IDX_FI_SMALL_TITLE),
-                        itemlistCursor.getString(PodDBAdapter.IDX_FI_SMALL_LINK),
-                        new Date(itemlistCursor.getLong(PodDBAdapter.IDX_FI_SMALL_PUBDATE)),
-                        itemlistCursor.getString(PodDBAdapter.IDX_FI_SMALL_PAYMENT_LINK),
-                        itemlistCursor.getLong(PodDBAdapter.IDX_FI_SMALL_FEED),
-                        new FlattrStatus(itemlistCursor.getLong(PodDBAdapter.IDX_FI_SMALL_FLATTR_STATUS)),
-                        itemlistCursor.getInt(PodDBAdapter.IDX_FI_SMALL_HAS_CHAPTERS) > 0,
-                        image,
-                        itemlistCursor.getInt(PodDBAdapter.IDX_FI_SMALL_READ),
-                        itemlistCursor.getString(PodDBAdapter.IDX_FI_SMALL_ITEM_IDENTIFIER),
-                        itemlistCursor.getInt(itemlistCursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DOWNLOAD)) > 0
-                        );
+                FeedItem item = FeedItem.fromCursor(itemlistCursor);
+                item.setImage(image);
 
                 itemIds.add(String.valueOf(item.getId()));
 
@@ -219,16 +194,18 @@ public final class DBReader {
     private static void extractMediafromItemlist(PodDBAdapter adapter,
                                                  List<FeedItem> items, ArrayList<String> itemIds) {
 
-        List<FeedItem> itemsCopy = new ArrayList<FeedItem>(items);
+        List<FeedItem> itemsCopy = new ArrayList<>(items);
         Cursor cursor = adapter.getFeedMediaCursorByItemID(itemIds
                 .toArray(new String[itemIds.size()]));
         if (cursor.moveToFirst()) {
             do {
-                long itemId = cursor.getLong(PodDBAdapter.KEY_MEDIA_FEEDITEM_INDEX);
+                int index = cursor.getColumnIndex(PodDBAdapter.KEY_FEEDITEM);
+                long itemId = cursor.getLong(index);
                 // find matching feed item
                 FeedItem item = getMatchingItemForMedia(itemId, itemsCopy);
                 if (item != null) {
-                    item.setMedia(extractFeedMediaFromCursorRow(cursor));
+                    FeedMedia media = FeedMedia.fromCursor(cursor);
+                    item.setMedia(media);
                     item.getMedia().setItem(item);
                 }
             } while (cursor.moveToNext());
@@ -236,104 +213,28 @@ public final class DBReader {
         cursor.close();
     }
 
-    private static FeedMedia extractFeedMediaFromCursorRow(final Cursor cursor) {
-        long mediaId = cursor.getLong(PodDBAdapter.KEY_ID_INDEX);
-        Date playbackCompletionDate = null;
-        long playbackCompletionTime = cursor
-                .getLong(PodDBAdapter.KEY_PLAYBACK_COMPLETION_DATE_INDEX);
-        if (playbackCompletionTime > 0) {
-            playbackCompletionDate = new Date(
-                    playbackCompletionTime);
-        }
-        Boolean hasEmbeddedPicture;
-        switch(cursor.getInt(cursor.getColumnIndex(PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE))) {
-            case 1:
-                hasEmbeddedPicture = Boolean.TRUE;
-                break;
-            case 0:
-                hasEmbeddedPicture = Boolean.FALSE;
-                break;
-            default:
-                hasEmbeddedPicture = null;
-                break;
-        }
-
-        return new FeedMedia(
-                mediaId,
-                null,
-                cursor.getInt(PodDBAdapter.KEY_DURATION_INDEX),
-                cursor.getInt(PodDBAdapter.KEY_POSITION_INDEX),
-                cursor.getLong(PodDBAdapter.KEY_SIZE_INDEX),
-                cursor.getString(PodDBAdapter.KEY_MIME_TYPE_INDEX),
-                cursor.getString(PodDBAdapter.KEY_FILE_URL_INDEX),
-                cursor.getString(PodDBAdapter.KEY_DOWNLOAD_URL_INDEX),
-                cursor.getInt(PodDBAdapter.KEY_DOWNLOADED_INDEX) > 0,
-                playbackCompletionDate,
-                cursor.getInt(PodDBAdapter.KEY_PLAYED_DURATION_INDEX),
-                hasEmbeddedPicture);
-    }
-
     private static Feed extractFeedFromCursorRow(PodDBAdapter adapter,
                                                  Cursor cursor) {
-        Date lastUpdate = new Date(
-                cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_LASTUPDATE));
-
         final FeedImage image;
-        long imageIndex = cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_IMAGE);
-        if (imageIndex != 0) {
-            image = getFeedImage(adapter, imageIndex);
+        int indexImage = cursor.getColumnIndex(PodDBAdapter.KEY_IMAGE);
+        long imageId = cursor.getLong(indexImage);
+        if (imageId != 0) {
+            image = getFeedImage(adapter, imageId);
         } else {
             image = null;
         }
-        Feed feed = new Feed(cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_ID),
-                lastUpdate,
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_TITLE),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_LINK),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_DESCRIPTION),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_PAYMENT_LINK),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_AUTHOR),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_LANGUAGE),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_TYPE),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_FEED_IDENTIFIER),
-                image,
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_FILE_URL),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_DOWNLOAD_URL),
-                cursor.getInt(PodDBAdapter.IDX_FEED_SEL_STD_DOWNLOADED) > 0,
-                new FlattrStatus(cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_FLATTR_STATUS)),
-                cursor.getInt(PodDBAdapter.IDX_FEED_SEL_STD_IS_PAGED) > 0,
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_STD_NEXT_PAGE_LINK),
-                cursor.getString(cursor.getColumnIndex(PodDBAdapter.KEY_HIDE)),
-                cursor.getInt(cursor.getColumnIndex(PodDBAdapter.KEY_LAST_UPDATE_FAILED)) > 0
-                );
 
+        Feed feed = Feed.fromCursor(cursor);
         if (image != null) {
+            feed.setImage(image);
             image.setOwner(feed);
         }
-        FeedPreferences preferences = new FeedPreferences(cursor.getLong(PodDBAdapter.IDX_FEED_SEL_STD_ID),
-                cursor.getInt(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_AUTO_DOWNLOAD) > 0,
-                FeedPreferences.AutoDeleteAction.values()[cursor.getInt(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_AUTO_DELETE_ACTION)],
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_USERNAME),
-                cursor.getString(PodDBAdapter.IDX_FEED_SEL_PREFERENCES_PASSWORD));
 
+        FeedPreferences preferences = FeedPreferences.fromCursor(cursor);
         feed.setPreferences(preferences);
+
         return feed;
     }
-
-    private static DownloadStatus extractDownloadStatusFromCursorRow(final Cursor cursor) {
-        long id = cursor.getLong(PodDBAdapter.KEY_ID_INDEX);
-        long feedfileId = cursor.getLong(PodDBAdapter.KEY_FEEDFILE_INDEX);
-        int feedfileType = cursor.getInt(PodDBAdapter.KEY_FEEDFILETYPE_INDEX);
-        boolean successful = cursor.getInt(PodDBAdapter.KEY_SUCCESSFUL_INDEX) > 0;
-        int reason = cursor.getInt(PodDBAdapter.KEY_REASON_INDEX);
-        String reasonDetailed = cursor.getString(PodDBAdapter.KEY_REASON_DETAILED_INDEX);
-        String title = cursor.getString(PodDBAdapter.KEY_DOWNLOADSTATUS_TITLE_INDEX);
-        Date completionDate = new Date(cursor.getLong(PodDBAdapter.KEY_COMPLETION_DATE_INDEX));
-
-        return new DownloadStatus(id, title, feedfileId,
-                feedfileType, successful, DownloadError.fromCode(reason), completionDate,
-                reasonDetailed);
-    }
-
 
     private static FeedItem getMatchingItemForMedia(long itemId,
                                                     List<FeedItem> items) {
@@ -345,33 +246,27 @@ public final class DBReader {
         return null;
     }
 
-    static List<FeedItem> getQueue(Context context, PodDBAdapter adapter) {
+    static List<FeedItem> getQueue(PodDBAdapter adapter) {
         Log.d(TAG, "getQueue()");
-
         Cursor itemlistCursor = adapter.getQueueCursor();
-        List<FeedItem> items = extractItemlistFromCursor(adapter,
-                itemlistCursor);
+        List<FeedItem> items = extractItemlistFromCursor(adapter, itemlistCursor);
         itemlistCursor.close();
-        loadFeedDataOfFeedItemlist(context, items);
-
+        loadFeedDataOfFeedItemlist(items);
         return items;
     }
 
     /**
      * Loads the IDs of the FeedItems in the queue. This method should be preferred over
-     * {@link #getQueue(android.content.Context)} if the FeedItems of the queue are not needed.
+     * {@link #getQueue()} if the FeedItems of the queue are not needed.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of IDs sorted by the same order as the queue. The caller can wrap the returned
      * list in a {@link de.danoeh.antennapod.core.util.QueueAccess} object for easier access to the queue's properties.
      */
-    public static LongList getQueueIDList(Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
-
+    public static LongList getQueueIDList() {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         LongList result = getQueueIDList(adapter);
         adapter.close();
-
         return result;
     }
 
@@ -389,37 +284,19 @@ public final class DBReader {
         return queueIds;
     }
 
-
-    /**
-     * Return the size of the queue.
-     *
-     * @param context A context that is used for opening a database connection.
-     * @return Size of the queue.
-     */
-    public static int getQueueSize(Context context) {
-        Log.d(TAG, "getQueueSize()");
-
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        int size = adapter.getQueueSize();
-        adapter.close();
-        return size;
-    }
-
     /**
      * Loads a list of the FeedItems in the queue. If the FeedItems of the queue are not used directly, consider using
-     * {@link #getQueueIDList(android.content.Context)} instead.
+     * {@link #getQueueIDList()} instead.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of FeedItems sorted by the same order as the queue. The caller can wrap the returned
      * list in a {@link de.danoeh.antennapod.core.util.QueueAccess} object for easier access to the queue's properties.
      */
-    public static List<FeedItem> getQueue(Context context) {
+    public static List<FeedItem> getQueue() {
         Log.d(TAG, "getQueue()");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        List<FeedItem> items = getQueue(context, adapter);
+        List<FeedItem> items = getQueue(adapter);
         adapter.close();
         return items;
     }
@@ -427,21 +304,19 @@ public final class DBReader {
     /**
      * Loads a list of FeedItems whose episode has been downloaded.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of FeedItems whose episdoe has been downloaded.
      */
-    public static List<FeedItem> getDownloadedItems(Context context) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Extracting downloaded items");
+    public static List<FeedItem> getDownloadedItems() {
+        Log.d(TAG, "Extracting downloaded items");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
         Cursor itemlistCursor = adapter.getDownloadedItemsCursor();
         List<FeedItem> items = extractItemlistFromCursor(adapter,
                 itemlistCursor);
         itemlistCursor.close();
-        loadFeedDataOfFeedItemlist(context, items);
+        loadFeedDataOfFeedItemlist(items);
         Collections.sort(items, new FeedItemPubdateComparator());
 
         adapter.close();
@@ -452,22 +327,18 @@ public final class DBReader {
     /**
      * Loads a list of FeedItems whose 'read'-attribute is set to false.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of FeedItems whose 'read'-attribute it set to false.
      */
-    public static List<FeedItem> getUnreadItemsList(Context context) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Extracting unread items list");
+    public static List<FeedItem> getUnreadItemsList() {
+        Log.d(TAG, "Extracting unread items list");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-
         Cursor itemlistCursor = adapter.getUnreadItemsCursor();
-        List<FeedItem> items = extractItemlistFromCursor(adapter,
-                itemlistCursor);
+        List<FeedItem> items = extractItemlistFromCursor(adapter, itemlistCursor);
         itemlistCursor.close();
 
-        loadFeedDataOfFeedItemlist(context, items);
+        loadFeedDataOfFeedItemlist(items);
 
         adapter.close();
 
@@ -477,20 +348,19 @@ public final class DBReader {
     /**
      * Loads a list of FeedItems that are considered new.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of FeedItems that are considered new.
      */
-    public static List<FeedItem> getNewItemsList(Context context) {
+    public static List<FeedItem> getNewItemsList() {
         Log.d(TAG, "getNewItemsList()");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
         Cursor itemlistCursor = adapter.getNewItemsCursor();
         List<FeedItem> items = extractItemlistFromCursor(adapter, itemlistCursor);
         itemlistCursor.close();
 
-        loadFeedDataOfFeedItemlist(context, items);
+        loadFeedDataOfFeedItemlist(items);
 
         adapter.close();
 
@@ -498,48 +368,21 @@ public final class DBReader {
     }
 
     /**
-     * Loads the IDs of the FeedItems whose 'read'-attribute is set to false.
-     *
-     * @param context A context that is used for opening a database connection.
-     * @return A list of IDs of the FeedItems whose 'read'-attribute is set to false. This method should be preferred
-     * over {@link #getUnreadItemsList(android.content.Context)} if the FeedItems in the UnreadItems list are not used.
-     */
-    public static LongList getNewItemIds(Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        Cursor cursor = adapter.getNewItemIdsCursor();
-        LongList itemIds = new LongList(cursor.getCount());
-        int i = 0;
-        if (cursor.moveToFirst()) {
-            do {
-                long id = cursor.getLong(PodDBAdapter.KEY_ID_INDEX);
-                itemIds.add(id);
-                i++;
-            } while (cursor.moveToNext());
-        }
-        cursor.close();
-        return itemIds;
-    }
-
-    /**
      * Loads a list of FeedItems sorted by pubDate in descending order.
      *
-     * @param context A context that is used for opening a database connection.
      * @param limit   The maximum number of episodes that should be loaded.
      */
-    public static List<FeedItem> getRecentlyPublishedEpisodes(Context context, int limit) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Extracting recently published items list");
+    public static List<FeedItem> getRecentlyPublishedEpisodes(int limit) {
+        Log.d(TAG, "Extracting recently published items list");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
         Cursor itemlistCursor = adapter.getRecentlyPublishedItemsCursor(limit);
-        List<FeedItem> items = extractItemlistFromCursor(adapter,
-                itemlistCursor);
+        List<FeedItem> items = extractItemlistFromCursor(adapter, itemlistCursor);
         itemlistCursor.close();
 
-        loadFeedDataOfFeedItemlist(context, items);
+        loadFeedDataOfFeedItemlist(items);
 
         adapter.close();
 
@@ -550,26 +393,25 @@ public final class DBReader {
      * Loads the playback history from the database. A FeedItem is in the playback history if playback of the correpsonding episode
      * has been completed at least once.
      *
-     * @param context A context that is used for opening a database connection.
      * @return The playback history. The FeedItems are sorted by their media's playbackCompletionDate in descending order.
      * The size of the returned list is limited by {@link #PLAYBACK_HISTORY_SIZE}.
      */
-    public static List<FeedItem> getPlaybackHistory(final Context context) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Loading playback history");
+    public static List<FeedItem> getPlaybackHistory() {
+        Log.d(TAG, "Loading playback history");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
         Cursor mediaCursor = adapter.getCompletedMediaCursor(PLAYBACK_HISTORY_SIZE);
         String[] itemIds = new String[mediaCursor.getCount()];
         for (int i = 0; i < itemIds.length && mediaCursor.moveToPosition(i); i++) {
-            itemIds[i] = Long.toString(mediaCursor.getLong(PodDBAdapter.KEY_MEDIA_FEEDITEM_INDEX));
+            int index = mediaCursor.getColumnIndex(PodDBAdapter.KEY_FEEDITEM);
+            itemIds[i] = Long.toString(mediaCursor.getLong(index));
         }
         mediaCursor.close();
         Cursor itemCursor = adapter.getFeedItemCursor(itemIds);
         List<FeedItem> items = extractItemlistFromCursor(adapter, itemCursor);
-        loadFeedDataOfFeedItemlist(context, items);
+        loadFeedDataOfFeedItemlist(items);
         itemCursor.close();
         adapter.close();
 
@@ -580,23 +422,21 @@ public final class DBReader {
     /**
      * Loads the download log from the database.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list with DownloadStatus objects that represent the download log.
      * The size of the returned list is limited by {@link #DOWNLOAD_LOG_SIZE}.
      */
-    public static List<DownloadStatus> getDownloadLog(Context context) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Extracting DownloadLog");
+    public static List<DownloadStatus> getDownloadLog() {
+        Log.d(TAG, "Extracting DownloadLog");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor logCursor = adapter.getDownloadLogCursor(DOWNLOAD_LOG_SIZE);
-        List<DownloadStatus> downloadLog = new ArrayList<DownloadStatus>(
-                logCursor.getCount());
+        List<DownloadStatus> downloadLog = new ArrayList<>(logCursor.getCount());
 
         if (logCursor.moveToFirst()) {
             do {
-                downloadLog.add(extractDownloadStatusFromCursorRow(logCursor));
+                DownloadStatus status = DownloadStatus.fromCursor(logCursor);
+                downloadLog.add(status);
             } while (logCursor.moveToNext());
         }
         logCursor.close();
@@ -607,50 +447,22 @@ public final class DBReader {
     /**
      * Loads the download log for a particular feed from the database.
      *
-     * @param context A context that is used for opening a database connection.
      * @param feed Feed for which the download log is loaded
      * @return A list with DownloadStatus objects that represent the feed's download log,
      *         newest events first.
      */
-    public static List<DownloadStatus> getFeedDownloadLog(Context context, Feed feed) {
-        Log.d(TAG, "getFeedDownloadLog(CONTEXT, " + feed.toString() + ")");
+    public static List<DownloadStatus> getFeedDownloadLog(Feed feed) {
+        Log.d(TAG, "getFeedDownloadLog(" + feed.toString() + ")");
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor cursor = adapter.getDownloadLog(Feed.FEEDFILETYPE_FEED, feed.getId());
-        List<DownloadStatus> downloadLog = new ArrayList<DownloadStatus>(
-                cursor.getCount());
+        List<DownloadStatus> downloadLog = new ArrayList<>(cursor.getCount());
 
         if (cursor.moveToFirst()) {
             do {
-                downloadLog.add(extractDownloadStatusFromCursorRow(cursor));
-            } while (cursor.moveToNext());
-        }
-        cursor.close();
-        Collections.sort(downloadLog, new DownloadStatusComparator());
-        return downloadLog;
-    }
-
-    /**
-     * Loads the download log for a particular feed media from the database.
-     *
-     * @param context A context that is used for opening a database connection.
-     * @param media Feed media for which the download log is loaded
-     * @return A list with DownloadStatus objects that represent the feed media's download log,
-     *         newest events first.
-     */
-    public static List<DownloadStatus> getFeedMediaDownloadLog(Context context, FeedMedia media) {
-        Log.d(TAG, "getFeedDownloadLog(CONTEXT, " + media.toString() + ")");
-
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        Cursor cursor = adapter.getDownloadLog(FeedMedia.FEEDFILETYPE_FEEDMEDIA, media.getId());
-        List<DownloadStatus> downloadLog = new ArrayList<DownloadStatus>(
-                cursor.getCount());
-
-        if (cursor.moveToFirst()) {
-            do {
-                downloadLog.add(extractDownloadStatusFromCursorRow(cursor));
+                DownloadStatus status = DownloadStatus.fromCursor(cursor);
+                downloadLog.add(status);
             } while (cursor.moveToNext());
         }
         cursor.close();
@@ -660,24 +472,20 @@ public final class DBReader {
 
     /**
      * Loads the FeedItemStatistics objects of all Feeds in the database. This method should be preferred over
-     * {@link #getFeedItemList(android.content.Context, de.danoeh.antennapod.core.feed.Feed)} if only metadata about
+     * {@link #getFeedItemList(Feed)} if only metadata about
      * the FeedItems is needed.
      *
-     * @param context A context that is used for opening a database connection.
      * @return A list of FeedItemStatistics objects sorted alphabetically by their Feed's title.
      */
-    public static List<FeedItemStatistics> getFeedStatisticsList(final Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static List<FeedItemStatistics> getFeedStatisticsList() {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        List<FeedItemStatistics> result = new ArrayList<FeedItemStatistics>();
+        List<FeedItemStatistics> result = new ArrayList<>();
         Cursor cursor = adapter.getFeedStatisticsCursor();
         if (cursor.moveToFirst()) {
             do {
-                result.add(new FeedItemStatistics(cursor.getLong(PodDBAdapter.IDX_FEEDSTATISTICS_FEED),
-                        cursor.getInt(PodDBAdapter.IDX_FEEDSTATISTICS_NUM_ITEMS),
-                        cursor.getInt(PodDBAdapter.IDX_FEEDSTATISTICS_NEW_ITEMS),
-                        cursor.getInt(PodDBAdapter.IDX_FEEDSTATISTICS_IN_PROGRESS_EPISODES),
-                        new Date(cursor.getLong(PodDBAdapter.IDX_FEEDSTATISTICS_LATEST_EPISODE))));
+                FeedItemStatistics fis = FeedItemStatistics.fromCursor(cursor);
+                result.add(fis);
             } while (cursor.moveToNext());
         }
 
@@ -689,28 +497,26 @@ public final class DBReader {
     /**
      * Loads a specific Feed from the database.
      *
-     * @param context A context that is used for opening a database connection.
      * @param feedId  The ID of the Feed
      * @return The Feed or null if the Feed could not be found. The Feeds FeedItems will also be loaded from the
      * database and the items-attribute will be set correctly.
      */
-    public static Feed getFeed(final Context context, final long feedId) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static Feed getFeed(final long feedId) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        Feed result = getFeed(context, feedId, adapter);
+        Feed result = getFeed(feedId, adapter);
         adapter.close();
         return result;
     }
 
-    static Feed getFeed(final Context context, final long feedId, PodDBAdapter adapter) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Loading feed with id " + feedId);
+    static Feed getFeed(final long feedId, PodDBAdapter adapter) {
+        Log.d(TAG, "Loading feed with id " + feedId);
         Feed feed = null;
 
         Cursor feedCursor = adapter.getFeedCursor(feedId);
         if (feedCursor.moveToFirst()) {
             feed = extractFeedFromCursorRow(adapter, feedCursor);
-            feed.setItems(getFeedItemList(context, feed));
+            feed.setItems(getFeedItemList(feed));
         } else {
             Log.e(TAG, "getFeed could not find feed with id " + feedId);
         }
@@ -718,9 +524,8 @@ public final class DBReader {
         return feed;
     }
 
-    static FeedItem getFeedItem(final Context context, final long itemId, PodDBAdapter adapter) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Loading feeditem with id " + itemId);
+    static FeedItem getFeedItem(final long itemId, PodDBAdapter adapter) {
+        Log.d(TAG, "Loading feeditem with id " + itemId);
         FeedItem item = null;
 
         Cursor itemCursor = adapter.getFeedItemCursor(Long.toString(itemId));
@@ -728,7 +533,7 @@ public final class DBReader {
             List<FeedItem> list = extractItemlistFromCursor(adapter, itemCursor);
             if (list.size() > 0) {
                 item = list.get(0);
-                loadFeedDataOfFeedItemlist(context, list);
+                loadFeedDataOfFeedItemlist(list);
                 if (item.hasChapters()) {
                     loadChaptersOfFeedItem(adapter, item);
                 }
@@ -738,7 +543,7 @@ public final class DBReader {
         return item;
     }
 
-    static List<FeedItem> getFeedItems(final Context context, PodDBAdapter adapter,  final long... itemIds) {
+    static List<FeedItem> getFeedItems(PodDBAdapter adapter, final long... itemIds) {
 
         String[] ids = new String[itemIds.length];
         for(int i = 0; i < itemIds.length; i++) {
@@ -751,7 +556,7 @@ public final class DBReader {
         Cursor itemCursor = adapter.getFeedItemCursor(ids);
         if (itemCursor.moveToFirst()) {
             result = extractItemlistFromCursor(adapter, itemCursor);
-            loadFeedDataOfFeedItemlist(context, result);
+            loadFeedDataOfFeedItemlist(result);
             for(FeedItem item : result) {
                 if (item.hasChapters()) {
                     loadChaptersOfFeedItem(adapter, item);
@@ -769,23 +574,21 @@ public final class DBReader {
      * Loads a specific FeedItem from the database. This method should not be used for loading more
      * than one FeedItem because this method might query the database several times for each item.
      *
-     * @param context A context that is used for opening a database connection.
      * @param itemId  The ID of the FeedItem
      * @return The FeedItem or null if the FeedItem could not be found. All FeedComponent-attributes
      * as well as chapter marks of the FeedItem will also be loaded from the database.
      */
-    public static FeedItem getFeedItem(final Context context, final long itemId) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Loading feeditem with id " + itemId);
+    public static FeedItem getFeedItem(final long itemId) {
+        Log.d(TAG, "Loading feeditem with id " + itemId);
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        FeedItem item = getFeedItem(context, itemId, adapter);
+        FeedItem item = getFeedItem(itemId, adapter);
         adapter.close();
         return item;
     }
 
-    static FeedItem getFeedItem(final Context context, final String podcastUrl, final String episodeUrl, PodDBAdapter adapter) {
+    static FeedItem getFeedItem(final String podcastUrl, final String episodeUrl, PodDBAdapter adapter) {
         Log.d(TAG, "Loading feeditem with podcast url " + podcastUrl + " and episode url " + episodeUrl);
         FeedItem item = null;
         Cursor itemCursor = adapter.getFeedItemCursor(podcastUrl, episodeUrl);
@@ -793,7 +596,7 @@ public final class DBReader {
             List<FeedItem> list = extractItemlistFromCursor(adapter, itemCursor);
             if (list.size() > 0) {
                 item = list.get(0);
-                loadFeedDataOfFeedItemlist(context, list);
+                loadFeedDataOfFeedItemlist(list);
                 if (item.hasChapters()) {
                     loadChaptersOfFeedItem(adapter, item);
                 }
@@ -807,17 +610,16 @@ public final class DBReader {
      * Loads specific FeedItems from the database. This method canbe used for loading more
      * than one FeedItem
      *
-     * @param context A context that is used for opening a database connection.
      * @param itemIds  The IDs of the FeedItems
      * @return The FeedItems or an empty list if none of the FeedItems could be found. All FeedComponent-attributes
      * as well as chapter marks of the FeedItems will also be loaded from the database.
      */
-    public static List<FeedItem> getFeedItems(final Context context, final long... itemIds) {
+    public static List<FeedItem> getFeedItems(final long... itemIds) {
         Log.d(TAG, "Loading feeditem with ids: " + StringUtils.join(itemIds, ","));
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        List<FeedItem> items = getFeedItems(context, adapter, itemIds);
+        List<FeedItem> items = getFeedItems(adapter, itemIds);
         adapter.close();
         return items;
     }
@@ -826,22 +628,21 @@ public final class DBReader {
     /**
      * Returns credentials based on image URL
      *
-     * @param context A context that is used for opening a database connection.
      * @param imageUrl  The URL of the image
      * @return Credentials in format "<Username>:<Password>", empty String if no authorization given
      */
-    public static String getImageAuthentication(final Context context, final String imageUrl) {
+    public static String getImageAuthentication(final String imageUrl) {
         Log.d(TAG, "Loading credentials for image with URL " + imageUrl);
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        String credentials = getImageAuthentication(context, imageUrl, adapter);
+        String credentials = getImageAuthentication(imageUrl, adapter);
         adapter.close();
         return credentials;
 
     }
 
-    static String getImageAuthentication(final Context context, final String imageUrl, PodDBAdapter adapter) {
+    static String getImageAuthentication(final String imageUrl, PodDBAdapter adapter) {
         String credentials = null;
         Cursor cursor = adapter.getImageAuthenticationCursor(imageUrl);
         try {
@@ -849,32 +650,33 @@ public final class DBReader {
                 String username = cursor.getString(0);
                 String password = cursor.getString(1);
                 if(username != null && password != null) {
-                    return username + ":" + password;
+                    credentials = username + ":" + password;
                 } else {
-                    return "";
+                    credentials = "";
                 }
+            } else {
+                credentials = "";
             }
-            return "";
         } finally {
             cursor.close();
         }
+        return credentials;
     }
 
     /**
      * Loads a specific FeedItem from the database.
      *
-     * @param context A context that is used for opening a database connection.
      * @param podcastUrl the corresponding feed's url
      * @param episodeUrl the feed item's url
      * @return The FeedItem or null if the FeedItem could not be found. All FeedComponent-attributes
      * as well as chapter marks of the FeedItem will also be loaded from the database.
      */
-    public static FeedItem getFeedItem(final Context context, final String podcastUrl, final String episodeUrl) {
+    public static FeedItem getFeedItem(final String podcastUrl, final String episodeUrl) {
         Log.d(TAG, "Loading feeditem with podcast url " + podcastUrl + " and episode url " + episodeUrl);
 
-        PodDBAdapter adapter = new PodDBAdapter(context);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        FeedItem item = getFeedItem(context, podcastUrl, episodeUrl, adapter);
+        FeedItem item = getFeedItem(podcastUrl, episodeUrl, adapter);
         adapter.close();
         return item;
     }
@@ -882,18 +684,17 @@ public final class DBReader {
     /**
      * Loads additional information about a FeedItem, e.g. shownotes
      *
-     * @param context A context that is used for opening a database connection.
      * @param item    The FeedItem
      */
-    public static void loadExtraInformationOfFeedItem(final Context context, final FeedItem item) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static void loadExtraInformationOfFeedItem(final FeedItem item) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         Cursor extraCursor = adapter.getExtraInformationOfItem(item);
         if (extraCursor.moveToFirst()) {
-            String description = extraCursor
-                    .getString(PodDBAdapter.IDX_FI_EXTRA_DESCRIPTION);
-            String contentEncoded = extraCursor
-                    .getString(PodDBAdapter.IDX_FI_EXTRA_CONTENT_ENCODED);
+            int indexDescription = extraCursor.getColumnIndex(PodDBAdapter.KEY_DESCRIPTION);
+            String description = extraCursor.getString(indexDescription);
+            int indexContentEncoded = extraCursor.getColumnIndex(PodDBAdapter.KEY_CONTENT_ENCODED);
+            String contentEncoded = extraCursor.getString(indexContentEncoded);
             item.setDescription(description);
             item.setContentEncoded(contentEncoded);
         }
@@ -906,31 +707,30 @@ public final class DBReader {
      * any chapters that this FeedItem has. If no chapters were found in the database, the chapters
      * reference of the FeedItem will be set to null.
      *
-     * @param context A context that is used for opening a database connection.
      * @param item    The FeedItem
      */
-    public static void loadChaptersOfFeedItem(final Context context, final FeedItem item) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static void loadChaptersOfFeedItem(final FeedItem item) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         loadChaptersOfFeedItem(adapter, item);
         adapter.close();
     }
 
     static void loadChaptersOfFeedItem(PodDBAdapter adapter, FeedItem item) {
-        Cursor chapterCursor = adapter
-                .getSimpleChaptersOfFeedItemCursor(item);
+        Cursor chapterCursor = adapter.getSimpleChaptersOfFeedItemCursor(item);
         if (chapterCursor.moveToFirst()) {
-            item.setChapters(new ArrayList<Chapter>());
+            item.setChapters(new ArrayList<>());
             do {
-                int chapterType = chapterCursor
-                        .getInt(PodDBAdapter.KEY_CHAPTER_TYPE_INDEX);
+                int indexType = chapterCursor.getColumnIndex(PodDBAdapter.KEY_CHAPTER_TYPE);
+                int indexStart = chapterCursor.getColumnIndex(PodDBAdapter.KEY_START);
+                int indexTitle = chapterCursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
+                int indexLink = chapterCursor.getColumnIndex(PodDBAdapter.KEY_LINK);
+
+                int chapterType = chapterCursor.getInt(indexType);
                 Chapter chapter = null;
-                long start = chapterCursor
-                        .getLong(PodDBAdapter.KEY_CHAPTER_START_INDEX);
-                String title = chapterCursor
-                        .getString(PodDBAdapter.KEY_TITLE_INDEX);
-                String link = chapterCursor
-                        .getString(PodDBAdapter.KEY_CHAPTER_LINK_INDEX);
+                long start = chapterCursor.getLong(indexStart);
+                String title = chapterCursor.getString(indexTitle);
+                String link = chapterCursor.getString(indexLink);
 
                 switch (chapterType) {
                     case SimpleChapter.CHAPTERTYPE_SIMPLECHAPTER:
@@ -947,8 +747,8 @@ public final class DBReader {
                         break;
                 }
                 if (chapter != null) {
-                    chapter.setId(chapterCursor
-                            .getLong(PodDBAdapter.KEY_ID_INDEX));
+                    int indexId = chapterCursor.getColumnIndex(PodDBAdapter.KEY_ID);
+                    chapter.setId(chapterCursor.getLong(indexId));
                     item.getChapters().add(chapter);
                 }
             } while (chapterCursor.moveToNext());
@@ -961,11 +761,10 @@ public final class DBReader {
     /**
      * Returns the number of downloaded episodes.
      *
-     * @param context A context that is used for opening a database connection.
      * @return The number of downloaded episodes.
      */
-    public static int getNumberOfDownloadedEpisodes(final Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static int getNumberOfDownloadedEpisodes() {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         final int result = adapter.getNumberOfDownloadedEpisodes();
         adapter.close();
@@ -973,28 +772,13 @@ public final class DBReader {
     }
 
     /**
-     * Returns the number of unread items.
-     *
-     * @param context A context that is used for opening a database connection.
-     * @return The number of unread items.
-     */
-    public static int getNumberOfNewItems(final Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        final int result = adapter.getNumberOfNewItems();
-        adapter.close();
-        return result;
-    }
-
-    /**
      * Searches the DB for a FeedImage of the given id.
      *
-     * @param context A context that is used for opening a database connection.
      * @param imageId The id of the object
      * @return The found object
      */
-    public static FeedImage getFeedImage(final Context context, final long imageId) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static FeedImage getFeedImage(final long imageId) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         FeedImage result = getFeedImage(adapter, imageId);
         adapter.close();
@@ -1012,15 +796,8 @@ public final class DBReader {
         if ((cursor.getCount() == 0) || !cursor.moveToFirst()) {
             return null;
         }
-        FeedImage image = new FeedImage(id, cursor.getString(cursor
-                .getColumnIndex(PodDBAdapter.KEY_TITLE)),
-                cursor.getString(cursor
-                        .getColumnIndex(PodDBAdapter.KEY_FILE_URL)),
-                cursor.getString(cursor
-                        .getColumnIndex(PodDBAdapter.KEY_DOWNLOAD_URL)),
-                cursor.getInt(cursor
-                        .getColumnIndex(PodDBAdapter.KEY_DOWNLOADED)) > 0
-        );
+        FeedImage image = FeedImage.fromCursor(cursor);
+        image.setId(id);
         cursor.close();
         return image;
     }
@@ -1028,21 +805,21 @@ public final class DBReader {
     /**
      * Searches the DB for a FeedMedia of the given id.
      *
-     * @param context A context that is used for opening a database connection.
      * @param mediaId The id of the object
      * @return The found object
      */
-    public static FeedMedia getFeedMedia(final Context context, final long mediaId) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static FeedMedia getFeedMedia(final long mediaId) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
 
         adapter.open();
         Cursor mediaCursor = adapter.getSingleFeedMediaCursor(mediaId);
 
         FeedMedia media = null;
         if (mediaCursor.moveToFirst()) {
-            final long itemId = mediaCursor.getLong(PodDBAdapter.KEY_MEDIA_FEEDITEM_INDEX);
-            media = extractFeedMediaFromCursorRow(mediaCursor);
-            FeedItem item = getFeedItem(context, itemId);
+            int indexFeedItem = mediaCursor.getColumnIndex(PodDBAdapter.KEY_FEEDITEM);
+            final long itemId = mediaCursor.getLong(indexFeedItem);
+            media = FeedMedia.fromCursor(mediaCursor);
+            FeedItem item = getFeedItem(itemId);
             if (media != null && item != null) {
                 media.setItem(item);
                 item.setMedia(media);
@@ -1058,13 +835,12 @@ public final class DBReader {
     /**
      * Returns the flattr queue as a List of FlattrThings. The list consists of Feeds and FeedItems.
      *
-     * @param context A context that is used for opening a database connection.
      * @return The flattr queue as a List.
      */
-    public static List<FlattrThing> getFlattrQueue(Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static List<FlattrThing> getFlattrQueue() {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        List<FlattrThing> result = new ArrayList<FlattrThing>();
+        List<FlattrThing> result = new ArrayList<>();
 
         // load feeds
         Cursor feedCursor = adapter.getFeedsInFlattrQueueCursor();
@@ -1085,29 +861,14 @@ public final class DBReader {
         return result;
     }
 
-
-    /**
-     * Returns true if the flattr queue is empty.
-     *
-     * @param context A context that is used for opening a database connection.
-     */
-    public static boolean getFlattrQueueEmpty(Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
-        adapter.open();
-        boolean empty = adapter.getFlattrQueueSize() == 0;
-        adapter.close();
-        return empty;
-    }
-
     /**
      * Returns data necessary for displaying the navigation drawer. This includes
      * the list of subscriptions, the number of items in the queue and the number of unread
      * items.
      *
-     * @param context A context that is used for opening a database connection.
      */
-    public static NavDrawerData getNavDrawerData(Context context) {
-        PodDBAdapter adapter = new PodDBAdapter(context);
+    public static NavDrawerData getNavDrawerData() {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         List<Feed> feeds = getFeedList(adapter);
         long[] feedIds = new long[feeds.size()];
@@ -1119,30 +880,24 @@ public final class DBReader {
         Comparator<Feed> comparator;
         int feedOrder = UserPreferences.getFeedOrder();
         if(feedOrder == UserPreferences.FEED_ORDER_COUNTER) {
-            comparator = new Comparator<Feed>() {
-                @Override
-                public int compare(Feed lhs, Feed rhs) {
-                    long counterLhs = feedCounters.get(lhs.getId());
-                    long counterRhs = feedCounters.get(rhs.getId());
-                    if(counterLhs > counterRhs) {
-                        // reverse natural order: podcast with most unplayed episodes first
-                        return -1;
-                    } else if(counterLhs == counterRhs) {
-                        return lhs.getTitle().compareTo(rhs.getTitle());
-                    } else {
-                        return 1;
-                    }
+            comparator = (lhs, rhs) -> {
+                long counterLhs = feedCounters.get(lhs.getId());
+                long counterRhs = feedCounters.get(rhs.getId());
+                if(counterLhs > counterRhs) {
+                    // reverse natural order: podcast with most unplayed episodes first
+                    return -1;
+                } else if(counterLhs == counterRhs) {
+                    return lhs.getTitle().compareTo(rhs.getTitle());
+                } else {
+                    return 1;
                 }
             };
         } else {
-            comparator = new Comparator<Feed>() {
-                @Override
-                public int compare(Feed lhs, Feed rhs) {
-                    if(lhs.getTitle() == null) {
-                        return 1;
-                    }
-                    return lhs.getTitle().compareTo(rhs.getTitle());
+            comparator = (lhs, rhs) -> {
+                if(lhs.getTitle() == null) {
+                    return 1;
                 }
+                return lhs.getTitle().compareTo(rhs.getTitle());
             };
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/EpisodeCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/EpisodeCleanupAlgorithm.java
@@ -24,7 +24,7 @@ public interface EpisodeCleanupAlgorithm<T> {
      * space to free to satisfy the episode cache conditions. If the conditions are already satisfied, this
      * method should not have any effects.
      */
-    public T getDefaultCleanupParameter(Context context);
+    public T getDefaultCleanupParameter();
 
     /**
      * Returns a parameter for performCleanup.
@@ -32,5 +32,5 @@ public interface EpisodeCleanupAlgorithm<T> {
      * @param items A list of FeedItems that are about to be downloaded. The implementation of this interface
      *              should decide how much space to free to satisfy the episode cache conditions.
      */
-    public T getPerformCleanupParameter(Context context, List<FeedItem> items);
+    public T getPerformCleanupParameter(List<FeedItem> items);
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/FeedItemStatistics.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/FeedItemStatistics.java
@@ -1,5 +1,7 @@
 package de.danoeh.antennapod.core.storage;
 
+import android.database.Cursor;
+
 import java.util.Date;
 
 /**
@@ -34,6 +36,15 @@ public class FeedItemStatistics {
         } else {
             this.lastUpdate = UNKNOWN_DATE;
         }
+    }
+
+    public static FeedItemStatistics fromCursor(Cursor cursor) {
+        return new FeedItemStatistics(
+                cursor.getLong(0),
+                cursor.getInt(1),
+                cursor.getInt(2),
+                cursor.getInt(4),
+                new Date(cursor.getLong(3)));
     }
 
     public long getFeedID() {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -17,8 +17,8 @@ import org.apache.commons.lang3.Validate;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.event.ProgressEvent;
 import de.danoeh.antennapod.core.feed.Chapter;
@@ -40,6 +40,7 @@ import de.greenrobot.event.EventBus;
  * Implements methods for accessing the database
  */
 public class PodDBAdapter {
+    
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
 
@@ -52,63 +53,6 @@ public class PodDBAdapter {
      * Maximum number of entries per search request.
      */
     public static final int SEARCH_LIMIT = 30;
-
-    // ----------- Column indices
-    // ----------- General indices
-    public static final int KEY_ID_INDEX = 0;
-    public static final int KEY_TITLE_INDEX = 1;
-    public static final int KEY_FILE_URL_INDEX = 2;
-    public static final int KEY_DOWNLOAD_URL_INDEX = 3;
-    public static final int KEY_DOWNLOADED_INDEX = 4;
-    public static final int KEY_LINK_INDEX = 5;
-    public static final int KEY_DESCRIPTION_INDEX = 6;
-    public static final int KEY_PAYMENT_LINK_INDEX = 7;
-    // ----------- Feed indices
-    public static final int KEY_LAST_UPDATE_INDEX = 8;
-    public static final int KEY_LANGUAGE_INDEX = 9;
-    public static final int KEY_AUTHOR_INDEX = 10;
-    public static final int KEY_IMAGE_INDEX = 11;
-    public static final int KEY_TYPE_INDEX = 12;
-    public static final int KEY_FEED_IDENTIFIER_INDEX = 13;
-    public static final int KEY_FEED_FLATTR_STATUS_INDEX = 14;
-    public static final int KEY_FEED_USERNAME_INDEX = 15;
-    public static final int KEY_FEED_PASSWORD_INDEX = 16;
-    public static final int KEY_IS_PAGED_INDEX = 17;
-    public static final int KEY_LOAD_ALL_PAGES_INDEX = 18;
-    public static final int KEY_NEXT_PAGE_LINK_INDEX = 19;
-    // ----------- FeedItem indices
-    public static final int KEY_CONTENT_ENCODED_INDEX = 2;
-    public static final int KEY_PUBDATE_INDEX = 3;
-    public static final int KEY_READ_INDEX = 4;
-    public static final int KEY_MEDIA_INDEX = 8;
-    public static final int KEY_FEED_INDEX = 9;
-    public static final int KEY_HAS_SIMPLECHAPTERS_INDEX = 10;
-    public static final int KEY_ITEM_IDENTIFIER_INDEX = 11;
-    public static final int KEY_ITEM_FLATTR_STATUS_INDEX = 12;
-    // ---------- FeedMedia indices
-    public static final int KEY_DURATION_INDEX = 1;
-    public static final int KEY_POSITION_INDEX = 5;
-    public static final int KEY_SIZE_INDEX = 6;
-    public static final int KEY_MIME_TYPE_INDEX = 7;
-    public static final int KEY_PLAYBACK_COMPLETION_DATE_INDEX = 8;
-    public static final int KEY_MEDIA_FEEDITEM_INDEX = 9;
-    public static final int KEY_PLAYED_DURATION_INDEX = 10;
-    // --------- Download log indices
-    public static final int KEY_FEEDFILE_INDEX = 1;
-    public static final int KEY_FEEDFILETYPE_INDEX = 2;
-    public static final int KEY_REASON_INDEX = 3;
-    public static final int KEY_SUCCESSFUL_INDEX = 4;
-    public static final int KEY_COMPLETION_DATE_INDEX = 5;
-    public static final int KEY_REASON_DETAILED_INDEX = 6;
-    public static final int KEY_DOWNLOADSTATUS_TITLE_INDEX = 7;
-    // --------- Queue indices
-    public static final int KEY_FEEDITEM_INDEX = 1;
-    public static final int KEY_QUEUE_FEED_INDEX = 2;
-    // --------- Chapters indices
-    public static final int KEY_CHAPTER_START_INDEX = 2;
-    public static final int KEY_CHAPTER_FEEDITEM_INDEX = 3;
-    public static final int KEY_CHAPTER_LINK_INDEX = 4;
-    public static final int KEY_CHAPTER_TYPE_INDEX = 5;
 
     // Key-constants
     public static final String KEY_ID = "id";
@@ -253,12 +197,7 @@ public class PodDBAdapter {
     public static final String CREATE_INDEX_SIMPLECHAPTERS_FEEDITEM = "CREATE INDEX "
             + TABLE_NAME_SIMPLECHAPTERS + "_" + KEY_FEEDITEM + " ON " + TABLE_NAME_SIMPLECHAPTERS + " ("
             + KEY_FEEDITEM + ")";
-
-
-    private SQLiteDatabase db;
-    private final Context context;
-    private PodDBHelper helper;
-
+    
     /**
      * Select all columns from the feed-table
      */
@@ -287,30 +226,7 @@ public class PodDBAdapter {
             TABLE_NAME_FEEDS + "." + KEY_LAST_UPDATE_FAILED,
             TABLE_NAME_FEEDS + "." + KEY_AUTO_DELETE_ACTION,
     };
-
-    // column indices for FEED_SEL_STD
-    public static final int IDX_FEED_SEL_STD_ID = 0;
-    public static final int IDX_FEED_SEL_STD_TITLE = 1;
-    public static final int IDX_FEED_SEL_STD_FILE_URL = 2;
-    public static final int IDX_FEED_SEL_STD_DOWNLOAD_URL = 3;
-    public static final int IDX_FEED_SEL_STD_DOWNLOADED = 4;
-    public static final int IDX_FEED_SEL_STD_LINK = 5;
-    public static final int IDX_FEED_SEL_STD_DESCRIPTION = 6;
-    public static final int IDX_FEED_SEL_STD_PAYMENT_LINK = 7;
-    public static final int IDX_FEED_SEL_STD_LASTUPDATE = 8;
-    public static final int IDX_FEED_SEL_STD_LANGUAGE = 9;
-    public static final int IDX_FEED_SEL_STD_AUTHOR = 10;
-    public static final int IDX_FEED_SEL_STD_IMAGE = 11;
-    public static final int IDX_FEED_SEL_STD_TYPE = 12;
-    public static final int IDX_FEED_SEL_STD_FEED_IDENTIFIER = 13;
-    public static final int IDX_FEED_SEL_PREFERENCES_AUTO_DOWNLOAD = 14;
-    public static final int IDX_FEED_SEL_STD_FLATTR_STATUS = 15;
-    public static final int IDX_FEED_SEL_STD_IS_PAGED = 16;
-    public static final int IDX_FEED_SEL_STD_NEXT_PAGE_LINK = 17;
-    public static final int IDX_FEED_SEL_PREFERENCES_USERNAME = 18;
-    public static final int IDX_FEED_SEL_PREFERENCES_PASSWORD = 19;
-    public static final int IDX_FEED_SEL_PREFERENCES_AUTO_DELETE_ACTION = 22;
-
+    
     /**
      * Select all columns from the feeditems-table except description and
      * content-encoded.
@@ -321,7 +237,8 @@ public class PodDBAdapter {
             TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE,
             TABLE_NAME_FEED_ITEMS + "." + KEY_READ,
             TABLE_NAME_FEED_ITEMS + "." + KEY_LINK,
-            TABLE_NAME_FEED_ITEMS + "." + KEY_PAYMENT_LINK, KEY_MEDIA,
+            TABLE_NAME_FEED_ITEMS + "." + KEY_PAYMENT_LINK,
+            TABLE_NAME_FEED_ITEMS + "." + KEY_MEDIA,
             TABLE_NAME_FEED_ITEMS + "." + KEY_FEED,
             TABLE_NAME_FEED_ITEMS + "." + KEY_HAS_CHAPTERS,
             TABLE_NAME_FEED_ITEMS + "." + KEY_ITEM_IDENTIFIER,
@@ -340,73 +257,59 @@ public class PodDBAdapter {
         SEL_FI_SMALL_STR = selFiSmall.substring(1, selFiSmall.length() - 1);
     }
 
-    // column indices for FEEDITEM_SEL_FI_SMALL
-
-    public static final int IDX_FI_SMALL_ID = 0;
-    public static final int IDX_FI_SMALL_TITLE = 1;
-    public static final int IDX_FI_SMALL_PUBDATE = 2;
-    public static final int IDX_FI_SMALL_READ = 3;
-    public static final int IDX_FI_SMALL_LINK = 4;
-    public static final int IDX_FI_SMALL_PAYMENT_LINK = 5;
-    public static final int IDX_FI_SMALL_MEDIA = 6;
-    public static final int IDX_FI_SMALL_FEED = 7;
-    public static final int IDX_FI_SMALL_HAS_CHAPTERS = 8;
-    public static final int IDX_FI_SMALL_ITEM_IDENTIFIER = 9;
-    public static final int IDX_FI_SMALL_FLATTR_STATUS = 10;
-    public static final int IDX_FI_SMALL_IMAGE = 11;
-
     /**
      * Select id, description and content-encoded column from feeditems.
      */
     private static final String[] SEL_FI_EXTRA = {KEY_ID, KEY_DESCRIPTION,
             KEY_CONTENT_ENCODED, KEY_FEED};
 
-    // column indices for SEL_FI_EXTRA
 
-    public static final int IDX_FI_EXTRA_ID = 0;
-    public static final int IDX_FI_EXTRA_DESCRIPTION = 1;
-    public static final int IDX_FI_EXTRA_CONTENT_ENCODED = 2;
-    public static final int IDX_FI_EXTRA_FEED = 3;
+    private SQLiteDatabase db;
+    private static Context context;
+    private static PodDBHelper dbHelper;
+    private static AtomicInteger counter = new AtomicInteger(0);
 
-    static PodDBHelper dbHelperSingleton;
+    public static void init(Context context) {
+        PodDBAdapter.context = context.getApplicationContext();
+    }
 
-    private static synchronized PodDBHelper getDbHelperSingleton(Context appContext) {
-        if (dbHelperSingleton == null) {
-            dbHelperSingleton = new PodDBHelper(appContext, DATABASE_NAME, null);
+    public static synchronized PodDBAdapter getInstance() {
+        if(dbHelper == null) {
+            dbHelper = new PodDBHelper(PodDBAdapter.context, DATABASE_NAME, null);
         }
-        return dbHelperSingleton;
+        return new PodDBAdapter();
     }
 
-    public PodDBAdapter(Context c) {
-        this.context = c;
-        helper = getDbHelperSingleton(c.getApplicationContext());
-    }
+    private PodDBAdapter() {}
 
     public PodDBAdapter open() {
+        counter.incrementAndGet();
         if (db == null || !db.isOpen() || db.isReadOnly()) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Opening DB");
+            Log.v(TAG, "Opening DB");
             try {
-                db = helper.getWritableDatabase();
+                db = dbHelper.getWritableDatabase();
             } catch (SQLException ex) {
-                ex.printStackTrace();
-                db = helper.getReadableDatabase();
+                Log.e(TAG, Log.getStackTraceString(ex));
+                db = dbHelper.getReadableDatabase();
             }
         }
         return this;
     }
 
     public void close() {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Closing DB");
-        //db.close();
+        if(counter.decrementAndGet() == 0) {
+            Log.v(TAG, "Closing DB");
+            db.close();
+        }
+        db = null;
     }
 
-    public static boolean deleteDatabase(Context context) {
-        Log.w(TAG, "Deleting database");
-        dbHelperSingleton.close();
-        dbHelperSingleton = null;
-        return context.deleteDatabase(DATABASE_NAME);
+    public static boolean deleteDatabase() {
+        if(dbHelper != null) {
+            dbHelper.close();
+            dbHelper = null;
+        }
+        return context.deleteDatabase(PodDBAdapter.DATABASE_NAME);
     }
 
     /**
@@ -484,7 +387,12 @@ public class PodDBAdapter {
      * @return the id of the entry
      */
     public long setImage(FeedImage image) {
-        db.beginTransaction();
+        boolean startedTransaction = false;
+        if(false == db.inTransaction()) {
+            db.beginTransaction();
+            startedTransaction = true;
+        }
+
         ContentValues values = new ContentValues();
         values.put(KEY_TITLE, image.getTitle());
         values.put(KEY_DOWNLOAD_URL, image.getDownload_url());
@@ -505,8 +413,10 @@ public class PodDBAdapter {
                 db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(image.getOwner().getId())});
             }
         }
-        db.setTransactionSuccessful();
-        db.endTransaction();
+        if(startedTransaction) {
+            db.setTransactionSuccessful();
+            db.endTransaction();
+        }
         return image.getId();
     }
 
@@ -527,8 +437,7 @@ public class PodDBAdapter {
         values.put(KEY_HAS_EMBEDDED_PICTURE, media.hasEmbeddedPicture());
 
         if (media.getPlaybackCompletionDate() != null) {
-            values.put(KEY_PLAYBACK_COMPLETION_DATE, media
-                    .getPlaybackCompletionDate().getTime());
+            values.put(KEY_PLAYBACK_COMPLETION_DATE, media.getPlaybackCompletionDate().getTime());
         } else {
             values.put(KEY_PLAYBACK_COMPLETION_DATE, 0);
         }
@@ -822,8 +731,7 @@ public class PodDBAdapter {
             values.put(KEY_LINK, chapter.getLink());
             values.put(KEY_CHAPTER_TYPE, chapter.getChapterType());
             if (chapter.getId() == 0) {
-                chapter.setId(db
-                        .insert(TABLE_NAME_SIMPLECHAPTERS, null, values));
+                chapter.setId(db.insert(TABLE_NAME_SIMPLECHAPTERS, null, values));
             } else {
                 db.update(TABLE_NAME_SIMPLECHAPTERS, values, KEY_ID + "=?",
                         new String[]{String.valueOf(chapter.getId())});
@@ -882,14 +790,6 @@ public class PodDBAdapter {
         }
         result.close();
         return count;
-    }
-
-    public void removeDownloadLogItems(long count) {
-        if (count > 0) {
-            final String sql = String.format("DELETE FROM %s WHERE %s in (SELECT %s from %s ORDER BY %s ASC LIMIT %d)",
-                    TABLE_NAME_DOWNLOAD_LOG, KEY_ID, KEY_ID, TABLE_NAME_DOWNLOAD_LOG, KEY_COMPLETION_DATE, count);
-            db.execSQL(sql, null);
-        }
     }
 
     public void setQueue(List<FeedItem> queue) {
@@ -961,11 +861,6 @@ public class PodDBAdapter {
                 new String[]{String.valueOf(feed.getId())});
         db.setTransactionSuccessful();
         db.endTransaction();
-    }
-
-    public void removeDownloadStatus(DownloadStatus remove) {
-        db.delete(TABLE_NAME_DOWNLOAD_LOG, KEY_ID + "=?",
-                new String[]{String.valueOf(remove.getId())});
     }
 
     public void clearPlaybackHistory() {
@@ -1075,21 +970,14 @@ public class PodDBAdapter {
      * cursor uses the FEEDITEM_SEL_FI_SMALL selection.
      */
     public final Cursor getQueueCursor() {
-        Object[] args = (Object[]) new String[]{
-                SEL_FI_SMALL_STR + "," + TABLE_NAME_QUEUE + "." + KEY_ID,
+        Object[] args = new String[] {
+                SEL_FI_SMALL_STR,
                 TABLE_NAME_FEED_ITEMS, TABLE_NAME_QUEUE,
                 TABLE_NAME_FEED_ITEMS + "." + KEY_ID,
                 TABLE_NAME_QUEUE + "." + KEY_FEEDITEM,
-                TABLE_NAME_QUEUE + "." + KEY_ID};
-        String query = String.format(
-                "SELECT %s FROM %s INNER JOIN %s ON %s=%s ORDER BY %s", args);
+                TABLE_NAME_QUEUE + "." + KEY_ID };
+        String query = String.format("SELECT %s FROM %s INNER JOIN %s ON %s=%s ORDER BY %s", args);
         Cursor c = db.rawQuery(query, null);
-        /*
-         * Cursor c = db.query(TABLE_NAME_FEED_ITEMS, FEEDITEM_SEL_FI_SMALL,
-		 * "INNER JOIN ? ON ?=?", new String[] { TABLE_NAME_QUEUE,
-		 * TABLE_NAME_FEED_ITEMS + "." + KEY_ID, TABLE_NAME_QUEUE + "." +
-		 * KEY_FEEDITEM }, null, null, TABLE_NAME_QUEUE + "." + KEY_FEEDITEM);
-		 */
         return c;
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -148,7 +148,7 @@ public class NetworkUtils {
                 }
                 subscriber.onNext(size);
                 subscriber.onCompleted();
-                DBWriter.setFeedMedia(context, media);
+                DBWriter.setFeedMedia(media);
             }
         })
                 .subscribeOn(Schedulers.newThread())

--- a/core/src/main/java/de/danoeh/antennapod/core/util/QueueSorter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/QueueSorter.java
@@ -83,7 +83,7 @@ public class QueueSorter {
         }
 
         if (comparator != null) {
-            DBWriter.sortQueue(context, comparator, broadcastUpdate);
+            DBWriter.sortQueue(comparator, broadcastUpdate);
         }
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
@@ -167,7 +167,7 @@ public class FlattrUtils {
         deleteToken();
         FlattrServiceCreator.deleteFlattrService();
         showRevokeDialog(context);
-        DBWriter.clearAllFlattrStatus(context);
+        DBWriter.clearAllFlattrStatus();
     }
 
     // ------------------------------------------------ DIALOGS

--- a/core/src/main/java/de/danoeh/antennapod/core/util/gui/UndoBarController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/gui/UndoBarController.java
@@ -89,7 +89,9 @@ public class UndoBarController<T> {
 
     public void close() {
         hideUndoBar(true);
-        mUndoListener.onHide(mUndoToken);
+        if(mUndoListener != null) {
+            mUndoListener.onHide(mUndoToken);
+        }
     }
 
     public void hideUndoBar(boolean immediate) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -164,7 +164,7 @@ public interface Playable extends Parcelable,
                 case FeedMedia.PLAYABLE_TYPE_FEEDMEDIA:
                     long mediaId = pref.getLong(FeedMedia.PREF_MEDIA_ID, -1);
                     if (mediaId != -1) {
-                        return DBReader.getFeedMedia(context, mediaId);
+                        return DBReader.getFeedMedia(mediaId);
                     }
                     break;
                 case ExternalMedia.PLAYABLE_TYPE_EXTERNAL_MEDIA:

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -56,7 +56,7 @@ public abstract class PlaybackController {
     private final Activity activity;
 
     private PlaybackService playbackService;
-    private Playable media;
+    protected Playable media;
     private PlayerStatus status;
 
     private ScheduledThreadPoolExecutor schedExecutor;
@@ -479,8 +479,10 @@ public abstract class PlaybackController {
 
     private void updatePlayButtonAppearance(int resource, CharSequence contentDescription) {
         ImageButton butPlay = getPlayButton();
-        butPlay.setImageResource(resource);
-        butPlay.setContentDescription(contentDescription);
+        if(butPlay != null) {
+            butPlay.setImageResource(resource);
+            butPlay.setContentDescription(contentDescription);
+        }
     }
 
     public abstract ImageButton getPlayButton();


### PR DESCRIPTION
Mostly removing the need to pass a context on every database access.
Most of the changes are pretty boring (and where refactored automatically), the interesting parts are probably ``PodDBAdapter`` and ``PlaybackTest``
Also added some null checks (when tests crashed) and replaced one or two asyntasks (Seems like the threads were not stopped immediately, so Android throw IllegalStateExceptions when the database was deleted in a tearDown but those threads still tried to access data; no problems once replaced by RxAndroid)