### PR TITLE
Cleanup when we show the mark as played/unplayed menus.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -100,10 +100,9 @@ public class FeedItemMenuHandler {
             mi.setItemVisibility(R.id.share_download_url_with_position_item, false);
         }
 
-        if (!(state == FeedItem.State.UNREAD || state == FeedItem.State.IN_PROGRESS)) {
+        if (selectedItem.isPlayed()) {
             mi.setItemVisibility(R.id.mark_read_item, false);
-        }
-        if (!(state == FeedItem.State.IN_PROGRESS || state == FeedItem.State.READ)) {
+        } else {
             mi.setItemVisibility(R.id.mark_unread_item, false);
         }
 


### PR DESCRIPTION
I think the logic we had previously might have been overly complicated.  If an item isn't played, you can now mark it played.  If it is played you can mark it unplayed.

fixes #1252 