### PR TITLE
OPML Import: Show dialog when no file has been selected

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportBaseActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportBaseActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Environment;
+import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
@@ -31,7 +32,7 @@ public class OpmlImportBaseActivity extends ActionBarActivity {
     private OpmlImportWorker importWorker;
 
 	private static final int PERMISSION_REQUEST_READ_EXTERNAL_STORAGE = 5;
-	private Uri uri;
+	@Nullable private Uri uri;
 
 	/**
 	 * Handles the choices made by the user in the OpmlFeedChooserActivity and
@@ -67,7 +68,14 @@ public class OpmlImportBaseActivity extends ActionBarActivity {
 		}
 	}
 
-	protected void importUri(Uri uri) {
+	protected void importUri(@Nullable Uri uri) {
+        if(uri == null) {
+            new MaterialDialog.Builder(this)
+                    .content(R.string.opml_import_error_no_file)
+                    .positiveText(android.R.string.ok)
+                    .show();
+            return;
+        }
 		this.uri = uri;
         if(uri.toString().contains(Environment.getExternalStorageDirectory().toString())) {
             int permission = ActivityCompat.checkSelfPermission(this, android.Manifest.permission.READ_EXTERNAL_STORAGE);
@@ -127,8 +135,9 @@ public class OpmlImportBaseActivity extends ActionBarActivity {
             importWorker.executeAsync();
         } catch (Exception e) {
             Log.d(TAG, Log.getStackTraceString(e));
+			String message = getString(R.string.opml_reader_error);
             new MaterialDialog.Builder(this)
-                    .content("Cannot open OPML file: " + e.getMessage())
+                    .content(message + " " + e.getMessage())
                     .positiveText(android.R.string.ok)
                     .show();
         }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -409,8 +409,8 @@
     <string name="opml_import_label">OPML Import</string>
     <string name="opml_directory_error">ERROR!</string>
     <string name="reading_opml_label">Reading OPML file</string>
-    <string name="opml_reader_error">An error has occurred while reading the opml document:</string>
-    <string name="opml_import_error_dir_empty">The import directory is empty.</string>
+    <string name="opml_reader_error">An error has occurred while reading the OPML document:</string>
+    <string name="opml_import_error_no_file">No file selected!</string>
     <string name="select_all_label">Select all</string>
     <string name="deselect_all_label">Deselect all</string>
     <string name="select_options_label">Select&#8230;</string>


### PR DESCRIPTION
``opml_import_error_dir_empty`` is not in use.

![1](https://cloud.githubusercontent.com/assets/6860662/13211542/64c1eb80-d939-11e5-8586-18d1121a7b92.png)

For testing: In ``OpmlImportFromPathActivity``, replace ``importUri(uri);`` with ``importUri(null);``

Resolves #1704