### PR TITLE
Replaced checkboxes with switches in preference screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -18,6 +18,7 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
@@ -26,6 +27,7 @@ import android.text.TextWatcher;
 import android.text.format.DateFormat;
 import android.util.Log;
 import android.widget.EditText;
+import android.widget.Switch;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -89,7 +91,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if(key.equals(UserPreferences.PREF_SONIC)) {
-            CheckBoxPreference prefSonic = (CheckBoxPreference) ui.findPreference(UserPreferences.PREF_SONIC);
+            SwitchPreference prefSonic = (SwitchPreference) ui.findPreference(UserPreferences.PREF_SONIC);
             if(prefSonic != null) {
                 prefSonic.setChecked(sharedPreferences.getBoolean(UserPreferences.PREF_SONIC, false));
             }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -32,25 +32,25 @@
                 android:summary="@string/pref_nav_drawer_feed_counter_sum"
                 android:defaultValue="0"/>
         </PreferenceScreen>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefExpandNotify"
             android:summary="@string/pref_expandNotify_sum"
             android:title="@string/pref_expandNotify_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefPersistNotify"
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefLockscreenBackground"
             android:summary="@string/pref_lockscreen_background_sum"
             android:title="@string/pref_lockscreen_background_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefShowDownloadReport"
@@ -59,7 +59,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/queue_label">
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefQueueAddToFront"
@@ -69,45 +69,45 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/playback_pref">
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefPauseOnHeadsetDisconnect"
             android:summary="@string/pref_pauseOnDisconnect_sum"
             android:title="@string/pref_pauseOnHeadsetDisconnect_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:dependency="prefPauseOnHeadsetDisconnect"
             android:key="prefUnpauseOnHeadsetReconnect"
             android:summary="@string/pref_unpauseOnHeadsetReconnect_sum"
             android:title="@string/pref_unpauseOnHeadsetReconnect_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:dependency="prefPauseOnHeadsetDisconnect"
             android:key="prefUnpauseOnBluetoothReconnect"
             android:summary="@string/pref_unpauseOnBluetoothReconnect_sum"
             android:title="@string/pref_unpauseOnBluetoothReconnect_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefHardwareForwardButtonSkips"
             android:summary="@string/pref_hardwareForwardButtonSkips_sum"
             android:title="@string/pref_hardwareForwardButtonSkips_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefFollowQueue"
             android:summary="@string/pref_followQueue_sum"
             android:title="@string/pref_followQueue_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefSkipKeepsEpisode"
             android:summary="@string/pref_skip_keeps_episodes_sum"
             android:title="@string/pref_skip_keeps_episodes_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefAutoDelete"
@@ -125,13 +125,13 @@
             android:summary="@string/pref_playback_speed_sum"
             android:title="@string/pref_playback_speed_title" />
 
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefPauseForFocusLoss"
             android:summary="@string/pref_pausePlaybackForFocusLoss_sum"
             android:title="@string/pref_pausePlaybackForFocusLoss_title" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefResumeAfterCall"
@@ -144,7 +144,7 @@
             android:key="prefAutoUpdateIntervall"
             android:summary="@string/pref_autoUpdateIntervallOrTime_sum"
             android:title="@string/pref_autoUpdateIntervallOrTime_title"/>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefMobileUpdate"
@@ -174,16 +174,16 @@
             android:summary="@string/pref_automatic_download_sum"
             android:key="prefAutoDownloadSettings"
             android:title="@string/pref_automatic_download_title">
-            <CheckBoxPreference
+            <SwitchPreference
                 android:key="prefEnableAutoDl"
                 android:title="@string/pref_automatic_download_title"
                 android:defaultValue="false"/>
-            <CheckBoxPreference
+            <SwitchPreference
                 android:key="prefEnableAutoDownloadOnBattery"
                 android:title="@string/pref_automatic_download_on_battery_title"
                 android:summary="@string/pref_automatic_download_on_battery_sum"
                 android:defaultValue="true"/>
-            <CheckBoxPreference
+            <SwitchPreference
                 android:key="prefEnableAutoDownloadWifiFilter"
                 android:title="@string/pref_autodl_wifi_filter_title"
                 android:summary="@string/pref_autodl_wifi_filter_sum"/>
@@ -258,7 +258,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/experimental_pref">
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:enabled="false"
         android:key="prefSonic"


### PR DESCRIPTION
According to [material design specs](https://www.google.com/design/spec/components/selection-controls.html#selection-controls-radio-button)

```
If you have a single option, avoid using a checkbox and use an on/off switch instead.
```
Each selection item in the preference screen have one checkbox to toggle an option on/off, which in this case would make more sense to use a Switch control instead of a checkbox.