### PR TITLE
Cleanup algorithm updates

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBCleanupTests.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBCleanupTests.java
@@ -1,0 +1,257 @@
+package de.test.antennapod.storage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.test.FlakyTest;
+import android.test.InstrumentationTestCase;
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
+import static de.test.antennapod.storage.DBTestUtils.saveFeedlist;
+
+/**
+ * Test class for DBTasks
+ */
+public class DBCleanupTests extends InstrumentationTestCase {
+
+    private static final String TAG = "DBTasksTest";
+    protected static final int EPISODE_CACHE_SIZE = 5;
+    private final int cleanupAlgorithm;
+
+    protected Context context;
+
+    protected File destFolder;
+
+    public DBCleanupTests() {
+        this.cleanupAlgorithm = UserPreferences.EPISODE_CLEANUP_DEFAULT;
+    }
+
+    public DBCleanupTests(int cleanupAlgorithm) {
+        this.cleanupAlgorithm = cleanupAlgorithm;
+    }
+
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+        assertTrue(PodDBAdapter.deleteDatabase());
+
+        cleanupDestFolder(destFolder);
+        assertTrue(destFolder.delete());
+    }
+
+    private void cleanupDestFolder(File destFolder) {
+        for (File f : destFolder.listFiles()) {
+            assertTrue(f.delete());
+        }
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        context = getInstrumentation().getTargetContext();
+        destFolder = context.getExternalCacheDir();
+        cleanupDestFolder(destFolder);
+        assertNotNull(destFolder);
+        assertTrue(destFolder.exists());
+        assertTrue(destFolder.canWrite());
+
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.close();
+
+        SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
+        prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
+        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, cleanupAlgorithm);
+        prefEdit.commit();
+
+        UserPreferences.init(context);
+    }
+
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldDelete() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            Date itemDate = new Date(NUM_ITEMS - i);
+            FeedItem item = new FeedItem(0, "title", "id", "link", itemDate, FeedItem.PLAYED, feed);
+
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, itemDate, 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (int i = 0; i < files.size(); i++) {
+            if (i < EPISODE_CACHE_SIZE) {
+                assertTrue(files.get(i).exists());
+            } else {
+                assertFalse(files.get(i).exists());
+            }
+        }
+    }
+
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupHandleUnplayed() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<FeedItem>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<File>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            Date itemDate = new Date(NUM_ITEMS - i);
+            FeedItem item = new FeedItem(0, "title", "id", "link", itemDate, FeedItem.UNPLAYED, feed);
+
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            assertTrue(f.exists());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, itemDate, 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (File file : files) {
+            assertTrue(file.exists());
+        }
+    }
+
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            Date itemDate = new Date(NUM_ITEMS - i);
+            FeedItem item = new FeedItem(0, "title", "id", "link", itemDate, FeedItem.PLAYED, feed);
+
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            assertTrue(f.exists());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, itemDate, 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.setQueue(items);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (File file : files) {
+            assertTrue(file.exists());
+        }
+    }
+
+    /**
+     * Reproduces a bug where DBTasks.performAutoCleanup(android.content.Context) would use the ID of the FeedItem in the
+     * call to DBWriter.deleteFeedMediaOfItem instead of the ID of the FeedMedia. This would cause the wrong item to be deleted.
+     * @throws IOException
+     */
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue_withFeedsWithNoMedia() throws IOException {
+        // add feed with no enclosures so that item ID != media ID
+        saveFeedlist(1, 10, false);
+
+        // add candidate for performAutoCleanup
+        List<Feed> feeds = saveFeedlist(1, 1, true);
+        FeedMedia m = feeds.get(0).getItems().get(0).getMedia();
+        m.setDownloaded(true);
+        m.setFile_url("file");
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setMedia(m);
+        adapter.close();
+
+        testPerformAutoCleanupShouldNotDeleteBecauseInQueue();
+    }
+
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldNotDeleteBecauseFavorite() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            Date itemDate = new Date(NUM_ITEMS - i);
+            FeedItem item = new FeedItem(0, "title", "id", "link", itemDate, FeedItem.PLAYED, feed);
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            assertTrue(f.exists());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, itemDate, 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.setFavorites(items);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (File file : files) {
+            assertTrue(file.exists());
+        }
+    }
+}

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBCleanupTests.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBCleanupTests.java
@@ -77,7 +77,7 @@ public class DBCleanupTests extends InstrumentationTestCase {
 
         SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
         prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
-        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, cleanupAlgorithm);
+        prefEdit.putString(UserPreferences.PREF_EPISODE_CLEANUP, Integer.toString(cleanupAlgorithm));
         prefEdit.commit();
 
         UserPreferences.init(context);

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBNullCleanupAlgorithmTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBNullCleanupAlgorithmTest.java
@@ -67,7 +67,7 @@ public class DBNullCleanupAlgorithmTest extends InstrumentationTestCase {
 
         SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
         prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
-        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, UserPreferences.EPISODE_CLEANUP_NULL);
+        prefEdit.putString(UserPreferences.PREF_EPISODE_CLEANUP, Integer.toString(UserPreferences.EPISODE_CLEANUP_NULL));
         prefEdit.commit();
 
         UserPreferences.init(context);

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBNullCleanupAlgorithmTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBNullCleanupAlgorithmTest.java
@@ -1,0 +1,115 @@
+package de.test.antennapod.storage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.test.FlakyTest;
+import android.test.InstrumentationTestCase;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
+import static de.test.antennapod.storage.DBTestUtils.saveFeedlist;
+
+/**
+ * Tests that the APNullCleanupAlgorithm is working correctly.
+ */
+public class DBNullCleanupAlgorithmTest extends InstrumentationTestCase {
+
+    private static final String TAG = "DBNullCleanupAlgorithmTest";
+    private static final int EPISODE_CACHE_SIZE = 5;
+
+    private Context context;
+
+    private File destFolder;
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+        assertTrue(PodDBAdapter.deleteDatabase());
+
+        cleanupDestFolder(destFolder);
+        assertTrue(destFolder.delete());
+    }
+
+    private void cleanupDestFolder(File destFolder) {
+        for (File f : destFolder.listFiles()) {
+            assertTrue(f.delete());
+        }
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        context = getInstrumentation().getTargetContext();
+        destFolder = context.getExternalCacheDir();
+        cleanupDestFolder(destFolder);
+        assertNotNull(destFolder);
+        assertTrue(destFolder.exists());
+        assertTrue(destFolder.canWrite());
+
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.close();
+
+        SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
+        prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
+        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, UserPreferences.EPISODE_CLEANUP_NULL);
+        prefEdit.commit();
+
+        UserPreferences.init(context);
+    }
+
+    /**
+     * A test with no items in the queue, but multiple items downloaded.
+     * The null algorithm should never delete any items, even if they're played and not in the queue.
+     * @throws IOException
+     */
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldNotDelete() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
+
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true,
+                    new Date(NUM_ITEMS - i), 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (int i = 0; i < files.size(); i++) {
+            assertTrue(files.get(i).exists());
+        }
+    }
+}

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBQueueCleanupAlgorithmTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBQueueCleanupAlgorithmTest.java
@@ -1,0 +1,177 @@
+package de.test.antennapod.storage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.test.FlakyTest;
+import android.test.InstrumentationTestCase;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
+import static de.test.antennapod.storage.DBTestUtils.saveFeedlist;
+
+/**
+ * Tests that the APQueueCleanupAlgorithm is working correctly.
+ */
+public class DBQueueCleanupAlgorithmTest extends InstrumentationTestCase {
+
+    private static final String TAG = "DBQueueCleanupAlgorithmTest";
+    private static final int EPISODE_CACHE_SIZE = 5;
+
+    private Context context;
+    
+    private File destFolder;
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+        assertTrue(PodDBAdapter.deleteDatabase());
+
+        cleanupDestFolder(destFolder);
+        assertTrue(destFolder.delete());
+    }
+
+    private void cleanupDestFolder(File destFolder) {
+        for (File f : destFolder.listFiles()) {
+            assertTrue(f.delete());
+        }
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        context = getInstrumentation().getTargetContext();
+        destFolder = context.getExternalCacheDir();
+        cleanupDestFolder(destFolder);
+        assertNotNull(destFolder);
+        assertTrue(destFolder.exists());
+        assertTrue(destFolder.canWrite());
+
+        // create new database
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.close();
+
+        SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
+        prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
+        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, UserPreferences.EPISODE_CLEANUP_QUEUE);
+        prefEdit.commit();
+
+        UserPreferences.init(context);
+    }
+
+    /**
+     * A test with no items in the queue, but multiple items downloaded. A certain
+     * number of items should be removed to make room in in the cache/queue.
+     * @throws IOException
+     */
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldDelete() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            FeedItem item = new FeedItem(0, "title", "id", "link", new Date(NUM_ITEMS - i), FeedItem.UNPLAYED, feed);
+
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, null, 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (int i = 0; i < files.size(); i++) {
+            if (i < EPISODE_CACHE_SIZE) {
+                assertTrue(files.get(i).exists());
+            } else {
+                assertFalse(files.get(i).exists());
+            }
+        }
+    }
+
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue() throws IOException {
+        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+
+        Feed feed = new Feed("url", new Date(), "title");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < NUM_ITEMS; i++) {
+            FeedItem item = new FeedItem(0, "title", "id", "link", new Date(NUM_ITEMS - i), FeedItem.PLAYED, feed);
+
+            File f = new File(destFolder, "file " + i);
+            assertTrue(f.createNewFile());
+            assertTrue(f.exists());
+            files.add(f);
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, new Date(NUM_ITEMS - i), 0));
+            items.add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.setQueue(items);
+        adapter.close();
+
+        assertTrue(feed.getId() != 0);
+        for (FeedItem item : items) {
+            assertTrue(item.getId() != 0);
+            assertTrue(item.getMedia().getId() != 0);
+        }
+        DBTasks.performAutoCleanup(context);
+        for (File file : files) {
+            assertTrue(file.exists());
+        }
+    }
+
+    /**
+     * Reproduces a bug where DBTasks.performAutoCleanup(android.content.Context) would use the ID of the FeedItem in the
+     * call to DBWriter.deleteFeedMediaOfItem instead of the ID of the FeedMedia. This would cause the wrong item to be deleted.
+     * @throws IOException
+     */
+    @FlakyTest(tolerance = 3)
+    public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue_withFeedsWithNoMedia() throws IOException {
+        // add feed with no enclosures so that item ID != media ID
+        saveFeedlist(1, 10, false);
+
+        // add candidate for performAutoCleanup
+        List<Feed> feeds = saveFeedlist(1, 1, true);
+        FeedMedia m = feeds.get(0).getItems().get(0).getMedia();
+        m.setDownloaded(true);
+        m.setFile_url("file");
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setMedia(m);
+        adapter.close();
+
+        testPerformAutoCleanupShouldNotDeleteBecauseInQueue();
+    }
+}

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBQueueCleanupAlgorithmTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBQueueCleanupAlgorithmTest.java
@@ -1,10 +1,6 @@
 package de.test.antennapod.storage;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 import android.test.FlakyTest;
-import android.test.InstrumentationTestCase;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,67 +15,23 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
-import static de.test.antennapod.storage.DBTestUtils.saveFeedlist;
-
 /**
  * Tests that the APQueueCleanupAlgorithm is working correctly.
  */
-public class DBQueueCleanupAlgorithmTest extends InstrumentationTestCase {
+public class DBQueueCleanupAlgorithmTest extends DBCleanupTests {
 
     private static final String TAG = "DBQueueCleanupAlgorithmTest";
-    private static final int EPISODE_CACHE_SIZE = 5;
 
-    private Context context;
-    
-    private File destFolder;
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-
-        assertTrue(PodDBAdapter.deleteDatabase());
-
-        cleanupDestFolder(destFolder);
-        assertTrue(destFolder.delete());
-    }
-
-    private void cleanupDestFolder(File destFolder) {
-        for (File f : destFolder.listFiles()) {
-            assertTrue(f.delete());
-        }
-    }
-
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        context = getInstrumentation().getTargetContext();
-        destFolder = context.getExternalCacheDir();
-        cleanupDestFolder(destFolder);
-        assertNotNull(destFolder);
-        assertTrue(destFolder.exists());
-        assertTrue(destFolder.canWrite());
-
-        // create new database
-        PodDBAdapter.deleteDatabase();
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        adapter.close();
-
-        SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
-        prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
-        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, UserPreferences.EPISODE_CLEANUP_QUEUE);
-        prefEdit.commit();
-
-        UserPreferences.init(context);
+    public DBQueueCleanupAlgorithmTest() {
+        super(UserPreferences.EPISODE_CLEANUP_QUEUE);
     }
 
     /**
-     * A test with no items in the queue, but multiple items downloaded. A certain
-     * number of items should be removed to make room in in the cache/queue.
-     * @throws IOException
+     * For APQueueCleanupAlgorithm we expect even unplayed episodes to be deleted if needed
+     * if they aren't in the queue
      */
     @FlakyTest(tolerance = 3)
-    public void testPerformAutoCleanupShouldDelete() throws IOException {
+    public void testPerformAutoCleanupHandleUnplayed() throws IOException {
         final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
 
         Feed feed = new Feed("url", new Date(), "title");
@@ -114,64 +66,5 @@ public class DBQueueCleanupAlgorithmTest extends InstrumentationTestCase {
                 assertFalse(files.get(i).exists());
             }
         }
-    }
-
-    @FlakyTest(tolerance = 3)
-    public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue() throws IOException {
-        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
-
-        Feed feed = new Feed("url", new Date(), "title");
-        List<FeedItem> items = new ArrayList<>();
-        feed.setItems(items);
-        List<File> files = new ArrayList<>();
-        for (int i = 0; i < NUM_ITEMS; i++) {
-            FeedItem item = new FeedItem(0, "title", "id", "link", new Date(NUM_ITEMS - i), FeedItem.PLAYED, feed);
-
-            File f = new File(destFolder, "file " + i);
-            assertTrue(f.createNewFile());
-            assertTrue(f.exists());
-            files.add(f);
-            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, new Date(NUM_ITEMS - i), 0));
-            items.add(item);
-        }
-
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        adapter.setCompleteFeed(feed);
-        adapter.setQueue(items);
-        adapter.close();
-
-        assertTrue(feed.getId() != 0);
-        for (FeedItem item : items) {
-            assertTrue(item.getId() != 0);
-            assertTrue(item.getMedia().getId() != 0);
-        }
-        DBTasks.performAutoCleanup(context);
-        for (File file : files) {
-            assertTrue(file.exists());
-        }
-    }
-
-    /**
-     * Reproduces a bug where DBTasks.performAutoCleanup(android.content.Context) would use the ID of the FeedItem in the
-     * call to DBWriter.deleteFeedMediaOfItem instead of the ID of the FeedMedia. This would cause the wrong item to be deleted.
-     * @throws IOException
-     */
-    @FlakyTest(tolerance = 3)
-    public void testPerformAutoCleanupShouldNotDeleteBecauseInQueue_withFeedsWithNoMedia() throws IOException {
-        // add feed with no enclosures so that item ID != media ID
-        saveFeedlist(1, 10, false);
-
-        // add candidate for performAutoCleanup
-        List<Feed> feeds = saveFeedlist(1, 1, true);
-        FeedMedia m = feeds.get(0).getItems().get(0).getMedia();
-        m.setDownloaded(true);
-        m.setFile_url("file");
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        adapter.setMedia(m);
-        adapter.close();
-
-        testPerformAutoCleanupShouldNotDeleteBecauseInQueue();
     }
 }

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBQueueCleanupAlgorithmTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBQueueCleanupAlgorithmTest.java
@@ -10,10 +10,8 @@ import java.util.List;
 
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBTasks;
-import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 /**
  * Tests that the APQueueCleanupAlgorithm is working correctly.
@@ -38,26 +36,8 @@ public class DBQueueCleanupAlgorithmTest extends DBCleanupTests {
         List<FeedItem> items = new ArrayList<>();
         feed.setItems(items);
         List<File> files = new ArrayList<>();
-        for (int i = 0; i < NUM_ITEMS; i++) {
-            FeedItem item = new FeedItem(0, "title", "id", "link", new Date(NUM_ITEMS - i), FeedItem.UNPLAYED, feed);
+        populateItems(NUM_ITEMS, feed, items, files, FeedItem.UNPLAYED, false, false);
 
-            File f = new File(destFolder, "file " + i);
-            assertTrue(f.createNewFile());
-            files.add(f);
-            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true, null, 0));
-            items.add(item);
-        }
-
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        adapter.setCompleteFeed(feed);
-        adapter.close();
-
-        assertTrue(feed.getId() != 0);
-        for (FeedItem item : items) {
-            assertTrue(item.getId() != 0);
-            assertTrue(item.getMedia().getId() != 0);
-        }
         DBTasks.performAutoCleanup(context);
         for (int i = 0; i < files.size(); i++) {
             if (i < EPISODE_CACHE_SIZE) {

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
@@ -110,7 +110,7 @@ public class DBTasksTest extends InstrumentationTestCase {
     }
 
     @FlakyTest(tolerance = 3)
-    public void testPerformAutoCleanupShouldNotDeleteBecauseUnread() throws IOException {
+    public void testPerformAutoCleanupShouldNotDeleteBecauseUnplayed() throws IOException {
         final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
 
         Feed feed = new Feed("url", new Date(), "title");

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTasksTest.java
@@ -65,6 +65,7 @@ public class DBTasksTest extends InstrumentationTestCase {
 
         SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
         prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
+        prefEdit.putInt(UserPreferences.PREF_EPISODE_CLEANUP, UserPreferences.EPISODE_CLEANUP_DEFAULT);
         prefEdit.commit();
 
         UserPreferences.init(context);

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -14,6 +14,7 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.PreferenceActivity;
@@ -59,12 +60,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clickOnText(solo.getString(R.string.pref_set_theme_title));
         solo.waitForDialogToOpen();
         solo.clickOnText(solo.getString(otherTheme));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getTheme() != theme;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getTheme() != theme, Timeout.getLargeTimeout()));
     }
 
     public void testSwitchThemeBack() {
@@ -78,140 +74,67 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clickOnText(solo.getString(R.string.pref_set_theme_title));
         solo.waitForDialogToOpen(1000);
         solo.clickOnText(solo.getString(otherTheme));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getTheme() != theme;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getTheme() != theme, Timeout.getLargeTimeout()));
     }
 
     public void testExpandNotification() {
         final int priority = UserPreferences.getNotifyPriority();
         solo.clickOnText(solo.getString(R.string.pref_expandNotify_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return priority != UserPreferences.getNotifyPriority();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> priority != UserPreferences.getNotifyPriority(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_expandNotify_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return priority == UserPreferences.getNotifyPriority();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> priority == UserPreferences.getNotifyPriority(), Timeout.getLargeTimeout()));
     }
 
     public void testEnablePersistentPlaybackControls() {
         final boolean persistNotify = UserPreferences.isPersistNotify();
         solo.clickOnText(solo.getString(R.string.pref_persistNotify_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return persistNotify != UserPreferences.isPersistNotify();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> persistNotify != UserPreferences.isPersistNotify(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_persistNotify_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return persistNotify == UserPreferences.isPersistNotify();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> persistNotify == UserPreferences.isPersistNotify(), Timeout.getLargeTimeout()));
     }
 
     public void testEnqueueAtFront() {
         final boolean enqueueAtFront = UserPreferences.enqueueAtFront();
         solo.clickOnText(solo.getString(R.string.pref_queueAddToFront_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return enqueueAtFront != UserPreferences.enqueueAtFront();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> enqueueAtFront != UserPreferences.enqueueAtFront(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_queueAddToFront_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return enqueueAtFront == UserPreferences.enqueueAtFront();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> enqueueAtFront == UserPreferences.enqueueAtFront(), Timeout.getLargeTimeout()));
     }
 
     public void testHeadPhonesDisconnect() {
         final boolean pauseOnHeadsetDisconnect = UserPreferences.isPauseOnHeadsetDisconnect();
         solo.clickOnText(solo.getString(R.string.pref_pauseOnHeadsetDisconnect_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return pauseOnHeadsetDisconnect != UserPreferences.isPauseOnHeadsetDisconnect();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> pauseOnHeadsetDisconnect != UserPreferences.isPauseOnHeadsetDisconnect(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_pauseOnHeadsetDisconnect_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return pauseOnHeadsetDisconnect == UserPreferences.isPauseOnHeadsetDisconnect();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> pauseOnHeadsetDisconnect == UserPreferences.isPauseOnHeadsetDisconnect(), Timeout.getLargeTimeout()));
     }
 
     public void testHeadPhonesReconnect() {
         if(UserPreferences.isPauseOnHeadsetDisconnect() == false) {
             solo.clickOnText(solo.getString(R.string.pref_pauseOnHeadsetDisconnect_title));
-            solo.waitForCondition(new Condition() {
-                @Override
-                public boolean isSatisfied() {
-                    return UserPreferences.isPauseOnHeadsetDisconnect();
-                }
-            }, Timeout.getLargeTimeout());
+            assertTrue(solo.waitForCondition(() -> UserPreferences.isPauseOnHeadsetDisconnect(), Timeout.getLargeTimeout()));
         }
         final boolean unpauseOnHeadsetReconnect = UserPreferences.isUnpauseOnHeadsetReconnect();
         solo.clickOnText(solo.getString(R.string.pref_unpauseOnHeadsetReconnect_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return unpauseOnHeadsetReconnect != UserPreferences.isUnpauseOnHeadsetReconnect();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> unpauseOnHeadsetReconnect != UserPreferences.isUnpauseOnHeadsetReconnect(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_unpauseOnHeadsetReconnect_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return unpauseOnHeadsetReconnect == UserPreferences.isUnpauseOnHeadsetReconnect();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> unpauseOnHeadsetReconnect == UserPreferences.isUnpauseOnHeadsetReconnect(), Timeout.getLargeTimeout()));
     }
 
     public void testContinuousPlayback() {
         final boolean continuousPlayback = UserPreferences.isFollowQueue();
         solo.clickOnText(solo.getString(R.string.pref_followQueue_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return continuousPlayback != UserPreferences.isFollowQueue();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> continuousPlayback != UserPreferences.isFollowQueue(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_followQueue_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return continuousPlayback == UserPreferences.isFollowQueue();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> continuousPlayback == UserPreferences.isFollowQueue(), Timeout.getLargeTimeout()));
     }
 
     public void testAutoDelete() {
         final boolean autoDelete = UserPreferences.isAutoDelete();
         solo.clickOnText(solo.getString(R.string.pref_auto_delete_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return autoDelete != UserPreferences.isAutoDelete();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> autoDelete != UserPreferences.isAutoDelete(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_auto_delete_title));
-        solo.waitForCondition(new Condition() {
-            @Override public boolean isSatisfied() {
-                return autoDelete == UserPreferences.isAutoDelete();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> autoDelete == UserPreferences.isAutoDelete(), Timeout.getLargeTimeout()));
     }
 
     public void testPlaybackSpeeds() {
@@ -225,31 +148,16 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
     public void testPauseForInterruptions() {
         final boolean pauseForFocusLoss = UserPreferences.shouldPauseForFocusLoss();
         solo.clickOnText(solo.getString(R.string.pref_pausePlaybackForFocusLoss_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return pauseForFocusLoss != UserPreferences.shouldPauseForFocusLoss();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> pauseForFocusLoss != UserPreferences.shouldPauseForFocusLoss(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_pausePlaybackForFocusLoss_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return pauseForFocusLoss == UserPreferences.shouldPauseForFocusLoss();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> pauseForFocusLoss == UserPreferences.shouldPauseForFocusLoss(), Timeout.getLargeTimeout()));
     }
 
     public void testDisableUpdateInterval() {
         solo.clickOnText(solo.getString(R.string.pref_autoUpdateIntervallOrTime_sum));
         solo.waitForDialogToOpen();
         solo.clickOnText(solo.getString(R.string.pref_autoUpdateIntervallOrTime_Disable));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getUpdateInterval() == 0;
-            }
-        }, 1000);
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getUpdateInterval() == 0, 1000));
     }
 
     public void testSetUpdateInterval() {
@@ -260,30 +168,16 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         String search = "12 " + solo.getString(R.string.pref_update_interval_hours_plural);
         solo.clickOnText(search);
         solo.waitForDialogToClose();
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getUpdateInterval() == 12;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getUpdateInterval() ==
+                TimeUnit.HOURS.toMillis(12), Timeout.getLargeTimeout()));
     }
 
     public void testMobileUpdates() {
         final boolean mobileUpdates = UserPreferences.isAllowMobileUpdate();
         solo.clickOnText(solo.getString(R.string.pref_mobileUpdate_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return mobileUpdates != UserPreferences.isAllowMobileUpdate();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> mobileUpdates != UserPreferences.isAllowMobileUpdate(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_mobileUpdate_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return mobileUpdates == UserPreferences.isAllowMobileUpdate();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> mobileUpdates == UserPreferences.isAllowMobileUpdate(), Timeout.getLargeTimeout()));
     }
 
     public void testSetSequentialDownload() {
@@ -292,12 +186,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clearEditText(0);
         solo.enterText(0, "1");
         solo.clickOnText(solo.getString(android.R.string.ok));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getParallelDownloads() == 1;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getParallelDownloads() == 1, Timeout.getLargeTimeout()));
     }
 
     public void testSetParallelDownloads() {
@@ -306,12 +195,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clearEditText(0);
         solo.enterText(0, "10");
         solo.clickOnText(solo.getString(android.R.string.ok));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getParallelDownloads() == 10;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getParallelDownloads() == 10, Timeout.getLargeTimeout()));
     }
 
     public void testSetParallelDownloadsInvalidInput() {
@@ -333,12 +217,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clickOnText(solo.getString(R.string.pref_episode_cache_title));
         solo.waitForDialogToOpen();
         solo.clickOnText(entry);
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getEpisodeCacheSize() == value;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getEpisodeCacheSize() == value, Timeout.getLargeTimeout()));
     }
 
     public void testSetEpisodeCacheMin() {
@@ -350,12 +229,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.waitForDialogToOpen(1000);
         solo.scrollUp();
         solo.clickOnText(minEntry);
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getEpisodeCacheSize() == minValue;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getEpisodeCacheSize() == minValue, Timeout.getLargeTimeout()));
     }
 
 
@@ -367,12 +241,7 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clickOnText(solo.getString(R.string.pref_episode_cache_title));
         solo.waitForDialogToOpen();
         solo.clickOnText(maxEntry);
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.getEpisodeCacheSize() == maxValue;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getEpisodeCacheSize() == maxValue, Timeout.getLargeTimeout()));
     }
 
     public void testAutomaticDownload() {
@@ -380,50 +249,20 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
         solo.waitForText(solo.getString(R.string.pref_automatic_download_title));
         solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return automaticDownload != UserPreferences.isEnableAutodownload();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> automaticDownload != UserPreferences.isEnableAutodownload(), Timeout.getLargeTimeout()));
         if(UserPreferences.isEnableAutodownload() == false) {
             solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
         }
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return UserPreferences.isEnableAutodownload() == true;
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> UserPreferences.isEnableAutodownload() == true, Timeout.getLargeTimeout()));
         final boolean enableAutodownloadOnBattery = UserPreferences.isEnableAutodownloadOnBattery();
         solo.clickOnText(solo.getString(R.string.pref_automatic_download_on_battery_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return enableAutodownloadOnBattery != UserPreferences.isEnableAutodownloadOnBattery();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> enableAutodownloadOnBattery != UserPreferences.isEnableAutodownloadOnBattery(), Timeout.getLargeTimeout()));
         solo.clickOnText(solo.getString(R.string.pref_automatic_download_on_battery_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return enableAutodownloadOnBattery == UserPreferences.isEnableAutodownloadOnBattery();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> enableAutodownloadOnBattery == UserPreferences.isEnableAutodownloadOnBattery(), Timeout.getLargeTimeout()));
         final boolean enableWifiFilter = UserPreferences.isEnableAutodownloadWifiFilter();
         solo.clickOnText(solo.getString(R.string.pref_autodl_wifi_filter_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return enableWifiFilter != UserPreferences.isEnableAutodownloadWifiFilter();
-            }
-        }, Timeout.getLargeTimeout());
-        solo.clickOnText(solo.getString(R.string.pref_automatic_download_on_battery_title));
-        solo.waitForCondition(new Condition() {
-            @Override
-            public boolean isSatisfied() {
-                return enableWifiFilter == UserPreferences.isEnableAutodownloadWifiFilter();
-            }
-        }, Timeout.getLargeTimeout());
+        assertTrue(solo.waitForCondition(() -> enableWifiFilter != UserPreferences.isEnableAutodownloadWifiFilter(), Timeout.getLargeTimeout()));
+        solo.clickOnText(solo.getString(R.string.pref_autodl_wifi_filter_title));
+        assertTrue(solo.waitForCondition(() -> enableWifiFilter == UserPreferences.isEnableAutodownloadWifiFilter(), Timeout.getLargeTimeout()));
     }
 }

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -19,6 +19,10 @@ import java.util.concurrent.TimeUnit;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.PreferenceActivity;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
+import de.danoeh.antennapod.core.storage.APNullCleanupAlgorithm;
+import de.danoeh.antennapod.core.storage.APQueueCleanupAlgorithm;
+import de.danoeh.antennapod.core.storage.EpisodeCleanupAlgorithm;
 
 public class PreferencesTest extends ActivityInstrumentationTestCase2<PreferenceActivity>  {
 
@@ -265,4 +269,42 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         solo.clickOnText(solo.getString(R.string.pref_autodl_wifi_filter_title));
         assertTrue(solo.waitForCondition(() -> enableWifiFilter == UserPreferences.isEnableAutodownloadWifiFilter(), Timeout.getLargeTimeout()));
     }
+
+    public void testEpisodeCleanupQueueOnly() {
+        solo.clickOnText(solo.getString(R.string.pref_episode_cleanup_title));
+        solo.waitForText(solo.getString(R.string.episode_cleanup_queue_removal));
+        solo.clickOnText(solo.getString(R.string.episode_cleanup_queue_removal));
+        assertTrue(solo.waitForCondition(() -> {
+                    EpisodeCleanupAlgorithm alg = UserPreferences.getEpisodeCleanupAlgorithm();
+                    return alg instanceof APQueueCleanupAlgorithm;
+                },
+                Timeout.getLargeTimeout()));
+    }
+
+    public void testEpisodeCleanupNeverAlg() {
+        solo.clickOnText(solo.getString(R.string.pref_episode_cleanup_title));
+        solo.waitForText(solo.getString(R.string.episode_cleanup_never));
+        solo.clickOnText(solo.getString(R.string.episode_cleanup_never));
+        assertTrue(solo.waitForCondition(() -> {
+                    EpisodeCleanupAlgorithm alg = UserPreferences.getEpisodeCleanupAlgorithm();
+                    return alg instanceof APNullCleanupAlgorithm;
+                },
+                Timeout.getLargeTimeout()));
+    }
+
+    public void testEpisodeCleanupClassic() {
+        solo.clickOnText(solo.getString(R.string.pref_episode_cleanup_title));
+        solo.waitForText(solo.getString(R.string.episode_cleanup_after_listening));
+        solo.clickOnText(solo.getString(R.string.episode_cleanup_after_listening));
+        assertTrue(solo.waitForCondition(() -> {
+                    EpisodeCleanupAlgorithm alg = UserPreferences.getEpisodeCleanupAlgorithm();
+                    if (alg instanceof APCleanupAlgorithm) {
+                        APCleanupAlgorithm cleanupAlg = (APCleanupAlgorithm)alg;
+                        return cleanupAlg.getNumberOfDaysAfterPlayback() == 0;
+                    }
+                    return false;
+                },
+                Timeout.getLargeTimeout()));
+    }
+
 }

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -307,4 +307,19 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
                 Timeout.getLargeTimeout()));
     }
 
+    public void testEpisodeCleanupNumDays() {
+        solo.clickOnText(solo.getString(R.string.pref_episode_cleanup_title));
+        solo.waitForText(solo.getString(R.string.episode_cleanup_after_listening));
+        solo.clickOnText("5");
+        assertTrue(solo.waitForCondition(() -> {
+                    EpisodeCleanupAlgorithm alg = UserPreferences.getEpisodeCleanupAlgorithm();
+                    if (alg instanceof APCleanupAlgorithm) {
+                        APCleanupAlgorithm cleanupAlg = (APCleanupAlgorithm)alg;
+                        return cleanupAlg.getNumberOfDaysAfterPlayback() == 5;
+                    }
+                    return false;
+                },
+                Timeout.getLargeTimeout()));
+    }
+
 }

--- a/app/src/main/java/de/danoeh/antennapod/config/DBTasksCallbacksImpl.java
+++ b/app/src/main/java/de/danoeh/antennapod/config/DBTasksCallbacksImpl.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.config;
 
 import de.danoeh.antennapod.core.DBTasksCallbacks;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APDownloadAlgorithm;
 import de.danoeh.antennapod.core.storage.AutomaticDownloadAlgorithm;
@@ -15,6 +16,6 @@ public class DBTasksCallbacksImpl implements DBTasksCallbacks {
 
     @Override
     public EpisodeCleanupAlgorithm getEpisodeCacheCleanupAlgorithm() {
-        return new APCleanupAlgorithm();
+        return UserPreferences.getEpisodeCleanupAlgorithm();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -366,7 +366,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                             public boolean onPreferenceChange(Preference preference, Object o) {
                                 if (o instanceof String) {
                                     int newValue = Integer.valueOf((String) o) * 1024 * 1024;
-                                    if(newValue != UserPreferences.getImageCacheSize()) {
+                                    if (newValue != UserPreferences.getImageCacheSize()) {
                                         AlertDialog.Builder dialog = new AlertDialog.Builder(ui.getActivity());
                                         dialog.setTitle(android.R.string.dialog_alert_title);
                                         dialog.setMessage(R.string.pref_restart_required);
@@ -379,6 +379,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                             }
                         }
                 );
+        buildEpisodeCleanupPreference();
         buildSmartMarkAsPlayedPreference();
         buildAutodownloadSelectedNetworsPreference();
         setSelectedNetworksEnabled(UserPreferences
@@ -430,6 +431,26 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
             }
         }
         return entries;
+    }
+
+    private void buildEpisodeCleanupPreference() {
+        final Resources res = ui.getActivity().getResources();
+
+        ListPreference pref = (ListPreference) ui.findPreference(UserPreferences.PREF_EPISODE_CLEANUP);
+        String[] values = res.getStringArray(
+                R.array.episode_cleanup_values);
+        String[] entries = new String[values.length];
+        for (int x = 0; x < values.length; x++) {
+            int v = Integer.parseInt(values[x]);
+            if (v == 0) {
+                entries[x] = res.getString(R.string.episode_cleanup_immediately);
+            } else if (v == -1){
+                entries[x] = res.getString(R.string.episode_cleanup_never);
+            } else {
+                entries[x] = res.getQuantityString(R.plurals.time_days_quantified, v, v);
+            }
+        }
+        pref.setEntries(entries);
     }
 
     private void buildSmartMarkAsPlayedPreference() {

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -442,9 +442,9 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         String[] entries = new String[values.length];
         for (int x = 0; x < values.length; x++) {
             int v = Integer.parseInt(values[x]);
-            if (v == -1) {
+            if (v == UserPreferences.EPISODE_CLEANUP_QUEUE) {
                 entries[x] = res.getString(R.string.episode_cleanup_queue_removal);
-            } else if (v == -2){
+            } else if (v == UserPreferences.EPISODE_CLEANUP_NULL){
                 entries[x] = res.getString(R.string.episode_cleanup_never);
             } else if (v == 0) {
                 entries[x] = res.getString(R.string.episode_cleanup_after_listening);

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -442,12 +442,14 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         String[] entries = new String[values.length];
         for (int x = 0; x < values.length; x++) {
             int v = Integer.parseInt(values[x]);
-            if (v == 0) {
-                entries[x] = res.getString(R.string.episode_cleanup_immediately);
-            } else if (v == -1){
+            if (v == -1) {
+                entries[x] = res.getString(R.string.episode_cleanup_queue_removal);
+            } else if (v == -2){
                 entries[x] = res.getString(R.string.episode_cleanup_never);
+            } else if (v == 0) {
+                entries[x] = res.getString(R.string.episode_cleanup_after_listening);
             } else {
-                entries[x] = res.getQuantityString(R.plurals.time_days_quantified, v, v);
+                entries[x] = res.getQuantityString(R.plurals.episode_cleanup_days_after_listening, v, v);
             }
         }
         pref.setEntries(entries);

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -137,6 +137,15 @@
             android:key="prefMobileUpdate"
             android:summary="@string/pref_mobileUpdate_sum"
             android:title="@string/pref_mobileUpdate_title"/>
+
+        <ListPreference
+            android:defaultValue="3"
+            android:entries="@array/episode_cleanup_entries"
+            android:key="prefEpisodeCleanup"
+            android:title="@string/pref_episode_cleanup_title"
+            android:summary="@string/pref_episode_cleanup_summary"
+            android:entryValues="@array/episode_cache_size_values"/>
+
         <de.danoeh.antennapod.preferences.CustomEditTextPreference
             android:defaultValue="6"
             android:inputType="number"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -139,12 +139,12 @@
             android:title="@string/pref_mobileUpdate_title"/>
 
         <ListPreference
-            android:defaultValue="3"
+            android:defaultValue="-1"
             android:entries="@array/episode_cleanup_entries"
             android:key="prefEpisodeCleanup"
             android:title="@string/pref_episode_cleanup_title"
             android:summary="@string/pref_episode_cleanup_summary"
-            android:entryValues="@array/episode_cache_size_values"/>
+            android:entryValues="@array/episode_cleanup_values"/>
 
         <de.danoeh.antennapod.preferences.CustomEditTextPreference
             android:defaultValue="6"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -492,7 +492,7 @@ public class UserPreferences {
     }
 
 
-    public static EpisodeCleanupAlgorithm<Integer> getEpisodeCleanupAlgorithm() {
+    public static EpisodeCleanupAlgorithm getEpisodeCleanupAlgorithm() {
         int cleanupValue = prefs.getInt(PREF_EPISODE_CLEANUP, -1);
         if (cleanupValue == -1) {
             return new APQueueCleanupAlgorithm();

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -27,6 +27,10 @@ import java.util.concurrent.TimeUnit;
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.receiver.FeedUpdateReceiver;
+import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
+import de.danoeh.antennapod.core.storage.APNullCleanupAlgorithm;
+import de.danoeh.antennapod.core.storage.APQueueCleanupAlgorithm;
+import de.danoeh.antennapod.core.storage.EpisodeCleanupAlgorithm;
 
 /**
  * Provides access to preferences set by the user in the settings screen. A
@@ -217,8 +221,6 @@ public class UserPreferences {
     public static boolean isFollowQueue() {
         return prefs.getBoolean(PREF_FOLLOW_QUEUE, true);
     }
-
-    public static int getEpisodeCleanupDays() { return Integer.valueOf(prefs.getString(PREF_EPISODE_CLEANUP, "3")); }
 
     public static boolean shouldSkipRemoveFromQueue() { return prefs.getBoolean(PREF_SKIP_REMOVES, false); }
 
@@ -489,6 +491,18 @@ public class UserPreferences {
             .apply();
     }
 
+
+    public static EpisodeCleanupAlgorithm<Integer> getEpisodeCleanupAlgorithm() {
+        int cleanupValue = prefs.getInt(PREF_EPISODE_CLEANUP, -1);
+        if (cleanupValue == -1) {
+            return new APQueueCleanupAlgorithm();
+        } else if (cleanupValue == -2) {
+            return new APNullCleanupAlgorithm();
+        } else {
+            return new APCleanupAlgorithm(cleanupValue);
+        }
+    }
+
     /**
      * Return the folder where the app stores all of its data. This method will
      * return the standard data folder if none has been set by the user.
@@ -648,5 +662,4 @@ public class UserPreferences {
     public static int readEpisodeCacheSize(String valueFromPrefs) {
         return readEpisodeCacheSizeInternal(valueFromPrefs);
     }
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -98,6 +98,9 @@ public class UserPreferences {
     // Experimental
     public static final String PREF_SONIC = "prefSonic";
     public static final String PREF_NORMALIZER = "prefNormalizer";
+    public static final int EPISODE_CLEANUP_QUEUE = -1;
+    public static final int EPISODE_CLEANUP_NULL = -2;
+    public static final int EPISODE_CLEANUP_DEFAULT = 0;
 
     // Constants
     private static int EPISODE_CACHE_SIZE_UNLIMITED = -1;
@@ -494,9 +497,9 @@ public class UserPreferences {
 
     public static EpisodeCleanupAlgorithm getEpisodeCleanupAlgorithm() {
         int cleanupValue = prefs.getInt(PREF_EPISODE_CLEANUP, -1);
-        if (cleanupValue == -1) {
+        if (cleanupValue == EPISODE_CLEANUP_QUEUE) {
             return new APQueueCleanupAlgorithm();
-        } else if (cleanupValue == -2) {
+        } else if (cleanupValue == EPISODE_CLEANUP_NULL) {
             return new APNullCleanupAlgorithm();
         } else {
             return new APCleanupAlgorithm(cleanupValue);

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -67,6 +67,7 @@ public class UserPreferences {
     // Network
     public static final String PREF_UPDATE_INTERVAL = "prefAutoUpdateIntervall";
     public static final String PREF_MOBILE_UPDATE = "prefMobileUpdate";
+    public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_PARALLEL_DOWNLOADS = "prefParallelDownloads";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
     public static final String PREF_ENABLE_AUTODL = "prefEnableAutoDl";
@@ -216,6 +217,8 @@ public class UserPreferences {
     public static boolean isFollowQueue() {
         return prefs.getBoolean(PREF_FOLLOW_QUEUE, true);
     }
+
+    public static int getEpisodeCleanupDays() { return Integer.valueOf(prefs.getString(PREF_EPISODE_CLEANUP, "3")); }
 
     public static boolean shouldSkipRemoveFromQueue() { return prefs.getBoolean(PREF_SKIP_REMOVES, false); }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -496,7 +496,7 @@ public class UserPreferences {
 
 
     public static EpisodeCleanupAlgorithm getEpisodeCleanupAlgorithm() {
-        int cleanupValue = prefs.getInt(PREF_EPISODE_CLEANUP, -1);
+        int cleanupValue = Integer.valueOf(prefs.getString(PREF_EPISODE_CLEANUP, "-1"));
         if (cleanupValue == EPISODE_CLEANUP_QUEUE) {
             return new APQueueCleanupAlgorithm();
         } else if (cleanupValue == EPISODE_CLEANUP_NULL) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -18,7 +18,7 @@ import de.danoeh.antennapod.core.util.LongList;
 /**
  * Implementation of the EpisodeCleanupAlgorithm interface used by AntennaPod.
  */
-public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
     private static final String TAG = "APCleanupAlgorithm";
     /** the number of days after playback to wait before an item is eligible to be cleaned up */
@@ -29,7 +29,7 @@ public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
     }
 
     @Override
-    public int performCleanup(Context context, Integer numberOfEpisodesToDelete) {
+    public int performCleanup(Context context, int numberOfEpisodesToDelete) {
         List<FeedItem> candidates = new ArrayList<>();
         List<FeedItem> downloadedItems = DBReader.getDownloadedItems();
         LongList queue = DBReader.getQueueIDList();
@@ -89,7 +89,7 @@ public class APCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
     }
 
     @Override
-    public Integer getDefaultCleanupParameter() {
+    public int getDefaultCleanupParameter() {
         return 0;
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -90,6 +90,6 @@ public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
     @Override
     public int getDefaultCleanupParameter() {
-        return 0;
+        return getNumEpisodesToCleanup(0);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -94,4 +94,6 @@ public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
     public int getDefaultCleanupParameter() {
         return getNumEpisodesToCleanup(0);
     }
+
+    public int getNumberOfDaysAfterPlayback() { return numberOfDaysAfterPlayback; }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -32,14 +32,16 @@ public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
     public int performCleanup(Context context, int numberOfEpisodesToDelete) {
         List<FeedItem> candidates = new ArrayList<>();
         List<FeedItem> downloadedItems = DBReader.getDownloadedItems();
-        LongList queue = DBReader.getQueueIDList();
         List<FeedItem> delete;
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.DAY_OF_MONTH, -1 * numberOfDaysAfterPlayback);
         Date mostRecentDateForDeletion = cal.getTime();
         for (FeedItem item : downloadedItems) {
-            if (item.hasMedia() && item.getMedia().isDownloaded()
-                    && !queue.contains(item.getId()) && item.isPlayed()) {
+            if (item.hasMedia()
+                    && item.getMedia().isDownloaded()
+                    && !item.isTagged(FeedItem.TAG_QUEUE)
+                    && item.isPlayed()
+                    && !item.isTagged(FeedItem.TAG_FAVORITE)) {
                 FeedMedia media = item.getMedia();
                 // make sure this candidate was played at least the proper amount of days prior
                 // to now

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -19,8 +19,6 @@ import de.danoeh.antennapod.core.util.PowerUtils;
 public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     private static final String TAG = "APDownloadAlgorithm";
 
-    private final APCleanupAlgorithm cleanupAlgorithm = new APCleanupAlgorithm();
-
     /**
      * Looks for undownloaded episodes in the queue or list of new items and request a download if
      * 1. Network is available
@@ -72,8 +70,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
 
                     int autoDownloadableEpisodes = candidates.size();
                     int downloadedEpisodes = DBReader.getNumberOfDownloadedEpisodes();
-                    int deletedEpisodes = cleanupAlgorithm.performCleanup(context,
-                            APCleanupAlgorithm.getPerformAutoCleanupArgs(autoDownloadableEpisodes));
+                    int deletedEpisodes = UserPreferences.getEpisodeCleanupAlgorithm().performCleanup(context,
+                            getPerformAutoCleanupArgs(autoDownloadableEpisodes));
                     boolean cacheIsUnlimited = UserPreferences.getEpisodeCacheSize() == UserPreferences
                             .getEpisodeCacheSizeUnlimited();
                     int episodeCacheSize = UserPreferences.getEpisodeCacheSize();
@@ -100,6 +98,22 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                 }
             }
         };
+    }
+
+    private int getPerformAutoCleanupArgs(final int numberOfEpisodesToDownload) {
+        if (numberOfEpisodesToDownload >= 0
+                && UserPreferences.getEpisodeCacheSize() != UserPreferences
+                .getEpisodeCacheSizeUnlimited()) {
+            int downloadedEpisodes = DBReader
+                    .getNumberOfDownloadedEpisodes();
+            if (downloadedEpisodes + numberOfEpisodesToDownload >= UserPreferences
+                    .getEpisodeCacheSize()) {
+
+                return downloadedEpisodes + numberOfEpisodesToDownload
+                        - UserPreferences.getEpisodeCacheSize();
+            }
+        }
+        return 0;
     }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -99,21 +99,4 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
             }
         };
     }
-
-    private int getPerformAutoCleanupArgs(final int numberOfEpisodesToDownload) {
-        if (numberOfEpisodesToDownload >= 0
-                && UserPreferences.getEpisodeCacheSize() != UserPreferences
-                .getEpisodeCacheSizeUnlimited()) {
-            int downloadedEpisodes = DBReader
-                    .getNumberOfDownloadedEpisodes();
-            if (downloadedEpisodes + numberOfEpisodesToDownload >= UserPreferences
-                    .getEpisodeCacheSize()) {
-
-                return downloadedEpisodes + numberOfEpisodesToDownload
-                        - UserPreferences.getEpisodeCacheSize();
-            }
-        }
-        return 0;
-    }
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -70,8 +70,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
 
                     int autoDownloadableEpisodes = candidates.size();
                     int downloadedEpisodes = DBReader.getNumberOfDownloadedEpisodes();
-                    int deletedEpisodes = UserPreferences.getEpisodeCleanupAlgorithm().performCleanup(context,
-                            getPerformAutoCleanupArgs(autoDownloadableEpisodes));
+                    int deletedEpisodes = UserPreferences.getEpisodeCleanupAlgorithm()
+                            .makeRoomForEpisodes(context, autoDownloadableEpisodes);
                     boolean cacheIsUnlimited = UserPreferences.getEpisodeCacheSize() == UserPreferences
                             .getEpisodeCacheSizeUnlimited();
                     int episodeCacheSize = UserPreferences.getEpisodeCacheSize();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APNullCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APNullCleanupAlgorithm.java
@@ -1,0 +1,19 @@
+package de.danoeh.antennapod.core.storage;
+
+import android.content.Context;
+
+/**
+ * A cleanup algorithm that never removes anything
+ */
+public class APNullCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+    @Override
+    public int performCleanup(Context context, Integer parameter) {
+        // never clean anything up
+        return 0;
+    }
+
+    @Override
+    public Integer getDefaultCleanupParameter() {
+        return 0;
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APNullCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APNullCleanupAlgorithm.java
@@ -1,14 +1,19 @@
 package de.danoeh.antennapod.core.storage;
 
 import android.content.Context;
+import android.util.Log;
 
 /**
  * A cleanup algorithm that never removes anything
  */
 public class APNullCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+
+    private static final String TAG = "APNullCleanupAlgorithm";
+
     @Override
     public int performCleanup(Context context, Integer parameter) {
         // never clean anything up
+        Log.i(TAG, "performCleanup: Not removing anything");
         return 0;
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APNullCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APNullCleanupAlgorithm.java
@@ -6,19 +6,19 @@ import android.util.Log;
 /**
  * A cleanup algorithm that never removes anything
  */
-public class APNullCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+public class APNullCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
     private static final String TAG = "APNullCleanupAlgorithm";
 
     @Override
-    public int performCleanup(Context context, Integer parameter) {
+    public int performCleanup(Context context, int parameter) {
         // never clean anything up
         Log.i(TAG, "performCleanup: Not removing anything");
         return 0;
     }
 
     @Override
-    public Integer getDefaultCleanupParameter() {
+    public int getDefaultCleanupParameter() {
         return 0;
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -74,6 +74,6 @@ public class APQueueCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
     @Override
     public int getDefaultCleanupParameter() {
-        return 0;
+        return getNumEpisodesToCleanup(0);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -18,12 +18,12 @@ import de.danoeh.antennapod.core.util.LongList;
  * A cleanup algorithm that removes any item that isn't in the queue and isn't a favorite
  * but only if space is needed.
  */
-public class APQueueCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+public class APQueueCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
     private static final String TAG = "APQueueCleanupAlgorithm";
 
     @Override
-    public int performCleanup(Context context, Integer numberOfEpisodesToDelete) {
+    public int performCleanup(Context context, int numberOfEpisodesToDelete) {
         List<FeedItem> candidates = new ArrayList<>();
         List<FeedItem> downloadedItems = DBReader.getDownloadedItems();
         LongList queue = DBReader.getQueueIDList();
@@ -73,7 +73,7 @@ public class APQueueCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer>
     }
 
     @Override
-    public Integer getDefaultCleanupParameter() {
+    public int getDefaultCleanupParameter() {
         return 0;
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -26,10 +26,12 @@ public class APQueueCleanupAlgorithm extends EpisodeCleanupAlgorithm {
     public int performCleanup(Context context, int numberOfEpisodesToDelete) {
         List<FeedItem> candidates = new ArrayList<>();
         List<FeedItem> downloadedItems = DBReader.getDownloadedItems();
-        LongList queue = DBReader.getQueueIDList();
         List<FeedItem> delete;
         for (FeedItem item : downloadedItems) {
-            if (!queue.contains(item.getId())) {
+            if (item.hasMedia()
+                    && item.getMedia().isDownloaded()
+                    && !item.isTagged(FeedItem.TAG_QUEUE)
+                    && !item.isTagged(FeedItem.TAG_FAVORITE)) {
                 candidates.add(item);
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -1,0 +1,19 @@
+package de.danoeh.antennapod.core.storage;
+
+import android.content.Context;
+
+/**
+ * A cleanup algorithm that removes any item that isn't in the queue and isn't a favorite
+ * but only if space is needed.
+ */
+public class APQueueCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+    @Override
+    public int performCleanup(Context context, Integer parameter) {
+        return 0;
+    }
+
+    @Override
+    public Integer getDefaultCleanupParameter() {
+        return 0;
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -1,15 +1,75 @@
 package de.danoeh.antennapod.core.storage;
 
 import android.content.Context;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.util.LongList;
 
 /**
  * A cleanup algorithm that removes any item that isn't in the queue and isn't a favorite
  * but only if space is needed.
  */
 public class APQueueCleanupAlgorithm implements EpisodeCleanupAlgorithm<Integer> {
+
+    private static final String TAG = "APQueueCleanupAlgorithm";
+
     @Override
-    public int performCleanup(Context context, Integer parameter) {
-        return 0;
+    public int performCleanup(Context context, Integer numberOfEpisodesToDelete) {
+        List<FeedItem> candidates = new ArrayList<>();
+        List<FeedItem> downloadedItems = DBReader.getDownloadedItems();
+        LongList queue = DBReader.getQueueIDList();
+        List<FeedItem> delete;
+        for (FeedItem item : downloadedItems) {
+            if (!queue.contains(item.getId())) {
+                candidates.add(item);
+            }
+        }
+
+        // in the absence of better data, we'll sort by item publication date
+        Collections.sort(candidates, (lhs, rhs) -> {
+            Date l = lhs.getPubDate();
+            Date r = rhs.getPubDate();
+
+            if (l == null) {
+                l = new Date();
+            }
+            if (r == null) {
+                r = new Date();
+            }
+            return l.compareTo(r);
+        });
+
+        if (candidates.size() > numberOfEpisodesToDelete) {
+            delete = candidates.subList(0, numberOfEpisodesToDelete);
+        } else {
+            delete = candidates;
+        }
+
+        for (FeedItem item : delete) {
+            try {
+                DBWriter.deleteFeedMediaOfItem(context, item.getMedia().getId()).get();
+            } catch (InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+
+        int counter = delete.size();
+
+
+        Log.i(TAG, String.format(
+                "Auto-delete deleted %d episodes (%d requested)", counter,
+                numberOfEpisodesToDelete));
+
+        return counter;
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -334,7 +334,7 @@ public final class DBTasks {
                     ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm()
                             .performCleanup(context,
                                     ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm()
-                                            .getPerformCleanupParameter(Arrays.asList(items)));
+                                            .getPerformCleanupParameter(items.length));
                 }
 
             }.start();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -332,9 +332,7 @@ public final class DBTasks {
                 @Override
                 public void run() {
                     ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm()
-                            .performCleanup(context,
-                                    ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm()
-                                            .getPerformCleanupParameter(items.length));
+                            .makeRoomForEpisodes(context, items.length);
                 }
 
             }.start();
@@ -390,8 +388,7 @@ public final class DBTasks {
      * @param context Used for accessing the DB.
      */
     public static void performAutoCleanup(final Context context) {
-        ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm().performCleanup(context,
-                ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm().getDefaultCleanupParameter());
+        ClientConfig.dbTasksCallbacks.getEpisodeCacheCleanupAlgorithm().performCleanup(context);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/EpisodeCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/EpisodeCleanupAlgorithm.java
@@ -17,20 +17,12 @@ public interface EpisodeCleanupAlgorithm<T> {
      *                  or getPerformCleanupParameter.
      * @return The number of episodes that were deleted.
      */
-    public int performCleanup(Context context, T parameter);
+    int performCleanup(Context context, T parameter);
 
     /**
      * Returns a parameter for performCleanup. The implementation of this interface should decide how much
      * space to free to satisfy the episode cache conditions. If the conditions are already satisfied, this
      * method should not have any effects.
      */
-    public T getDefaultCleanupParameter();
-
-    /**
-     * Returns a parameter for performCleanup.
-     *
-     * @param items A list of FeedItems that are about to be downloaded. The implementation of this interface
-     *              should decide how much space to free to satisfy the episode cache conditions.
-     */
-    public T getPerformCleanupParameter(List<FeedItem> items);
+    T getDefaultCleanupParameter();
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -790,6 +790,21 @@ public class PodDBAdapter {
         db.execSQL(sql);
     }
 
+    public void setFavorites(List<FeedItem> favorites) {
+        ContentValues values = new ContentValues();
+        db.beginTransaction();
+        db.delete(TABLE_NAME_FAVORITES, null, null);
+        for (int i = 0; i < favorites.size(); i++) {
+            FeedItem item = favorites.get(i);
+            values.put(KEY_ID, i);
+            values.put(KEY_FEEDITEM, item.getId());
+            values.put(KEY_FEED, item.getFeed().getId());
+            db.insertWithOnConflict(TABLE_NAME_FAVORITES, null, values, SQLiteDatabase.CONFLICT_REPLACE);
+        }
+        db.setTransactionSuccessful();
+        db.endTransaction();
+    }
+
     /**
      * Adds the item to favorites
      */

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -44,12 +44,31 @@
         <item>100</item>
         <item>@string/pref_episode_cache_unlimited</item>
     </string-array>
+
     <string-array name="episode_cache_size_values">
         <item>5</item>
         <item>10</item>
         <item>25</item>
         <item>50</item>
         <item>100</item>
+        <item>-1</item>
+    </string-array>
+
+    <string-array name="episode_cleanup_entries">
+        <item>@string/episode_cleanup_immediately</item>
+        <item>1</item>
+        <item>3</item>
+        <item>5</item>
+        <item>7</item>
+        <item>@string/episode_cleanup_never</item>
+    </string-array>
+
+    <string-array name="episode_cleanup_values">
+        <item>0</item>
+        <item>1</item>
+        <item>3</item>
+        <item>5</item>
+        <item>7</item>
         <item>-1</item>
     </string-array>
 

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -55,7 +55,8 @@
     </string-array>
 
     <string-array name="episode_cleanup_entries">
-        <item>@string/episode_cleanup_immediately</item>
+        <item>@string/episode_cleanup_queue_removal</item>
+        <item>0</item>
         <item>1</item>
         <item>3</item>
         <item>5</item>
@@ -64,12 +65,13 @@
     </string-array>
 
     <string-array name="episode_cleanup_values">
+        <item>-1</item>
         <item>0</item>
         <item>1</item>
         <item>3</item>
         <item>5</item>
         <item>7</item>
-        <item>-1</item>
+        <item>-2</item>
     </string-array>
 
     <string-array name="playback_speed_values">

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="feed_auto_download_always">Always</string>
     <string name="feed_auto_download_never">Never</string>
     <string name="send_label">Send...</string>
+    <string name="episode_cleanup_never">Never</string>
+    <string name="episode_cleanup_immediately">when not in queue</string>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>
@@ -266,6 +268,8 @@
     <string name="queue_label">Queue</string>
     <string name="services_label">Services</string>
     <string name="flattr_label">Flattr</string>
+    <string name="pref_episode_cleanup_title">Episode Cleanup</string>
+    <string name="pref_episode_cleanup_summary">Episodes that aren\'t in the queue and aren\'t favorites should be eligible for removal if space is needed</string>
     <string name="pref_pauseOnHeadsetDisconnect_sum">Pause playback when the headphones are disconnected</string>
     <string name="pref_unpauseOnHeadsetReconnect_sum">Resume playback when the headphones are reconnected</string>
     <string name="pref_followQueue_sum">Jump to next queue item when playback completes</string>
@@ -417,6 +421,10 @@
         <item quantity="other">%d hours</item>
     </plurals>
 
+    <plurals name="time_days_quantified">
+        <item quantity="one">1 day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
     <!-- gpodder.net -->
     <string name="gpodnet_taglist_header">CATEGORIES</string>
     <string name="gpodnet_toplist_header">TOP PODCASTS</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -87,7 +87,12 @@
     <string name="feed_auto_download_never">Never</string>
     <string name="send_label">Send...</string>
     <string name="episode_cleanup_never">Never</string>
-    <string name="episode_cleanup_immediately">when not in queue</string>
+    <string name="episode_cleanup_queue_removal">When not in queue</string>
+    <string name="episode_cleanup_after_listening">After listening</string>
+    <plurals name="episode_cleanup_days_after_listening">
+        <item quantity="one">1 day after listening</item>
+        <item quantity="other">%d days after listening</item>
+    </plurals>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>
@@ -421,10 +426,6 @@
         <item quantity="other">%d hours</item>
     </plurals>
 
-    <plurals name="time_days_quantified">
-        <item quantity="one">1 day</item>
-        <item quantity="other">%d days</item>
-    </plurals>
     <!-- gpodder.net -->
     <string name="gpodnet_taglist_header">CATEGORIES</string>
     <string name="gpodnet_toplist_header">TOP PODCASTS</string>


### PR DESCRIPTION
Here I am on my vacation submitting updates...

fixes #1234 and fixes #1060 

Preferences now has an 'Episode Cleanup' option that allows the user to specify how they want their episodes removed or deleted. The default is "if it isn't in the queue or favorites then it is eligible to be deleted if stuff needs to be downloaded".  However the user may override this and choose some other other setting.  They may choose "never' or any of 0, 1, 3, 5, and 7 days after the episode has completed playback.

I'm open to any suggestions on how/if things should be reworded.

I'm also willing to entertain some sort of indicator on an episode (perhaps in Completed Downloads) that shows it is eligible for deletion.  I have *no* idea what that indicator should look like though.

I also went through and fixed the PreferencesTest which wasn't checking the results of waitForCondition().

![device-2015-10-02-165820](https://cloud.githubusercontent.com/assets/5216560/10257690/df66355e-6926-11e5-9ff2-75c2ad425fc3.png)
![device-2015-10-02-165824](https://cloud.githubusercontent.com/assets/5216560/10257691/df683d54-6926-11e5-9f66-54da15604455.png)
