### PR TITLE
Video player: Delay controls hide on interaction

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -763,8 +763,7 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
 
         if (butRev != null) {
             butRev.setOnClickListener(v -> {
-                int curr = controller.getPosition();
-                controller.seekTo(curr - UserPreferences.getRewindSecs() * 1000);
+                onRewind();
             });
             butRev.setOnLongClickListener(new View.OnLongClickListener() {
 
@@ -800,12 +799,13 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
             });
         }
 
-        butPlay.setOnClickListener(controller.newOnPlayButtonClickListener());
+        butPlay.setOnClickListener(v -> {
+            onPlayPause();
+        });
 
         if (butFF != null) {
             butFF.setOnClickListener(v -> {
-                int curr = controller.getPosition();
-                controller.seekTo(curr + UserPreferences.getFastFowardSecs() * 1000);
+                onFastForward();
             });
             butFF.setOnLongClickListener(new View.OnLongClickListener() {
 
@@ -846,6 +846,29 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
                 sendBroadcast(new Intent(PlaybackService.ACTION_SKIP_CURRENT_EPISODE));
             });
         }
+    }
+
+    protected void onRewind() {
+        if (controller == null) {
+            return;
+        }
+        int curr = controller.getPosition();
+        controller.seekTo(curr - UserPreferences.getRewindSecs() * 1000);
+    }
+
+    protected void onPlayPause() {
+        if(controller == null) {
+            return;
+        }
+        controller.playPause();
+    }
+
+    protected void onFastForward() {
+        if (controller == null) {
+            return;
+        }
+        int curr = controller.getPosition();
+        controller.seekTo(curr + UserPreferences.getFastFowardSecs() * 1000);
     }
 
     protected abstract int getContentViewResourceId();

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -202,6 +202,24 @@ public class VideoplayerActivity extends MediaplayerActivity {
         videoControlsShowing = !videoControlsShowing;
     }
 
+    @Override
+    protected void onRewind() {
+        super.onRewind();
+        setupVideoControlsToggler();
+    }
+
+    @Override
+    protected void onPlayPause() {
+        super.onPlayPause();
+        setupVideoControlsToggler();
+    }
+
+    @Override
+    protected void onFastForward() {
+        super.onFastForward();
+        setupVideoControlsToggler();
+    }
+
 
     private final SurfaceHolder.Callback surfaceHolderCallback = new SurfaceHolder.Callback() {
         @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -330,7 +330,7 @@ public class VideoplayerActivity extends MediaplayerActivity {
 
     private static class VideoControlsHider extends Handler {
 
-        private static final int DELAY = 5000;
+        private static final int DELAY = 2500;
 
         private WeakReference<VideoplayerActivity> activity;
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
@@ -72,7 +72,11 @@ public class ExternalPlayerFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         controller = setupPlaybackController();
-        butPlay.setOnClickListener(controller.newOnPlayButtonClickListener());
+        butPlay.setOnClickListener(v -> {
+            if(controller != null) {
+                controller.playPause();
+            }
+        });
     }
 
     private PlaybackController setupPlaybackController() {
@@ -87,7 +91,6 @@ public class ExternalPlayerFragment extends Fragment {
             public ImageButton getPlayButton() {
                 return butPlay;
             }
-
 
             @Override
             public boolean loadMediaInfo() {
@@ -145,8 +148,11 @@ public class ExternalPlayerFragment extends Fragment {
         }
         controller = setupPlaybackController();
         if (butPlay != null) {
-            butPlay.setOnClickListener(controller
-                    .newOnPlayButtonClickListener());
+            butPlay.setOnClickListener(v -> {
+                if(controller != null) {
+                    controller.playPause();
+                }
+            });
         }
         controller.init();
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -604,7 +604,11 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
      * Returns the position of the current media object or INVALID_TIME if the position could not be retrieved.
      */
     public int getPosition() {
-        if (!playerLock.tryLock()) {
+        try {
+            if (!playerLock.tryLock(50, TimeUnit.MILLISECONDS)) {
+                return INVALID_TIME;
+            }
+        } catch (InterruptedException e) {
             return INVALID_TIME;
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -574,34 +574,32 @@ public abstract class PlaybackController {
 
     }
 
-    public OnClickListener newOnPlayButtonClickListener() {
-        return v -> {
-            if (playbackService == null) {
-                Log.w(TAG, "Play/Pause button was pressed, but playbackservice was null!");
-                return;
-            }
-            switch (status) {
-                case PLAYING:
-                    playbackService.pause(true, reinitOnPause);
-                    break;
-                case PAUSED:
-                case PREPARED:
-                    playbackService.resume();
-                    break;
-                case PREPARING:
-                    playbackService.setStartWhenPrepared(!playbackService
-                            .isStartWhenPrepared());
-                    if (reinitOnPause
-                            && playbackService.isStartWhenPrepared() == false) {
-                        playbackService.reinit();
-                    }
-                    break;
-                case INITIALIZED:
-                    playbackService.setStartWhenPrepared(true);
-                    playbackService.prepare();
-                    break;
-            }
-        };
+    public void playPause() {
+        if (playbackService == null) {
+            Log.w(TAG, "Play/Pause button was pressed, but playbackservice was null!");
+            return;
+        }
+        switch (status) {
+            case PLAYING:
+                playbackService.pause(true, reinitOnPause);
+                break;
+            case PAUSED:
+            case PREPARED:
+                playbackService.resume();
+                break;
+            case PREPARING:
+                playbackService.setStartWhenPrepared(!playbackService
+                        .isStartWhenPrepared());
+                if (reinitOnPause
+                        && playbackService.isStartWhenPrepared() == false) {
+                    playbackService.reinit();
+                }
+                break;
+            case INITIALIZED:
+                playbackService.setStartWhenPrepared(true);
+                playbackService.prepare();
+                break;
+        }
     }
 
     public boolean serviceAvailable() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -19,7 +19,6 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.view.SurfaceHolder;
-import android.view.View.OnClickListener;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.TextView;
@@ -424,6 +423,7 @@ public abstract class PlaybackController {
                 clearStatusMsg();
                 checkMediaInfoLoaded();
                 cancelPositionObserver();
+                onPositionObserverUpdate();
                 updatePlayButtonAppearance(playResource, playText);
                 if (PlaybackService.getCurrentMediaType() == MediaType.VIDEO) {
                     setScreenOn(false);


### PR DESCRIPTION
When rewind, play/pause or ff is pressed, the controls hiding is delayed.
Lowered the general delay for hiding from 5s to 2,5s. (In comparison, in VLC the default value is only 1s)
The position now also updates (e.g. when seeking) when playback is paused.

I noticed that often the current position is not updated because tryLock is false (race condition) and the position is not actually read.
So I added a timeout of 50ms. Really not sure if this is a good idea. 50ms should not be noticeable, but we are running on the main thread here...

Resolves #1687