### PR TITLE
apply the correct rxjava rules. version 1.4.1.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compile "de.greenrobot:eventbus:$eventbusVersion"
     compile "io.reactivex:rxandroid:$rxAndroidVersion"
     compile "io.reactivex:rxjava:$rxJavaVersion"
+    // And ProGuard rules for RxJava!
+    compile "com.artemzin.rxjava:proguard-rules:$rxJavaRulesVersion"
     compile "com.joanzapata.iconify:android-iconify-fontawesome:2.1.0"
     compile "com.afollestad:material-dialogs:0.7.8.1"
     compile "com.yqritc:recyclerview-flexibledivider:1.2.6"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
-    android:versionCode="1040100"
-    android:versionName="1.4.1.0">
+    android:versionCode="1040101"
+    android:versionName="1.4.1.1">
     <!--
       Version code schema:
       "1.2.3-SNAPSHOT" -> 1020300

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ project.ext {
     jsoupVersion = "1.7.3"
     rxAndroidVersion = "1.0.1"
     rxJavaVersion = "1.0.16"
+    rxJavaRulesVersion = "1.0.16.1"
     okhttpVersion = "2.5.0"
     okioVersion = "1.6.0"
 }


### PR DESCRIPTION
resolves crash on start that was happening in release versions. updates version to 1.4.1.1 for immediate release.