### PR TITLE
ItemFragmentList: Exception when deleting current feed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -278,7 +278,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         }
     }
 
-    public void loadFragment(final String tag, Bundle args) {
+    public void loadFragment(String tag, Bundle args) {
         Log.d(TAG, "loadFragment(tag: " + tag + ", args: " + args + ")");
         Fragment fragment = null;
         switch (tag) {
@@ -299,7 +299,9 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
                 break;
             default:
                 // default to the queue
+                tag = QueueFragment.TAG;
                 fragment = new QueueFragment();
+                args = null;
                 break;
         }
         currentTitle = navAdapter.getLabel(tag);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -274,7 +274,7 @@ public class ItemlistFragment extends ListFragment {
                                 @Override
                                 protected void onPostExecute(Void result) {
                                     super.onPostExecute(result);
-                                    ((MainActivity) getActivity()).loadFragment(NewEpisodesFragment.TAG, null);
+                                    ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null);
                                 }
                             };
                             ConfirmationDialog conDialog = new ConfirmationDialog(getActivity(),


### PR DESCRIPTION
Fixes #1358

```
java.lang.ArrayIndexOutOfBoundsException: length=5; index=-1
	at de.danoeh.antennapod.adapter.NavListAdapter.getLabel(NavListAdapter.java:86)
	at de.danoeh.antennapod.activity.MainActivity.loadFragment(MainActivity.java:305)
	at de.danoeh.antennapod.fragment.ItemlistFragment$3.onPostExecute(ItemlistFragment.java:277)
	at de.danoeh.antennapod.fragment.ItemlistFragment$3.onPostExecute(ItemlistFragment.java:273)
	at android.os.AsyncTask.finish(AsyncTask.java:636)
	at android.os.AsyncTask.access$500(AsyncTask.java:177)
	at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:653)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:135)
	at android.app.ActivityThread.main(ActivityThread.java:5278)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:375)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:904)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:699)
```

When deleting the feed, the ItemlistFragment would try to load the NewEpisodesFragment which is not reachable from the drawer.