### PR TITLE
Adapt variable speed preference dialog for sonic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'com.joanzapata.iconify:android-iconify-fontawesome:2.0.3'
     compile 'com.afollestad:material-dialogs:0.7.8.0'
 
-    compile 'com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0'
+    compile 'com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0.1'
 
     compile project(':core')
     compile project(':library:drag-sort-listview')

--- a/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
@@ -3,22 +3,35 @@ package de.danoeh.antennapod.dialog;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
+import android.util.Log;
+import android.view.View;
+
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
 
 import java.util.Arrays;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.util.IntentUtils;
 
 public class VariableSpeedDialog {
+
+	private static final String TAG = VariableSpeedDialog.class.getSimpleName();
+
+	private static final Intent playStoreIntent = new Intent(Intent.ACTION_VIEW,
+		Uri.parse("market://details?id=com.falconware.prestissimo"));
+
 	private VariableSpeedDialog() {
 	}
 
 	public static void showDialog(final Context context) {
-		if (org.antennapod.audio.MediaPlayer.isPrestoLibraryInstalled(context)) {
+		if (org.antennapod.audio.MediaPlayer.isPrestoLibraryInstalled(context)
+			|| UserPreferences.useSonic()) {
 			showSpeedSelectorDialog(context);
 		} else {
 			showGetPluginDialog(context);
@@ -26,26 +39,46 @@ public class VariableSpeedDialog {
 	}
 
 	private static void showGetPluginDialog(final Context context) {
-		AlertDialog.Builder builder = new AlertDialog.Builder(context);
-		builder.setTitle(R.string.no_playback_plugin_title);
-		builder.setMessage(R.string.no_playback_plugin_msg);
-		builder.setNegativeButton(R.string.close_label, null);
-		builder.setPositiveButton(R.string.download_plugin_label,
-				new DialogInterface.OnClickListener() {
-					@Override
-					public void onClick(DialogInterface dialog, int which) {
-                        try {
-						    Intent playStoreIntent = new Intent(
-								    Intent.ACTION_VIEW,
-							    	Uri.parse("market://details?id=com.falconware.prestissimo"));
-						    context.startActivity(playStoreIntent);
-                        } catch (ActivityNotFoundException e) {
-                            // this is usually thrown on an emulator if the Android market is not installed
-                            e.printStackTrace();
-                        }
-					}
-				});
-		builder.create().show();
+		MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
+		builder.title(R.string.no_playback_plugin_title);
+		builder.content(R.string.no_playback_plugin_or_sonic_msg);
+		builder.positiveText(R.string.download_plugin_label);
+		builder.negativeText(R.string.enable_sonic);
+		builder.neutralText(R.string.close_label);
+		builder.callback(new MaterialDialog.ButtonCallback() {
+			@Override
+			public void onPositive(MaterialDialog dialog) {
+				try {
+					context.startActivity(playStoreIntent);
+				} catch (ActivityNotFoundException e) {
+					// this is usually thrown on an emulator if the Android market is not installed
+					Log.e(TAG, Log.getStackTraceString(e));
+				}
+			}
+
+			@Override
+			public void onNegative(MaterialDialog dialog) {
+				if (Build.VERSION.SDK_INT >= 16) { // just to be safe
+					UserPreferences.enableSonic(true);
+					showSpeedSelectorDialog(context);
+				}
+			}
+
+			@Override
+			public void onNeutral(MaterialDialog dialog) {
+				super.onNeutral(dialog);
+			}
+		});
+		builder.forceStacking(true);
+		MaterialDialog dialog = builder.show();
+		if(!IntentUtils.isCallable(context.getApplicationContext(), playStoreIntent)) {
+			View pos = dialog.getActionButton(DialogAction.POSITIVE);
+			pos.setEnabled(false);
+		}
+		if (Build.VERSION.SDK_INT < 16) {
+			View pos = dialog.getActionButton(DialogAction.NEGATIVE);
+			pos.setEnabled(false);
+		}
 	}
 
 	private static void showSpeedSelectorDialog(final Context context) {
@@ -65,37 +98,30 @@ public class VariableSpeedDialog {
 		AlertDialog.Builder builder = new AlertDialog.Builder(context);
 		builder.setTitle(R.string.set_playback_speed_label);
 		builder.setMultiChoiceItems(R.array.playback_speed_values,
-				speedChecked, new DialogInterface.OnMultiChoiceClickListener() {
-					@Override
-					public void onClick(DialogInterface dialog, int which,
-							boolean isChecked) {
-						speedChecked[which] = isChecked;
-					}
-
-				});
+			speedChecked, (dialog, which, isChecked) -> {
+				speedChecked[which] = isChecked;
+			});
 		builder.setNegativeButton(android.R.string.cancel, null);
 		builder.setPositiveButton(android.R.string.ok,
-				new DialogInterface.OnClickListener() {
-					@Override
-					public void onClick(DialogInterface dialog, int which) {
-						int choiceCount = 0;
-						for (int i = 0; i < speedChecked.length; i++) {
-							if (speedChecked[i]) {
-								choiceCount++;
-							}
-						}
-						String[] newSpeedValues = new String[choiceCount];
-						int newSpeedIndex = 0;
-						for (int i = 0; i < speedChecked.length; i++) {
-							if (speedChecked[i]) {
-								newSpeedValues[newSpeedIndex++] = speedValues[i];
-							}
-						}
-
-						UserPreferences.setPlaybackSpeedArray(newSpeedValues);
-
+			(dialog, which) -> {
+				int choiceCount = 0;
+				for (int i = 0; i < speedChecked.length; i++) {
+					if (speedChecked[i]) {
+						choiceCount++;
 					}
-				});
+				}
+				String[] newSpeedValues = new String[choiceCount];
+				int newSpeedIndex = 0;
+				for (int i = 0; i < speedChecked.length; i++) {
+					if (speedChecked[i]) {
+						newSpeedValues[newSpeedIndex++] = speedValues[i];
+					}
+				}
+
+				UserPreferences.setPlaybackSpeedArray(newSpeedValues);
+
+			});
 		builder.create().show();
 	}
+
 }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -6,6 +6,7 @@ import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
@@ -14,6 +15,7 @@ import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
+import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -48,7 +50,8 @@ import de.danoeh.antennapod.dialog.VariableSpeedDialog;
 /**
  * Sets up a preference UI that lets the user change user preferences.
  */
-public class PreferenceController {
+public class PreferenceController implements SharedPreferences.OnSharedPreferenceChangeListener {
+
     private static final String TAG = "PreferenceController";
     public static final String PREF_FLATTR_SETTINGS = "prefFlattrSettings";
     public static final String PREF_FLATTR_AUTH = "pref_flattr_authenticate";
@@ -71,6 +74,18 @@ public class PreferenceController {
 
     public PreferenceController(PreferenceUI ui) {
         this.ui = ui;
+        PreferenceManager.getDefaultSharedPreferences(ui.getActivity().getApplicationContext())
+            .registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if(key.equals(UserPreferences.PREF_SONIC)) {
+            CheckBoxPreference prefSonic = (CheckBoxPreference) ui.findPreference(UserPreferences.PREF_SONIC);
+            if(prefSonic != null) {
+                prefSonic.setChecked(sharedPreferences.getBoolean(UserPreferences.PREF_SONIC, false));
+            }
+        }
     }
 
     /**
@@ -601,8 +616,7 @@ public class PreferenceController {
                 hiddenDrawerItems.add(NAV_DRAWER_TAGS[which]);
             }
         });
-        builder.setPositiveButton(R.string.confirm_label, new DialogInterface
-                .OnClickListener() {
+        builder.setPositiveButton(R.string.confirm_label, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 UserPreferences.setHiddenDrawerItems(context, hiddenDrawerItems);
@@ -646,12 +660,12 @@ public class PreferenceController {
                     minute = updateTime[1];
                 }
                 TimePickerDialog timePickerDialog = new TimePickerDialog(context,
-                        (view, selectedHourOfDay, selectedMinute) -> {
-                            if (view.getTag() == null) { // onTimeSet() may get called twice!
-                                view.setTag("TAGGED");
-                                UserPreferences.setUpdateTimeOfDay(selectedHourOfDay, selectedMinute);
-                            }
-                        }, hourOfDay, minute, DateFormat.is24HourFormat(context));
+                    (view, selectedHourOfDay, selectedMinute) -> {
+                        if (view.getTag() == null) { // onTimeSet() may get called twice!
+                            view.setTag("TAGGED");
+                            UserPreferences.setUpdateTimeOfDay(selectedHourOfDay, selectedMinute);
+                        }
+                    }, hourOfDay, minute, DateFormat.is24HourFormat(context));
                 timePickerDialog.setTitle(context.getString(R.string.pref_autoUpdateIntervallOrTime_TimeOfDay));
                 timePickerDialog.show();
             }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.3.1'
         classpath 'me.tatarka:gradle-retrolambda:3.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,5 +57,5 @@ dependencies {
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'io.reactivex:rxandroid:1.0.1'
 
-    compile 'com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0'
+    compile 'com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0.1'
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -480,6 +480,12 @@ public class UserPreferences {
         return prefs.getBoolean(PREF_SONIC, false);
     }
 
+    public static void enableSonic(boolean enable) {
+        prefs.edit()
+            .putBoolean(PREF_SONIC, enable)
+            .apply();
+    }
+
     /**
      * Return the folder where the app stores all of its data. This method will
      * return the standard data folder if none has been set by the user.

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -584,6 +584,9 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
                 || playerStatus == PlayerStatus.PREPARED
                 || playerStatus == PlayerStatus.SEEKING) {
             retVal = mediaPlayer.getCurrentPosition();
+            if(retVal <= 0 && media != null && media.getPosition() > 0) {
+                retVal = media.getPosition();
+            }
         } else if (media != null && media.getPosition() > 0) {
             retVal = media.getPosition();
         }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -252,8 +252,9 @@
     <!--  Variable Speed -->
     <string name="download_plugin_label">Download Plugin</string>
     <string name="no_playback_plugin_title">Plugin Not Installed</string>
-    <string name="no_playback_plugin_msg">For variable speed playback to work, a third party library must be installed.\n\nTap \'Download Plugin\' to download a free plugin from the Play Store\n\nAny problems found using this plugin are not the responsibility of AntennaPod and should be reported to the plugin owner.</string>
+    <string name="no_playback_plugin_or_sonic_msg">For variable speed playback to work, you have to install a third party library or enable the experimental Sonic player [Android 4.1+].\n\nTap \'Download Plugin\' to download a free plugin from the Play Store.\n\nAny problems found using this plugin are not the responsibility of AntennaPod and should be reported to the plugin owner.</string>
     <string name="set_playback_speed_label">Playback Speeds</string>
+    <string name="enable_sonic">Enable Sonic</string>
 
     <!-- Empty list labels -->
     <string name="no_items_label">There are no items in this list.</string>


### PR DESCRIPTION
![pref](https://cloud.githubusercontent.com/assets/6860662/10122980/0d1c0c9e-652b-11e5-915a-f7afe1a35258.png)

(Yep, on older devices, the content part is scrollable!)

* Fixed issue in Sonic player where switching would cause an unknown error (calling pause when in prepared state was considered an error)
* Variable Speed dialog: Thought it would be a good idea to mention sonic and allow the user to enable it instead of installing prestissimo.
* Now full dialog needed stacked buttons...
* Disable respective button when play store is not available or the android version is too low
* When switching to sonic, the media extractor doesn't give us the correct position after seeking. So, whenever the media player position doesn't seem to make sense, we have a look at the current playable

(I know, it's rather odd that enabling sonic is the negative action and closing the dialog is the neutral one. But that is the order that makes most sense to me when displayed in the dialog)

Fixes #1230 