### PR TITLE
Fix datetime parsing StringIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -88,9 +88,13 @@ public class DateUtils {
         for(String pattern : patterns) {
             parser.applyPattern(pattern);
             pos.setIndex(0);
-            Date result = parser.parse(date, pos);
-            if(result != null && pos.getIndex() == date.length()) {
-                return result;
+            try {
+                Date result = parser.parse(date, pos);
+                if (result != null && pos.getIndex() == date.length()) {
+                    return result;
+                }
+            } catch(Exception e) {
+                Log.e(TAG, Log.getStackTraceString(e));
             }
         }
 


### PR DESCRIPTION
Fixes #1301 

I figured, parsing is not that critical, so whenever the VM feels like throwing an exception, we should basically just ignore it.
Catching ``StringIndexOutOfBoundsException`` should actually be enough, but better safe than sorry. The app should not crash because some publication date might be displayed incorrectly.