### PR TITLE
Fix huawei npe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 1.4.0.12
+----------------
+* Fix for crash on Huawei devices (media buttons may not work)
+
 Version 1.4
 -----------
 * BLUETOOTH PERMISSION: Needed to be able to resume playback when a Bluetooth device reconnects with your phone

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="1040011"
-    android:versionName="1.4.0.11">
+    android:versionCode="1040012"
+    android:versionName="1.4.0.12">
     <!--
       Version code schema:
       "1.2.3-SNAPSHOT" -> 1020300

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -116,9 +116,19 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
         PendingIntent buttonReceiverIntent = PendingIntent.getBroadcast(context, 0, mediaButtonIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         mediaSession = new MediaSessionCompat(context, TAG, eventReceiver, buttonReceiverIntent);
-        mediaSession.setCallback(sessionCallback);
-        mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
-        mediaSession.setActive(true);
+
+        try {
+            mediaSession.setCallback(sessionCallback);
+            mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
+            mediaSession.setActive(true);
+        } catch (NullPointerException npe) {
+            // on some devices (Huawei) setting active can cause a NullPointerException
+            // even with correct use of the api.
+            // See http://stackoverflow.com/questions/31556679/android-huawei-mediassessioncompat
+            // and https://plus.google.com/+IanLake/posts/YgdTkKFxz7d
+            Log.e(TAG, "NullPointerException while setting up MediaSession");
+            npe.printStackTrace();
+        }
 
         mediaPlayer = null;
         statusBeforeSeeking = null;


### PR DESCRIPTION
This NPE was reported on play. It seems to be an issue with Huawei devices. See http://stackoverflow.com/questions/31556679/android-huawei-mediassessioncompat and https://plus.google.com/+IanLake/posts/YgdTkKFxz7d

```
java.lang.RuntimeException: Unable to create service de.danoeh.antennapod.core.service.playback.PlaybackService: java.lang.NullPointerException
	at android.app.ActivityThread.handleCreateService(ActivityThread.java:2699)
	at android.app.ActivityThread.access$2000(ActivityThread.java:143)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1336)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:136)
	at android.app.ActivityThread.main(ActivityThread.java:5291)
	at java.lang.reflect.Method.invokeNative(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:515)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:849)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:665)
	at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.NullPointerException
	at android.os.Parcel.readException(Parcel.java:1474)
	at android.os.Parcel.readException(Parcel.java:1422)
	at android.media.IAudioService$Stub$Proxy.registerMediaButtonIntent(IAudioService.java:1691)
	at android.media.AudioManager.registerMediaButtonIntent(AudioManager.java:2236)
	at android.media.AudioManager.registerMediaButtonEventReceiver(AudioManager.java:2221)
	at android.support.v4.media.session.MediaSessionCompatApi18.registerMediaButtonEventReceiver(MediaSessionCompatApi18.java:35)
	at android.support.v4.media.session.MediaSessionCompat$MediaSessionImplBase.update(MediaSessionCompat.java:1284)
	at android.support.v4.media.session.MediaSessionCompat$MediaSessionImplBase.setActive(MediaSessionCompat.java:1147)
	at android.support.v4.media.session.MediaSessionCompat.setActive(MediaSessionCompat.java:248)
	at de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer.<init>(PlaybackServiceMediaPlayer.java:121)
	at de.danoeh.antennapod.core.service.playback.PlaybackService.onCreate(PlaybackService.java:237)
	at android.app.ActivityThread.handleCreateService(ActivityThread.java:2679)
	... 10 more
```