### PR TITLE
Add a unique default playback speed fro each feed.

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -116,7 +116,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     private Playable writeTestPlayable(String downloadUrl, String fileUrl) {
         final Context c = getInstrumentation().getTargetContext();
         Feed f = new Feed(0, new Date(), "f", "l", "d", null, null, null, null, "i", null, null, "l", false);
-        FeedPreferences prefs = new FeedPreferences(f.getId(), false, FeedPreferences.AutoDeleteAction.NO, null, null);
+        FeedPreferences prefs = new FeedPreferences(f.getId(), false, FeedPreferences.AutoDeleteAction.NO, "GLOBAL", null, null);
         f.setPreferences(prefs);
         f.setItems(new ArrayList<>());
         FeedItem i = new FeedItem(0, "t", "i", "l", new Date(), FeedItem.UNPLAYED, f);

--- a/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -576,6 +576,8 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
 
     private void updateButPlaybackSpeed() {
         if (controller != null && controller.canSetPlaybackSpeed()) {
+            //Feed feed = <must somehow get feed here!!>
+            //butPlaybackSpeed.setText(feed.getPreferences().getCurrentPlaybackSpeed());
             butPlaybackSpeed.setText(UserPreferences.getPlaybackSpeed());
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -251,7 +251,7 @@ public class OnlineFeedViewActivity extends ActionBarActivity {
         url = URLChecker.prepareURL(url);
         feed = new Feed(url, new Date(0));
         if (username != null && password != null) {
-            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, username, password));
+            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, "GLOBAL", username, password));
         }
         String fileUrl = new File(getExternalCacheDir(),
                 FileNameGenerator.generateFileName(feed.getDownload_url())).toString();

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -166,7 +166,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 app:columnCount="2"
-                app:rowCount="1">
+                app:rowCount="2">
 
                 <TextView
                     android:id="@+id/txtvFeedAutoDelete"
@@ -185,6 +185,29 @@
                     android:entries="@array/spnAutoDeleteItems"
                     android:layout_marginTop="8dp"
                     app:layout_row="0"
+                    app:layout_column="1"
+                    android:spinnerMode="dropdown"
+                    app:layout_gravity="center"
+                    android:dropDownWidth="wrap_content"
+                    android:clickable="true" />
+
+                <TextView
+                    android:id="@+id/txtvFeedAutoDelete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/auto_playback_speed_label"
+                    app:layout_row="1"
+                    app:layout_column="0"
+                    app:layout_gravity="center_vertical"
+                    android:layout_marginRight="10dp" />
+
+                <Spinner
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:id="@+id/spnPlaybackSpeed"
+                    android:entries="@array/playback_speed_values"
+                    android:layout_marginTop="8dp"
+                    app:layout_row="1"
                     app:layout_column="1"
                     android:spinnerMode="dropdown"
                     app:layout_gravity="center"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -169,7 +169,7 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
      */
     public Feed(String url, Date lastUpdate, String title, String username, String password) {
         this(url, lastUpdate, title);
-        preferences = new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL, username, password);
+        preferences = new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL, "GLOBAL", username, password);
     }
 
     public static Feed fromCursor(Cursor cursor) {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -22,13 +22,15 @@ public class FeedPreferences {
         NO
     }
     private AutoDeleteAction auto_delete_action;
+    private String playback_speed;
     private String username;
     private String password;
 
-    public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String username, String password) {
+    public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String playback_speed, String username, String password) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
         this.auto_delete_action = auto_delete_action;
+        this.playback_speed = playback_speed;
         this.username = username;
         this.password = password;
     }
@@ -39,6 +41,7 @@ public class FeedPreferences {
         int indexAutoDeleteAction = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DELETE_ACTION);
         int indexUsername = cursor.getColumnIndex(PodDBAdapter.KEY_USERNAME);
         int indexPassword = cursor.getColumnIndex(PodDBAdapter.KEY_PASSWORD);
+        int indexPlaybackSpeed = cursor.getColumnIndex(PodDBAdapter.KEY_PLAYBACK_SPEED);
 
         long feedId = cursor.getLong(indexId);
         boolean autoDownload = cursor.getInt(indexAutoDownload) > 0;
@@ -46,13 +49,14 @@ public class FeedPreferences {
         AutoDeleteAction autoDeleteAction = AutoDeleteAction.values()[autoDeleteActionIndex];
         String username = cursor.getString(indexUsername);
         String password = cursor.getString(indexPassword);
-        return new FeedPreferences(feedId, autoDownload, autoDeleteAction, username, password);
+        String playbackSpeed = cursor.getString(indexPlaybackSpeed);
+        return new FeedPreferences(feedId, autoDownload, autoDeleteAction, playbackSpeed, username, password);
     }
 
 
 
     /**
-     * Compare another FeedPreferences with this one. The feedID, autoDownload and AutoDeleteAction attribute are excluded from the
+     * Compare another FeedPreferences with this one. The feedID, autoDownload, AutoDeleteAction and PlaybackSpeed attribute are excluded from the
      * comparison.
      *
      * @return True if the two objects are different.
@@ -70,7 +74,7 @@ public class FeedPreferences {
     }
 
     /**
-     * Update this FeedPreferences object from another one. The feedID, autoDownload and AutoDeleteAction attributes are excluded
+     * Update this FeedPreferences object from another one. The feedID, autoDownload, AutoDeleteAction and PlaybackSpeed attributes are excluded
      * from the update.
      */
     public void updateFromOther(FeedPreferences other) {
@@ -116,6 +120,21 @@ public class FeedPreferences {
                 return false;
         }
         return false; // TODO - add exceptions here
+    }
+
+    public String getPlaybackSpeed() {
+        return playback_speed;
+    }
+
+    public void setPlaybackSpeed(String playback_speed) {
+        this.playback_speed = playback_speed;
+    }
+
+    public String getCurrentPlaybackSpeed() {
+        if (playback_speed.equals("GLOBAL")) {
+            return UserPreferences.getPlaybackSpeed();
+        }
+        return playback_speed;
     }
 
     public void save(Context context) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -819,7 +819,7 @@ public class DownloadService extends Service {
             feed.setFile_url(request.getDestination());
             feed.setId(request.getFeedfileId());
             feed.setDownloaded(true);
-            feed.setPreferences(new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL,
+            feed.setPreferences(new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL, "GLOBAL",
                     request.getUsername(), request.getPassword()));
             feed.setPageNr(request.getArguments().getInt(DownloadRequester.REQUEST_ARG_PAGE_NR, 0));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -95,6 +95,7 @@ public class PodDBAdapter {
     public static final String KEY_PLAYBACK_COMPLETION_DATE = "playback_completion_date";
     public static final String KEY_AUTO_DOWNLOAD = "auto_download";
     public static final String KEY_AUTO_DELETE_ACTION = "auto_delete_action";
+    public static final String KEY_PLAYBACK_SPEED = "playback_speed";
     public static final String KEY_PLAYED_DURATION = "played_duration";
     public static final String KEY_USERNAME = "username";
     public static final String KEY_PASSWORD = "password";
@@ -134,7 +135,8 @@ public class PodDBAdapter {
             + KEY_NEXT_PAGE_LINK + " TEXT,"
             + KEY_HIDE + " TEXT,"
             + KEY_LAST_UPDATE_FAILED + " INTEGER DEFAULT 0,"
-            + KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0)";
+            + KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0,"
+            + KEY_PLAYBACK_SPEED + " TEXT)";
 
     public static final String CREATE_TABLE_FEED_ITEMS = "CREATE TABLE "
             + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY + KEY_TITLE
@@ -230,8 +232,9 @@ public class PodDBAdapter {
             TABLE_NAME_FEEDS + "." + KEY_HIDE,
             TABLE_NAME_FEEDS + "." + KEY_LAST_UPDATE_FAILED,
             TABLE_NAME_FEEDS + "." + KEY_AUTO_DELETE_ACTION,
+            TABLE_NAME_FEEDS + "." + KEY_PLAYBACK_SPEED,
     };
-    
+	
     /**
      * Select all columns from the feeditems-table except description and
      * content-encoded.
@@ -378,6 +381,7 @@ public class PodDBAdapter {
         ContentValues values = new ContentValues();
         values.put(KEY_AUTO_DOWNLOAD, prefs.getAutoDownload());
         values.put(KEY_AUTO_DELETE_ACTION,prefs.getAutoDeleteAction().ordinal());
+        values.put(KEY_PLAYBACK_SPEED,prefs.getPlaybackSpeed());
         values.put(KEY_USERNAME, prefs.getUsername());
         values.put(KEY_PASSWORD, prefs.getPassword());
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(prefs.getFeedID())});
@@ -1439,7 +1443,7 @@ public class PodDBAdapter {
      */
     private static class PodDBHelper extends SQLiteOpenHelper {
 
-        private final static int VERSION = 1040001;
+        private final static int VERSION = 1040002;
 
         private Context context;
 
@@ -1672,6 +1676,10 @@ public class PodDBAdapter {
             }
             if(oldVersion < 1040001) {
                 db.execSQL(CREATE_TABLE_FAVORITES);
+			}
+            if(oldVersion < 1040002) {
+                db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                        + " ADD COLUMN " + PodDBAdapter.KEY_PLAYBACK_SPEED + " INTEGER DEFAULT 0");
             }
             EventBus.getDefault().post(ProgressEvent.end());
         }

--- a/core/src/main/res/values-iw-rIL/strings.xml
+++ b/core/src/main/res/values-iw-rIL/strings.xml
@@ -59,11 +59,13 @@
   <string name="retry_label">נסה שוב</string>
   <string name="auto_download_label">כלול בהורדות אוטומטיות</string>
   <string name="auto_delete_label">מחק לאחר ההשמעה\n(גובר על ההגדרה הגלובלית)</string>
+  <string name="auto_playback_speed_label">מהירות השמעה\n(גובר על ההגדרה הגלובלית)</string>
   <string name="parallel_downloads_suffix">\u0020הורדות במקביל</string>
   <string name="feed_auto_download_global">לפי הגדרה גלובלית</string>
   <string name="feed_auto_download_always">תמיד</string>
   <string name="feed_auto_download_never">אף פעם</string>
-  <!--'Add Feed' Activity labels-->
+    <string name="feed_playback_speed_default">ברירת מחדל</string>
+    <!--'Add Feed' Activity labels-->
   <string name="feedurl_label">כתובת הזנה</string>
   <string name="etxtFeedurlHint">כתובת של הזנה או אתר אינטרנט</string>
   <string name="txtvfeedurl_label">הוסף פודקאסט לפי כתובת אתר</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="auto_download_apply_to_items_title">Apply to Previous Episodes</string>
     <string name="auto_download_apply_to_items_message">The new <i>Auto Download</i> setting will automatically be applied to new episodes.\nDo you also want to apply it to previously published episodes?</string>
     <string name="auto_delete_label">Auto Delete Episode\n(override global default)</string>
+    <string name="auto_playback_speed_label">Playback Speed\n(override global default)</string>
+    <string name="feed_playback_speed_default">Default</string>
     <string name="parallel_downloads_suffix">\u0020parallel downloads</string>
     <string name="feed_auto_download_global">Global</string>
     <string name="feed_auto_download_always">Always</string>


### PR DESCRIPTION
everything works except the reading speed change:
* FeedItem has a new field for feed-specific playback speed
* Playback speed spinner has an extra 'Default' option
* List of possible speeds is copied on-the-fly from the original playback speed array resource and a new array is created from it with an extra 'Default' option. For a C++ guy like me it looks very wasteful, but I understand this is the "Java way"
* New per-feed default speed is saved in feed preferences and DB version is checked for DB migration.

I am stuck on how to get a Feed class instance in the AudioplayerActivity, please see  app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java lines 572-573:

    private void updateButPlaybackSpeed() {
        if (controller != null && controller.canSetPlaybackSpeed()) {
            //Feed feed = <must somehow get feed here!!>
            //butPlaybackSpeed.setText(feed.getPreferences().getCurrentPlaybackSpeed());
            butPlaybackSpeed.setText(UserPreferences.getPlaybackSpeed());
        }
    }

My shallow Android knowledge, based on googling for stackoverflow answers is not good enough yet on how to solve this.

The code in its current form demonstrates the GUI, the preferences save, but does not actually use the new per-feed value due to the issue above.

@mfietz , @TomHennen  can you help me on this single issue and review the code?
