### PR TITLE
prevent NPE when 'chapters' is null

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/ChapterListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ChapterListAdapter.java
@@ -163,9 +163,11 @@ public class ChapterListAdapter extends ArrayAdapter<Chapter> {
 	public int getCount() {
 		// ignore invalid chapters
 		int counter = 0;
-		for (Chapter chapter : chapters) {
-			if (!ignoreChapter(chapter)) {
-				counter++;
+		if (chapters != null) {
+			for (Chapter chapter : chapters) {
+				if (!ignoreChapter(chapter)) {
+					counter++;
+				}
 			}
 		}
 		return counter;


### PR DESCRIPTION
merging the fix from #1202 in to develop.  #1198 still needs to be merged in, but that's slightly more complicated since the problem file in question has been moved to a different library.  Perhaps @mfietz can deal with that?

refs #1225.