### PR TITLE
Prevent native mediaplayer from unpausing when playback speed is changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ project.ext {
     rxJavaVersion = "1.1.0"
     rxJavaRulesVersion = "1.1.0.0"
 
-    audioPlayerVersion = "v1.0.9"
+    audioPlayerVersion = "v1.0.10"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
Resolves #1601 

Doesn't work perfectly, but as this seems to be a problem in Android, this might be the best workaround [1].

--
[1] see https://github.com/AntennaPod/AntennaPod-AudioPlayer/commit/a3d3967b0715905d8f13674f4bd5620a65c4e4ca