### PR TITLE
Fix "Could not find com.afollestad:material-dialogs:0.7.8.0" error.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'io.reactivex:rxandroid:1.0.1'
     compile 'com.joanzapata.iconify:android-iconify-fontawesome:2.0.3'
-    compile 'com.afollestad:material-dialogs:0.7.8.0'
+    compile 'com.afollestad:material-dialogs:0.7.8.1'
 
     compile 'com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0.2'
 


### PR DESCRIPTION
material-dialogs:0.7.8.0 can't be downloaded but it seems that things work fine with 0.7.8.1. It seems simple enough to upgrade the dependency here.