### PR TITLE
Lower memory usage

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -1,10 +1,12 @@
 package de.danoeh.antennapod.activity;
 
+import android.annotation.TargetApi;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PixelFormat;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.AlertDialog;
@@ -12,7 +14,6 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
@@ -20,9 +21,9 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.bumptech.glide.Glide;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
@@ -237,6 +238,19 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected void onDestroy() {
         super.onDestroy();
         Log.d(TAG, "onDestroy()");
+    }
+
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        Glide.get(this).trimMemory(level);
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        Glide.get(this).clearMemory();
     }
 
     @Override

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -33,8 +33,8 @@
 
         <ImageView
             android:id="@+id/imgvCover"
-            android:layout_height="wrap_content"
-            android:layout_width="wrap_content"
+            android:layout_height="64dp"
+            android:layout_width="64dp"
             android:layout_alignLeft="@id/txtvPlaceholder"
             android:layout_alignTop="@id/txtvPlaceholder"
             android:layout_alignRight="@id/txtvPlaceholder"

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -46,8 +46,8 @@
             android:ellipsize="end"/>
         <ImageView
             android:id="@+id/imgvCover"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
             android:layout_alignLeft="@id/txtvPlaceholder"
             android:layout_alignTop="@id/txtvPlaceholder"
             android:layout_alignRight="@id/txtvPlaceholder"

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -30,7 +30,6 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
@@ -808,14 +807,11 @@ public class PlaybackService extends Service {
                                     .load(info.playable.getImageUri())
                                     .asBitmap()
                                     .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
-                                    .into(-1, -1) // this resizing would not be exact, so we have
-                                                  // scale the bitmap ourselves
+                                    .centerCrop()
+                                    .into(iconSize, iconSize)
                                     .get();
-                            icon = Bitmap.createScaledBitmap(icon, iconSize, iconSize, true);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        } catch (ExecutionException e) {
-                            e.printStackTrace();
+                        } catch(Exception e) {
+                            Log.e(TAG, Log.getStackTraceString(e));
                         }
                     }
                 }
@@ -835,7 +831,7 @@ public class PlaybackService extends Service {
                     String contentTitle = info.playable.getFeedTitle();
                     Notification notification = null;
 
-                    NotificationCompat.Builder notificationBuilder = new android.support.v7.app.NotificationCompat.Builder(
+                    NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(
                             PlaybackService.this)
                             .setContentTitle(contentTitle)
                             .setContentText(contentText)

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -19,7 +19,7 @@ import android.os.Build;
 import android.os.IBinder;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
+import android.support.v7.app.NotificationCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
@@ -831,7 +831,8 @@ public class PlaybackService extends Service {
                     String contentTitle = info.playable.getFeedTitle();
                     Notification notification = null;
 
-                    NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(
+                    // Builder is v7, even if some not overwritten methods return its parent's v4 interface
+                    NotificationCompat.Builder notificationBuilder = (NotificationCompat.Builder) new NotificationCompat.Builder(
                             PlaybackService.this)
                             .setContentTitle(contentTitle)
                             .setContentText(contentText)

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -810,8 +810,8 @@ public class PlaybackService extends Service {
                                     .centerCrop()
                                     .into(iconSize, iconSize)
                                     .get();
-                        } catch(Exception e) {
-                            Log.e(TAG, Log.getStackTraceString(e));
+                        } catch(Throwable tr) {
+                            Log.e(TAG, Log.getStackTraceString(tr));
                         }
                     }
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -306,8 +306,8 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
                             .into(display.getWidth(), display.getHeight())
                             .get();
                     builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
-                } catch (Exception e) {
-                    Log.e(TAG, Log.getStackTraceString(e));
+                } catch (Throwable tr) {
+                    Log.e(TAG, Log.getStackTraceString(tr));
                 }
             }
             mediaSession.setMetadata(builder.build());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -17,12 +17,13 @@ import android.support.v4.media.session.PlaybackStateCompat;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.util.Pair;
+import android.view.Display;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.SurfaceHolder;
+import android.view.WindowManager;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.request.target.Target;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -292,20 +293,21 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
             builder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, p.getDuration());
             builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, p.getEpisodeTitle());
             builder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, p.getFeedTitle());
-            if (p.getImageUri() != null) {
-                if (UserPreferences.setLockscreenBackground()) {
-                    builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageUri().toString());
-                    try {
-                        Bitmap art = Glide.with(context)
+            if (p.getImageUri() != null && UserPreferences.setLockscreenBackground()) {
+                builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageUri().toString());
+                try {
+                    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+                    Display display = wm.getDefaultDisplay();
+                    Bitmap art = Glide.with(context)
                             .load(p.getImageUri())
                             .asBitmap()
                             .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
-                            .into(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
+                            .centerCrop()
+                            .into(display.getWidth(), display.getHeight())
                             .get();
-                        builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
-                    } catch (Exception e) {
-                        Log.e(TAG, Log.getStackTraceString(e));
-                    }
+                    builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
+                } catch (Exception e) {
+                    Log.e(TAG, Log.getStackTraceString(e));
                 }
             }
             mediaSession.setMetadata(builder.build());


### PR DESCRIPTION
Doesn't really fix #1464, but should have positive impact on memory. (At least it doesn't hurt)

→ http://stackoverflow.com/a/31062339/5369600
Basically, ``wrap_content `` is bad for images, because Glide would still has to load the full image. We should only use ``match_parent`` and fixed dp size. 