### PR TITLE
Settings: Moved episode cache size to auto download sub-menu

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PlaybackSonicTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PlaybackSonicTest.java
@@ -49,9 +49,10 @@ public class PlaybackSonicTest extends ActivityInstrumentationTestCase2<MainActi
     public void setUp() throws Exception {
         super.setUp();
 
-        PodDBAdapter.deleteDatabase();
-
         context = getInstrumentation().getTargetContext();
+
+        PodDBAdapter.init(context);
+        PodDBAdapter.deleteDatabase();
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         prefs.edit()

--- a/app/src/androidTest/java/de/test/antennapod/ui/PlaybackTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PlaybackTest.java
@@ -46,9 +46,10 @@ public class PlaybackTest extends ActivityInstrumentationTestCase2<MainActivity>
     public void setUp() throws Exception {
         super.setUp();
 
-        PodDBAdapter.deleteDatabase();
-
         context = getInstrumentation().getTargetContext();
+
+        PodDBAdapter.init(context);
+        PodDBAdapter.deleteDatabase();
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         prefs.edit()

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -3,17 +3,10 @@ package de.test.antennapod.ui;
 import android.content.Context;
 import android.content.res.Resources;
 import android.test.ActivityInstrumentationTestCase2;
-import android.test.FlakyTest;
 
-import com.robotium.solo.Condition;
 import com.robotium.solo.Solo;
 import com.robotium.solo.Timeout;
 
-import org.apache.commons.io.IOUtils;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.R;
@@ -230,6 +223,8 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         String[] values = res.getStringArray(R.array.episode_cache_size_values);
         String entry = entries[entries.length/2];
         final int value = Integer.valueOf(values[values.length/2]);
+        solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
+        solo.waitForText(solo.getString(R.string.pref_automatic_download_title));
         solo.clickOnText(solo.getString(R.string.pref_episode_cache_title));
         solo.waitForDialogToOpen();
         solo.clickOnText(entry);
@@ -241,6 +236,11 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         String[] values = res.getStringArray(R.array.episode_cache_size_values);
         String minEntry = entries[0];
         final int minValue = Integer.valueOf(values[0]);
+        solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
+        solo.waitForText(solo.getString(R.string.pref_automatic_download_title));
+        if(!UserPreferences.isEnableAutodownload()) {
+            solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
+        }
         solo.clickOnText(solo.getString(R.string.pref_episode_cache_title));
         solo.waitForDialogToOpen(1000);
         solo.scrollUp();
@@ -248,12 +248,16 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         assertTrue(solo.waitForCondition(() -> UserPreferences.getEpisodeCacheSize() == minValue, Timeout.getLargeTimeout()));
     }
 
-
     public void testSetEpisodeCacheMax() {
         String[] entries = res.getStringArray(R.array.episode_cache_size_entries);
         String[] values = res.getStringArray(R.array.episode_cache_size_values);
         String maxEntry = entries[entries.length-1];
         final int maxValue = Integer.valueOf(values[values.length-1]);
+        solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
+        solo.waitForText(solo.getString(R.string.pref_automatic_download_title));
+        if(!UserPreferences.isEnableAutodownload()) {
+            solo.clickOnText(solo.getString(R.string.pref_automatic_download_title));
+        }
         solo.clickOnText(solo.getString(R.string.pref_episode_cache_title));
         solo.waitForDialogToOpen();
         solo.clickOnText(maxEntry);

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -216,17 +216,16 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                     }
                 });
 
-        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL)
-                .setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                    @Override
-                    public boolean onPreferenceChange(Preference preference, Object newValue) {
-                        if (newValue instanceof Boolean) {
-                            ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled((Boolean) newValue);
-                            setSelectedNetworksEnabled((Boolean) newValue && UserPreferences.isEnableAutodownloadWifiFilter());
-                            ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled((Boolean) newValue);
-                        }
-                        return true;
+        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL).setOnPreferenceChangeListener(
+                (preference, newValue) -> {
+                    if (newValue instanceof Boolean) {
+                        boolean enabled = (Boolean) newValue;
+                        ui.findPreference(UserPreferences.PREF_EPISODE_CACHE_SIZE).setEnabled(enabled);
+                        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled(enabled);
+                        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled(enabled);
+                        setSelectedNetworksEnabled(enabled && UserPreferences.isEnableAutodownloadWifiFilter());
                     }
+                    return true;
                 });
         ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER)
                 .setOnPreferenceChangeListener(
@@ -527,21 +526,17 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
 
     @SuppressWarnings("deprecation")
     private void checkItemVisibility() {
-
         boolean hasFlattrToken = FlattrUtils.hasToken();
-
         ui.findPreference(PreferenceController.PREF_FLATTR_SETTINGS).setEnabled(FlattrUtils.hasAPICredentials());
         ui.findPreference(PreferenceController.PREF_FLATTR_AUTH).setEnabled(!hasFlattrToken);
         ui.findPreference(PreferenceController.PREF_FLATTR_REVOKE).setEnabled(hasFlattrToken);
         ui.findPreference(PreferenceController.PREF_AUTO_FLATTR_PREFS).setEnabled(hasFlattrToken);
 
-        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER)
-                .setEnabled(UserPreferences.isEnableAutodownload());
-        setSelectedNetworksEnabled(UserPreferences.isEnableAutodownload()
-                && UserPreferences.isEnableAutodownloadWifiFilter());
-
-        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY)
-                .setEnabled(UserPreferences.isEnableAutodownload());
+        boolean autoDownload = UserPreferences.isEnableAutodownload();
+        ui.findPreference(UserPreferences.PREF_EPISODE_CACHE_SIZE).setEnabled(autoDownload);
+        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled(autoDownload);
+        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled(autoDownload);
+        setSelectedNetworksEnabled(autoDownload && UserPreferences.isEnableAutodownloadWifiFilter());
 
         ui.findPreference("prefSendCrashReport").setEnabled(CrashReportWriter.getFile().exists());
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -170,13 +170,6 @@
             android:key="prefParallelDownloads"
             android:title="@string/pref_parallel_downloads_title"
             app:useStockLayout="true"/>
-        <com.afollestad.materialdialogs.prefs.MaterialListPreference
-            android:defaultValue="20"
-            android:entries="@array/episode_cache_size_entries"
-            android:key="prefEpisodeCacheSize"
-            android:title="@string/pref_episode_cache_title"
-            android:entryValues="@array/episode_cache_size_values"
-            app:useStockLayout="true"/>
         <PreferenceScreen
             android:summary="@string/pref_automatic_download_sum"
             android:key="prefAutoDownloadSettings"
@@ -185,6 +178,13 @@
                 android:key="prefEnableAutoDl"
                 android:title="@string/pref_automatic_download_title"
                 android:defaultValue="false"/>
+            <com.afollestad.materialdialogs.prefs.MaterialListPreference
+                android:defaultValue="20"
+                android:entries="@array/episode_cache_size_entries"
+                android:key="prefEpisodeCacheSize"
+                android:title="@string/pref_episode_cache_title"
+                android:entryValues="@array/episode_cache_size_values"
+                app:useStockLayout="true"/>
             <de.danoeh.antennapod.preferences.SwitchCompatPreference
                 android:key="prefEnableAutoDownloadOnBattery"
                 android:title="@string/pref_automatic_download_on_battery_title"


### PR DESCRIPTION
After the episode cache limit makes only sense in connection with auto downloading, it should be in the corresponding sub menu.

Before
![before](https://cloud.githubusercontent.com/assets/6860662/12302560/0188514e-ba26-11e5-97a9-e0ebced72ceb.png)

After
![after](https://cloud.githubusercontent.com/assets/6860662/12302564/04ec3544-ba26-11e5-89a2-826981371c3b.png)

All tests passed.