### PR TITLE
Lockscreen background, media session and playback state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -325,6 +325,11 @@
                     android:scheme="package"/>
             </intent-filter>
         </receiver>
+        <receiver android:name="de.danoeh.antennapod.core.service.playback.MediaButtonIntentReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
 
         <meta-data
             android:name="de.danoeh.antennapod.core.glide.ApGlideModule"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -45,7 +45,7 @@
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:enabled="true"
             android:key="prefLockscreenBackground"
             android:summary="@string/pref_lockscreen_background_sum"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -45,6 +45,12 @@
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefLockscreenBackground"
+            android:summary="@string/pref_lockscreen_background_sum"
+            android:title="@string/pref_lockscreen_background_title"/>
+        <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefShowDownloadReport"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -47,6 +47,7 @@ public class UserPreferences {
     public static final String PREF_DRAWER_FEED_COUNTER = "prefDrawerFeedIndicator";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
+    public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     public static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
 
     // Queue
@@ -169,6 +170,15 @@ public class UserPreferences {
      */
     public static boolean isPersistNotify() {
         return prefs.getBoolean(PREF_PERSISTENT_NOTIFICATION, false);
+    }
+
+    /**
+     * Returns true if notifications are persistent
+     *
+     * @return {@code true} if notifications are persistent, {@code false}  otherwise
+     */
+    public static boolean setLockscreenBackground() {
+        return prefs.getBoolean(PREF_LOCKSCREEN_BACKGROUND, false);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -178,7 +178,7 @@ public class UserPreferences {
      * @return {@code true} if notifications are persistent, {@code false}  otherwise
      */
     public static boolean setLockscreenBackground() {
-        return prefs.getBoolean(PREF_LOCKSCREEN_BACKGROUND, false);
+        return prefs.getBoolean(PREF_LOCKSCREEN_BACKGROUND, true);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/MediaButtonIntentReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/MediaButtonIntentReceiver.java
@@ -4,11 +4,10 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
-import android.view.KeyEvent;
 
 public class MediaButtonIntentReceiver extends BroadcastReceiver {
 
-    private static final String TAG = "MediaButtonIntentReceiver";
+    private static final String TAG = "MediaButtonIntentRcver";
 
     private static PlaybackServiceMediaPlayer mMediaPlayer;
 
@@ -20,7 +19,7 @@ public class MediaButtonIntentReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "onReceive(Context, " + intent.toString() +")");
         if (mMediaPlayer != null && Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
-            mMediaPlayer.handleMediaKey((KeyEvent)intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT));
+            mMediaPlayer.handleMediaKey(intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT));
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -4,9 +4,12 @@ import android.app.PendingIntent;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.net.wifi.WifiManager;
 import android.os.PowerManager;
+import android.preference.PreferenceManager;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
@@ -15,6 +18,9 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.SurfaceHolder;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.target.Target;
 
 import org.apache.commons.lang3.Validate;
 
@@ -30,6 +36,7 @@ import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
+import de.danoeh.antennapod.core.glide.ApGlideSettings;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.playback.AudioPlayer;
@@ -40,7 +47,7 @@ import de.danoeh.antennapod.core.util.playback.VideoPlayer;
 /**
  * Manages the MediaPlayer object of the PlaybackService.
  */
-public class PlaybackServiceMediaPlayer {
+public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPreferenceChangeListener {
     public static final String TAG = "PlaybackSvcMediaPlayer";
 
     /**
@@ -103,7 +110,7 @@ public class PlaybackServiceMediaPlayer {
         ComponentName eventReceiver = new ComponentName(context.getPackageName(), MediaButtonIntentReceiver.class.getName());
         Intent mediaButtonIntent = new Intent(Intent.ACTION_MEDIA_BUTTON);
         mediaButtonIntent.setComponent(eventReceiver);
-        PendingIntent buttonReceiverIntent = PendingIntent.getBroadcast(context, 0, mediaButtonIntent, 0);
+        PendingIntent buttonReceiverIntent = PendingIntent.getBroadcast(context, 0, mediaButtonIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         mediaSession = new MediaSessionCompat(context, TAG, eventReceiver, buttonReceiverIntent);
         mediaSession.setCallback(sessionCallback);
@@ -116,6 +123,16 @@ public class PlaybackServiceMediaPlayer {
         mediaType = MediaType.UNKNOWN;
         playerStatus = PlayerStatus.STOPPED;
         videoSize = null;
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefs.registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if(key.equals(UserPreferences.PREF_LOCKSCREEN_BACKGROUND)) {
+            updateMediaSessionMetadata();
+        }
     }
 
     /**
@@ -224,7 +241,7 @@ public class PlaybackServiceMediaPlayer {
         setPlayerStatus(PlayerStatus.INITIALIZING, media);
         try {
             media.loadMetadata();
-            mediaSession.setMetadata(getMediaSessionMetadata(media));
+            updateMediaSessionMetadata();
             if (stream) {
                 mediaPlayer.setDataSource(media.getStreamUrl());
             } else {
@@ -255,13 +272,33 @@ public class PlaybackServiceMediaPlayer {
         }
     }
 
-    private MediaMetadataCompat getMediaSessionMetadata(Playable p) {
-        MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder();
-        builder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, p.getFeedTitle());
-        builder.putString(MediaMetadataCompat.METADATA_KEY_TITLE, p.getEpisodeTitle());
-        builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, p.getEpisodeTitle());
-        builder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, p.getFeedTitle());
-        return builder.build();
+    private void updateMediaSessionMetadata() {
+        executor.execute(() -> {
+            Playable p = this.media;
+            MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder();
+            builder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, p.getFeedTitle());
+            builder.putString(MediaMetadataCompat.METADATA_KEY_TITLE, p.getEpisodeTitle());
+            builder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, p.getDuration());
+            builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, p.getEpisodeTitle());
+            builder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, p.getFeedTitle());
+            if (p.getImageUri() != null) {
+                if (UserPreferences.setLockscreenBackground()) {
+                    builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageUri().toString());
+                    try {
+                        Bitmap art = Glide.with(context)
+                                .load(p.getImageUri())
+                                .asBitmap()
+                                .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
+                                .into(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
+                                .get();
+                        builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
+                    } catch (Exception e) {
+                        Log.e(TAG, Log.getStackTraceString(e));
+                    }
+                }
+            }
+            mediaSession.setMetadata(builder.build());
+        });
     }
 
 
@@ -812,7 +849,12 @@ public class PlaybackServiceMediaPlayer {
         } else {
             state = PlaybackStateCompat.STATE_NONE;
         }
-        sessionState.setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, getPlaybackSpeed());
+        sessionState.setState(state, getPosition(), getPlaybackSpeed());
+        sessionState.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE
+                | PlaybackStateCompat.ACTION_REWIND
+                | PlaybackStateCompat.ACTION_FAST_FORWARD
+                | PlaybackStateCompat.ACTION_SKIP_TO_NEXT);
+        mediaSession.setPlaybackState(sessionState.build());
 
         callback.statusChanged(new PSMPInfo(playerStatus, media));
     }
@@ -1218,7 +1260,14 @@ public class PlaybackServiceMediaPlayer {
                         stop();
                         return true;
                     }
+                    case KeyEvent.KEYCODE_MEDIA_NEXT:
+                    {
+                        Log.d(TAG, "Received next event from RemoteControlClient");
+                        endPlayback();
+                        return true;
+                    }
                     default:
+                        Log.d(TAG, "Unhandled key code: " + event.getKeyCode());
                         break;
                 }
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -273,6 +273,9 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
     }
 
     private void updateMediaSessionMetadata() {
+        if(this.media == null) {
+            return;
+        }
         executor.execute(() -> {
             Playable p = this.media;
             MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -273,11 +273,11 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
     }
 
     private void updateMediaSessionMetadata() {
-        if(this.media == null) {
-            return;
-        }
         executor.execute(() -> {
-            Playable p = this.media;
+            final Playable p = this.media;
+            if(p == null) {
+                return;
+            }
             MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder();
             builder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, p.getFeedTitle());
             builder.putString(MediaMetadataCompat.METADATA_KEY_TITLE, p.getEpisodeTitle());

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources
     xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation"
-    >
+    tools:ignore="MissingTranslation">
 
     <!-- Activitiy and fragment titles -->
     <string name="app_name">AntennaPod</string>
@@ -335,6 +334,8 @@
     <string name="pref_expandNotify_sum">Always expand the notification to show playback buttons.</string>
     <string name="pref_persistNotify_title">Persistent Playback Controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
+    <string name="pref_lockscreen_background_title">Lockscreen Background</string>
+    <string name="pref_lockscreen_background_sum">Set the lockscreen background to the current episode\'s image.</string>
     <string name="pref_showDownloadReport_title">Show Download Report</string>
     <string name="pref_showDownloadReport_sum">If downloads fail, generate a report that shows the details of the failure.</string>
     <string name="pref_expand_notify_unsupport_toast">Android versions before 4.1 do not support expanded notifications.</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -334,8 +334,8 @@
     <string name="pref_expandNotify_sum">Always expand the notification to show playback buttons.</string>
     <string name="pref_persistNotify_title">Persistent Playback Controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
-    <string name="pref_lockscreen_background_title">Lockscreen Background</string>
-    <string name="pref_lockscreen_background_sum">Set the lockscreen background to the current episode\'s image.</string>
+    <string name="pref_lockscreen_background_title">Set Lockscreen Background</string>
+    <string name="pref_lockscreen_background_sum">Set the lockscreen background to the current episode\'s image. As a side effect, this will also show the image in third party apps.</string>
     <string name="pref_showDownloadReport_title">Show Download Report</string>
     <string name="pref_showDownloadReport_sum">If downloads fail, generate a report that shows the details of the failure.</string>
     <string name="pref_expand_notify_unsupport_toast">Android versions before 4.1 do not support expanded notifications.</string>


### PR DESCRIPTION
![lockscreen](https://cloud.githubusercontent.com/assets/6860662/9860746/4ea2d2ee-5b2e-11e5-801c-c6cf8c11c1c0.png)
(Cover of http://www.npr.org/sections/money/)

The next button doesn't actually mean there is another episode in the queue, it might end the playback altogether.

APod is now able to set the lockscreen background. It is a preference: There are probably a lot of people that prefer their own background image to the episode image on the lockscreen.
Maybe "lockscreen background" is a bit misleading: Basically, any other app/service that is "listening" (that receives MediaSession information) can read that image and show it. If enabled, watch apps will also be able to show the cover. "Cover art"? Not sure it this is any better, might only be more confusing.
Because of Glide, the meta data is updated in a background thread. Not sure if executing on the executor service is the best idea or if this should just run in its own thread... I guess we'll see if this leads to unwanted behavior

Receiving media button events from external apps also seems to work now.

Resolve #762
