### PR TITLE
Reset episode to new if episode file is added later

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -195,6 +195,8 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
         if (other.media != null) {
             if (media == null) {
                 setMedia(other.media);
+                // reset to new if feed item did link to a file before
+                setNew();
             } else if (media.compareWithOther(other.media)) {
                 media.updateFromOther(other.media);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import java.util.Date;
 import java.util.List;
@@ -168,10 +167,6 @@ public class FeedMedia extends FeedFile implements Playable {
     }
 
     public void updateFromOther(FeedMedia other) {
-        // reset to new if feed item did link to a file before
-        if(TextUtils.isEmpty(download_url) && !TextUtils.isEmpty(other.download_url)) {
-            item.setNew();
-        }
         super.updateFromOther(other);
         if (other.size > 0) {
             size = other.size;


### PR DESCRIPTION
Resolves #1529

Can be tested with http://test.mfietz.de/delay
(Basically, the feed contains 2 episodes. One is published just now, without a file. The other one minute ago with a file. The guid of an episode is the minute it was published. Subscribe, mark as played, wait little less than a minute, refresh. The just marked episode should be reset to new.)