### PR TITLE
Google Store description: Tagline + player

### DIFF
--- a/description/en.txt
+++ b/description/en.txt
@@ -1,10 +1,12 @@
-AntennaPod is a podcast manager that gives you instant access to millions of free and paid podcasts, from independent podcasters to large publishing houses such as the BBC, NPR and CNN. Add, import and export their feeds hassle-free using the iTunes podcast database, OPML files or simple RSS URLs. Save effort, battery power and mobile data usage with powerful automation controls for downloading episodes (specify times, intervals and WiFi networks) and deleting episodes (based your favourites and delay settings).<br>
+Easy-to-use, flexible and open-source podcast manager and player
+
+AntennaPod is a podcast manager and player that gives you instant access to millions of free and paid podcasts, from independent podcasters to large publishing houses such as the BBC, NPR and CNN. Add, import and export their feeds hassle-free using the iTunes podcast database, OPML files or simple RSS URLs. Save effort, battery power and mobile data usage with powerful automation controls for downloading episodes (specify times, intervals and WiFi networks) and deleting episodes (based your favourites and delay settings).<br>
 But most importantly: Download, stream or queue episodes and enjoy them the way you like with adjustable playback speeds, chapter support and a sleep timer. You can even show your love to the content creators  with our Flattr integration.
 
 Made by podcast-enthousiast, AntennaPod is free in all senses of the word: open source, no costs, no ads.
 
 <b>All features:</b><br>
-IMPORT, MANAGE AND PLAY<br>
+IMPORT, ORGANISE AND PLAY<br>
 &#8226; Add and import feeds via the iTunes and gPodder.net directories, OPML files and RSS or Atom links<br>
 &#8226; Manage playback from anywhere: homescreen widget, system notification and earplug and bluetooth controls<br>
 &#8226; Enjoy listening your way with adjustable playback speed, chapter support (MP3, VorbisComment and Podlove), remembered playback position and an advanced sleep timer (shake to reset, lower volume and slow down playback)<br>

--- a/description/en.txt
+++ b/description/en.txt
@@ -6,7 +6,7 @@ But most importantly: Download, stream or queue episodes and enjoy them the way 
 Made by podcast-enthousiast, AntennaPod is free in all senses of the word: open source, no costs, no ads.
 
 <b>All features:</b><br>
-IMPORT, ORGANISE AND PLAY<br>
+IMPORT, ORGANIZE AND PLAY<br>
 &#8226; Add and import feeds via the iTunes and gPodder.net directories, OPML files and RSS or Atom links<br>
 &#8226; Manage playback from anywhere: homescreen widget, system notification and earplug and bluetooth controls<br>
 &#8226; Enjoy listening your way with adjustable playback speed, chapter support (MP3, VorbisComment and Podlove), remembered playback position and an advanced sleep timer (shake to reset, lower volume and slow down playback)<br>


### PR DESCRIPTION
Re-added accidentally removed Play Store tagline for mobile devices (the "Short description").
Added word 'player' in first sentence; most apps call themselves podcasting player. Hopefully improves Google Play Store listing a bit.