### PR TITLE
resolve 'no empty constructor' error

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -11,7 +11,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
@@ -23,7 +22,6 @@ import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,9 +56,16 @@ public class EpisodesApplyActionFragment extends Fragment {
 
     private int textColor;
 
-    public EpisodesApplyActionFragment(List<FeedItem> episodes) {
-        this.episodes = episodes;
-        this.idMap = new HashMap<>(episodes.size());
+    public EpisodesApplyActionFragment() {
+        this.episodes = new ArrayList<>();
+        this.idMap = new HashMap<>();
+
+    }
+
+    public void setEpisodes(List<FeedItem> episodes) {
+        this.episodes.clear();
+        this.episodes.addAll(episodes);
+        this.idMap.clear();
         for(FeedItem episode : episodes) {
             this.idMap.put(episode.getId(), episode);
         }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -59,7 +59,6 @@ public class EpisodesApplyActionFragment extends Fragment {
     public EpisodesApplyActionFragment() {
         this.episodes = new ArrayList<>();
         this.idMap = new HashMap<>();
-
     }
 
     public void setEpisodes(List<FeedItem> episodes) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -257,7 +257,8 @@ public class ItemlistFragment extends ListFragment {
                 if (!FeedMenuHandler.onOptionsItemClicked(getActivity(), item, feed)) {
                     switch (item.getItemId()) {
                         case R.id.episode_actions:
-                            Fragment fragment = new EpisodesApplyActionFragment(feed.getItems());
+                            EpisodesApplyActionFragment fragment = new EpisodesApplyActionFragment();
+                            fragment.setEpisodes(feed.getItems());
                             ((MainActivity)getActivity()).loadChildFragment(fragment);
                             return true;
                         case R.id.remove_item:


### PR DESCRIPTION
Resolves this error seen in the play store:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{de.danoeh.antennapod/de.danoeh.antennapod.activity.MainActivity}: android.support.v4.app.Fragment$InstantiationException: Unable to instantiate fragment de.danoeh.antennapod.dialog.EpisodesApplyActionFragment: make sure class name exists, is public, and has an empty constructor that is public
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2449)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2509)
	at android.app.ActivityThread.access$900(ActivityThread.java:172)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1308)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:146)
	at android.app.ActivityThread.main(ActivityThread.java:5694)
	at java.lang.reflect.Method.invokeNative(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:515)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1291)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1107)
	at dalvik.system.NativeStart.main(Native Method)
Caused by: android.support.v4.app.Fragment$InstantiationException: Unable to instantiate fragment de.danoeh.antennapod.dialog.EpisodesApplyActionFragment: make sure class name exists, is public, and has an empty constructor that is public
	at android.support.v4.app.Fragment.instantiate(Fragment.java:432)
	at android.support.v4.app.FragmentState.instantiate(Fragment.java:102)
	at android.support.v4.app.FragmentManagerImpl.restoreAllState(FragmentManager.java:1835)
	at android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:266)
	at android.support.v7.app.AppCompatActivity.onCreate(AppCompatActivity.java:58)
	at de.danoeh.antennapod.activity.MainActivity.onCreate(MainActivity.java:124)
	at android.app.Activity.performCreate(Activity.java:5541)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1093)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2413)
	... 11 more
Caused by: java.lang.InstantiationException: can't instantiate class de.danoeh.antennapod.dialog.EpisodesApplyActionFragment; no empty constructor
	at java.lang.Class.newInstanceImpl(Native Method)
	at java.lang.Class.newInstance(Class.java:1208)
	at android.support.v4.app.Fragment.instantiate(Fragment.java:421)
	... 19 more
```