### PR TITLE
Promote Sonic

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -76,6 +76,12 @@
     <PreferenceCategory android:title="@string/playback_pref">
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="true"
+            android:enabled="false"
+            android:key="prefSonic"
+            android:summary="@string/pref_sonic_message"
+            android:title="@string/pref_sonic_title"/>
+        <de.danoeh.antennapod.preferences.SwitchCompatPreference
+            android:defaultValue="true"
             android:enabled="true"
             android:key="prefPauseOnHeadsetDisconnect"
             android:summary="@string/pref_pauseOnDisconnect_sum"
@@ -263,14 +269,5 @@
             android:title="@string/crash_report_title"
             android:summary="@string/crash_report_sum"/>
     </PreferenceCategory>
-
-    <PreferenceCategory android:title="@string/experimental_pref">
-    <de.danoeh.antennapod.preferences.SwitchCompatPreference
-        android:defaultValue="false"
-        android:enabled="false"
-        android:key="prefSonic"
-        android:summary="@string/pref_sonic_message"
-        android:title="@string/pref_sonic_title"/>
-    </PreferenceCategory>
-
+    
 </PreferenceScreen>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -267,7 +267,7 @@
     <!--  Variable Speed -->
     <string name="download_plugin_label">Download Plugin</string>
     <string name="no_playback_plugin_title">Plugin Not Installed</string>
-    <string name="no_playback_plugin_or_sonic_msg">For variable speed playback to work, you have to install a third party library or enable the experimental Sonic player [Android 4.1+].\n\nTap \'Download Plugin\' to download a free plugin from the Play Store.\n\nAny problems found using this plugin are not the responsibility of AntennaPod and should be reported to the plugin owner.</string>
+    <string name="no_playback_plugin_or_sonic_msg">For variable speed playback to work, we recommend to enable the built-in Sonic mediaplayer [Android 4.1+].\n\nAlternatively, you can download the third party plugin <i>Prestissimo</i> from the Play Store.\nAny problems with Prestissimo are not the responsibility of AntennaPod and should be reported to the plugin owner.</string>
     <string name="set_playback_speed_label">Playback Speeds</string>
     <string name="enable_sonic">Enable Sonic</string>
 
@@ -380,7 +380,7 @@
     <string name="send_email">Send e-mail</string>
     <string name="experimental_pref">Experimental</string>
     <string name="pref_sonic_title">Sonic media player</string>
-    <string name="pref_sonic_message">Use built-in sonic media player as a replacement for Prestissimo</string>
+    <string name="pref_sonic_message">Use built-in sonic media player as a replacement for Android\'s native mediaplayer and Prestissimo</string>
     <string name="pref_current_value">Current value: %1$s</string>
 
     <!-- Auto-Flattr dialog -->


### PR DESCRIPTION
Changes:
Sonic is now enabled by default. Instead of being in the experimental section of the settings, it is the first item in the playback section (above headphones disconnect/reconnect etc.).
See below: Also added a dialog that asks current users to switch to sonic (Android 4.1-5.1.1). Changing the dialog that is shown when variable playback speed is not available (native mediaplayer, pre-Marshmallow) also made sense to me.

![promote_sonic](https://cloud.githubusercontent.com/assets/6860662/12372379/3d8369b0-bc54-11e5-9d4d-2f30c01d886c.png)
[Download Plugin is greyed out because screenshot was taken on an emulator]

Resolves #1309