### PR TITLE
Refresh feed view

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -87,6 +87,7 @@ public class ItemlistFragment extends ListFragment {
     private static final String TAG = "ItemlistFragment";
 
     private static final int EVENTS = EventDistributor.UNREAD_ITEMS_UPDATE
+            | EventDistributor.FEED_LIST_UPDATE
             | EventDistributor.PLAYER_STATUS_UPDATE;
 
     public static final String EXTRA_SELECTED_FEEDITEM = "extra.de.danoeh.antennapod.activity.selected_feeditem";


### PR DESCRIPTION
Problem: When refreshing the current feed, the view would not refresh the list of episodes.

Tried to find out if this bug was introduced in a recent change. But even older commits did not include the feed list update event.