### PR TITLE
AudioPlayer v1.0.7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "com.afollestad:material-dialogs:0.7.8.1"
     compile "com.yqritc:recyclerview-flexibledivider:1.2.6"
 
-    compile "com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0.2"
+    compile "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     compile project(":core")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:1.3.1"
+        classpath "com.android.tools.build:gradle:1.5.0"
         classpath "me.tatarka:gradle-retrolambda:3.2.3"
         classpath "me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2"
 
@@ -53,6 +53,8 @@ project.ext {
     rxJavaRulesVersion = "1.0.16.1"
     okhttpVersion = "2.5.0"
     okioVersion = "1.6.0"
+
+    audioPlayerVersion = "v1.0.7"
 }
 
 task wrapper(type: Wrapper) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,5 +57,5 @@ dependencies {
     compile "de.greenrobot:eventbus:$eventbusVersion"
     compile "io.reactivex:rxandroid:$rxAndroidVersion"
 
-    compile "com.github.AntennaPod:AntennaPod-AudioPlayer:v1.0.2"
+    compile "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -1127,9 +1127,13 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
 
     private final org.antennapod.audio.MediaPlayer.OnErrorListener audioErrorListener = new org.antennapod.audio.MediaPlayer.OnErrorListener() {
         @Override
-        public boolean onError(org.antennapod.audio.MediaPlayer mp, int what,
-                               int extra) {
-            return genericOnError(mp, what, extra);
+        public boolean onError(org.antennapod.audio.MediaPlayer mp, int what, int extra) {
+            if(mp.canFallback()) {
+                mp.fallback();
+                return true;
+            } else {
+                return genericOnError(mp, what, extra);
+            }
         }
     };
 


### PR DESCRIPTION
If Sonic fails (e.g. sample rate cannot be read), fall back to native mediaplayer.
If Sonic failed, we only reconsider using Sonic again when the playback service is restarted. Because we constantly reset audio players (and thereby forgetting we were in an error state), this seemed to be the easiest solution.

On Marshmallow, native pitch and playback speed work now. (Tested on N4 with Marshmallow)

Also includes downmixing (stereo to mono), which users will be able to enable in another PR.

# Testing

Clone https://github.com/AntennaPod/AntennaPod-AudioPlayer/

See https://github.com/AntennaPod/AntennaPod-AudioPlayer/#local-testing

Call ``error()`` in ``SonicAudioPlayer.initStream()``

All tests passed on 4.4.4 virtual device.