### PR TITLE
fix the volume conversion upon user interaction

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -493,14 +493,9 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
                         barLeftVolume.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
                             @Override
                             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                                float leftVolume = 1.0f, rightVolume = 1.0f;
-                                if (progress < 100) {
-                                    leftVolume = progress / 100.0f;
-                                }
-                                if (barRightVolume.getProgress() < 100) {
-                                    rightVolume = barRightVolume.getProgress() / 100.0f;
-                                }
-                                controller.setVolume(leftVolume, rightVolume);
+                                controller.setVolume(
+                                        Converter.getVolumeFromPercentage(progress),
+                                        Converter.getVolumeFromPercentage(barRightVolume.getProgress()));
                             }
 
                             @Override
@@ -514,14 +509,9 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
                         barRightVolume.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
                             @Override
                             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                                float leftVolume = 1.0f, rightVolume = 1.0f;
-                                if (progress < 100) {
-                                    rightVolume = progress / 100.0f;
-                                }
-                                if (barLeftVolume.getProgress() < 100) {
-                                    leftVolume = barLeftVolume.getProgress() / 100.0f;
-                                }
-                                controller.setVolume(leftVolume, rightVolume);
+                                controller.setVolume(
+                                        Converter.getVolumeFromPercentage(barLeftVolume.getProgress()),
+                                        Converter.getVolumeFromPercentage(progress));
                             }
 
                             @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -479,9 +479,9 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
                         barPlaybackSpeed.setProgress((int) (20 * currentSpeed) - 10);
 
                         final SeekBar barLeftVolume = (SeekBar) dialog.findViewById(R.id.volume_left);
-                        barLeftVolume.setProgress(100);
+                        barLeftVolume.setProgress(UserPreferences.getLeftVolumePercentage());
                         final SeekBar barRightVolume = (SeekBar) dialog.findViewById(R.id.volume_right);
-                        barRightVolume.setProgress(100);
+                        barRightVolume.setProgress(UserPreferences.getRightVolumePercentage());
                         final CheckBox stereoToMono = (CheckBox) dialog.findViewById(R.id.stereo_to_mono);
                         stereoToMono.setChecked(UserPreferences.stereoToMono());
                         if (controller != null && !controller.canDownmix()) {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -269,6 +269,14 @@ public class UserPreferences {
         return Converter.getVolumeFromPercentage(volume);
     }
 
+    public static int getLeftVolumePercentage() {
+        return prefs.getInt(PREF_LEFT_VOLUME, 100);
+    }
+
+    public static int getRightVolumePercentage() {
+        return prefs.getInt(PREF_RIGHT_VOLUME, 100);
+    }
+
     public static boolean shouldPauseForFocusLoss() {
         return prefs.getBoolean(PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS, false);
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -29,6 +29,7 @@ import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APNullCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APQueueCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.EpisodeCleanupAlgorithm;
+import de.danoeh.antennapod.core.util.Converter;
 
 /**
  * Provides access to preferences set by the user in the settings screen. A
@@ -260,20 +261,12 @@ public class UserPreferences {
 
     public static float getLeftVolume() {
         int volume = prefs.getInt(PREF_LEFT_VOLUME, 100);
-        if(volume == 100) {
-            return 1.0f;
-        } else {
-            return (float) (1 - (Math.log(100 - volume) / Math.log(100)));
-        }
+        return Converter.getVolumeFromPercentage(volume);
     }
 
     public static float getRightVolume() {
         int volume = prefs.getInt(PREF_RIGHT_VOLUME, 100);
-        if(volume == 100) {
-            return 1.0f;
-        } else {
-            return (float) (1 - (Math.log(100 - volume) / Math.log(100)));
-        }
+        return Converter.getVolumeFromPercentage(volume);
     }
 
     public static boolean shouldPauseForFocusLoss() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -118,5 +118,16 @@ public final class Converter {
         result += minutes;
         return result;
     }
-    
+
+    /**
+     * Converts the volume as read as the progress from a SeekBar scaled to 100 and as saved in
+     * UserPreferences to the format taken by setVolume methods.
+     * @param progress integer between 0 to 100 taken from the SeekBar progress
+     * @return the appropriate volume as float taken by setVolume methods
+     */
+    public static float getVolumeFromPercentage(int progress){
+        if (progress==100)
+            return 1f;
+        return (float) (1 - (Math.log(101 - progress) / Math.log(101)));
+    }
 }


### PR DESCRIPTION
There was an inconsistency with the user set volumes, as the one experienced by the user when moving the seekbar isn't the same as the one later returned by UserPreferences.

This fixes that, and also moves the conversion formula into a new method on core.util.Converter

Also, I took the freedom to slightly alter the formula, since as it was it was giving the same output for 99 as for 100.

Besides, the volume bars progress were always initialized to 100, so I created methods on UserPreferences to read the saved values (different than returning a float between 0 and 1) and called them when initializing the seekbars.