### PR TITLE
Replace DirectoryChooser with simple dialog listing all external directories

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compile("org.shredzone.flattr4j:flattr4j-core:$flattr4jVersion") {
         exclude group: "org.json", module: "json"
     }
+
     compile "commons-io:commons-io:$commonsioVersion"
     compile "org.jsoup:jsoup:$jsoupVersion"
     compile "com.github.bumptech.glide:glide:$glideVersion"

--- a/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod.activity;
 
 import android.app.Activity;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Environment;
@@ -15,23 +14,28 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.*;
-import android.widget.AdapterView.OnItemClickListener;
-import de.danoeh.antennapod.BuildConfig;
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ImageButton;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
+import de.danoeh.antennapod.BuildConfig;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+
 /**
  * Let's the user choose a directory on the storage device. The selected folder
  * will be sent back to the starting activity as an activity result.
  */
 public class DirectoryChooserActivity extends ActionBarActivity {
-	private static final String TAG = "DirectoryChooserActivity";
+	private static final String TAG = "DirectoryChooserActivit";
 
 	private static final String CREATE_DIRECTORY_NAME = "AntennaPod";
 
@@ -103,7 +107,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 		listDirectories.setOnItemClickListener((adapter, view, position, id) -> {
             Log.d(TAG, "Selected index: " + position);
-            if (filesInDir != null && position >= 0
+			if (filesInDir != null && position >= 0
                     && position < filesInDir.length) {
                 changeDirectory(filesInDir[position]);
             }
@@ -137,7 +141,7 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 			resultData.putExtra(RESULT_SELECTED_DIR,
 					selectedDir.getAbsolutePath());
 		}
-		setResult(RESULT_CODE_DIR_SELECTED, resultData);
+		setResult(Activity.RESULT_OK, resultData);
 		finish();
 	}
 
@@ -155,6 +159,13 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 		if (fileObserver != null) {
 			fileObserver.startWatching();
 		}
+	}
+
+	@Override
+	public void onStop() {
+		super.onStop();
+		listDirectoriesAdapter = null;
+		fileObserver = null;
 	}
 
 	/**
@@ -191,20 +202,15 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 				listDirectoriesAdapter.notifyDataSetChanged();
 				fileObserver = createFileObserver(dir.getAbsolutePath());
 				fileObserver.startWatching();
-				if (BuildConfig.DEBUG)
-					Log.d(TAG, "Changed directory to " + dir.getAbsolutePath());
+				Log.d(TAG, "Changed directory to " + dir.getAbsolutePath());
 			} else {
-				if (BuildConfig.DEBUG)
-					Log.d(TAG,
-							"Could not change folder: contents of dir were null");
+				Log.d(TAG, "Could not change folder: contents of dir were null");
 			}
 		} else {
 			if (dir == null) {
-				if (BuildConfig.DEBUG)
-					Log.d(TAG, "Could not change folder: dir was null");
+				Log.d(TAG, "Could not change folder: dir was null");
 			} else {
-				if (BuildConfig.DEBUG)
-					Log.d(TAG, "Could not change folder: dir is no directory");
+				Log.d(TAG, "Could not change folder: dir is no directory");
 			}
 		}
 		refreshButtonState();
@@ -235,15 +241,8 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 			@Override
 			public void onEvent(int event, String path) {
-				if (BuildConfig.DEBUG)
-					Log.d(TAG, "FileObserver received event " + event);
-				runOnUiThread(new Runnable() {
-
-					@Override
-					public void run() {
-						refreshDirectory();
-					}
-				});
+				Log.d(TAG, "FileObserver received event " + event);
+				runOnUiThread(() -> refreshDirectory());
 			}
 		};
 	}
@@ -292,25 +291,17 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 		builder.setMessage(String.format(getString(R.string.create_folder_msg),
 				CREATE_DIRECTORY_NAME));
 		builder.setNegativeButton(R.string.cancel_label,
-				new DialogInterface.OnClickListener() {
-
-					@Override
-					public void onClick(DialogInterface dialog, int which) {
-						dialog.dismiss();
-					}
-				});
+				(dialog, which) -> {
+                    dialog.dismiss();
+                });
 		builder.setPositiveButton(R.string.confirm_label,
-				new DialogInterface.OnClickListener() {
-
-					@Override
-					public void onClick(DialogInterface dialog, int which) {
-						dialog.dismiss();
-						int msg = createFolder();
-						Toast t = Toast.makeText(DirectoryChooserActivity.this,
-								msg, Toast.LENGTH_SHORT);
-						t.show();
-					}
-				});
+				(dialog, which) -> {
+                    dialog.dismiss();
+                    int msg = createFolder();
+                    Toast t = Toast.makeText(DirectoryChooserActivity.this,
+                            msg, Toast.LENGTH_SHORT);
+                    t.show();
+                });
 		builder.create().show();
 	}
 
@@ -340,7 +331,6 @@ public class DirectoryChooserActivity extends ActionBarActivity {
 
 	/** Returns true if the selected file or directory would be valid selection. */
 	private boolean isValidFile(File file) {
-		return (file != null && file.isDirectory() && file.canRead() && file
-				.canWrite());
+		return file != null && file.isDirectory() && file.canRead() && file.canWrite();
 	}
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/DirectoryChooserActivity.java
@@ -35,85 +35,85 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
  * will be sent back to the starting activity as an activity result.
  */
 public class DirectoryChooserActivity extends ActionBarActivity {
-	private static final String TAG = "DirectoryChooserActivit";
+    private static final String TAG = "DirectoryChooserActivit";
 
-	private static final String CREATE_DIRECTORY_NAME = "AntennaPod";
+    private static final String CREATE_DIRECTORY_NAME = "AntennaPod";
 
-	public static final String RESULT_SELECTED_DIR = "selected_dir";
-	public static final int RESULT_CODE_DIR_SELECTED = 1;
+    public static final String RESULT_SELECTED_DIR = "selected_dir";
+    public static final int RESULT_CODE_DIR_SELECTED = 1;
 
-	private Button butConfirm;
-	private Button butCancel;
-	private ImageButton butNavUp;
-	private TextView txtvSelectedFolder;
-	private ListView listDirectories;
+    private Button butConfirm;
+    private Button butCancel;
+    private ImageButton butNavUp;
+    private TextView txtvSelectedFolder;
+    private ListView listDirectories;
 
-	private ArrayAdapter<String> listDirectoriesAdapter;
-	private ArrayList<String> filenames;
-	/** The directory that is currently being shown. */
-	private File selectedDir;
-	private File[] filesInDir;
+    private ArrayAdapter<String> listDirectoriesAdapter;
+    private ArrayList<String> filenames;
+    /** The directory that is currently being shown. */
+    private File selectedDir;
+    private File[] filesInDir;
 
-	private FileObserver fileObserver;
+    private FileObserver fileObserver;
 
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		setTheme(UserPreferences.getTheme());
-		super.onCreate(savedInstanceState);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        setTheme(UserPreferences.getTheme());
+        super.onCreate(savedInstanceState);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-		setContentView(R.layout.directory_chooser);
-		butConfirm = (Button) findViewById(R.id.butConfirm);
-		butCancel = (Button) findViewById(R.id.butCancel);
-		butNavUp = (ImageButton) findViewById(R.id.butNavUp);
-		txtvSelectedFolder = (TextView) findViewById(R.id.txtvSelectedFolder);
-		listDirectories = (ListView) findViewById(R.id.directory_list);
+        setContentView(R.layout.directory_chooser);
+        butConfirm = (Button) findViewById(R.id.butConfirm);
+        butCancel = (Button) findViewById(R.id.butCancel);
+        butNavUp = (ImageButton) findViewById(R.id.butNavUp);
+        txtvSelectedFolder = (TextView) findViewById(R.id.txtvSelectedFolder);
+        listDirectories = (ListView) findViewById(R.id.directory_list);
 
-		butConfirm.setOnClickListener(new OnClickListener() {
+        butConfirm.setOnClickListener(new OnClickListener() {
 
-			@Override
-			public void onClick(View v) {
-				if (isValidFile(selectedDir)) {
-					if (selectedDir.list().length == 0) {
-						returnSelectedFolder();
-					} else {
-						showNonEmptyDirectoryWarning();
-					}
-				}
-			}
+            @Override
+            public void onClick(View v) {
+                if (isValidFile(selectedDir)) {
+                    if (selectedDir.list().length == 0) {
+                        returnSelectedFolder();
+                    } else {
+                        showNonEmptyDirectoryWarning();
+                    }
+                }
+            }
 
-			private void showNonEmptyDirectoryWarning() {
-				AlertDialog.Builder adb = new AlertDialog.Builder(
-						DirectoryChooserActivity.this);
-				adb.setTitle(R.string.folder_not_empty_dialog_title);
-				adb.setMessage(R.string.folder_not_empty_dialog_msg);
-				adb.setNegativeButton(R.string.cancel_label,
-						(dialog, which) -> {
+            private void showNonEmptyDirectoryWarning() {
+                AlertDialog.Builder adb = new AlertDialog.Builder(
+                        DirectoryChooserActivity.this);
+                adb.setTitle(R.string.folder_not_empty_dialog_title);
+                adb.setMessage(R.string.folder_not_empty_dialog_msg);
+                adb.setNegativeButton(R.string.cancel_label,
+                        (dialog, which) -> {
                             dialog.dismiss();
                         });
-				adb.setPositiveButton(R.string.confirm_label,
-						(dialog, which) -> {
+                adb.setPositiveButton(R.string.confirm_label,
+                        (dialog, which) -> {
                             dialog.dismiss();
                             returnSelectedFolder();
                         });
-				adb.create().show();
-			}
-		});
+                adb.create().show();
+            }
+        });
 
-		butCancel.setOnClickListener(v -> {
+        butCancel.setOnClickListener(v -> {
             setResult(Activity.RESULT_CANCELED);
             finish();
         });
 
-		listDirectories.setOnItemClickListener((adapter, view, position, id) -> {
+        listDirectories.setOnItemClickListener((adapter, view, position, id) -> {
             Log.d(TAG, "Selected index: " + position);
-			if (filesInDir != null && position >= 0
+            if (filesInDir != null && position >= 0
                     && position < filesInDir.length) {
                 changeDirectory(filesInDir[position]);
             }
         });
 
-		butNavUp.setOnClickListener(v -> {
+        butNavUp.setOnClickListener(v -> {
             File parent = null;
             if (selectedDir != null
                     && (parent = selectedDir.getParentFile()) != null) {
@@ -121,216 +121,216 @@ public class DirectoryChooserActivity extends ActionBarActivity {
             }
         });
 
-		filenames = new ArrayList<>();
-		listDirectoriesAdapter = new ArrayAdapter<>(this,
-				android.R.layout.simple_list_item_1, filenames);
-		listDirectories.setAdapter(listDirectoriesAdapter);
-		changeDirectory(Environment.getExternalStorageDirectory());
-	}
+        filenames = new ArrayList<>();
+        listDirectoriesAdapter = new ArrayAdapter<>(this,
+                android.R.layout.simple_list_item_1, filenames);
+        listDirectories.setAdapter(listDirectoriesAdapter);
+        changeDirectory(Environment.getExternalStorageDirectory());
+    }
 
-	/**
-	 * Finishes the activity and returns the selected folder as a result. The
-	 * selected folder can also be null.
-	 */
-	private void returnSelectedFolder() {
-		if (selectedDir != null && BuildConfig.DEBUG)
-			Log.d(TAG, "Returning " + selectedDir.getAbsolutePath()
-					+ " as result");
-		Intent resultData = new Intent();
-		if (selectedDir != null) {
-			resultData.putExtra(RESULT_SELECTED_DIR,
-					selectedDir.getAbsolutePath());
-		}
-		setResult(Activity.RESULT_OK, resultData);
-		finish();
-	}
+    /**
+     * Finishes the activity and returns the selected folder as a result. The
+     * selected folder can also be null.
+     */
+    private void returnSelectedFolder() {
+        if (selectedDir != null && BuildConfig.DEBUG)
+            Log.d(TAG, "Returning " + selectedDir.getAbsolutePath()
+                    + " as result");
+        Intent resultData = new Intent();
+        if (selectedDir != null) {
+            resultData.putExtra(RESULT_SELECTED_DIR,
+                    selectedDir.getAbsolutePath());
+        }
+        setResult(Activity.RESULT_OK, resultData);
+        finish();
+    }
 
-	@Override
-	protected void onPause() {
-		super.onPause();
-		if (fileObserver != null) {
-			fileObserver.stopWatching();
-		}
-	}
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if (fileObserver != null) {
+            fileObserver.stopWatching();
+        }
+    }
 
-	@Override
-	protected void onResume() {
-		super.onResume();
-		if (fileObserver != null) {
-			fileObserver.startWatching();
-		}
-	}
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (fileObserver != null) {
+            fileObserver.startWatching();
+        }
+    }
 
-	@Override
-	public void onStop() {
-		super.onStop();
-		listDirectoriesAdapter = null;
-		fileObserver = null;
-	}
+    @Override
+    public void onStop() {
+        super.onStop();
+        listDirectoriesAdapter = null;
+        fileObserver = null;
+    }
 
-	/**
-	 * Change the directory that is currently being displayed.
-	 * 
-	 * @param dir
-	 *            The file the activity should switch to. This File must be
-	 *            non-null and a directory, otherwise the displayed directory
-	 *            will not be changed
-	 */
-	private void changeDirectory(File dir) {
-		if (dir != null && dir.isDirectory()) {
-			File[] contents = dir.listFiles();
-			if (contents != null) {
-				int numDirectories = 0;
-				for (File f : contents) {
-					if (f.isDirectory()) {
-						numDirectories++;
-					}
-				}
-				filesInDir = new File[numDirectories];
-				filenames.clear();
-				for (int i = 0, counter = 0; i < numDirectories; counter++) {
-					if (contents[counter].isDirectory()) {
-						filesInDir[i] = contents[counter];
-						filenames.add(contents[counter].getName());
-						i++;
-					}
-				}
-				Arrays.sort(filesInDir);
-				Collections.sort(filenames);
-				selectedDir = dir;
-				txtvSelectedFolder.setText(dir.getAbsolutePath());
-				listDirectoriesAdapter.notifyDataSetChanged();
-				fileObserver = createFileObserver(dir.getAbsolutePath());
-				fileObserver.startWatching();
-				Log.d(TAG, "Changed directory to " + dir.getAbsolutePath());
-			} else {
-				Log.d(TAG, "Could not change folder: contents of dir were null");
-			}
-		} else {
-			if (dir == null) {
-				Log.d(TAG, "Could not change folder: dir was null");
-			} else {
-				Log.d(TAG, "Could not change folder: dir is no directory");
-			}
-		}
-		refreshButtonState();
-	}
+    /**
+     * Change the directory that is currently being displayed.
+     * 
+     * @param dir
+     *            The file the activity should switch to. This File must be
+     *            non-null and a directory, otherwise the displayed directory
+     *            will not be changed
+     */
+    private void changeDirectory(File dir) {
+        if (dir != null && dir.isDirectory()) {
+            File[] contents = dir.listFiles();
+            if (contents != null) {
+                int numDirectories = 0;
+                for (File f : contents) {
+                    if (f.isDirectory()) {
+                        numDirectories++;
+                    }
+                }
+                filesInDir = new File[numDirectories];
+                filenames.clear();
+                for (int i = 0, counter = 0; i < numDirectories; counter++) {
+                    if (contents[counter].isDirectory()) {
+                        filesInDir[i] = contents[counter];
+                        filenames.add(contents[counter].getName());
+                        i++;
+                    }
+                }
+                Arrays.sort(filesInDir);
+                Collections.sort(filenames);
+                selectedDir = dir;
+                txtvSelectedFolder.setText(dir.getAbsolutePath());
+                listDirectoriesAdapter.notifyDataSetChanged();
+                fileObserver = createFileObserver(dir.getAbsolutePath());
+                fileObserver.startWatching();
+                Log.d(TAG, "Changed directory to " + dir.getAbsolutePath());
+            } else {
+                Log.d(TAG, "Could not change folder: contents of dir were null");
+            }
+        } else {
+            if (dir == null) {
+                Log.d(TAG, "Could not change folder: dir was null");
+            } else {
+                Log.d(TAG, "Could not change folder: dir is no directory");
+            }
+        }
+        refreshButtonState();
+    }
 
-	/**
-	 * Changes the state of the buttons depending on the currently selected file
-	 * or folder.
-	 */
-	private void refreshButtonState() {
-		if (selectedDir != null) {
-			butConfirm.setEnabled(isValidFile(selectedDir));
-			supportInvalidateOptionsMenu();
-		}
-	}
+    /**
+     * Changes the state of the buttons depending on the currently selected file
+     * or folder.
+     */
+    private void refreshButtonState() {
+        if (selectedDir != null) {
+            butConfirm.setEnabled(isValidFile(selectedDir));
+            supportInvalidateOptionsMenu();
+        }
+    }
 
-	/** Refresh the contents of the directory that is currently shown. */
-	private void refreshDirectory() {
-		if (selectedDir != null) {
-			changeDirectory(selectedDir);
-		}
-	}
+    /** Refresh the contents of the directory that is currently shown. */
+    private void refreshDirectory() {
+        if (selectedDir != null) {
+            changeDirectory(selectedDir);
+        }
+    }
 
-	/** Sets up a FileObserver to watch the current directory. */
-	private FileObserver createFileObserver(String path) {
-		return new FileObserver(path, FileObserver.CREATE | FileObserver.DELETE
-				| FileObserver.MOVED_FROM | FileObserver.MOVED_TO) {
+    /** Sets up a FileObserver to watch the current directory. */
+    private FileObserver createFileObserver(String path) {
+        return new FileObserver(path, FileObserver.CREATE | FileObserver.DELETE
+                | FileObserver.MOVED_FROM | FileObserver.MOVED_TO) {
 
-			@Override
-			public void onEvent(int event, String path) {
-				Log.d(TAG, "FileObserver received event " + event);
-				runOnUiThread(() -> refreshDirectory());
-			}
-		};
-	}
+            @Override
+            public void onEvent(int event, String path) {
+                Log.d(TAG, "FileObserver received event " + event);
+                runOnUiThread(() -> refreshDirectory());
+            }
+        };
+    }
 
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu) {
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-		menu.findItem(R.id.new_folder_item)
-				.setVisible(isValidFile(selectedDir));
-		return true;
-	}
+        menu.findItem(R.id.new_folder_item)
+                .setVisible(isValidFile(selectedDir));
+        return true;
+    }
 
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-		MenuInflater inflater = getMenuInflater();
-		inflater.inflate(R.menu.directory_chooser, menu);
-		return true;
-	}
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.directory_chooser, menu);
+        return true;
+    }
 
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		switch (item.getItemId()) {
-		case android.R.id.home:
-			NavUtils.navigateUpFromSameTask(this);
-			return true;
-		case R.id.new_folder_item:
-			openNewFolderDialog();
-			return true;
-		case R.id.set_to_default_folder_item:
-			selectedDir = null;
-			returnSelectedFolder();
-			return true;
-		default:
-			return false;
-		}
-	}
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+        case android.R.id.home:
+            NavUtils.navigateUpFromSameTask(this);
+            return true;
+        case R.id.new_folder_item:
+            openNewFolderDialog();
+            return true;
+        case R.id.set_to_default_folder_item:
+            selectedDir = null;
+            returnSelectedFolder();
+            return true;
+        default:
+            return false;
+        }
+    }
 
-	/**
-	 * Shows a confirmation dialog that asks the user if he wants to create a
-	 * new folder.
-	 */
-	private void openNewFolderDialog() {
-		AlertDialog.Builder builder = new AlertDialog.Builder(this);
-		builder.setTitle(R.string.create_folder_label);
-		builder.setMessage(String.format(getString(R.string.create_folder_msg),
-				CREATE_DIRECTORY_NAME));
-		builder.setNegativeButton(R.string.cancel_label,
-				(dialog, which) -> {
+    /**
+     * Shows a confirmation dialog that asks the user if he wants to create a
+     * new folder.
+     */
+    private void openNewFolderDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(R.string.create_folder_label);
+        builder.setMessage(String.format(getString(R.string.create_folder_msg),
+                CREATE_DIRECTORY_NAME));
+        builder.setNegativeButton(R.string.cancel_label,
+                (dialog, which) -> {
                     dialog.dismiss();
                 });
-		builder.setPositiveButton(R.string.confirm_label,
-				(dialog, which) -> {
+        builder.setPositiveButton(R.string.confirm_label,
+                (dialog, which) -> {
                     dialog.dismiss();
                     int msg = createFolder();
                     Toast t = Toast.makeText(DirectoryChooserActivity.this,
                             msg, Toast.LENGTH_SHORT);
                     t.show();
                 });
-		builder.create().show();
-	}
+        builder.create().show();
+    }
 
-	/**
-	 * Creates a new folder in the current directory with the name
-	 * CREATE_DIRECTORY_NAME.
-	 */
-	private int createFolder() {
-		if (selectedDir == null) {
-			return R.string.create_folder_error;
-		} else if (selectedDir.canWrite()) {
-			File newDir = new File(selectedDir, CREATE_DIRECTORY_NAME);
-			if (!newDir.exists()) {
-				boolean result = newDir.mkdir();
-				if (result) {
-					return R.string.create_folder_success;
-				} else {
-					return R.string.create_folder_error;
-				}
-			} else {
-				return R.string.create_folder_error_already_exists;
-			}
-		} else {
-			return R.string.create_folder_error_no_write_access;
-		}
-	}
+    /**
+     * Creates a new folder in the current directory with the name
+     * CREATE_DIRECTORY_NAME.
+     */
+    private int createFolder() {
+        if (selectedDir == null) {
+            return R.string.create_folder_error;
+        } else if (selectedDir.canWrite()) {
+            File newDir = new File(selectedDir, CREATE_DIRECTORY_NAME);
+            if (!newDir.exists()) {
+                boolean result = newDir.mkdir();
+                if (result) {
+                    return R.string.create_folder_success;
+                } else {
+                    return R.string.create_folder_error;
+                }
+            } else {
+                return R.string.create_folder_error_already_exists;
+            }
+        } else {
+            return R.string.create_folder_error_no_write_access;
+        }
+    }
 
-	/** Returns true if the selected file or directory would be valid selection. */
-	private boolean isValidFile(File file) {
-		return file != null && file.isDirectory() && file.canRead() && file.canWrite();
-	}
+    /** Returns true if the selected file or directory would be valid selection. */
+    private boolean isValidFile(File file) {
+        return file != null && file.isDirectory() && file.canRead() && file.canWrite();
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -565,7 +565,7 @@ public class UserPreferences {
     }
 
     public static void setDataFolder(String dir) {
-        Log.d(TAG, "Result from DirectoryChooser: " + dir);
+        Log.d(TAG, "setDataFolder(dir: " + dir + ")");
         prefs.edit()
              .putString(PREF_DATA_FOLDER, dir)
              .apply();

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="playback_history_label">Playback History</string>
     <string name="gpodnet_main_label">gpodder.net</string>
     <string name="gpodnet_auth_label">gpodder.net Login</string>
+    <string name="free_space_label">"%1$s free</string>
 
     <!-- New episodes fragment -->
     <string name="recently_published_episodes_label">Recently published</string>
@@ -464,11 +465,15 @@
     <string name="selected_folder_label">Selected folder:</string>
     <string name="create_folder_label">Create folder</string>
     <string name="choose_data_directory">Choose Data Folder</string>
+    <string name="choose_data_directory_message">Please choose the base of your data folder. AntennaPod will create the appropriate sub-directories.</string>
     <string name="create_folder_msg">Create new folder with name "%1$s"?</string>
     <string name="create_folder_success">Created new folder</string>
     <string name="create_folder_error_no_write_access">Cannot write to this folder</string>
     <string name="create_folder_error_already_exists">Folder already exists</string>
     <string name="create_folder_error">Could not create folder</string>
+    <string name="folder_does_not_exist_error">"%1$s" does not exist</string>
+    <string name="folder_not_readable_error">"%1$s" is not readable</string>
+    <string name="folder_not_writable_error">"%1$s" is not writable</string>
     <string name="folder_not_empty_dialog_title">Folder is not empty</string>
     <string name="folder_not_empty_dialog_msg">The folder you have selected is not empty. Media downloads and other files will be placed directly in this folder. Continue anyway?</string>
     <string name="set_to_default_folder">Choose default folder</string>
@@ -477,6 +482,7 @@
     <string name="pref_resumeAfterCall_sum">Resume playback after a phone call completes</string>
     <string name="pref_resumeAfterCall_title">Resume after Call</string>
     <string name="pref_restart_required">AntennaPod has to be restarted for this change to take effect.</string>
+
 
     <!-- Online feed view -->
     <string name="subscribe_label">Subscribe</string>


### PR DESCRIPTION
Instead of the DirectoryChooser, we show:

![data_folder](https://cloud.githubusercontent.com/assets/6860662/11277766/27ca4f7e-8ee8-11e5-88dd-23db76ad617c.png)

As explained in #951, this will probably not solve the sd card issue on all devices (manufacturer dependent).
I choose not to show the whole path. Here, "Android/data/de.danoeh.antennapod[.debug]/files/" is truncated. Showing the available space should make it easier for users to identify the right folder.

Still not moving the data folder contents, this is a task for another day/PR.