### PR TITLE
Fix #1781

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -409,7 +409,7 @@ public class QueueFragment extends Fragment {
                     Log.d(TAG, "remove(" + position + ")");
                     final FeedItem item = queue.get(position);
                     final boolean isRead = item.isPlayed();
-                    DBWriter.markItemPlayed(FeedItem.PLAYED, item.getId());
+                    DBWriter.markItemPlayed(FeedItem.PLAYED, false, item.getId());
                     DBWriter.removeQueueItem(getActivity(), item, true);
                     Snackbar snackbar = Snackbar.make(root, getString(R.string.marked_as_read_label), Snackbar.LENGTH_LONG);
                     snackbar.setAction(getString(R.string.undo), v -> {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -583,18 +583,33 @@ public class DBWriter {
     /*
      * Sets the 'read'-attribute of all specified FeedItems
      *
-     * @param context A context that is used for opening a database connection.
      * @param played  New value of the 'read'-attribute, one of FeedItem.PLAYED, FeedItem.NEW,
      *                FeedItem.UNPLAYED
      * @param itemIds IDs of the FeedItems.
      */
     public static Future<?> markItemPlayed(final int played, final long... itemIds) {
+        return markItemPlayed(played, true, itemIds);
+    }
+
+    /*
+     * Sets the 'read'-attribute of all specified FeedItems
+     *
+     * @param played  New value of the 'read'-attribute, one of FeedItem.PLAYED, FeedItem.NEW,
+     *                FeedItem.UNPLAYED
+     * @param broadcastUpdate true if this operation should trigger a UnreadItemsUpdate broadcast.
+     *        This option is usually set to true
+     * @param itemIds IDs of the FeedItems.
+     */
+    public static Future<?> markItemPlayed(final int played, final boolean broadcastUpdate,
+                                           final long... itemIds) {
         return dbExec.submit(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
             adapter.setFeedItemRead(played, itemIds);
             adapter.close();
-            EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
+            if(broadcastUpdate) {
+                EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #1781 

Only have a vague idea what is happening. Most likely, DBWriter.markItemPlayed (EventDistributor.UNREAD_ITEMS_UPDATE) interferes with the removal from the queue (QueueEvent).
We don't really need to be notified about the episode being marked as played...