### PR TITLE
Prevent gpodder sync duplicates

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
@@ -735,13 +735,19 @@ public class GpodnetService {
         List<String> added = new LinkedList<String>();
         JSONArray jsonAdded = object.getJSONArray("add");
         for (int i = 0; i < jsonAdded.length(); i++) {
-            added.add(jsonAdded.getString(i));
+            String addedUrl = jsonAdded.getString(i);
+            // gpodder escapes colons unnecessarily
+            addedUrl = addedUrl.replace("%3A", ":");
+            added.add(addedUrl);
         }
 
         List<String> removed = new LinkedList<String>();
         JSONArray jsonRemoved = object.getJSONArray("remove");
         for (int i = 0; i < jsonRemoved.length(); i++) {
-            removed.add(jsonRemoved.getString(i));
+            String removedUrl = jsonRemoved.getString(i);
+            // gpodder escapes colons unnecessarily
+            removedUrl = removedUrl.replace("%3A", ":");
+            removed.add(removedUrl);
         }
 
         long timestamp = object.getLong("timestamp");


### PR DESCRIPTION
Resolves #1658

gpodder escapes colons (``:``) which seems to be pretty unnecessary. See [1] and [2]

--
[1] http://stackoverflow.com/questions/2053132/is-a-colon-safe-for-friendly-url-use/2053640#2053640
[2] https://www.w3.org/TR/html4/types.html#type-name