### PR TITLE
Fix refresh indicator and (queue) dragging while downloading

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -303,6 +303,7 @@ public class AllEpisodesFragment extends Fragment {
         View root = inflater.inflate(fragmentResource, container, false);
 
         recyclerView = (RecyclerView) root.findViewById(android.R.id.list);
+        recyclerView.getItemAnimator().setSupportsChangeAnimations(false);
         layoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setHasFixedSize(true);
@@ -397,14 +398,15 @@ public class AllEpisodesFragment extends Fragment {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if(update.feedIds.length > 0) {
-            if (isUpdatingFeeds != updateRefreshMenuItemChecker.isRefreshing()) {
+        if (isUpdatingFeeds != update.feedIds.length > 0) {
                 getActivity().supportInvalidateOptionsMenu();
-            }
         }
-        if(update.mediaIds.length > 0) {
-            if(listAdapter != null) {
-                listAdapter.notifyDataSetChanged();
+        if(listAdapter != null && update.mediaIds.length > 0) {
+            for(long mediaId : update.mediaIds) {
+                int pos = FeedItemUtil.indexOfItemWithMediaId(episodes, mediaId);
+                if(pos >= 0) {
+                    listAdapter.notifyItemChanged(pos);
+                }
             }
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -9,7 +9,6 @@ import android.graphics.Color;
 import android.graphics.LightingColorFilter;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.ListFragment;
 import android.support.v4.util.Pair;
 import android.support.v4.view.MenuItemCompat;
@@ -417,13 +416,11 @@ public class ItemlistFragment extends ListFragment {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if(update.feedIds.length > 0) {
+        if (isUpdatingFeed != event.update.feedIds.length > 0) {
             updateProgressBarVisibility();
         }
-        if(update.mediaIds.length > 0) {
-            if (adapter != null) {
-                adapter.notifyDataSetChanged();
-            }
+        if(adapter != null && update.mediaIds.length > 0) {
+            adapter.notifyDataSetChanged();
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -179,13 +179,15 @@ public class QueueFragment extends Fragment {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if (update.feedIds.length > 0) {
-            if (isUpdatingFeeds != updateRefreshMenuItemChecker.isRefreshing()) {
-                getActivity().supportInvalidateOptionsMenu();
-            }
-        } else if (update.mediaIds.length > 0) {
-            if (recyclerAdapter != null) {
-                recyclerAdapter.notifyDataSetChanged();
+        if (isUpdatingFeeds != update.feedIds.length > 0) {
+            getActivity().supportInvalidateOptionsMenu();
+        }
+        if (recyclerAdapter != null && update.mediaIds.length > 0) {
+            for (long mediaId : update.mediaIds) {
+                int pos = FeedItemUtil.indexOfItemWithMediaId(queue, mediaId);
+                if (pos >= 0) {
+                    recyclerAdapter.notifyItemChanged(pos);
+                }
             }
         }
     }
@@ -363,6 +365,7 @@ public class QueueFragment extends Fragment {
         View root = inflater.inflate(R.layout.queue_fragment, container, false);
         infoBar = (TextView) root.findViewById(R.id.info_bar);
         recyclerView = (RecyclerView) root.findViewById(R.id.recyclerView);
+        recyclerView.getItemAnimator().setSupportsChangeAnimations(false);
         layoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(getActivity()).build());

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -29,6 +29,16 @@ public class FeedItemUtil {
         return -1;
     }
 
+    public static int indexOfItemWithMediaId(List<FeedItem> items, long mediaId) {
+        for(int i=0; i < items.size(); i++) {
+            FeedItem item = items.get(i);
+            if(item != null && item.getMedia() != null && item.getMedia().getId() == mediaId) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public static long[] getIds(FeedItem... items) {
         if(items == null || items.length == 0) {
             return new long[0];


### PR DESCRIPTION
Resolves #1462 
Fixes feed refresh indicator in queue, episodes and feed overview.

Another optimization: When downloading, I chose to refresh the whole list because the change animation for a single list item looked pretty stupid. Just found out I can disable it... Now only items that are actually downloaded are refreshed.
I encountered an issue on my smartphone where dragging while downloading dropped the item at the current position (when the download progresses are updated). This change seems to fix it.