### PR TITLE
Update feed URL when redirected

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -292,7 +292,8 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
     }
 
     public void updateFromOther(Feed other) {
-        super.updateFromOther(other);
+        // don't update feed's download_url, we do that manually if redirected
+        // see AntennapodHttpClient
         if (other.title != null) {
             title = other.title;
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
@@ -5,10 +5,14 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.internal.http.StatusLine;
 
 import java.io.IOException;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
+import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.security.GeneralSecurityException;
@@ -17,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+
+import de.danoeh.antennapod.core.storage.DBWriter;
 
 /**
  * Provides access to a HttpClient singleton.
@@ -57,6 +63,22 @@ public class AntennapodHttpClient {
         System.setProperty("http.maxConnections", String.valueOf(MAX_CONNECTIONS));
 
         OkHttpClient client = new OkHttpClient();
+
+        // detect 301 Moved permanently and 308 Permanent Redirect
+        client.networkInterceptors().add(chain -> {
+            Request request = chain.request();
+            Response response = chain.proceed(request);
+            if(response.code() == HttpURLConnection.HTTP_MOVED_PERM ||
+                    response.code() == StatusLine.HTTP_PERM_REDIRECT) {
+                String location = response.header("Location");
+                try {
+                    DBWriter.updateFeedDownloadURL(request.urlString(), location).get();
+                } catch (Exception e) {
+                    Log.e(TAG, Log.getStackTraceString(e));
+                }
+            }
+            return response;
+        });
 
         // set cookie handler
         CookieManager cm = new CookieManager();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -6,7 +6,6 @@ import android.database.Cursor;
 import android.util.Log;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -258,7 +257,7 @@ public final class DBTasks {
      */
     public static void refreshFeed(Context context, Feed feed)
             throws DownloadRequestException {
-        Log.d(TAG, "id " + feed.getId());
+        Log.d(TAG, "refreshFeed(feed.id: " + feed.getId() +")");
         refreshFeed(context, feed, false);
     }
 
@@ -431,7 +430,7 @@ public final class DBTasks {
         return queue.contains(feedItemId);
     }
 
-    private static Feed searchFeedByIdentifyingValueOrID(Context context, PodDBAdapter adapter,
+    private static Feed searchFeedByIdentifyingValueOrID(PodDBAdapter adapter,
                                                          Feed feed) {
         if (feed.getId() != 0) {
             return DBReader.getFeed(feed.getId(), adapter);
@@ -486,7 +485,7 @@ public final class DBTasks {
             final Feed newFeed = newFeeds[feedIdx];
 
             // Look up feed in the feedslist
-            final Feed savedFeed = searchFeedByIdentifyingValueOrID(context, adapter,
+            final Feed savedFeed = searchFeedByIdentifyingValueOrID(adapter,
                     newFeed);
             if (savedFeed == null) {
                 Log.d(TAG, "Found no existing Feed with title "

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -19,12 +19,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.asynctask.FlattrClickWorker;
 import de.danoeh.antennapod.core.event.FavoritesEvent;
@@ -382,7 +380,7 @@ public class DBWriter {
                                     events.add(QueueEvent.added(item, 0 + i));
                                 } else {
                                     queue.add(item);
-                                    events.add(QueueEvent.added(item, queue.size()-1));
+                                    events.add(QueueEvent.added(item, queue.size() - 1));
                                 }
                                 queueModified = true;
                                 if (item.isNew()) {
@@ -393,7 +391,7 @@ public class DBWriter {
                     }
                     if (queueModified) {
                         adapter.setQueue(queue);
-                        for(QueueEvent event : events) {
+                        for (QueueEvent event : events) {
                             EventBus.getDefault().post(event);
                         }
                         if (markAsUnplayedIds.size() > 0) {
@@ -785,19 +783,14 @@ public class DBWriter {
     }
 
     /**
-     * Updates download URLs of feeds from a given Map. The key of the Map is the original URL of the feed
-     * and the value is the updated URL
+     * Updates download URL of a feed
      */
-    public static Future<?> updateFeedDownloadURLs(final Map<String, String> urls) {
+    public static Future<?> updateFeedDownloadURL(final String original, final String updated) {
+        Log.d(TAG, "updateFeedDownloadURL(original: " + original + ", updated: " + updated +")");
         return dbExec.submit(() -> {
             PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
-            for (String key : urls.keySet()) {
-                if (BuildConfig.DEBUG)
-                    Log.d(TAG, "Replacing URL " + key + " with url " + urls.get(key));
-
-                adapter.setFeedDownloadUrl(key, urls.get(key));
-            }
+            adapter.setFeedDownloadUrl(original, updated);
             adapter.close();
         });
     }


### PR DESCRIPTION
Frankly, inceptor is not the only solution, but the easiest.

Another would be the HttpDownloader, but it gets far more complicated. We would have to check prior requests, if one of those was redirected. Then, the DownloadRequest source (download url) would have to be non-final. Next, we would have to check any code that used the DownloadRequest if it assumes the source field to be final and so on (e.g. when removing the requests from the current downloads).

I think it is easier to update the field when we encounter a redirect. I don't think there is any other reason for a feed URL to change, so we actually don't need to update a saved feed's URL when refreshing the same.