### PR TITLE
Prefer iTunes image over everything else

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
@@ -1,10 +1,11 @@
 package de.danoeh.antennapod.core.syndication.namespace;
 
-import de.danoeh.antennapod.core.feed.FeedImage;
-import de.danoeh.antennapod.core.syndication.handler.HandlerState;
 import org.xml.sax.Attributes;
 
 import java.util.concurrent.TimeUnit;
+
+import de.danoeh.antennapod.core.feed.FeedImage;
+import de.danoeh.antennapod.core.syndication.handler.HandlerState;
 
 public class NSITunes extends Namespace {
     public static final String NSTAG = "itunes";
@@ -34,10 +35,9 @@ public class NSITunes extends Namespace {
 
             } else  {
                 // this is the feed image
-                if (state.getFeed().getImage() == null) {
-                    image.setOwner(state.getFeed());
-                    state.getFeed().setImage(image);
-                }
+                // prefer to all other images
+                image.setOwner(state.getFeed());
+                state.getFeed().setImage(image);
             }
 
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import org.xml.sax.Attributes;
 
 import de.danoeh.antennapod.core.BuildConfig;
+import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedImage;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
@@ -73,8 +74,11 @@ public class NSRSS20 extends Namespace {
 			if (state.getTagstack().size() >= 1) {
 				String parent = state.getTagstack().peek().getName();
 				if (parent.equals(CHANNEL)) {
-					state.getFeed().setImage(new FeedImage());
-                    state.getFeed().getImage().setOwner(state.getFeed());
+					Feed feed = state.getFeed();
+					if(feed.getImage() == null) {
+						feed.setImage(new FeedImage());
+						feed.getImage().setOwner(state.getFeed());
+					}
 				}
 			}
 		}
@@ -126,7 +130,9 @@ public class NSRSS20 extends Namespace {
 					state.getFeed().setTitle(title);
 				} else if (second.equals(IMAGE) && third != null
 						&& third.equals(CHANNEL)) {
-					state.getFeed().getImage().setTitle(title);
+					if(state.getFeed().getImage().getTitle() == null) {
+						state.getFeed().getImage().setTitle(title);
+					}
 				}
 			} else if (top.equals(LINK)) {
 				if (second.equals(CHANNEL)) {
@@ -139,7 +145,9 @@ public class NSRSS20 extends Namespace {
 						DateUtils.parse(content));
 			} else if (top.equals(URL) && second.equals(IMAGE) && third != null
 					&& third.equals(CHANNEL)) {
-				state.getFeed().getImage().setDownload_url(content);
+				if(state.getFeed().getImage().getDownload_url() == null) { // prefer itunes:image
+					state.getFeed().getImage().setDownload_url(content);
+				}
 			} else if (localName.equals(DESCR)) {
 				if (second.equals(CHANNEL)) {
 					state.getFeed().setDescription(content);

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -199,7 +199,9 @@ public class NSAtom extends Namespace {
                             DateUtils.parse(content));
                 }
             } else if (top.equals(IMAGE)) {
-                state.getFeed().setImage(new FeedImage(state.getFeed(), content, null));
+                if(state.getFeed().getImage() == null) {
+                    state.getFeed().setImage(new FeedImage(state.getFeed(), content, null));
+                }
             }
 
         }


### PR DESCRIPTION
Problem: RSS feeds often have both an image tag and itunes:image tag. In my experience, the "normal" image tag often points nowhere or not to the image we want. The itunes tag is usually right.

Thus, we should prefer the itunes:image tag to the other tags and only use those as a fallback when the itunes tag is not present.

This is a partial solution to #1332, which might not even be a real problem after all.