### PR TITLE
ItemAccess: Prevent ArrayIndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -819,7 +819,7 @@ public class AudioplayerActivity extends MediaplayerActivity implements ItemDesc
 
         @Override
         public Feed getItem(int position) {
-            if (navDrawerData != null && position < navDrawerData.feeds.size()) {
+            if (navDrawerData != null && 0 <= position && position < navDrawerData.feeds.size()) {
                 return navDrawerData.feeds.get(position);
             } else {
                 return null;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -615,7 +615,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
 
         @Override
         public Feed getItem(int position) {
-            if (navDrawerData != null && position < navDrawerData.feeds.size()) {
+            if (navDrawerData != null && 0 <= position && position < navDrawerData.feeds.size()) {
                 return navDrawerData.feeds.get(position);
             } else {
                 return null;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -349,7 +349,7 @@ public class AllEpisodesFragment extends Fragment {
 
         @Override
         public FeedItem getItem(int position) {
-            if (episodes != null && position < episodes.size()) {
+            if (episodes != null && 0 <= position && position < episodes.size()) {
                 return episodes.get(position);
             }
             return null;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -131,7 +131,11 @@ public class CompletedDownloadsFragment extends ListFragment {
 
         @Override
         public FeedItem getItem(int position) {
-            return (items != null) ? items.get(position) : null;
+            if (items != null && 0 <= position && position < items.size()) {
+                return items.get(position);
+            } else {
+                return null;
+            }
         }
 
         @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/DownloadLogFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/DownloadLogFragment.java
@@ -91,7 +91,11 @@ public class DownloadLogFragment extends ListFragment {
 
         @Override
         public DownloadStatus getItem(int position) {
-            return (downloadLog != null) ? downloadLog.get(position) : null;
+            if (downloadLog != null && 0 <= position && position < downloadLog.size()) {
+                return downloadLog.get(position);
+            } else {
+                return null;
+            }
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -592,7 +592,11 @@ public class ItemlistFragment extends ListFragment {
 
         @Override
         public FeedItem getItem(int position) {
-            return (feed != null) ? feed.getItemAtIndex(position) : null;
+            if (feed != null && 0 <= position && position < feed.getNumOfItems()) {
+                return feed.getItemAtIndex(position);
+            } else {
+                return null;
+            }
         }
 
         @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -22,10 +22,10 @@ import de.danoeh.antennapod.adapter.DefaultActionButtonCallback;
 import de.danoeh.antennapod.adapter.FeedItemlistAdapter;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.DownloaderUpdate;
+import de.danoeh.antennapod.core.event.QueueEvent;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
-import de.danoeh.antennapod.core.event.QueueEvent;
 import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -244,7 +244,11 @@ public class PlaybackHistoryFragment extends ListFragment {
 
         @Override
         public FeedItem getItem(int position) {
-            return (playbackHistory != null) ? playbackHistory.get(position) : null;
+            if (playbackHistory != null && 0 <= position && position < playbackHistory.size()) {
+                return playbackHistory.get(position);
+            } else {
+                return null;
+            }
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -503,7 +503,7 @@ public class QueueFragment extends Fragment {
 
         @Override
         public FeedItem getItem(int position) {
-            if(queue != null && position < queue.size()) {
+            if (queue != null && 0 <= position && position < queue.size()) {
                 return queue.get(position);
             }
             return null;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
@@ -83,7 +83,11 @@ public class RunningDownloadsFragment extends ListFragment {
 
         @Override
         public Downloader getItem(int position) {
-            return (downloaderList != null) ? downloaderList.get(position) : null;
+            if (downloaderList != null && 0 <= position && position < downloaderList.size()) {
+                return downloaderList.get(position);
+            } else {
+                return null;
+            }
         }
 
         @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -192,7 +192,11 @@ public class SearchFragment extends ListFragment {
 
         @Override
         public SearchResult getItem(int position) {
-            return (searchResults != null) ? searchResults.get(position) : null;
+            if (searchResults != null && 0 <= position && position < searchResults.size()) {
+                return searchResults.get(position);
+            } else {
+                return null;
+            }
         }
     };
 


### PR DESCRIPTION
Pretty much a no-brainer.
Prevents getting items with negative index (which throw ArrayIndexOutOfBoundsExceptions) from lists.

All tests passed.

Resolves #1479