### PR TITLE
Eliminate confusion from UI elements that change playback speed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
@@ -35,11 +35,15 @@ public class VariableSpeedDialog {
                 || Build.VERSION.SDK_INT >= 23) {
             showSpeedSelectorDialog(context);
         } else {
-            showGetPluginDialog(context);
+            showGetPluginDialog(context, true);
         }
     }
 
-    private static void showGetPluginDialog(final Context context) {
+    public static void showGetPluginDialog(final Context context) {
+        showGetPluginDialog(context, false);
+    }
+
+    private static void showGetPluginDialog(final Context context, boolean showSpeedSelector) {
         MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
         builder.title(R.string.no_playback_plugin_title);
         builder.content(R.string.no_playback_plugin_or_sonic_msg);
@@ -49,7 +53,9 @@ public class VariableSpeedDialog {
         builder.onPositive((dialog, which) -> {
             if (Build.VERSION.SDK_INT >= 16) { // just to be safe
                 UserPreferences.enableSonic(true);
-                showSpeedSelectorDialog(context);
+                if(showSpeedSelector) {
+                    showSpeedSelectorDialog(context);
+                }
             }
         });
         builder.onNegative((dialog, which) -> {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -11,6 +11,7 @@ import android.content.SharedPreferences;
 import android.content.res.TypedArray;
 import android.media.MediaPlayer;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -34,6 +35,7 @@ import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
@@ -677,6 +679,11 @@ public abstract class PlaybackController {
     }
 
     public boolean canSetPlaybackSpeed() {
+        if (org.antennapod.audio.MediaPlayer.isPrestoLibraryInstalled(activity.getApplicationContext())
+                || UserPreferences.useSonic()
+                || Build.VERSION.SDK_INT >= 23) {
+            return true;
+        }
         return playbackService != null && playbackService.canSetSpeed();
     }
 


### PR DESCRIPTION
Resolves #1603 

Changes in ``canSetPlaybackSpeed()`` go beyond the linked issue. Necessary because we often change the media player "on the fly". The current mp might not have playback speed capabilities, but we can switch to an implementation that does.