### PR TITLE
When retrieving position of current episode, regard position 0 as valid

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -618,10 +618,8 @@ public class PlaybackServiceMediaPlayer implements SharedPreferences.OnSharedPre
                 || playerStatus == PlayerStatus.PREPARED
                 || playerStatus == PlayerStatus.SEEKING) {
             retVal = mediaPlayer.getCurrentPosition();
-            if(retVal <= 0 && media != null && media.getPosition() > 0) {
-                retVal = media.getPosition();
-            }
-        } else if (media != null && media.getPosition() > 0) {
+        }
+        if (retVal <= 0 && media != null && media.getPosition() >= 0) {
             retVal = media.getPosition();
         }
 


### PR DESCRIPTION
It is becoming really hard to come up with meaningful titles...

Scenario: One episode ends, continuous playback is off. Next episode is loaded, position is 0. Until now, position 0 is regarded as invalid, the seekbar in audioplayer will not show the new position.

Resolves #1780