### PR TITLE
Added 'Keep Updated' option for Feeds

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -177,7 +177,6 @@ public class FeedInfoActivity extends ActionBarActivity {
                                 feed, checked);
                         dialog.createNewDialog().show();
                     });
-                    cbxGlobalRefresh.setEnabled(true);
                     cbxGlobalRefresh.setChecked(prefs.getGlobalRefresh());
                     cbxGlobalRefresh.setOnCheckedChangeListener((compoundButton, checked) -> {
                         feed.getPreferences().setGlobalRefresh(checked);

--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -66,7 +66,7 @@ public class FeedInfoActivity extends ActionBarActivity {
     private RadioButton rdoFilterInclude;
     private RadioButton rdoFilterExclude;
     private CheckBox cbxAutoDownload;
-    private CheckBox cbxGlobalRefresh;
+    private CheckBox cbxKeepUpdated;
     private Spinner spnAutoDelete;
     private boolean filterInclude = true;
 
@@ -106,7 +106,7 @@ public class FeedInfoActivity extends ActionBarActivity {
         txtvAuthor = (TextView) findViewById(R.id.txtvAuthor);
         txtvUrl = (TextView) findViewById(R.id.txtvUrl);
         cbxAutoDownload = (CheckBox) findViewById(R.id.cbxAutoDownload);
-        cbxGlobalRefresh = (CheckBox) findViewById(R.id.cbxGlobalRefresh);
+        cbxKeepUpdated = (CheckBox) findViewById(R.id.cbxKeepUpdated);
         spnAutoDelete = (Spinner) findViewById(R.id.spnAutoDelete);
         etxtUsername = (EditText) findViewById(R.id.etxtUsername);
         etxtPassword = (EditText) findViewById(R.id.etxtPassword);
@@ -177,9 +177,9 @@ public class FeedInfoActivity extends ActionBarActivity {
                                 feed, checked);
                         dialog.createNewDialog().show();
                     });
-                    cbxGlobalRefresh.setChecked(prefs.getGlobalRefresh());
-                    cbxGlobalRefresh.setOnCheckedChangeListener((compoundButton, checked) -> {
-                        feed.getPreferences().setGlobalRefresh(checked);
+                    cbxKeepUpdated.setChecked(prefs.getKeepUpdated());
+                    cbxKeepUpdated.setOnCheckedChangeListener((compoundButton, checked) -> {
+                        feed.getPreferences().setKeepUpdated(checked);
                         feed.savePreferences(FeedInfoActivity.this);
                     });
                     spnAutoDelete.setOnItemSelectedListener(new OnItemSelectedListener() {

--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -18,7 +18,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.RadioButton;
@@ -67,6 +66,7 @@ public class FeedInfoActivity extends ActionBarActivity {
     private RadioButton rdoFilterInclude;
     private RadioButton rdoFilterExclude;
     private CheckBox cbxAutoDownload;
+    private CheckBox cbxGlobalRefresh;
     private Spinner spnAutoDelete;
     private boolean filterInclude = true;
 
@@ -106,6 +106,7 @@ public class FeedInfoActivity extends ActionBarActivity {
         txtvAuthor = (TextView) findViewById(R.id.txtvAuthor);
         txtvUrl = (TextView) findViewById(R.id.txtvUrl);
         cbxAutoDownload = (CheckBox) findViewById(R.id.cbxAutoDownload);
+        cbxGlobalRefresh = (CheckBox) findViewById(R.id.cbxGlobalRefresh);
         spnAutoDelete = (Spinner) findViewById(R.id.spnAutoDelete);
         etxtUsername = (EditText) findViewById(R.id.etxtUsername);
         etxtPassword = (EditText) findViewById(R.id.etxtPassword);
@@ -168,16 +169,19 @@ public class FeedInfoActivity extends ActionBarActivity {
 
                     cbxAutoDownload.setEnabled(UserPreferences.isEnableAutodownload());
                     cbxAutoDownload.setChecked(prefs.getAutoDownload());
-                    cbxAutoDownload.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                        @Override
-                        public void onCheckedChanged(CompoundButton compoundButton, boolean checked) {
-                            feed.getPreferences().setAutoDownload(checked);
-                            feed.savePreferences(FeedInfoActivity.this);
-                            updateAutoDownloadSettings();
-                            ApplyToEpisodesDialog dialog = new ApplyToEpisodesDialog(FeedInfoActivity.this,
-                                    feed, checked);
-                            dialog.createNewDialog().show();
-                        }
+                    cbxAutoDownload.setOnCheckedChangeListener((compoundButton, checked) -> {
+                        feed.getPreferences().setAutoDownload(checked);
+                        feed.savePreferences(FeedInfoActivity.this);
+                        updateAutoDownloadSettings();
+                        ApplyToEpisodesDialog dialog = new ApplyToEpisodesDialog(FeedInfoActivity.this,
+                                feed, checked);
+                        dialog.createNewDialog().show();
+                    });
+                    cbxGlobalRefresh.setEnabled(true);
+                    cbxGlobalRefresh.setChecked(prefs.getGlobalRefresh());
+                    cbxGlobalRefresh.setOnCheckedChangeListener((compoundButton, checked) -> {
+                        feed.getPreferences().setGlobalRefresh(checked);
+                        feed.savePreferences(FeedInfoActivity.this);
                     });
                     spnAutoDelete.setOnItemSelectedListener(new OnItemSelectedListener() {
                         @Override

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -182,11 +182,11 @@
             </android.support.v7.widget.GridLayout>
 
             <CheckBox
-                android:id="@+id/cbxGlobalRefresh"
+                android:id="@+id/cbxKeepUpdated"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="@string/global_refresh"
+                android:text="@string/keep_updated"
                 android:enabled="true"
                 android:textColor="?android:attr/textColorPrimary"
                 tools:background="@android:color/holo_red_light"

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -181,6 +181,17 @@
                     android:clickable="true" />
             </android.support.v7.widget.GridLayout>
 
+            <CheckBox
+                android:id="@+id/cbxGlobalRefresh"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/global_refresh"
+                android:enabled="false"
+                android:textColor="?android:attr/textColorPrimary"
+                tools:background="@android:color/holo_red_light"
+                android:checked="false" />
+
             <TextView
                 android:id="@+id/txtvAuthentication"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -187,10 +187,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:text="@string/global_refresh"
-                android:enabled="false"
+                android:enabled="true"
                 android:textColor="?android:attr/textColorPrimary"
                 tools:background="@android:color/holo_red_light"
-                android:checked="false" />
+                android:checked="true" />
 
             <TextView
                 android:id="@+id/txtvAuthentication"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -18,6 +18,7 @@ public class FeedPreferences {
     private FeedFilter filter;
     private long feedID;
     private boolean autoDownload;
+    private boolean globalRefresh;
 
     public enum AutoDeleteAction {
         GLOBAL,
@@ -29,12 +30,13 @@ public class FeedPreferences {
     private String password;
 
     public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String username, String password) {
-        this(feedID, autoDownload, auto_delete_action, username, password, new FeedFilter());
+        this(feedID, autoDownload, true, auto_delete_action, username, password, new FeedFilter());
     }
 
-    public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter) {
+    public FeedPreferences(long feedID, boolean autoDownload, boolean globalRefresh, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
+        this.globalRefresh = globalRefresh;
         this.auto_delete_action = auto_delete_action;
         this.username = username;
         this.password = password;
@@ -44,6 +46,7 @@ public class FeedPreferences {
     public static FeedPreferences fromCursor(Cursor cursor) {
         int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
         int indexAutoDownload = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DOWNLOAD);
+        int indexAutoRefresh = cursor.getColumnIndex(PodDBAdapter.KEY_GLOBAL_REFRESH);
         int indexAutoDeleteAction = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DELETE_ACTION);
         int indexUsername = cursor.getColumnIndex(PodDBAdapter.KEY_USERNAME);
         int indexPassword = cursor.getColumnIndex(PodDBAdapter.KEY_PASSWORD);
@@ -52,13 +55,14 @@ public class FeedPreferences {
 
         long feedId = cursor.getLong(indexId);
         boolean autoDownload = cursor.getInt(indexAutoDownload) > 0;
+        boolean autoRefresh = cursor.getInt(indexAutoRefresh) > 0;
         int autoDeleteActionIndex = cursor.getInt(indexAutoDeleteAction);
         AutoDeleteAction autoDeleteAction = AutoDeleteAction.values()[autoDeleteActionIndex];
         String username = cursor.getString(indexUsername);
         String password = cursor.getString(indexPassword);
         String includeFilter = cursor.getString(indexIncludeFilter);
         String excludeFilter = cursor.getString(indexExcludeFilter);
-        return new FeedPreferences(feedId, autoDownload, autoDeleteAction, username, password, new FeedFilter(includeFilter, excludeFilter));
+        return new FeedPreferences(feedId, autoDownload, autoRefresh, autoDeleteAction, username, password, new FeedFilter(includeFilter, excludeFilter));
     }
 
     /**
@@ -70,6 +74,18 @@ public class FeedPreferences {
 
     public void setFilter(@NonNull FeedFilter filter) {
         this.filter = filter;
+    }
+
+    /**
+     * @return true if this feed should be refreshed when everything else is being refreshed
+     *         if false the feed should only be refreshed if requested directly.
+     */
+    public boolean getGlobalRefresh() {
+        return globalRefresh;
+    }
+
+    public void setGlobalRefresh(boolean globalRefresh) {
+        this.globalRefresh = globalRefresh;
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -18,7 +18,7 @@ public class FeedPreferences {
     private FeedFilter filter;
     private long feedID;
     private boolean autoDownload;
-    private boolean globalRefresh;
+    private boolean keepUpdated;
 
     public enum AutoDeleteAction {
         GLOBAL,
@@ -33,10 +33,10 @@ public class FeedPreferences {
         this(feedID, autoDownload, true, auto_delete_action, username, password, new FeedFilter());
     }
 
-    public FeedPreferences(long feedID, boolean autoDownload, boolean globalRefresh, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter) {
+    public FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
-        this.globalRefresh = globalRefresh;
+        this.keepUpdated = keepUpdated;
         this.auto_delete_action = auto_delete_action;
         this.username = username;
         this.password = password;
@@ -46,7 +46,7 @@ public class FeedPreferences {
     public static FeedPreferences fromCursor(Cursor cursor) {
         int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
         int indexAutoDownload = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DOWNLOAD);
-        int indexAutoRefresh = cursor.getColumnIndex(PodDBAdapter.KEY_GLOBAL_REFRESH);
+        int indexAutoRefresh = cursor.getColumnIndex(PodDBAdapter.KEY_KEEP_UPDATED);
         int indexAutoDeleteAction = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DELETE_ACTION);
         int indexUsername = cursor.getColumnIndex(PodDBAdapter.KEY_USERNAME);
         int indexPassword = cursor.getColumnIndex(PodDBAdapter.KEY_PASSWORD);
@@ -80,12 +80,12 @@ public class FeedPreferences {
      * @return true if this feed should be refreshed when everything else is being refreshed
      *         if false the feed should only be refreshed if requested directly.
      */
-    public boolean getGlobalRefresh() {
-        return globalRefresh;
+    public boolean getKeepUpdated() {
+        return keepUpdated;
     }
 
-    public void setGlobalRefresh(boolean globalRefresh) {
-        this.globalRefresh = globalRefresh;
+    public void setKeepUpdated(boolean keepUpdated) {
+        this.keepUpdated = keepUpdated;
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -371,7 +371,7 @@ public final class DBReader {
 
     /**
      * Loads a list of FeedItems that are considered new.
-     *
+     * Excludes items from feeds that do not have global refresh enabled.
      * @return A list of FeedItems that are considered new.
      */
     public static List<FeedItem> getNewItemsList() {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -371,7 +371,7 @@ public final class DBReader {
 
     /**
      * Loads a list of FeedItems that are considered new.
-     * Excludes items from feeds that do not have global refresh enabled.
+     * Excludes items from feeds that do not have keep updated enabled.
      * @return A list of FeedItems that are considered new.
      */
     public static List<FeedItem> getNewItemsList() {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -196,9 +196,9 @@ public final class DBTasks {
 
         for (Feed feed : feedList) {
             FeedPreferences prefs = feed.getPreferences();
-            // feeds with !getGlobalRefresh can only be refreshed
+            // feeds with !getKeepUpdated can only be refreshed
             // directly from the FeedActivity
-            if (prefs.getGlobalRefresh()) {
+            if (prefs.getKeepUpdated()) {
                 try {
                     refreshFeed(context, feed);
                 } catch (DownloadRequestException e) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -26,6 +26,7 @@ import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.service.GpodnetSyncService;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
@@ -186,21 +187,30 @@ public final class DBTasks {
         }
     }
 
+    /**
+     * @param context
+     * @param feedList the list of feeds to refresh
+     */
     private static void refreshFeeds(final Context context,
                                      final List<Feed> feedList) {
 
         for (Feed feed : feedList) {
-            try {
-                refreshFeed(context, feed);
-            } catch (DownloadRequestException e) {
-                e.printStackTrace();
-                DBWriter.addDownloadStatus(
-                        new DownloadStatus(feed, feed
-                                .getHumanReadableIdentifier(),
-                                DownloadError.ERROR_REQUEST_ERROR, false, e
-                                .getMessage()
-                        )
-                );
+            FeedPreferences prefs = feed.getPreferences();
+            // feeds with !getGlobalRefresh can only be refreshed
+            // directly from the FeedActivity
+            if (prefs.getGlobalRefresh()) {
+                try {
+                    refreshFeed(context, feed);
+                } catch (DownloadRequestException e) {
+                    e.printStackTrace();
+                    DBWriter.addDownloadStatus(
+                            new DownloadStatus(feed, feed
+                                    .getHumanReadableIdentifier(),
+                                    DownloadError.ERROR_REQUEST_ERROR, false, e
+                                    .getMessage()
+                            )
+                    );
+                }
             }
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1147,6 +1147,7 @@ public class PodDBAdapter {
 
     /**
      * Returns a cursor which contains all feed items that are considered new.
+     * Excludes those feeds that do not have 'global_refresh' enabled.
      * The returned cursor uses the FEEDITEM_SEL_FI_SMALL selection.
      */
     public final Cursor getNewItemsCursor() {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -92,6 +92,7 @@ public class PodDBAdapter {
     public static final String KEY_CHAPTER_TYPE = "type";
     public static final String KEY_PLAYBACK_COMPLETION_DATE = "playback_completion_date";
     public static final String KEY_AUTO_DOWNLOAD = "auto_download";
+    public static final String KEY_GLOBAL_REFRESH = "global_refresh";
     public static final String KEY_AUTO_DELETE_ACTION = "auto_delete_action";
     public static final String KEY_PLAYED_DURATION = "played_duration";
     public static final String KEY_USERNAME = "username";
@@ -132,6 +133,7 @@ public class PodDBAdapter {
             + KEY_PASSWORD + " TEXT,"
             + KEY_INCLUDE_FILTER + " TEXT DEFAULT '',"
             + KEY_EXCLUDE_FILTER + " TEXT DEFAULT '',"
+            + KEY_GLOBAL_REFRESH + " INTEGER DEFAULT 1,"
             + KEY_IS_PAGED + " INTEGER DEFAULT 0,"
             + KEY_NEXT_PAGE_LINK + " TEXT,"
             + KEY_HIDE + " TEXT,"
@@ -234,6 +236,7 @@ public class PodDBAdapter {
             TABLE_NAME_FEEDS + "." + KEY_TYPE,
             TABLE_NAME_FEEDS + "." + KEY_FEED_IDENTIFIER,
             TABLE_NAME_FEEDS + "." + KEY_AUTO_DOWNLOAD,
+            TABLE_NAME_FEEDS + "." + KEY_GLOBAL_REFRESH,
             TABLE_NAME_FEEDS + "." + KEY_FLATTR_STATUS,
             TABLE_NAME_FEEDS + "." + KEY_IS_PAGED,
             TABLE_NAME_FEEDS + "." + KEY_NEXT_PAGE_LINK,
@@ -398,6 +401,7 @@ public class PodDBAdapter {
         }
         ContentValues values = new ContentValues();
         values.put(KEY_AUTO_DOWNLOAD, prefs.getAutoDownload());
+        values.put(KEY_GLOBAL_REFRESH, prefs.getGlobalRefresh());
         values.put(KEY_AUTO_DELETE_ACTION,prefs.getAutoDeleteAction().ordinal());
         values.put(KEY_USERNAME, prefs.getUsername());
         values.put(KEY_PASSWORD, prefs.getPassword());
@@ -1796,6 +1800,10 @@ public class PodDBAdapter {
 
                 db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                         + " ADD COLUMN " + PodDBAdapter.KEY_EXCLUDE_FILTER + " TEXT DEFAULT ''");
+
+                // and now auto refresh
+                db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                        + " ADD COLUMN " + PodDBAdapter.KEY_GLOBAL_REFRESH + " INTEGER DEFAULT 1");
             }
 
             EventBus.getDefault().post(ProgressEvent.end());

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1131,13 +1131,6 @@ public class PodDBAdapter {
         return c;
     }
 
-    public final Cursor getNewItemIdsCursor() {
-        final String query = "SELECT " + KEY_ID
-                + " FROM " + TABLE_NAME_FEED_ITEMS
-                + " WHERE " + KEY_READ + "=" + FeedItem.NEW;
-        return db.rawQuery(query, null);
-    }
-
     /**
      * Returns a cursor which contains all items of a feed that are considered new.
      * The returned cursor uses the FEEDITEM_SEL_FI_SMALL selection.
@@ -1157,10 +1150,15 @@ public class PodDBAdapter {
      * The returned cursor uses the FEEDITEM_SEL_FI_SMALL selection.
      */
     public final Cursor getNewItemsCursor() {
-        final String query = "SELECT " + SEL_FI_SMALL_STR
-                + " FROM " + TABLE_NAME_FEED_ITEMS
-                + " WHERE " + KEY_READ + "=" + FeedItem.NEW
-                + " ORDER BY " + KEY_PUBDATE + " DESC";
+        String[] args = new String[] {
+                SEL_FI_SMALL_STR,
+                TABLE_NAME_FEED_ITEMS,
+                TABLE_NAME_FEEDS,
+                TABLE_NAME_FEED_ITEMS + "." + KEY_FEED + "=" + TABLE_NAME_FEEDS + "." + KEY_ID,
+                TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW + " AND " + TABLE_NAME_FEEDS + "." + KEY_GLOBAL_REFRESH + " > 0",
+                KEY_PUBDATE + " DESC"
+        };
+        final String query = String.format("SELECT %s FROM %s INNER JOIN %s ON %s WHERE %s ORDER BY %s", args);
         Cursor c = db.rawQuery(query, null);
         return c;
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -92,7 +92,7 @@ public class PodDBAdapter {
     public static final String KEY_CHAPTER_TYPE = "type";
     public static final String KEY_PLAYBACK_COMPLETION_DATE = "playback_completion_date";
     public static final String KEY_AUTO_DOWNLOAD = "auto_download";
-    public static final String KEY_GLOBAL_REFRESH = "global_refresh";
+    public static final String KEY_KEEP_UPDATED = "keep_updated";
     public static final String KEY_AUTO_DELETE_ACTION = "auto_delete_action";
     public static final String KEY_PLAYED_DURATION = "played_duration";
     public static final String KEY_USERNAME = "username";
@@ -133,7 +133,7 @@ public class PodDBAdapter {
             + KEY_PASSWORD + " TEXT,"
             + KEY_INCLUDE_FILTER + " TEXT DEFAULT '',"
             + KEY_EXCLUDE_FILTER + " TEXT DEFAULT '',"
-            + KEY_GLOBAL_REFRESH + " INTEGER DEFAULT 1,"
+            + KEY_KEEP_UPDATED + " INTEGER DEFAULT 1,"
             + KEY_IS_PAGED + " INTEGER DEFAULT 0,"
             + KEY_NEXT_PAGE_LINK + " TEXT,"
             + KEY_HIDE + " TEXT,"
@@ -236,7 +236,7 @@ public class PodDBAdapter {
             TABLE_NAME_FEEDS + "." + KEY_TYPE,
             TABLE_NAME_FEEDS + "." + KEY_FEED_IDENTIFIER,
             TABLE_NAME_FEEDS + "." + KEY_AUTO_DOWNLOAD,
-            TABLE_NAME_FEEDS + "." + KEY_GLOBAL_REFRESH,
+            TABLE_NAME_FEEDS + "." + KEY_KEEP_UPDATED,
             TABLE_NAME_FEEDS + "." + KEY_FLATTR_STATUS,
             TABLE_NAME_FEEDS + "." + KEY_IS_PAGED,
             TABLE_NAME_FEEDS + "." + KEY_NEXT_PAGE_LINK,
@@ -401,7 +401,7 @@ public class PodDBAdapter {
         }
         ContentValues values = new ContentValues();
         values.put(KEY_AUTO_DOWNLOAD, prefs.getAutoDownload());
-        values.put(KEY_GLOBAL_REFRESH, prefs.getGlobalRefresh());
+        values.put(KEY_KEEP_UPDATED, prefs.getKeepUpdated());
         values.put(KEY_AUTO_DELETE_ACTION,prefs.getAutoDeleteAction().ordinal());
         values.put(KEY_USERNAME, prefs.getUsername());
         values.put(KEY_PASSWORD, prefs.getPassword());
@@ -1147,7 +1147,7 @@ public class PodDBAdapter {
 
     /**
      * Returns a cursor which contains all feed items that are considered new.
-     * Excludes those feeds that do not have 'global_refresh' enabled.
+     * Excludes those feeds that do not have 'Keep Updated' enabled.
      * The returned cursor uses the FEEDITEM_SEL_FI_SMALL selection.
      */
     public final Cursor getNewItemsCursor() {
@@ -1156,7 +1156,7 @@ public class PodDBAdapter {
                 TABLE_NAME_FEED_ITEMS,
                 TABLE_NAME_FEEDS,
                 TABLE_NAME_FEED_ITEMS + "." + KEY_FEED + "=" + TABLE_NAME_FEEDS + "." + KEY_ID,
-                TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW + " AND " + TABLE_NAME_FEEDS + "." + KEY_GLOBAL_REFRESH + " > 0",
+                TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW + " AND " + TABLE_NAME_FEEDS + "." + KEY_KEEP_UPDATED + " > 0",
                 KEY_PUBDATE + " DESC"
         };
         final String query = String.format("SELECT %s FROM %s INNER JOIN %s ON %s WHERE %s ORDER BY %s", args);
@@ -1802,7 +1802,7 @@ public class PodDBAdapter {
 
                 // and now auto refresh
                 db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
-                        + " ADD COLUMN " + PodDBAdapter.KEY_GLOBAL_REFRESH + " INTEGER DEFAULT 1");
+                        + " ADD COLUMN " + PodDBAdapter.KEY_KEEP_UPDATED + " INTEGER DEFAULT 1");
             }
 
             EventBus.getDefault().post(ProgressEvent.end());

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -536,7 +536,7 @@
     <string name="episode_filters_include">Include</string>
     <string name="episode_filters_exclude">Exclude</string>
     <string name="episode_filters_hint">Single words \n\"Multiple Words\"</string>
-    <string name="global_refresh">Global Refresh</string>
+    <string name="keep_updated">Keep Updated</string>
 
     <!-- Progress information -->
     <string name="progress_upgrading_database">Upgrading the database</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -536,6 +536,7 @@
     <string name="episode_filters_include">Include</string>
     <string name="episode_filters_exclude">Exclude</string>
     <string name="episode_filters_hint">Single words \n\"Multiple Words\"</string>
+    <string name="global_refresh">Global Refresh</string>
 
     <!-- Progress information -->
     <string name="progress_upgrading_database">Upgrading the database</string>


### PR DESCRIPTION
Added a 'Global Refresh' option for feeds.  Defaults to true.

If you disable global refresh for a feed then if you refresh the feed list from the queue, from the episodes list or from a scheduled update then that feed will *not* be refreshed.  Further, any new episodes for the feed will *not* show up in 'New Episodes' though they will continue to show up under the Feed's episode view.

![global_refresh](https://cloud.githubusercontent.com/assets/5216560/12565558/f8dfb9fe-c382-11e5-861f-743ea690beab.png)

resolves #1182 and resolves #286