### PR TITLE
Prevent DownloadLog NPE

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
@@ -134,12 +134,16 @@ public class DownloadLogAdapter extends BaseAdapter {
 				}
 			} else if(holder.typeId == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
 				FeedMedia media = DBReader.getFeedMedia(holder.id);
-				try {
-					DBTasks.downloadFeedItems(context, media.getItem());
-					Toast.makeText(context, R.string.status_downloading_label, Toast.LENGTH_SHORT).show();
-				} catch (DownloadRequestException e) {
-					e.printStackTrace();
-					DownloadRequestErrorDialogCreator.newRequestErrorDialog(context, e.getMessage());
+				if (media != null) {
+					try {
+						DBTasks.downloadFeedItems(context, media.getItem());
+						Toast.makeText(context, R.string.status_downloading_label, Toast.LENGTH_SHORT).show();
+					} catch (DownloadRequestException e) {
+						e.printStackTrace();
+						DownloadRequestErrorDialogCreator.newRequestErrorDialog(context, e.getMessage());
+					}
+				} else {
+					Log.wtf(TAG, "Could not find media for id: " + holder.id);
 				}
 			} else {
 				Log.wtf(TAG, "Unexpected type id: " + holder.typeId);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -223,6 +223,11 @@ public class DBWriter {
                 }
                 EventDistributor.getInstance().sendFeedUpdateBroadcast();
 
+                // we assume we also removed download log entries for the feed or its media files.
+                // especially important if download or refresh failed, as the user should not be able
+                // to retry these
+                EventDistributor.getInstance().sendDownloadLogUpdateBroadcast();
+
                 BackupManager backupManager = new BackupManager(context);
                 backupManager.dataChanged();
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -886,6 +886,10 @@ public class PodDBAdapter {
     }
 
     public void removeFeedMedia(FeedMedia media) {
+        // delete download log entries for feed media
+        db.delete(TABLE_NAME_DOWNLOAD_LOG, KEY_FEEDFILE + "=? AND " + KEY_FEEDFILETYPE +"=?",
+                new String[] { String.valueOf(media.getId()), String.valueOf(FeedMedia.FEEDFILETYPE_FEEDMEDIA) });
+
         db.delete(TABLE_NAME_FEED_MEDIA, KEY_ID + "=?",
                 new String[]{String.valueOf(media.getId())});
     }
@@ -930,6 +934,9 @@ public class PodDBAdapter {
                 removeFeedItem(item);
             }
         }
+        // delete download log entries for feed
+        db.delete(TABLE_NAME_DOWNLOAD_LOG, KEY_FEEDFILE + "=? AND " + KEY_FEEDFILETYPE +"=?",
+                new String[] { String.valueOf(feed.getId()), String.valueOf(Feed.FEEDFILETYPE_FEED) });
 
         db.delete(TABLE_NAME_FEEDS, KEY_ID + "=?",
                 new String[]{String.valueOf(feed.getId())});


### PR DESCRIPTION
Now, when a feed is removed, we also remove the corresponding entries from the download log. The user should not be able to retry refreshing a removed feed or to retry a failed download of one of its episodes.

Resolves #1522