### PR TITLE
Set default episode cache size to 25

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -185,7 +185,7 @@
                 android:title="@string/pref_automatic_download_title"
                 android:defaultValue="false"/>
             <com.afollestad.materialdialogs.prefs.MaterialListPreference
-                android:defaultValue="20"
+                android:defaultValue="25"
                 android:entries="@array/episode_cache_size_entries"
                 android:key="prefEpisodeCacheSize"
                 android:title="@string/pref_episode_cache_title"


### PR DESCRIPTION
Sets the default episode cache size for new users to 10. Assuming that you have at least once a day access to a fast network and that 10 episodes is something like 3 hours of listening, 10 should be a reasonable default value.
To not make old users angry, the current default value of 20 (which is not actually any of the options) is bumped up to 25 if the user has not changed the default.

Resolves #1654