### PR TITLE
Reverse (un)lock icons in queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -267,10 +267,17 @@ public class QueueFragment extends Fragment {
         if (!super.onOptionsItemSelected(item)) {
             switch (item.getItemId()) {
                 case R.id.queue_lock:
-                    boolean locked = !UserPreferences.isQueueLocked();
-                    UserPreferences.setQueueLocked(locked);
+                    boolean newLockState = !UserPreferences.isQueueLocked();
+                    UserPreferences.setQueueLocked(newLockState);
                     getActivity().supportInvalidateOptionsMenu();
-                    recyclerAdapter.setLocked(locked);
+                    recyclerAdapter.setLocked(newLockState);
+                    if (newLockState) {
+                        Snackbar.make(getActivity().findViewById(R.id.content), R.string
+                                .queue_locked, Snackbar.LENGTH_SHORT).show();
+                    } else {
+                        Snackbar.make(getActivity().findViewById(R.id.content), R.string
+                                .queue_unlocked, Snackbar.LENGTH_SHORT).show();
+                    }
                     return true;
                 case R.id.refresh_item:
                     List<Feed> feeds = ((MainActivity) getActivity()).getFeeds();

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
@@ -34,10 +34,10 @@ public class MenuItemUtils extends de.danoeh.antennapod.core.menuhandler.MenuIte
         TypedArray ta = context.obtainStyledAttributes(lockIcons);
         if (UserPreferences.isQueueLocked()) {
             queueLock.setTitle(de.danoeh.antennapod.R.string.unlock_queue);
-            queueLock.setIcon(ta.getDrawable(1));
+            queueLock.setIcon(ta.getDrawable(0));
         } else {
             queueLock.setTitle(de.danoeh.antennapod.R.string.lock_queue);
-            queueLock.setIcon(ta.getDrawable(0));
+            queueLock.setIcon(ta.getDrawable(1));
         }
     }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -217,6 +217,8 @@
     <!-- Queue operations -->
     <string name="lock_queue">Lock Queue</string>
     <string name="unlock_queue">Unlock Queue</string>
+    <string name="queue_locked">Queue locked</string>
+    <string name="queue_unlocked">Queue unlocked</string>
     <string name="clear_queue_label">Clear Queue</string>
     <string name="undo">Undo</string>
     <string name="removed_from_queue">Item removed</string>


### PR DESCRIPTION
Icons should be indicative of buttons' actions. When the action of the button is to lock the queue, the icon should be a closed lock, not an open one, as the button's purpose is to perform an action and not act as a status indicator.