### PR TITLE
Only reset episode to new if feed item did not link to a file before

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -168,9 +168,8 @@ public class FeedMedia extends FeedFile implements Playable {
     }
 
     public void updateFromOther(FeedMedia other) {
-        // we try to cover two cases: (1) feed did include file before (2) feed contained wrong URL
-        // if item.getAutoDownload() is false, the file has been downloaded before
-        if((TextUtils.isEmpty(download_url) || item.getAutoDownload()) && !TextUtils.isEmpty(other.download_url)) {
+        // reset to new if feed item did link to a file before
+        if(TextUtils.isEmpty(download_url) && !TextUtils.isEmpty(other.download_url)) {
             item.setNew();
         }
         super.updateFromOther(other);


### PR DESCRIPTION
Resolves #1616 (Hopefully)

"if item.getAutoDownload() is false, the file has been downloaded before" is only correct for files downloaded recently.
Actually, checking ``getAutoDownload()`` should not really be necessary. Items with a former wrong URL (that 404'd) should still be new (if the user did not tamper with them).