### PR TITLE
Fix PreferenceActivity NPE

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -102,13 +102,17 @@ public class PreferenceActivity extends ActionBarActivity {
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.preferences);
-            instance.preferenceController.onCreate();
+            if(instance.preferenceController != null) {
+                instance.preferenceController.onCreate();
+            }
         }
 
         @Override
         public void onResume() {
             super.onResume();
-            instance.preferenceController.onResume();
+            if(instance.preferenceController != null) {
+                instance.preferenceController.onResume();
+            }
         }
     }
 }


### PR DESCRIPTION
NPE can occur when dialog is showing and the screen is rotated.
There probably still is an underlying problem, but I hope support lib v23 will make all of this obsolete.
This will at least keep the app from crashing.

Fixes #1220