### PR TITLE
Feed Remover: Don't let the user cancel the ProgressDialog

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/FeedRemover.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/FeedRemover.java
@@ -3,14 +3,13 @@ package de.danoeh.antennapod.core.asynctask;
 import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnCancelListener;
 import android.os.AsyncTask;
+
+import java.util.concurrent.ExecutionException;
+
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.storage.DBWriter;
-
-import java.util.concurrent.ExecutionException;
 
 /** Removes a feed in the background. */
 public class FeedRemover extends AsyncTask<Void, Void, Void> {
@@ -35,12 +34,7 @@ public class FeedRemover extends AsyncTask<Void, Void, Void> {
         }
         return null;
 	}
-
-	@Override
-	protected void onCancelled() {
-		dialog.dismiss();
-	}
-
+	
 	@Override
 	protected void onPostExecute(Void result) {
 		dialog.dismiss();
@@ -50,15 +44,8 @@ public class FeedRemover extends AsyncTask<Void, Void, Void> {
 	protected void onPreExecute() {
 		dialog = new ProgressDialog(context);
 		dialog.setMessage(context.getString(R.string.feed_remover_msg));
-		dialog.setOnCancelListener(new OnCancelListener() {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				cancel(true);
-
-			}
-
-		});
+		dialog.setIndeterminate(true);
+		dialog.setCancelable(false);
 		dialog.show();
 	}
 


### PR DESCRIPTION
Resolves #1304

Also considered using an IntentService or another background class.
Problem: At least two activities and one fragment react to the completed deletion in similar, but different ways. An IntentService could just send ProgressEvents, but the MainActivity would need some mechanism to find out what ("FeedRemover") actually completed.
This might not be the cleanest solution, but it should prevent the exception. One could also argue that changing only as little as possible to fix the issue is good ^^