### PR TITLE
Pub date formatting

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -4,7 +4,6 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
-import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -15,7 +14,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -36,6 +34,7 @@ import de.danoeh.antennapod.core.glide.ApGlideSettings;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.fragment.ItemFragment;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
@@ -118,8 +117,8 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         holder.placeholder.setVisibility(View.VISIBLE);
         holder.placeholder.setText(item.getFeed().getTitle());
         holder.title.setText(item.getTitle());
-        holder.pubDate.setText(DateUtils.formatDateTime(mainActivityRef.get(),
-                item.getPubDate().getTime(), DateUtils.FORMAT_ABBREV_ALL));
+        String pubDateStr = DateUtils.formatAbbrev(mainActivityRef.get(), item.getPubDate());
+        holder.pubDate.setText(pubDateStr);
         if (showOnlyNewEpisodes || false == item.isNew()) {
             holder.statusUnread.setVisibility(View.INVISIBLE);
         } else {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadedEpisodesListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadedEpisodesListAdapter.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
-import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,12 +10,12 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.glide.ApGlideSettings;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.DateUtils;
 
 /**
  * Shows a list of downloaded episodes
@@ -75,7 +74,8 @@ public class DownloadedEpisodesListAdapter extends BaseAdapter {
         }
 
         holder.title.setText(item.getTitle());
-        holder.pubDate.setText(DateUtils.formatDateTime(context, item.getPubDate().getTime(), DateUtils.FORMAT_ABBREV_ALL));
+        String pubDateStr = DateUtils.formatAbbrev(context, item.getPubDate());
+        holder.pubDate.setText(pubDateStr);
         holder.txtvSize.setText(Converter.byteToString(item.getMedia().getSize()));
         FeedItem.State state = item.getState();
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -2,7 +2,6 @@ package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -23,6 +22,7 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
+import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.ThemeUtils;
 
 /**
@@ -143,8 +143,8 @@ public class FeedItemlistAdapter extends BaseAdapter {
                 ViewHelper.setAlpha(convertView, 1.0f);
             }
 
-            holder.published.setText(DateUtils.formatDateTime(context, item.getPubDate().getTime(), DateUtils.FORMAT_ABBREV_ALL));
-
+            String pubDateStr = DateUtils.formatAbbrev(context, item.getPubDate());
+            holder.published.setText(pubDateStr);
 
             FeedMedia media = item.getMedia();
             if (media == null) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -6,7 +6,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.MotionEventCompat;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
-import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -28,6 +27,8 @@ import com.bumptech.glide.request.target.GlideDrawableImageViewTarget;
 import com.joanzapata.iconify.Iconify;
 import com.nineoldandroids.view.ViewHelper;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.lang.ref.WeakReference;
 
 import de.danoeh.antennapod.R;
@@ -38,6 +39,7 @@ import de.danoeh.antennapod.core.glide.ApGlideSettings;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.fragment.ItemFragment;
@@ -209,9 +211,21 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
             FeedMedia media = item.getMedia();
 
             title.setText(item.getTitle());
-            String pubDateStr = DateUtils.formatDateTime(mainActivity.get(),
-                item.getPubDate().getTime(), DateUtils.FORMAT_ABBREV_ALL);
-            pubDate.setText(pubDateStr.replace(" ", "\n"));
+            String pubDateStr = DateUtils.formatAbbrev(mainActivity.get(), item.getPubDate());
+            int index = 0;
+            if(StringUtils.countMatches(pubDateStr, ' ') == 1 || StringUtils.countMatches(pubDateStr, ' ') == 2) {
+                index = pubDateStr.lastIndexOf(' ');
+            } else if(StringUtils.countMatches(pubDateStr, '.') == 2) {
+                index = pubDateStr.lastIndexOf('.');
+            } else if(StringUtils.countMatches(pubDateStr, '-') == 2) {
+                index = pubDateStr.lastIndexOf('-');
+            } else if(StringUtils.countMatches(pubDateStr, '/') == 2) {
+                index = pubDateStr.lastIndexOf('/');
+            }
+            if(index > 0) {
+                pubDateStr = pubDateStr.substring(0, index+1).trim() + "\n" + pubDateStr.substring(index+1);
+            }
+            pubDate.setText(pubDateStr);
 
             if (media != null) {
                 final boolean isDownloadingMedia = DownloadRequester.getInstance().isDownloadingFile(media);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -11,7 +11,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.util.Pair;
 import android.text.TextUtils;
-import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -55,6 +54,7 @@ import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequestException;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.ShareUtils;
@@ -297,7 +297,8 @@ public class ItemFragment extends Fragment {
         txtvTitle.setText(item.getTitle());
 
         if (item.getPubDate() != null) {
-            txtvPublished.setText(DateUtils.formatDateTime(getActivity(), item.getPubDate().getTime(), DateUtils.FORMAT_ABBREV_ALL));
+            String pubDateStr = DateUtils.formatAbbrev(getActivity(), item.getPubDate());
+            txtvPublished.setText(pubDateStr);
         }
 
         Glide.with(getActivity())

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -77,7 +77,7 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentTop="true"
             android:layout_marginLeft="8dp"
-            android:gravity="right|bottom"
+            android:gravity="right|top"
             android:text="Feb\n12"
             tools:background="@android:color/holo_blue_light" />
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.util;
 
+import android.content.Context;
 import android.util.Log;
 
 import org.apache.commons.lang3.StringUtils;
@@ -7,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -140,5 +142,18 @@ public class DateUtils {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         format.setTimeZone(defaultTimezone);
         return format.format(date);
+    }
+
+    public static String formatAbbrev(final Context context, final Date date) {
+        GregorianCalendar cal = new GregorianCalendar();
+        cal.add(GregorianCalendar.YEAR, -1);
+        // some padding, because no one really remembers what day of the month it is
+        cal.add(GregorianCalendar.DAY_OF_MONTH, 10);
+        boolean withinLastYear = date.after(cal.getTime());
+        int format = android.text.format.DateUtils.FORMAT_ABBREV_ALL;
+        if(withinLastYear) {
+            format |= android.text.format.DateUtils.FORMAT_NO_YEAR;
+        }
+        return android.text.format.DateUtils.formatDateTime(context, date.getTime(), format);
     }
 }


### PR DESCRIPTION
In the first step, I made the date wrap more nicely.

The second step follows the idea that the year is not really necessary if the podcast was published within the last year.
I also added some padding. Today is January 15,  2016. To not get confusing, on January 5, 2017, we will start showing the year of publication for a podcast published today.

[Before, intermediate, result]
![pub_date](https://cloud.githubusercontent.com/assets/6860662/12363870/7d2a7830-bbcb-11e5-9e62-ef8724e8a80b.png)
