### PR TITLE
fix the audio ducking feature (issue 996)

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -75,6 +75,11 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
     private volatile boolean pausedBecauseOfTransientAudiofocusLoss;
     private volatile Pair<Integer, Integer> videoSize;
 
+    private volatile boolean ducked;
+    private volatile float mVolumeLeft;
+    private volatile float mVolumeRight;
+    private static final float DUCK_FACTOR = 0.25f;
+
     /**
      * Some asynchronous calls might change the state of the MediaPlayer object. Therefore calls in other threads
      * have to wait until these operations have finished.
@@ -135,6 +140,10 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
         mediaType = MediaType.UNKNOWN;
         playerStatus = PlayerStatus.STOPPED;
         videoSize = null;
+
+        mVolumeLeft = 1f;
+        mVolumeRight = 1f;
+        ducked = false;
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         prefs.registerOnSharedPreferenceChangeListener(this);
@@ -693,7 +702,7 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
     }
 
     /**
-     * Sets the playback speed.
+     * Sets the playback volume.
      * This method is executed on an internal executor service.
      */
     public void setVolume(final float volumeLeft, float volumeRight) {
@@ -701,15 +710,53 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
     }
 
     /**
-     * Sets the playback speed.
+     * Sets the playback volume.
      * This method is executed on the caller's thread.
      */
     private void setVolumeSync(float volumeLeft, float volumeRight) {
         playerLock.lock();
         if (media != null && media.getMediaType() == MediaType.AUDIO) {
-            mediaPlayer.setVolume(volumeLeft, volumeRight);
-            Log.d(TAG, "Media player volume was set to " + volumeLeft + " " + volumeRight);
+            mVolumeLeft = volumeLeft;
+            mVolumeRight = volumeRight;
+            updateVolume();
         }
+        playerLock.unlock();
+    }
+
+    /**
+     * Helper method to set the playback volume.
+     * This method requires the playerLock and is executed on the caller's thread.
+     */
+    private void updateVolume(){
+        if (!playerLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("method requires playerLock");
+        }
+        if(ducked){
+            mediaPlayer.setVolume(DUCK_FACTOR*mVolumeLeft, DUCK_FACTOR*mVolumeRight);
+            Log.d(TAG, "Media player volume was set to " + DUCK_FACTOR*mVolumeLeft + " " + DUCK_FACTOR*mVolumeRight);
+        } else {
+            mediaPlayer.setVolume(mVolumeLeft, mVolumeRight);
+            Log.d(TAG, "Media player volume was set to " + mVolumeLeft + " " + mVolumeRight);
+        }
+    }
+
+    /**
+     * Sets the audio ducking mode.
+     * This method is executed on an internal executor service.
+     */
+    public void setDucking(boolean duck) {
+        executor.submit(() -> setDuckingSync(duck));
+    }
+
+    /**
+     * Sets the audio ducking mode.
+     * This method is executed on the caller's thread.
+     */
+    private void setDuckingSync(boolean duck) {
+        playerLock.lock();
+        this.ducked = duck;
+        updateVolume();
+        Log.d(TAG, "Ducking set to " + duck);
         playerLock.unlock();
     }
 
@@ -946,15 +993,13 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
                         if (pausedBecauseOfTransientAudiofocusLoss) { // we paused => play now
                             resume();
                         } else { // we ducked => raise audio level back
-                            audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                                    AudioManager.ADJUST_RAISE, 0);
+                            setDucking(false);
                         }
                     } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
                         if (playerStatus == PlayerStatus.PLAYING) {
                             if (!UserPreferences.shouldPauseForFocusLoss()) {
                                 Log.d(TAG, "Lost audio focus temporarily. Ducking...");
-                                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                                        AudioManager.ADJUST_LOWER, 0);
+                                setDucking(true);
                                 pausedBecauseOfTransientAudiofocusLoss = false;
                             } else {
                                 Log.d(TAG, "Lost audio focus temporarily. Could duck, but won't, pausing...");


### PR DESCRIPTION
This should fix issue #996. At least it did for my particular problem, and since I couldn't reproduce the problems initially reported, I'm not entirely sure whether it will work for them as well.

Changes made were simply to introduce a layer on PlaybackServiceMediaPlayer on the volume settings in order to automatically reduce the set volume whenever it should be ducked.

Future methods to read the volume levels (in order to update the seekbars) should use the member variables mVolumeLeft/Right, as long as it's the expected behavior to keep ducking effects away from the user's control (other than ducking becoming possibly an optional feature in preferences).