### PR TITLE
FeedMedia: item might be null

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
@@ -189,6 +189,7 @@ public class DBWriterTest extends InstrumentationTestCase {
             c.close();
             c = adapter.getSimpleChaptersOfFeedItemCursor(item);
             assertEquals(0, c.getCount());
+            c.close();
         }
     }
 


### PR DESCRIPTION
Resolves #1472

Still not really sure how this issue is caused. Probably when unsubscribing (deleting) from a feed.

At least the new code is more defensive, which makes it better.

All tests passed.