### PR TITLE
Allow only alphanumeric and a few other characters in media filenames

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
@@ -351,7 +351,7 @@ public class DownloadRequester {
         if (media.getItem() != null && media.getItem().getTitle() != null) {
             String title = media.getItem().getTitle();
             // Delete reserved characters
-            titleBaseFilename = title.replaceAll("[\\\\/%\\?\\*:|<>\"\\p{Cntrl}]", "");
+            titleBaseFilename = title.replaceAll("[^a-zA-Z0-9 ._()-]", "");
             titleBaseFilename = titleBaseFilename.trim();
         }
 


### PR DESCRIPTION
Resolves #1203

Instead of replacing a few special characters that we know are not allowed in filenames, only allow that few characters (alphanumeric, spaces and so on) that are unproblematic.

Also considered applying this the generation of the directory name, but I fear this could break backward compatibility. Current feeds with special characters in their title (that might create issues on some devices or file systems) could end up with a second directory for their media files.
While this would probably not be a problem I didn't want to risk fixing one issue and creating another.

All tests completed successfully.