### PR TITLE
Mobile Data: Do not show retrieving filesize spinner when download is not allowed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AdapterUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AdapterUtils.java
@@ -47,9 +47,10 @@ public class AdapterUtils {
                                 - media.getPosition()));
             }
         } else if (!media.isDownloaded()) {
+            Log.d(TAG, "size: " + media.getSize());
             if (media.getSize() > 0) {
                 txtvPos.setText(Converter.byteToString(media.getSize()));
-            } else if(false == media.checkedOnSizeButUnknown()) {
+            } else if(NetworkUtils.isDownloadAllowed() && false == media.checkedOnSizeButUnknown()) {
                 txtvPos.setText("{fa-spinner}");
                 Iconify.addIcons(txtvPos);
                 NetworkUtils.getFeedMediaSizeObservable(media)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -135,7 +135,7 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
                 holder.txtvDuration.setText(Converter.getDurationStringLong(media.getDuration()));
             } else if (media.getSize() > 0) {
                 holder.txtvDuration.setText(Converter.byteToString(media.getSize()));
-            } else if(false == media.checkedOnSizeButUnknown()) {
+            } else if(NetworkUtils.isDownloadAllowed() && false == media.checkedOnSizeButUnknown()) {
                 holder.txtvDuration.setText("{fa-spinner}");
                 Iconify.addIcons(holder.txtvDuration);
                 NetworkUtils.getFeedMediaSizeObservable(media)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -253,7 +253,7 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                 } else {
                     if(media.getSize() > 0) {
                         progressLeft.setText(Converter.byteToString(media.getSize()));
-                    } else if(false == media.checkedOnSizeButUnknown()) {
+                    } else if(NetworkUtils.isDownloadAllowed() && false == media.checkedOnSizeButUnknown()) {
                         progressLeft.setText("{fa-spinner}");
                         Iconify.addIcons(progressLeft);
                         NetworkUtils.getFeedMediaSizeObservable(media)


### PR DESCRIPTION
Resolves #1655