### PR TITLE
Update strings.xml

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -4,18 +4,14 @@
     tools:ignore="MissingTranslation">
 
     <!-- Activitiy and fragment titles -->
-    <string name="app_name">AntennaPod</string>
+    <string name="app_name" translate="false">AntennaPod</string>
     <string name="feeds_label">Feeds</string>
     <string name="statistics_label">Statistics</string>
     <string name="add_feed_label">Add Podcast</string>
-    <string name="podcasts_label">PODCASTS</string>
     <string name="episodes_label">Episodes</string>
-    <string name="new_episodes_label">New Episodes</string>
-    <string name="all_episodes_label">All Episodes</string>
     <string name="all_episodes_short_label">All</string>
     <string name="favorite_episodes_label">Favorites</string>
     <string name="new_label">New</string>
-    <string name="waiting_list_label">Waiting List</string>
     <string name="settings_label">Settings</string>
     <string name="add_new_feed_label">Add Podcast</string>
     <string name="downloads_label">Downloads</string>
@@ -30,10 +26,6 @@
     <string name="free_space_label">%1$s free</string>
     <string name="episode_cache_full_title">Episode cache full</string>
     <string name="episode_cache_full_message">The episode cache limit has been reached. You can increase the cache size in the Settings.</string>
-
-    <!-- New episodes fragment -->
-    <string name="recently_published_episodes_label">Recently published</string>
-    <string name="episode_filter_label">Show only new Episodes</string>
 
     <!-- Statistics fragment -->
     <string name="total_time_listened_to_podcasts">Total time of podcasts played:</string>
@@ -90,9 +82,9 @@
     <string name="auto_download_label">Include in auto downloads</string>
     <string name="auto_download_apply_to_items_title">Apply to Previous Episodes</string>
     <string name="auto_download_apply_to_items_message">The new <i>Auto Download</i> setting will automatically be applied to new episodes.\nDo you also want to apply it to previously published episodes?</string>
-    <string name="auto_delete_label">Auto Delete Episode\n(override global default)</string>
+    <string name="auto_delete_label">Auto Delete Episode</string>
     <string name="parallel_downloads_suffix">\u0020parallel downloads</string>
-    <string name="feed_auto_download_global">Global</string>
+    <string name="feed_auto_download_global">Global default</string>
     <string name="feed_auto_download_always">Always</string>
     <string name="feed_auto_download_never">Never</string>
     <string name="send_label">Send&#8230;</string>
@@ -124,8 +116,8 @@
     <string name="share_link_label">Share Link</string>
     <string name="share_link_with_position_label">Share Link with Position</string>
     <string name="share_feed_url_label">Share Feed URL</string>
-    <string name="share_item_url_label">Share Episode URL</string>
-    <string name="share_item_url_with_position_label">Share Episode URL with Position</string>
+    <string name="share_item_url_label">Share Episode File URL</string>
+    <string name="share_item_url_with_position_label">Share Episode File URL with Position</string>
     <string name="feed_delete_confirmation_msg">Please confirm that you want to delete this feed and ALL episodes of this feed that you have downloaded.</string>
     <string name="feed_remover_msg">Removing Feed</string>
     <string name="load_complete_feed">Refresh complete Feed</string>
@@ -162,8 +154,6 @@
     <string name="removed_from_favorites">Removed from Favorites</string>
     <string name="visit_website_label">Visit Website</string>
     <string name="support_label">Flattr this</string>
-    <string name="enqueue_all_new">Enqueue all</string>
-    <string name="download_all">Download all</string>
     <string name="skip_episode_label">Skip episode</string>
     <string name="activate_auto_download">Activate Auto Download</string>
     <string name="deactivate_auto_download">Deactivate Auto Download</string>
@@ -224,7 +214,7 @@
     <string name="playback_error_server_died">Server died</string>
     <string name="playback_error_unknown">Unknown Error</string>
     <string name="no_media_playing_label">No media playing</string>
-    <string name="position_default_label">00:00:00</string>
+    <string name="position_default_label" translate="false">00:00:00</string>
     <string name="player_buffering_msg">Buffering</string>
     <string name="playbackservice_notification_title">Playing podcast</string>
     <string name="unknown_media_key">AntennaPod - Unknown media key: %1$d</string>
@@ -287,7 +277,6 @@
     <string name="no_feeds_label">You haven\'t subscribed to any feeds yet.</string>
     <string name="no_chapters_label">This episode has no chapters.</string>
     <string name="no_shownotes_label">This episode has no shownotes.</string>
-
 
     <!-- Preferences -->
     <string name="storage_pref">Storage</string>
@@ -527,29 +516,19 @@
     <string name="pref_resumeAfterCall_title">Resume after Call</string>
     <string name="pref_restart_required">AntennaPod has to be restarted for this change to take effect.</string>
 
-
     <!-- Online feed view -->
     <string name="subscribe_label">Subscribe</string>
     <string name="subscribed_label">Subscribed</string>
     <string name="downloading_label">Downloading&#8230;</string>
 
     <!-- Content descriptions for image buttons -->
-    <string name="show_chapters_label">Show chapters</string>
-    <string name="show_shownotes_label">Show shownotes</string>
-    <string name="show_cover_label">Show picture</string>
     <string name="rewind_label">Rewind</string>
     <string name="fast_forward_label">Fast forward</string>
     <string name="media_type_audio_label">Audio</string>
     <string name="media_type_video_label">Video</string>
     <string name="navigate_upwards_label">Navigate upwards</string>
-    <string name="butAction_label">More actions</string>
-    <string name="status_playing_label">Episode is being played</string>
     <string name="status_downloading_label">Episode is being downloaded</string>
-    <string name="status_downloaded_label">Episode is downloaded</string>
-    <string name="status_unread_label">Item is new</string>
     <string name="in_queue_label">Episode is in the queue</string>
-    <string name="new_episodes_count_label">Number of new episodes</string>
-    <string name="in_progress_episodes_count_label">Number of episodes you have started listening to</string>
     <string name="drag_handle_content_description">Drag to change the position of this item</string>
     <string name="load_next_page_label">Load next page</string>
 
@@ -568,12 +547,12 @@
     <string name="progress_upgrading_database">Upgrading the database</string>
 
     <!-- AntennaPodSP -->
-
     <string name="sp_apps_importing_feeds_msg">Importing subscriptions from single-purpose apps&#8230;</string>
-    <string name="search_itunes_label">Search iTunes</string>
 
-    <string name="select_label"><b>Select&#8230;</b></string>
+    <string name="search_itunes_label">Search iTunes</string>
     <string name="filter">Filter</string>
+    
+    <!-- Episodes apply actions -->
     <string name="all_label">All</string>
     <string name="selected_all_label">Selected all Episodes</string>
     <string name="none_label">None</string>
@@ -590,7 +569,8 @@
     <string name="selected_queued_label">Selected queued Episodes</string>
     <string name="not_queued_label">Not queued</string>
     <string name="selected_not_queued_label">Selected not queued Episodes</string>
-    <string name="sort_title"><b>Sort by&#8230;</b></string>
+
+    <!-- Sort  -->
     <string name="sort_title_a_z">Title (A \u2192 Z)</string>
     <string name="sort_title_z_a">Title (Z \u2192 A)</string>
     <string name="sort_date_new_old">Date (New \u2192 Old)</string>
@@ -624,8 +604,8 @@
     <string name="proxy_checking">Checking&#8230;</string>
     <string name="proxy_test_successful">Test successful</string>
     <string name="proxy_test_failed">Test failed</string>
-    <string name="proxy_host_empty_error">Host must not be empty</string>
-    <string name="proxy_host_invalid_error">Host not valid IP address or domain</string>
+    <string name="proxy_host_empty_error">Host can not be empty</string>
+    <string name="proxy_host_invalid_error">Host is not a valid IP address or domain</string>
     <string name="proxy_port_invalid_error">Port not valid</string>
 
 </resources>


### PR DESCRIPTION
- proxy_host_invalid_error: add verb & article to improve clarity
- proxy_host_empty_error: replace 'must not' by 'can not'
- removed set of strings that aren't used (anymore)
- for feed setting "Auto remove episode": Improve clarity of setting name (feed_auto_download_global -> "Global default") and delete explanatory info ("override global default" in auto_delete_label). Removes unnecessary screen clutter, removes double & in most cases false info (if setting is 'global' it doesn't "override default")
- share_item_url_label & share_item_url_with_position_label: add 'file' to clarify what URL is shared (media file, not episode webpage)
- prevent position_default_label ('00:00:00') and 'app_name' (the same in all languages so far) from being translated