### PR TITLE
Do not show full disk icon if cache size is unlimited

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -232,7 +232,7 @@ public class NavListAdapter extends BaseAdapter
             int spaceUsed = itemAccess.getNumberOfDownloadedItems() -
                     itemAccess.getReclaimableItems();
 
-            if (spaceUsed >= epCacheSize) {
+            if (epCacheSize > 0 && spaceUsed >= epCacheSize) {
                 holder.count.setText("{md-disc-full 150%}");
                 Iconify.addIcons(holder.count);
                 holder.count.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Resolves #1714

~~(Did not even test this...)~~ Tested, works.