### PR TITLE
Play episodes in correct order after reordering

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -25,7 +25,6 @@ import android.widget.Toast;
 
 import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 
-import java.util.Collections;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
@@ -165,8 +164,12 @@ public class QueueFragment extends Fragment {
             case MOVED:
                 int from = FeedItemUtil.indexOfItemWithId(queue, event.item.getId());
                 int to = event.position;
-                queue.add(to, queue.remove(from));
-                recyclerAdapter.notifyItemMoved(from, to);
+                if(from != to) {
+                    queue.add(to, queue.remove(from));
+                    recyclerAdapter.notifyItemMoved(from, to);
+                } else {
+                    // QueueFragment itself sent the event and already moved the item
+                }
                 break;
         }
         onFragmentLoaded();
@@ -367,7 +370,7 @@ public class QueueFragment extends Fragment {
                     Log.d(TAG, "move(" + from + ", " + to + ")");
                     queue.add(to, queue.remove(from));
                     recyclerAdapter.notifyItemMoved(from, to);
-                    DBWriter.moveQueueItem(from, to, false);
+                    DBWriter.moveQueueItem(from, to, true);
                     return true;
                 }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -31,7 +31,7 @@ import de.greenrobot.event.EventBus;
  * to notify the PlaybackService about updates from the running tasks.
  */
 public class PlaybackServiceTaskManager {
-    private static final String TAG = "PlaybackServiceTaskManager";
+    private static final String TAG = "PlaybackServiceTaskMgr";
 
     /**
      * Update interval of position saver in milliseconds.
@@ -81,6 +81,7 @@ public class PlaybackServiceTaskManager {
     }
 
     public void onEvent(QueueEvent event) {
+        Log.d(TAG, "onEvent(QueueEvent " + event +")");
         cancelQueueLoader();
         loadQueue();
     }


### PR DESCRIPTION
Problem: The PlaybackServiceTaskManager would not reload its cached queue when the queue items are reordered.

Fixes #1386