### PR TITLE
Statistics: More accurate played duration

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -949,12 +949,8 @@ public final class DBReader {
                     continue;
                 }
 
-                if(item.isPlayed()) {
-                    feedPlayedTime += media.getDuration() / 1000;
-                } else {
-                    feedPlayedTime += media.getPosition() / 1000;
-                }
-                if(item.isPlayed() || media.getPosition() != 0) {
+                feedPlayedTime += media.getPlayedDuration() / 1000;
+                if(media.getPlayedDuration() > 0) {
                     episodesStarted++;
                 }
                 feedTotalTime += media.getDuration() / 1000;


### PR DESCRIPTION
Yet, I'm not sure that the users understand that played duration != real time listened to podcasts (when playback speed != 1.00)