### PR TITLE
try to fix circleci problem and speed up future builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,15 @@ machine:
   java:
     version: oraclejdk8
 dependencies:
+  cache_directories:
+    - ~/.android
+    - ~/android
   pre:
     - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,android-23"
     - echo y | android update sdk --no-ui --all --filter "build-tools-23.0.2"
+  override:
+    - echo override dependencies
+
 test:
   override:
     - ./gradlew assembleDebug -PdisablePreDex


### PR DESCRIPTION
circleci has been failing because it stopped trying to run 'gradle dependencies' and is instead running 'gradle compileTestJava' which doesn't exist.

We could probably also create a dummy gradle task to deal with that...
