### PR TITLE
Player: Toggle "time left" and "total time" #1456 

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -600,7 +600,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         if (controller != null) {
             prog = controller.onSeekBarProgressChanged(seekBar, progress, fromUser,
                     txtvPosition);
-            if(timeLeft) {
+            if(timeLeft && prog!=0) {
                 int duration = controller.getDuration();
                 txtvLength.setText("-"+Converter
                         .getDurationStringLong(duration - (int) (prog * duration)));

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -50,6 +50,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected SeekBar sbPosition;
     protected ImageButton butPlay;
     protected ImageButton butRev;
+    protected Boolean timeLeft = false;
     protected TextView txtvRev;
     protected ImageButton butFF;
     protected TextView txtvFF;
@@ -397,8 +398,14 @@ public abstract class MediaplayerActivity extends ActionBarActivity
             if (currentPosition != PlaybackService.INVALID_TIME
                     && duration != PlaybackService.INVALID_TIME
                     && controller.getMedia() != null) {
-                txtvPosition.setText(Converter
-                        .getDurationStringLong(currentPosition));
+                if(timeLeft) {
+                    txtvPosition.setText("-"+Converter
+                            .getDurationStringLong(duration - currentPosition));
+                }
+                else {
+                    txtvPosition.setText(Converter
+                            .getDurationStringLong(currentPosition));
+                }
                 txtvLength.setText(Converter.getDurationStringLong(duration));
                 updateProgressbarPosition(currentPosition, duration);
             } else {
@@ -443,6 +450,13 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         setContentView(getContentViewResourceId());
         sbPosition = (SeekBar) findViewById(R.id.sbPosition);
         txtvPosition = (TextView) findViewById(R.id.txtvPosition);
+
+        txtvPosition.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        timeLeft = !timeLeft;
+                    }
+        });
         txtvLength = (TextView) findViewById(R.id.txtvLength);
         butPlay = (ImageButton) findViewById(R.id.butPlay);
         butRev = (ImageButton) findViewById(R.id.butRev);

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -6,6 +6,7 @@ import android.annotation.TargetApi;
 >>>>>>> remove yet to be used imports and change from Boolean to boolean
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.PixelFormat;
 import android.media.AudioManager;
 import android.net.Uri;
@@ -46,6 +47,8 @@ import de.danoeh.antennapod.dialog.SleepTimerDialog;
 public abstract class MediaplayerActivity extends ActionBarActivity
         implements OnSeekBarChangeListener {
     private static final String TAG = "MediaplayerActivity";
+    private static final String PREFS = "MediaPlayerActivityPreferences";
+    private static final String PREF_SHOW_TIME_LEFT = "showTimeLeft";
 
     protected PlaybackController controller;
 
@@ -54,7 +57,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected SeekBar sbPosition;
     protected ImageButton butPlay;
     protected ImageButton butRev;
-    protected boolean timeLeft = false;
+    protected boolean showTimeLeft = false;
     protected TextView txtvRev;
     protected ImageButton butFF;
     protected TextView txtvFF;
@@ -417,7 +420,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                     && controller.getMedia() != null) {
                 txtvPosition.setText(Converter
                         .getDurationStringLong(currentPosition));
-                if(timeLeft) {
+                if(showTimeLeft) {
                     txtvLength.setText("-"+Converter
                             .getDurationStringLong(duration - currentPosition));
                 }
@@ -447,6 +450,8 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected boolean loadMediaInfo() {
         Log.d(TAG, "loadMediaInfo()");
         Playable media = controller.getMedia();
+        SharedPreferences prefs = getSharedPreferences(PREFS, MODE_PRIVATE);
+        showTimeLeft = prefs.getBoolean(PREF_SHOW_TIME_LEFT,false);
         if (media != null) {
             txtvPosition.setText(Converter.getDurationStringLong((media
                     .getPosition())));
@@ -457,6 +462,10 @@ public abstract class MediaplayerActivity extends ActionBarActivity
                 float progress = ((float) media.getPosition())
                         / media.getDuration();
                 sbPosition.setProgress((int) (progress * sbPosition.getMax()));
+                if(showTimeLeft) {
+                    txtvLength.setText("-"+Converter.getDurationStringLong((media
+                                                .getDuration()-media.getPosition())));
+                }
             }
             return true;
         } else {
@@ -469,11 +478,18 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         sbPosition = (SeekBar) findViewById(R.id.sbPosition);
         txtvPosition = (TextView) findViewById(R.id.txtvPosition);
 
+        SharedPreferences prefs = getSharedPreferences(PREFS, MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        showTimeLeft = prefs.getBoolean(PREF_SHOW_TIME_LEFT,false);
+        Log.w("timeleft",showTimeLeft? "true":"false");
         txtvLength = (TextView) findViewById(R.id.txtvLength);
         txtvLength.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                timeLeft = !timeLeft;
+                showTimeLeft = !showTimeLeft;
+                editor.putBoolean(PREF_SHOW_TIME_LEFT,showTimeLeft);
+                editor.commit();
+                Log.w("timeleft on click",showTimeLeft? "true":"false");
             }
         });
 
@@ -617,7 +633,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         if (controller != null) {
             prog = controller.onSeekBarProgressChanged(seekBar, progress, fromUser,
                     txtvPosition);
-            if(timeLeft && prog!=0) {
+            if(showTimeLeft && prog!=0) {
                 int duration = controller.getDuration();
                 txtvLength.setText("-"+Converter
                         .getDurationStringLong(duration - (int) (prog * duration)));

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -1,6 +1,9 @@
 package de.danoeh.antennapod.activity;
 
+<<<<<<< HEAD
 import android.annotation.TargetApi;
+=======
+>>>>>>> remove yet to be used imports and change from Boolean to boolean
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PixelFormat;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -1,9 +1,6 @@
 package de.danoeh.antennapod.activity;
 
-<<<<<<< HEAD
 import android.annotation.TargetApi;
-=======
->>>>>>> remove yet to be used imports and change from Boolean to boolean
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -1,9 +1,7 @@
 package de.danoeh.antennapod.activity;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.PixelFormat;
 import android.media.AudioManager;
 import android.net.Uri;
@@ -52,7 +50,7 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected SeekBar sbPosition;
     protected ImageButton butPlay;
     protected ImageButton butRev;
-    protected Boolean timeLeft = false;
+    protected boolean timeLeft = false;
     protected TextView txtvRev;
     protected ImageButton butFF;
     protected TextView txtvFF;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -1,10 +1,12 @@
 package de.danoeh.antennapod.activity;
 
+import android.annotation.TargetApi;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PixelFormat;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.AlertDialog;
@@ -12,7 +14,6 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
@@ -20,9 +21,9 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.bumptech.glide.Glide;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
@@ -238,6 +239,19 @@ public abstract class MediaplayerActivity extends ActionBarActivity
     protected void onDestroy() {
         super.onDestroy();
         Log.d(TAG, "onDestroy()");
+    }
+
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        Glide.get(this).trimMemory(level);
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        Glide.get(this).clearMemory();
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -1,7 +1,9 @@
 package de.danoeh.antennapod.activity;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.PixelFormat;
 import android.media.AudioManager;
 import android.net.Uri;
@@ -398,15 +400,16 @@ public abstract class MediaplayerActivity extends ActionBarActivity
             if (currentPosition != PlaybackService.INVALID_TIME
                     && duration != PlaybackService.INVALID_TIME
                     && controller.getMedia() != null) {
+                txtvPosition.setText(Converter
+                        .getDurationStringLong(currentPosition));
                 if(timeLeft) {
-                    txtvPosition.setText("-"+Converter
+                    txtvLength.setText("-"+Converter
                             .getDurationStringLong(duration - currentPosition));
                 }
                 else {
-                    txtvPosition.setText(Converter
-                            .getDurationStringLong(currentPosition));
+                    txtvLength.setText(Converter
+                            .getDurationStringLong(duration));
                 }
-                txtvLength.setText(Converter.getDurationStringLong(duration));
                 updateProgressbarPosition(currentPosition, duration);
             } else {
                 Log.w(TAG, "Could not react to position observer update because of invalid time");
@@ -451,13 +454,14 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         sbPosition = (SeekBar) findViewById(R.id.sbPosition);
         txtvPosition = (TextView) findViewById(R.id.txtvPosition);
 
-        txtvPosition.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        timeLeft = !timeLeft;
-                    }
-        });
         txtvLength = (TextView) findViewById(R.id.txtvLength);
+        txtvLength.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                timeLeft = !timeLeft;
+            }
+        });
+
         butPlay = (ImageButton) findViewById(R.id.butPlay);
         butRev = (ImageButton) findViewById(R.id.butRev);
         txtvRev = (TextView) findViewById(R.id.txtvRev);
@@ -598,6 +602,11 @@ public abstract class MediaplayerActivity extends ActionBarActivity
         if (controller != null) {
             prog = controller.onSeekBarProgressChanged(seekBar, progress, fromUser,
                     txtvPosition);
+            if(timeLeft) {
+                int duration = controller.getDuration();
+                txtvLength.setText("-"+Converter
+                        .getDurationStringLong(duration - (int) (prog * duration)));
+            }
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -303,6 +303,7 @@ public class AllEpisodesFragment extends Fragment {
         View root = inflater.inflate(fragmentResource, container, false);
 
         recyclerView = (RecyclerView) root.findViewById(android.R.id.list);
+        recyclerView.getItemAnimator().setSupportsChangeAnimations(false);
         layoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setHasFixedSize(true);
@@ -397,14 +398,15 @@ public class AllEpisodesFragment extends Fragment {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if(update.feedIds.length > 0) {
-            if (isUpdatingFeeds != updateRefreshMenuItemChecker.isRefreshing()) {
+        if (isUpdatingFeeds != update.feedIds.length > 0) {
                 getActivity().supportInvalidateOptionsMenu();
-            }
         }
-        if(update.mediaIds.length > 0) {
-            if(listAdapter != null) {
-                listAdapter.notifyDataSetChanged();
+        if(listAdapter != null && update.mediaIds.length > 0) {
+            for(long mediaId : update.mediaIds) {
+                int pos = FeedItemUtil.indexOfItemWithMediaId(episodes, mediaId);
+                if(pos >= 0) {
+                    listAdapter.notifyItemChanged(pos);
+                }
             }
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -9,7 +9,6 @@ import android.graphics.Color;
 import android.graphics.LightingColorFilter;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.ListFragment;
 import android.support.v4.util.Pair;
 import android.support.v4.view.MenuItemCompat;
@@ -417,13 +416,11 @@ public class ItemlistFragment extends ListFragment {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if(update.feedIds.length > 0) {
+        if (isUpdatingFeed != event.update.feedIds.length > 0) {
             updateProgressBarVisibility();
         }
-        if(update.mediaIds.length > 0) {
-            if (adapter != null) {
-                adapter.notifyDataSetChanged();
-            }
+        if(adapter != null && update.mediaIds.length > 0) {
+            adapter.notifyDataSetChanged();
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -179,13 +179,15 @@ public class QueueFragment extends Fragment {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if (update.feedIds.length > 0) {
-            if (isUpdatingFeeds != updateRefreshMenuItemChecker.isRefreshing()) {
-                getActivity().supportInvalidateOptionsMenu();
-            }
-        } else if (update.mediaIds.length > 0) {
-            if (recyclerAdapter != null) {
-                recyclerAdapter.notifyDataSetChanged();
+        if (isUpdatingFeeds != update.feedIds.length > 0) {
+            getActivity().supportInvalidateOptionsMenu();
+        }
+        if (recyclerAdapter != null && update.mediaIds.length > 0) {
+            for (long mediaId : update.mediaIds) {
+                int pos = FeedItemUtil.indexOfItemWithMediaId(queue, mediaId);
+                if (pos >= 0) {
+                    recyclerAdapter.notifyItemChanged(pos);
+                }
             }
         }
     }
@@ -363,6 +365,7 @@ public class QueueFragment extends Fragment {
         View root = inflater.inflate(R.layout.queue_fragment, container, false);
         infoBar = (TextView) root.findViewById(R.id.info_bar);
         recyclerView = (RecyclerView) root.findViewById(R.id.recyclerView);
+        recyclerView.getItemAnimator().setSupportsChangeAnimations(false);
         layoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(getActivity()).build());

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -33,8 +33,8 @@
 
         <ImageView
             android:id="@+id/imgvCover"
-            android:layout_height="wrap_content"
-            android:layout_width="wrap_content"
+            android:layout_height="64dp"
+            android:layout_width="64dp"
             android:layout_alignLeft="@id/txtvPlaceholder"
             android:layout_alignTop="@id/txtvPlaceholder"
             android:layout_alignRight="@id/txtvPlaceholder"

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -46,8 +46,8 @@
             android:ellipsize="end"/>
         <ImageView
             android:id="@+id/imgvCover"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
             android:layout_alignLeft="@id/txtvPlaceholder"
             android:layout_alignTop="@id/txtvPlaceholder"
             android:layout_alignRight="@id/txtvPlaceholder"

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -30,7 +30,6 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
@@ -808,14 +807,11 @@ public class PlaybackService extends Service {
                                     .load(info.playable.getImageUri())
                                     .asBitmap()
                                     .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
-                                    .into(-1, -1) // this resizing would not be exact, so we have
-                                                  // scale the bitmap ourselves
+                                    .centerCrop()
+                                    .into(iconSize, iconSize)
                                     .get();
-                            icon = Bitmap.createScaledBitmap(icon, iconSize, iconSize, true);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        } catch (ExecutionException e) {
-                            e.printStackTrace();
+                        } catch(Exception e) {
+                            Log.e(TAG, Log.getStackTraceString(e));
                         }
                     }
                 }
@@ -835,7 +831,7 @@ public class PlaybackService extends Service {
                     String contentTitle = info.playable.getFeedTitle();
                     Notification notification = null;
 
-                    NotificationCompat.Builder notificationBuilder = new android.support.v7.app.NotificationCompat.Builder(
+                    NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(
                             PlaybackService.this)
                             .setContentTitle(contentTitle)
                             .setContentText(contentText)

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -19,7 +19,7 @@ import android.os.Build;
 import android.os.IBinder;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
+import android.support.v7.app.NotificationCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
@@ -831,7 +831,8 @@ public class PlaybackService extends Service {
                     String contentTitle = info.playable.getFeedTitle();
                     Notification notification = null;
 
-                    NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(
+                    // Builder is v7, even if some not overwritten methods return its parent's v4 interface
+                    NotificationCompat.Builder notificationBuilder = (NotificationCompat.Builder) new NotificationCompat.Builder(
                             PlaybackService.this)
                             .setContentTitle(contentTitle)
                             .setContentText(contentText)

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -810,8 +810,8 @@ public class PlaybackService extends Service {
                                     .centerCrop()
                                     .into(iconSize, iconSize)
                                     .get();
-                        } catch(Exception e) {
-                            Log.e(TAG, Log.getStackTraceString(e));
+                        } catch(Throwable tr) {
+                            Log.e(TAG, Log.getStackTraceString(tr));
                         }
                     }
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -306,8 +306,8 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
                             .into(display.getWidth(), display.getHeight())
                             .get();
                     builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
-                } catch (Exception e) {
-                    Log.e(TAG, Log.getStackTraceString(e));
+                } catch (Throwable tr) {
+                    Log.e(TAG, Log.getStackTraceString(tr));
                 }
             }
             mediaSession.setMetadata(builder.build());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -17,12 +17,13 @@ import android.support.v4.media.session.PlaybackStateCompat;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.util.Pair;
+import android.view.Display;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.SurfaceHolder;
+import android.view.WindowManager;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.request.target.Target;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -292,20 +293,21 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
             builder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, p.getDuration());
             builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, p.getEpisodeTitle());
             builder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, p.getFeedTitle());
-            if (p.getImageUri() != null) {
-                if (UserPreferences.setLockscreenBackground()) {
-                    builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageUri().toString());
-                    try {
-                        Bitmap art = Glide.with(context)
+            if (p.getImageUri() != null && UserPreferences.setLockscreenBackground()) {
+                builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageUri().toString());
+                try {
+                    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+                    Display display = wm.getDefaultDisplay();
+                    Bitmap art = Glide.with(context)
                             .load(p.getImageUri())
                             .asBitmap()
                             .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
-                            .into(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
+                            .centerCrop()
+                            .into(display.getWidth(), display.getHeight())
                             .get();
-                        builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
-                    } catch (Exception e) {
-                        Log.e(TAG, Log.getStackTraceString(e));
-                    }
+                    builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, art);
+                } catch (Exception e) {
+                    Log.e(TAG, Log.getStackTraceString(e));
                 }
             }
             mediaSession.setMetadata(builder.build());

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -29,6 +29,16 @@ public class FeedItemUtil {
         return -1;
     }
 
+    public static int indexOfItemWithMediaId(List<FeedItem> items, long mediaId) {
+        for(int i=0; i < items.size(); i++) {
+            FeedItem item = items.get(i);
+            if(item != null && item.getMedia() != null && item.getMedia().getId() == mediaId) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public static long[] getIds(FeedItem... items) {
         if(items == null || items.length == 0) {
             return new long[0];


### PR DESCRIPTION
Reference: This should close #1456 

By tapping the duration of some media the user can see the time left instead, this change is saved in SharedPreferences so that when the activity is resumed the user won't need to tap it again. It also works when the user moves through the seekbar.