### PR TITLE
Episode view: Go to previous/next list item when swiping right/left

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -295,7 +295,8 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         public void onClick(View v) {
             MainActivity mainActivity = mainActivityRef.get();
             if (mainActivity != null) {
-                mainActivity.loadChildFragment(ItemFragment.newInstance(item.getId()));
+                long[] ids = itemAccess.getItemsIds().toArray();
+                mainActivity.loadChildFragment(ItemFragment.newInstance(ids, position));
             }
         }
 
@@ -342,6 +343,8 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         int getCount();
 
         FeedItem getItem(int position);
+
+        LongList getItemsIds();
 
         int getItemDownloadProgressPercent(FeedItem item);
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -29,6 +29,8 @@ import com.bumptech.glide.request.target.GlideDrawableImageViewTarget;
 import com.joanzapata.iconify.Iconify;
 import com.nineoldandroids.view.ViewHelper;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.lang.ref.WeakReference;
 
 import de.danoeh.antennapod.R;
@@ -165,7 +167,9 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
         public void onClick(View v) {
             MainActivity activity = mainActivity.get();
             if (activity != null) {
-                activity.loadChildFragment(ItemFragment.newInstance(item.getId()));
+                long[] ids = itemAccess.getQueueIds().toArray();
+                int position = ArrayUtils.indexOf(ids, item.getId());
+                activity.loadChildFragment(ItemFragment.newInstance(ids, position));
             }
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -349,6 +349,18 @@ public class AllEpisodesFragment extends Fragment {
         }
 
         @Override
+        public LongList getItemsIds() {
+            if(episodes == null) {
+                return new LongList(0);
+            }
+            LongList ids = new LongList(episodes.size());
+            for(FeedItem episode : episodes) {
+                ids.add(episode.getId());
+            }
+            return ids;
+        }
+
+        @Override
         public int getItemDownloadProgressPercent(FeedItem item) {
             if (downloaderList != null) {
                 for (Downloader downloader : downloaderList) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -25,6 +25,7 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.dialog.EpisodesApplyActionFragment;
 import rx.Observable;
 import rx.Subscription;
@@ -116,10 +117,9 @@ public class CompletedDownloadsFragment extends ListFragment {
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);
-        FeedItem item = listAdapter.getItem(position - l.getHeaderViewsCount());
-        if (item != null) {
-            ((MainActivity) getActivity()).loadChildFragment(ItemFragment.newInstance(item.getId()));
-        }
+        position -= l.getHeaderViewsCount();
+        long[] ids = FeedItemUtil.getIds(items);
+        ((MainActivity) getActivity()).loadChildFragment(ItemFragment.newInstance(ids, position));
     }
 
     private void onFragmentLoaded() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.fragment;
 
-import android.annotation.TargetApi;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
@@ -10,6 +9,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.view.GestureDetectorCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -17,12 +17,14 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -61,6 +63,8 @@ import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.ShareUtils;
 import de.danoeh.antennapod.core.util.playback.Timeline;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
+import de.danoeh.antennapod.view.OnSwipeGesture;
+import de.danoeh.antennapod.view.SwipeGestureDetector;
 import de.greenrobot.event.EventBus;
 import rx.Observable;
 import rx.Subscription;
@@ -70,13 +74,17 @@ import rx.schedulers.Schedulers;
 /**
  * Displays information about a FeedItem and actions.
  */
-public class ItemFragment extends Fragment {
+public class ItemFragment extends Fragment implements OnSwipeGesture {
 
     private static final String TAG = "ItemFragment";
 
     private static final int EVENTS = EventDistributor.UNREAD_ITEMS_UPDATE;
 
-    private static final String ARG_FEEDITEM = "feeditem";
+    private static final String ARG_FEEDITEMS = "feeditems";
+    private static final String ARG_FEEDITEM_POS = "feeditem_pos";
+
+    private GestureDetectorCompat headerGestureDetector;
+    private GestureDetectorCompat webviewGestureDetector;
 
     /**
      * Creates a new instance of an ItemFragment
@@ -85,15 +93,28 @@ public class ItemFragment extends Fragment {
      * @return The ItemFragment instance
      */
     public static ItemFragment newInstance(long feeditem) {
+        return newInstance(new long[] { feeditem }, 0);
+    }
+
+    /**
+     * Creates a new instance of an ItemFragment
+     *
+     * @param feeditems The IDs of the FeedItems that belong to the same list
+     * @param feedItemPos The position of the FeedItem that is currently shown
+     * @return The ItemFragment instance
+     */
+    public static ItemFragment newInstance(long[] feeditems, int feedItemPos) {
         ItemFragment fragment = new ItemFragment();
         Bundle args = new Bundle();
-        args.putLong(ARG_FEEDITEM, feeditem);
+        args.putLongArray(ARG_FEEDITEMS, feeditems);
+        args.putInt(ARG_FEEDITEM_POS, feedItemPos);
         fragment.setArguments(args);
         return fragment;
     }
 
     private boolean itemsLoaded = false;
-    private long itemID;
+    private long[] feedItems;
+    private int feedItemPos;
     private FeedItem item;
     private LongList queue;
     private LongList favorites;
@@ -126,16 +147,31 @@ public class ItemFragment extends Fragment {
         setRetainInstance(true);
         setHasOptionsMenu(true);
 
-        itemID = getArguments().getLong(ARG_FEEDITEM, -1);
+        feedItems = getArguments().getLongArray(ARG_FEEDITEMS);
+        feedItemPos = getArguments().getInt(ARG_FEEDITEM_POS);
+
+        headerGestureDetector = new GestureDetectorCompat(getActivity(), new SwipeGestureDetector(this));
+        webviewGestureDetector = new GestureDetectorCompat(getActivity(), new SwipeGestureDetector(this) {
+            // necessary for the longclick context menu to work properly
+            @Override
+            public boolean onDown(MotionEvent e) {
+                return false;
+            }
+        });
     }
 
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
         View layout = inflater.inflate(R.layout.feeditem_fragment, container, false);
 
         root = (ViewGroup) layout.findViewById(R.id.content_root);
+
+        LinearLayout header = (LinearLayout) root.findViewById(R.id.header);
+        if(feedItems.length > 0) {
+            header.setOnTouchListener((v, event) -> headerGestureDetector.onTouchEvent(event));
+        }
+
         txtvPodcast = (TextView) layout.findViewById(R.id.txtvPodcast);
         txtvTitle = (TextView) layout.findViewById(R.id.txtvTitle);
         txtvDuration = (TextView) layout.findViewById(R.id.txtvDuration);
@@ -155,7 +191,10 @@ public class ItemFragment extends Fragment {
         webvDescription.getSettings().setLayoutAlgorithm(
             WebSettings.LayoutAlgorithm.NARROW_COLUMNS);
         webvDescription.getSettings().setLoadWithOverviewMode(true);
-        webvDescription.setOnLongClickListener(webViewLongClickListener);
+        if(feedItems.length > 0) {
+            webvDescription.setOnLongClickListener(webViewLongClickListener);
+        }
+        webvDescription.setOnTouchListener((v, event) -> webviewGestureDetector.onTouchEvent(event));
         webvDescription.setWebViewClient(new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
@@ -246,6 +285,25 @@ public class ItemFragment extends Fragment {
     }
 
     @Override
+    public boolean onSwipeLeftToRight() {
+        Log.d(TAG, "onSwipeLeftToRight()");
+        feedItemPos = feedItemPos - 1;
+        if(feedItemPos < 0) {
+            feedItemPos = feedItems.length - 1;
+        }
+        load();
+        return true;
+    }
+
+    @Override
+    public boolean onSwipeRightToLeft() {
+        Log.d(TAG, "onSwipeRightToLeft()");
+        feedItemPos = (feedItemPos + 1) % feedItems.length;
+        load();
+        return true;
+    }
+
+    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         if(!isAdded() || item == null) {
             return;
@@ -284,7 +342,6 @@ public class ItemFragment extends Fragment {
 
 
     private void onFragmentLoaded() {
-        progbarLoading.setVisibility(View.INVISIBLE);
         if (webviewData != null) {
             webvDescription.loadDataWithBaseURL(null, webviewData, "text/html",
                     "utf-8", "about:blank");
@@ -457,13 +514,13 @@ public class ItemFragment extends Fragment {
     }
 
     public void onEventMainThread(QueueEvent event) {
-        if(event.contains(itemID)) {
+        if(event.contains(feedItems[feedItemPos])) {
             load();
         }
     }
 
     public void onEventMainThread(FavoritesEvent event) {
-        if(event.item.getId() == itemID) {
+        if(event.item.getId() == feedItems[feedItemPos]) {
             load();
         }
     }
@@ -471,7 +528,7 @@ public class ItemFragment extends Fragment {
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         for(FeedItem item : event.items) {
-            if(itemID == item.getId()) {
+            if(feedItems[feedItemPos] == item.getId()) {
                 load();
                 return;
             }
@@ -507,6 +564,7 @@ public class ItemFragment extends Fragment {
         if(subscription != null) {
             subscription.unsubscribe();
         }
+        progbarLoading.setVisibility(View.VISIBLE);
         subscription = Observable.fromCallable(this::loadInBackground)
             .subscribeOn(Schedulers.newThread())
             .observeOn(AndroidSchedulers.mainThread())
@@ -514,6 +572,7 @@ public class ItemFragment extends Fragment {
                 item = (FeedItem) result[0];
                 queue = (LongList) result[1];
                 favorites = (LongList) result[2];
+                progbarLoading.setVisibility(View.GONE);
                 if (!itemsLoaded) {
                     itemsLoaded = true;
                     onFragmentLoaded();
@@ -526,7 +585,7 @@ public class ItemFragment extends Fragment {
     }
 
     private Object[] loadInBackground() {
-        FeedItem feedItem = DBReader.getFeedItem(itemID);
+        FeedItem feedItem = DBReader.getFeedItem(feedItems[feedItemPos]);
         if (feedItem != null) {
             Timeline t = new Timeline(getActivity(), feedItem);
             webviewData = t.processShownotes(false);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -374,12 +374,11 @@ public class ItemlistFragment extends ListFragment {
         if(adapter == null) {
             return;
         }
-        FeedItem selection = adapter.getItem(position - l.getHeaderViewsCount());
-        if (selection != null) {
-            MainActivity activity = (MainActivity) getActivity();
-            activity.loadChildFragment(ItemFragment.newInstance(selection.getId()));
-            activity.getSupportActionBar().setTitle(feed.getTitle());
-        }
+        position -= l.getHeaderViewsCount();
+        MainActivity activity = (MainActivity) getActivity();
+        long[] ids = FeedItemUtil.getIds(feed.getItems());
+        activity.loadChildFragment(ItemFragment.newInstance(ids, position));
+        activity.getSupportActionBar().setTitle(feed.getTitle());
     }
 
     public void onEvent(QueueEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -28,6 +28,7 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.LongList;
 import de.greenrobot.event.EventBus;
 import rx.Observable;
@@ -140,10 +141,9 @@ public class PlaybackHistoryFragment extends ListFragment {
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);
-        FeedItem item = adapter.getItem(position - l.getHeaderViewsCount());
-        if (item != null) {
-            ((MainActivity) getActivity()).loadChildFragment(ItemFragment.newInstance(item.getId()));
-        }
+        position -= l.getHeaderViewsCount();
+        long[] ids = FeedItemUtil.getIds(playbackHistory);
+        ((MainActivity) getActivity()).loadChildFragment(ItemFragment.newInstance(ids, position));
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/view/OnSwipeGesture.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/OnSwipeGesture.java
@@ -1,0 +1,9 @@
+package de.danoeh.antennapod.view;
+
+public interface OnSwipeGesture {
+
+    boolean onSwipeLeftToRight();
+
+    boolean onSwipeRightToLeft();
+
+}

--- a/app/src/main/java/de/danoeh/antennapod/view/SwipeGestureDetector.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/SwipeGestureDetector.java
@@ -1,0 +1,44 @@
+package de.danoeh.antennapod.view;
+
+import android.util.Log;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+public class SwipeGestureDetector extends GestureDetector.SimpleOnGestureListener {
+
+    private static final String TAG = "SwipeGestureDetector";
+
+    private static final int SWIPE_MIN_DISTANCE = 120;
+    private static final int SWIPE_MAX_OFF_PATH = 250;
+    private static final int SWIPE_THRESHOLD_VELOCITY = 200;
+
+    private final OnSwipeGesture callback;
+
+    public SwipeGestureDetector(OnSwipeGesture callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public boolean onDown(MotionEvent e) {
+        return true;
+    }
+
+    @Override
+    public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+        try {
+            if (Math.abs(e1.getY() - e2.getY()) > SWIPE_MAX_OFF_PATH)
+                return false;
+            if (e1.getX() - e2.getX() > SWIPE_MIN_DISTANCE
+                    && Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY) {
+                return callback.onSwipeRightToLeft();
+            } else if (e2.getX() - e1.getX() > SWIPE_MIN_DISTANCE
+                    && Math.abs(velocityX) > SWIPE_THRESHOLD_VELOCITY) {
+                return callback.onSwipeLeftToRight();
+            }
+        } catch (Exception e) {
+            Log.d(TAG, Log.getStackTraceString(e));
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
Instead of having a single feeditem id, we now have a list of feeditem ids and a position.
When the user swipes left or right, the position is adapted accordingly and the UI is updated.

Works in all episodes, new episodes, favorites, queue, feed view...

As of now, it does not take into account that items that are represented in this list might be removed while in the episode view. Easiest solution would probably be to just finish the fragment when the next (or current) item is not found.

Resolves #662