### PR TITLE
LinePageIndicator uses MathFloat, which doesn't exist anymore.

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -102,3 +102,6 @@
     **[] $VALUES;
     public *;
 }
+
+# for ViewPageIndicator problems (https://github.com/JakeWharton/ViewPagerIndicator/issues/366):
+-dontwarn com.viewpagerindicator.LinePageIndicator


### PR DESCRIPTION
 I don't think we use it so we should be OK to ignore this.

@mfietz can correct me and suggest an alternative fix if he disagrees.