### PR TITLE
Rating Dialog

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -9,6 +9,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.database.DataSetObserver;
 import android.media.AudioManager;
+import android.media.Rating;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -54,6 +55,7 @@ import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.StorageUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
+import de.danoeh.antennapod.dialog.RatingDialog;
 import de.danoeh.antennapod.fragment.AddFeedFragment;
 import de.danoeh.antennapod.fragment.DownloadsFragment;
 import de.danoeh.antennapod.fragment.EpisodesFragment;
@@ -452,6 +454,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         super.onStart();
         EventDistributor.getInstance().register(contentUpdate);
         EventBus.getDefault().register(this);
+        RatingDialog.init(this);
     }
 
     @Override
@@ -469,8 +472,8 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
                 (intent.hasExtra(EXTRA_NAV_INDEX) || intent.hasExtra(EXTRA_FRAGMENT_TAG))) {
             handleNavIntent();
         }
-
         loadData();
+        RatingDialog.check();
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/dialog/RatingDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/RatingDialog.java
@@ -1,0 +1,136 @@
+package de.danoeh.antennapod.dialog;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
+
+import de.danoeh.antennapod.R;
+
+public class RatingDialog {
+
+    private static final String TAG = RatingDialog.class.getSimpleName();
+    private static final int AFTER_DAYS = 7;
+
+    private static WeakReference<Context> mContext;
+    private static SharedPreferences mPreferences;
+    private static Dialog mDialog;
+
+    private static final String PREFS_NAME = "RatingPrefs";
+    private static final String KEY_RATED = "KEY_WAS_RATED";
+    private static final String KEY_FIRST_START_DATE = "KEY_FIRST_HIT_DATE";
+
+    public static void init(Context context) {
+        mContext = new WeakReference<>(context);
+        mPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+
+        long firstDate = mPreferences.getLong(KEY_FIRST_START_DATE, 0);
+        if (firstDate == 0) {
+            resetStartDate();
+        }
+    }
+
+    public static void check() {
+        if (mDialog != null && mDialog.isShowing()) {
+            return;
+        }
+        if (shouldShow()) {
+            try {
+                mDialog = createDialog();
+                if (mDialog != null) {
+                    mDialog.show();
+                }
+            } catch (Exception e) {
+                Log.e(TAG, Log.getStackTraceString(e));
+            }
+        }
+    }
+
+    public static void rateNow() {
+        Context context = mContext.get();
+        if(context == null) {
+            return;
+        }
+        final String appPackage = "de.danoeh.antennapod";
+        final Uri uri = Uri.parse("https://play.google.com/store/apps/details?id=" + appPackage);
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+        saveRated();
+    }
+
+    public static boolean rated() {
+        return mPreferences.getBoolean(KEY_RATED, false);
+    }
+
+    public static void saveRated() {
+        mPreferences
+                .edit()
+                .putBoolean(KEY_RATED, true)
+                .apply();
+    }
+
+    private static void resetStartDate() {
+        mPreferences
+                .edit()
+                .putLong(KEY_FIRST_START_DATE, System.currentTimeMillis())
+                .apply();
+    }
+
+    private static boolean shouldShow() {
+        if (rated()) {
+            return false;
+        }
+
+        long now = System.currentTimeMillis();
+        long firstDate = mPreferences.getLong(KEY_FIRST_START_DATE, now);
+        long diff = now - firstDate;
+        long diffDays = TimeUnit.DAYS.convert(diff, TimeUnit.MILLISECONDS);
+        if (diffDays >= AFTER_DAYS) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Nullable
+    private static MaterialDialog createDialog() {
+        Context context = mContext.get();
+        if(context == null) {
+            return null;
+        }
+        MaterialDialog dialog = new MaterialDialog.Builder(context)
+                .title(R.string.rating_title)
+                .content(R.string.rating_message)
+                .positiveText(R.string.rating_now_label)
+                .negativeText(R.string.rating_never_label)
+                .neutralText(R.string.rating_later_label)
+                .callback(new MaterialDialog.ButtonCallback() {
+                    @Override
+                    public void onPositive(MaterialDialog dialog) {
+                        rateNow();
+                    }
+
+                    @Override
+                    public void onNegative(MaterialDialog dialog) {
+                        saveRated();
+                    }
+
+                    @Override
+                    public void onNeutral(MaterialDialog dialog) {
+                        resetStartDate();
+                    }
+                })
+                .cancelListener(dialog1 -> resetStartDate())
+                .build();
+        return dialog;
+    }
+}

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -536,4 +536,12 @@
     <string name="sort_date_old_new">Date (Old \u2192 New)</string>
     <string name="sort_duration_short_long">Duration (Short \u2192 Long)</string>
     <string name="sort_duration_long_short">Duration (Long \u2192 Short)</string>
+
+    <!-- Rating dialog -->
+    <string name="rating_title">Like AntennaPod?</string>
+    <string name="rating_message">We would appreciate it if you take the time to rate AntennaPod.</string>
+    <string name="rating_never_label">Leave me alone</string>
+    <string name="rating_later_label">Remind me later</string>
+    <string name="rating_now_label">Sure, let\'s do this!</string>
+
 </resources>


### PR DESCRIPTION
7 days after the first app start (or 7 days after the upgrade):

![rating](https://cloud.githubusercontent.com/assets/6860662/11047868/efee6640-8734-11e5-8648-1b04f2eec80c.png)

If the user chooses remind me later, we wait another 7 days and show the dialog again.
