### PR TITLE
OPML Import: Fix URI containing absolute path

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromIntentActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromIntentActivity.java
@@ -18,6 +18,9 @@ public class OpmlImportFromIntentActivity extends OpmlImportBaseActivity {
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         Uri uri = getIntent().getData();
+        if(uri.toString().startsWith("/")) {
+            uri = Uri.parse("file://" + uri.toString());
+        }
         importUri(uri);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
@@ -135,6 +135,9 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if (resultCode == RESULT_OK && requestCode == CHOOSE_OPML_FILE) {
             Uri uri = data.getData();
+            if(uri.toString().startsWith("/")) {
+                uri = Uri.parse("file://" + uri.toString());
+            }
             importUri(uri);
         }
     }


### PR DESCRIPTION
When Ghost Commander is used to open an OPML file *From local filesystem*, we would expect to receive a URI like ``file:///storage/emulated/0/FILE.opml``, but we receive ``/storage/emulated/0/FILE.opml``

Resolves #1502 