### PR TITLE
Licenses: Material Dialogs, bug fix, nicer layout

### DIFF
--- a/app/src/main/assets/LICENSE_MATERIAL_DIALOGS.txt
+++ b/app/src/main/assets/LICENSE_MATERIAL_DIALOGS.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Aidan Michael Follestad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/src/main/templates/about.html
+++ b/app/src/main/templates/about.html
@@ -83,6 +83,9 @@ licensed under the MIT license <a href="LICENSE_JSOUP.txt">(View)</a>
 <h2>Material Design Icons <a href="https://github.com/google/material-design-icons">(Link)</a></h2>
 by Google, licensed under an Attribution-ShareAlike 4.0 International license <a href="LICENSE_MATERIAL_DESIGN_ICONS.txt">(View)</a>
 
+<h2>Material Dialogs <a href="https://github.com/afollestad/material-dialogs">(Link)</a></h2>
+by Aidan Michael Follestad, licensed under the MIT License <a href="LICENSE_MATERIAL_DIALOGS.txt">(View)</a>
+
 <h2>OkHttp <a href="https://github.com/square/okhttp">(Link)</a></h2>
 by Square, licensed under the Apache 2.0 license <a href="LICENSE_OKHTTP.txt">(View)</a>
 

--- a/app/src/main/templates/about.html
+++ b/app/src/main/templates/about.html
@@ -52,7 +52,7 @@
 
     <p>Created by Daniel Oeh</p>
 
-    <p>Copyright © 2015 AntennaPod Contributors <a href="https://github.com/AntennaPod/AntennaPod/blob/master/CONTRIBUTORS">(View)</a></p>
+    <p>Copyright &copy; 2015 AntennaPod Contributors <a href="https://github.com/AntennaPod/AntennaPod/blob/master/CONTRIBUTORS">(View)</a></p>
 
     <p>Licensed under the MIT License <a href="LICENSE.html">(View)</a></p>
 </div>


### PR DESCRIPTION
Forgot the Material Dialogs license in the cropped buttons PR.
Seems like I messed up showing the licenses, so I fixed that.
Also works with dark theme nicely.