### PR TITLE
Widget: Update playback position every second

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
+++ b/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
@@ -128,7 +128,7 @@ public class PlayerWidgetService extends Service {
 
                 views.setTextViewText(R.id.txtvTitle, media.getEpisodeTitle());
 
-                String progressString = getProgressString(media);
+                String progressString = getProgressString();
                 if (progressString != null) {
                     views.setViewVisibility(R.id.txtvProgress, View.VISIBLE);
                     views.setTextViewText(R.id.txtvProgress, progressString);
@@ -181,9 +181,9 @@ public class PlayerWidgetService extends Service {
         return PendingIntent.getBroadcast(this, 0, startingIntent, 0);
     }
 
-    private String getProgressString(Playable media) {
-        int position = media.getPosition();
-        int duration = media.getDuration();
+    private String getProgressString() {
+        int position = playbackService.getCurrentPosition();
+        int duration = playbackService.getDuration();
         if (position > 0 && duration > 0) {
             return Converter.getDurationStringLong(position) + " / "
                     + Converter.getDurationStringLong(duration);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -39,7 +39,7 @@ public class PlaybackServiceTaskManager {
     /**
      * Notification interval of widget updater in milliseconds.
      */
-    public static final int WIDGET_UPDATER_NOTIFICATION_INTERVAL = 1500;
+    public static final int WIDGET_UPDATER_NOTIFICATION_INTERVAL = 1000;
 
     private static final int SCHED_EX_POOL_SIZE = 2;
     private final ScheduledThreadPoolExecutor schedExecutor;


### PR DESCRIPTION
Problem: FeedMedia's internal position is only updated every 5 seconds [1]. The widget would get updated about every 1.5s, but would read this often obsolete value. Now, we get the position directly from the playback service (and update every second).

Resolves #1278

--
[1] https://github.com/AntennaPod/AntennaPod/blob/f3758e33c28eae203bd6cfd0fee8cf3fb9c6b2d5/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java#L38