### PR TITLE
Prevent NPE in MainActivity.onContextItemSelected()

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -551,8 +551,11 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
             menuInfo = lastMenuInfo;
         }
 
-        if(menuInfo.targetView.getParent() instanceof ListView == false
-                || ((ListView)menuInfo.targetView.getParent()).getId() != R.id.nav_list) {
+        if(menuInfo == null
+            || menuInfo.targetView == null
+            || menuInfo.targetView.getParent() == null
+            || menuInfo.targetView.getParent() instanceof ListView == false
+            || ((ListView)menuInfo.targetView.getParent()).getId() != R.id.nav_list) {
             return false;
         }
         final int position = menuInfo.position;


### PR DESCRIPTION
Fixes #1293

Checking menuInfo for null should be enough, but I wanted to make sure there isn't another NPE around the corner, so we now just check everything for null