### PR TITLE
Audioplayer v1.0.14 & Audio controls dialog fix

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -879,7 +879,9 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
 
     private void updateButPlaybackSpeed() {
         if (controller != null && butPlaybackSpeed != null) {
-            butPlaybackSpeed.setText(UserPreferences.getPlaybackSpeed() + "x");
+            float speed = Float.valueOf(UserPreferences.getPlaybackSpeed());
+            String speedStr = String.format("%.2fx", speed);
+            butPlaybackSpeed.setText(speedStr);
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -31,6 +31,8 @@ import com.bumptech.glide.Glide;
 import com.joanzapata.iconify.IconDrawable;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
+import java.util.Locale;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
@@ -458,9 +460,10 @@ public abstract class MediaplayerActivity extends AppCompatActivity implements O
                                 if(controller != null && controller.canSetPlaybackSpeed()) {
                                     float playbackSpeed = (progress + 10) / 20.0f;
                                     controller.setPlaybackSpeed(playbackSpeed);
-                                    String speed = String.format("%.2f", playbackSpeed);
-                                    UserPreferences.setPlaybackSpeed(speed);
-                                    txtvPlaybackSpeed.setText(speed + "x");
+                                    String speedPref = String.format(Locale.US, "%.2f", playbackSpeed);
+                                    UserPreferences.setPlaybackSpeed(speedPref);
+                                    String speedStr = String.format("%.2fx", playbackSpeed);
+                                    txtvPlaybackSpeed.setText(speedStr);
                                 } else if(fromUser) {
                                     float speed = Float.valueOf(UserPreferences.getPlaybackSpeed());
                                     barPlaybackSpeed.post(() -> {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ project.ext {
     rxJavaVersion = "1.1.0"
     rxJavaRulesVersion = "1.1.0.0"
 
-    audioPlayerVersion = "v1.0.13"
+    audioPlayerVersion = "v1.0.14"
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ project.ext {
     rxJavaVersion = "1.1.0"
     rxJavaRulesVersion = "1.1.0.0"
 
-    audioPlayerVersion = "v1.0.12"
+    audioPlayerVersion = "v1.0.13"
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
I know, branch name is a bit misleading...

Newest audio player should fix fallback to android's native player and catch all decoder thread exceptions (and fail gracefully).

When your locale is not us, the audio controls dialog saved the the playback speed from the slider in a wrong format. This leads to errors like this
```
E/PlaybackSvcMediaPlayer: java.lang.NumberFormatException: Invalid float: "1,70"
```