### PR TITLE
Say '1 download left' instead of '1 downloads left'

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -361,7 +361,8 @@ public class DownloadService extends Service {
         int numDownloads = requester.getNumberOfDownloads();
         String downloadsLeft;
         if (numDownloads > 0) {
-            downloadsLeft = requester.getNumberOfDownloads() + getString(R.string.downloads_left);
+            downloadsLeft = getResources()
+                    .getQuantityString(R.plurals.downloads_left, numDownloads, numDownloads);
         } else {
             downloadsLeft = getString(R.string.downloads_processing);
         }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -187,7 +187,10 @@
     <string name="download_error_io_error">IO Error</string>
     <string name="download_error_request_error">Request Error</string>
     <string name="download_error_db_access">Database Access Error</string>
-    <string name="downloads_left">\u0020Downloads left</string>
+    <plurals name="downloads_left">
+        <item quantity="one">%d download left</item>
+        <item quantity="other">%d downloads left</item>
+    </plurals>
     <string name="downloads_processing">Processing downloads</string>
     <string name="download_notification_title">Downloading podcast data</string>
     <string name="download_report_content">%1$d downloads succeeded, %2$d failed</string>


### PR DESCRIPTION
Uses `<plurals>` instead of just a normal string

Fixes #818