### PR TITLE
Avoid download retry loop when storage is full

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -68,6 +68,7 @@ public class QueueFragment extends Fragment {
     public static final String TAG = "QueueFragment";
 
     private static final int EVENTS = EventDistributor.DOWNLOAD_HANDLED |
+            EventDistributor.UNREAD_ITEMS_UPDATE | // sent when playback position is reset
             EventDistributor.PLAYER_STATUS_UPDATE;
 
     private TextView infoBar;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -204,8 +204,10 @@ public class DownloadService extends Service {
                                         return;
                                     }
                                     FeedItem item = media.getItem();
-                                    if (status.getReason() == DownloadError.ERROR_HTTP_DATA_ERROR &&
-                                            Integer.valueOf(status.getReasonDetailed()) == HttpURLConnection.HTTP_NOT_FOUND) {
+                                    boolean httpNotFound = status.getReason() == DownloadError.ERROR_HTTP_DATA_ERROR
+                                            && String.valueOf(HttpURLConnection.HTTP_NOT_FOUND).equals(status.getReasonDetailed());
+                                    boolean notEnoughSpace = status.getReason() == DownloadError.ERROR_NOT_ENOUGH_SPACE;
+                                    if (httpNotFound || notEnoughSpace) {
                                         DBWriter.saveFeedItemAutoDownloadFailed(item).get();
                                     }
                                     // to make lists reload the failed item, we fake an item update

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -993,7 +993,6 @@ public class DBWriter {
     public static Future<?> saveFeedItemAutoDownloadFailed(final FeedItem feedItem) {
         return dbExec.submit(() -> {
             int failedAttempts = feedItem.getFailedAutoDownloadAttempts() + 1;
-            Log.d(TAG, "failedAttempts: " + failedAttempts);
             long autoDownload;
             if(!feedItem.getAutoDownload() || failedAttempts >= 10) {
                 autoDownload = 0; // giving up, disable auto download
@@ -1001,8 +1000,6 @@ public class DBWriter {
             } else {
                 long now = System.currentTimeMillis();
                 autoDownload = (now / 10) * 10 + failedAttempts;
-                Log.d(TAG, "now: " + now);
-                Log.d(TAG, "autoDownload: " + autoDownload);
             }
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();


### PR DESCRIPTION
~~Honestly no idea how to test this.~~~
If you can't make it, fake it. throw the exception in HttpDownloader, manually. Seems to work.

Basically, this piggybacks on the functionality for 404 HTTP errors.

Resolves #1296 

[Dang, based this on #1566. But now I'm to lazy to fix it...]