### PR TITLE
PreferenceController: Prevent NPE in Data Folder Chooser

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -711,7 +711,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
             } else {
                 choices[i] = path;
             }
-            long bytes = StorageUtils.getFreeSpaceAvailable();
+            long bytes = StorageUtils.getFreeSpaceAvailable(path);
             String freeSpace = String.format(context.getString(R.string.free_space_label),
                     Converter.byteToString(bytes));
             choices[i] = Html.fromHtml("<html><small>" + choices[i]

--- a/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
@@ -51,8 +51,19 @@ public class StorageUtils {
      * Get the number of free bytes that are available on the external storage.
      */
     public static long getFreeSpaceAvailable() {
-        StatFs stat = new StatFs(UserPreferences.getDataFolder(
-                null).getAbsolutePath());
+        File dataFolder = UserPreferences.getDataFolder(null);
+        if (dataFolder != null) {
+            return getFreeSpaceAvailable(dataFolder.getAbsolutePath());
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Get the number of free bytes that are available on the external storage.
+     */
+    public static long getFreeSpaceAvailable(String path) {
+        StatFs stat = new StatFs(path);
         long availableBlocks;
         long blockSize;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {


### PR DESCRIPTION
No idea how this can be reproduced... But showing an error message is still better than just crashing

Shows an error dialog when we cannot access external directories:

![error](https://cloud.githubusercontent.com/assets/6860662/12064681/e52f3938-afc9-11e5-82f2-4855cff4c3d8.png)

Also resolves another issue: The "free memory" information was not calculated for the specific choice for an external directory.

Resolves #1506 