### PR TITLE
Optionally show rewind/forward buttons on the lockscreen

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -90,6 +90,30 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         assertTrue(solo.waitForCondition(() -> persistNotify == UserPreferences.isPersistNotify(), Timeout.getLargeTimeout()));
     }
 
+    public void testSetLockscreenButtons() {
+        String[] buttons = res.getStringArray(R.array.compact_notification_buttons_options);
+        solo.clickOnText(solo.getString(R.string.pref_compact_notification_buttons_title));
+        solo.waitForDialogToOpen(1000);
+        // First uncheck every checkbox
+        for (int i=0; i<buttons.length; i++) {
+            assertTrue(solo.searchText(buttons[i]));
+            if (solo.isTextChecked(buttons[i])) {
+                solo.clickOnText(buttons[i]);
+            }
+        }
+        // Now try to check all checkboxes
+        solo.clickOnText(buttons[0]);
+        solo.clickOnText(buttons[1]);
+        solo.clickOnText(buttons[2]);
+        // Make sure that the third checkbox is unchecked
+        assertTrue(!solo.isTextChecked(buttons[2]));
+        solo.clickOnText(solo.getString(R.string.confirm_label));
+        solo.waitForDialogToClose(1000);
+        assertTrue(solo.waitForCondition(() -> UserPreferences.showRewindOnCompactNotification(), Timeout.getLargeTimeout()));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.showFastForwardOnCompactNotification(), Timeout.getLargeTimeout()));
+        assertTrue(solo.waitForCondition(() -> !UserPreferences.showSkipOnCompactNotification(), Timeout.getLargeTimeout()));
+    }
+
     public void testEnqueueAtFront() {
         final boolean enqueueAtFront = UserPreferences.enqueueAtFront();
         solo.clickOnText(solo.getString(R.string.pref_queueAddToFront_title));

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -56,9 +56,9 @@
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
         <Preference
-            android:key="prefNotificationButtons"
-            android:summary="@string/pref_notification_buttons_sum"
-            android:title="@string/pref_notification_buttons_title"/>
+            android:key="prefCompactNotificationButtons"
+            android:summary="@string/pref_compact_notification_buttons_sum"
+            android:title="@string/pref_compact_notification_buttons_title"/>
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="true"
             android:enabled="true"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -55,14 +55,10 @@
             android:key="prefPersistNotify"
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
-        <com.afollestad.materialdialogs.prefs.MaterialMultiSelectListPreference
-            android:entries="@array/prioritised_notification_buttons_options"
-            android:entryValues="@array/prioritised_notification_buttons_values"
-            android:defaultValue="@array/prioritised_notification_buttons_default_values"
-            android:title="@string/pref_prioritised_notification_buttons_title"
-            android:key="prefPrioritisedNotificationButtons"
-            android:summary="@string/pref_prioritised_notification_buttons_sum"
-            app:useStockLayout="true"/>
+        <Preference
+            android:key="prefNotificationButtons"
+            android:summary="@string/pref_notification_buttons_sum"
+            android:title="@string/pref_notification_buttons_title"/>
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="true"
             android:enabled="true"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -55,6 +55,14 @@
             android:key="prefPersistNotify"
             android:summary="@string/pref_persistNotify_sum"
             android:title="@string/pref_persistNotify_title"/>
+        <com.afollestad.materialdialogs.prefs.MaterialMultiSelectListPreference
+            android:entries="@array/prioritised_notification_buttons_options"
+            android:entryValues="@array/prioritised_notification_buttons_values"
+            android:defaultValue="@array/prioritised_notification_buttons_default_values"
+            android:title="@string/pref_prioritised_notification_buttons_title"
+            android:key="prefPrioritisedNotificationButtons"
+            android:summary="@string/pref_prioritised_notification_buttons_sum"
+            app:useStockLayout="true"/>
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="true"
             android:enabled="true"

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
 project.ext {
     compileSdkVersion = 23
     buildToolsVersion = "23.0.2"
-    minSdkVersion = 10
+    minSdkVersion = 11
     targetSdkVersion = 23
 
     supportVersion = "23.2.1"

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
 project.ext {
     compileSdkVersion = 23
     buildToolsVersion = "23.0.2"
-    minSdkVersion = 11
+    minSdkVersion = 10
     targetSdkVersion = 23
 
     supportVersion = "23.2.1"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.core.R;
@@ -53,7 +52,7 @@ public class UserPreferences {
     public static final String PREF_DRAWER_FEED_COUNTER = "prefDrawerFeedIndicator";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
-    public static final String PREF_PRIORITISED_NOTIFICATION_BUTTONS = "prefPrioritisedNotificationButtons";
+    public static final String PREF_NOTIFICATION_BUTTONS = "prefNotificationButtons";
     public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     public static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
     public static final String PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER = "prefShowSubscriptionsInDrawer";
@@ -168,6 +167,11 @@ public class UserPreferences {
         return new ArrayList<>(Arrays.asList(TextUtils.split(hiddenItems, ",")));
     }
 
+    public static List<String> getNotificationButtons() {
+        String hiddenItems = prefs.getString(PREF_NOTIFICATION_BUTTONS, "skip");
+        return new ArrayList<>(Arrays.asList(TextUtils.split(hiddenItems, ",")));
+    }
+
     public static int getFeedOrder() {
         String value = prefs.getString(PREF_DRAWER_FEED_ORDER, "0");
         return Integer.parseInt(value);
@@ -180,10 +184,6 @@ public class UserPreferences {
 
     public static boolean showSubscriptionsInDrawer() {
         return prefs.getBoolean(PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER, true);
-    }
-
-    public static Set<String> getPrioritisedNotificationButtons() {
-        return prefs.getStringSet(PREF_PRIORITISED_NOTIFICATION_BUTTONS, null);
     }
 
     /**
@@ -530,6 +530,13 @@ public class UserPreferences {
         String str = TextUtils.join(",", items);
         prefs.edit()
              .putString(PREF_HIDDEN_DRAWER_ITEMS, str)
+             .apply();
+    }
+
+    public static void setNotificationButtons(List<String> items) {
+        String str = TextUtils.join(",", items);
+        prefs.edit()
+             .putString(PREF_NOTIFICATION_BUTTONS, str)
              .apply();
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -52,7 +52,7 @@ public class UserPreferences {
     public static final String PREF_DRAWER_FEED_COUNTER = "prefDrawerFeedIndicator";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
-    public static final String PREF_NOTIFICATION_BUTTONS = "prefNotificationButtons";
+    public static final String PREF_COMPACT_NOTIFICATION_BUTTONS = "prefCompactNotificationButtons";
     public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     public static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
     public static final String PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER = "prefShowSubscriptionsInDrawer";
@@ -117,6 +117,9 @@ public class UserPreferences {
     public static final int EPISODE_CLEANUP_DEFAULT = 0;
 
     // Constants
+    private static final int NOTIFICATION_BUTTON_REWIND = 0;
+    private static final int NOTIFICATION_BUTTON_FAST_FORWARD = 1;
+    private static final int NOTIFICATION_BUTTON_SKIP = 2;
     private static int EPISODE_CACHE_SIZE_UNLIMITED = -1;
     public static int FEED_ORDER_COUNTER = 0;
     public static int FEED_ORDER_ALPHABETICAL = 1;
@@ -167,9 +170,40 @@ public class UserPreferences {
         return new ArrayList<>(Arrays.asList(TextUtils.split(hiddenItems, ",")));
     }
 
-    public static List<String> getNotificationButtons() {
-        String hiddenItems = prefs.getString(PREF_NOTIFICATION_BUTTONS, "skip");
-        return new ArrayList<>(Arrays.asList(TextUtils.split(hiddenItems, ",")));
+    public static List<Integer> getCompactNotificationButtons() {
+        String[] buttons = TextUtils.split(
+                prefs.getString(PREF_COMPACT_NOTIFICATION_BUTTONS,
+                        String.valueOf(NOTIFICATION_BUTTON_SKIP)),
+                ",");
+        List<Integer> notificationButtons = new ArrayList<>();
+        for (int i=0; i<buttons.length; i++) {
+            notificationButtons.add(Integer.parseInt(buttons[i]));
+        }
+        return notificationButtons;
+    }
+
+    /**
+     * Helper function to return whether the specified button should be shown on compact
+     * notifications.
+     *
+     * @param buttonId Either NOTIFICATION_BUTTON_REWIND, NOTIFICATION_BUTTON_FAST_FORWARD or
+     *                 NOTIFICATION_BUTTON_SKIP.
+     * @return {@code true} if button should be shown, {@code false}  otherwise
+     */
+    private static boolean showButtonOnCompactNotification(int buttonId) {
+        return getCompactNotificationButtons().contains(buttonId);
+    }
+
+    public static boolean showRewindOnCompactNotification() {
+        return showButtonOnCompactNotification(NOTIFICATION_BUTTON_REWIND);
+    }
+
+    public static boolean showFastForwardOnCompactNotification() {
+        return showButtonOnCompactNotification(NOTIFICATION_BUTTON_FAST_FORWARD);
+    }
+
+    public static boolean showSkipOnCompactNotification() {
+        return showButtonOnCompactNotification(NOTIFICATION_BUTTON_SKIP);
     }
 
     public static int getFeedOrder() {
@@ -197,16 +231,6 @@ public class UserPreferences {
         } else {
             return NotificationCompat.PRIORITY_DEFAULT;
         }
-    }
-
-    /**
-     * Returns true if additional playback buttons should be shown in the notification even when
-     * on the lockscreen
-     *
-     * @return {@code true} if additional playback buttons should be shown, {@code false}  otherwise
-     */
-    public static boolean showAdditionalNotificationButtons() {
-        return prefs.getBoolean(PREF_EXPANDED_NOTIFICATION, false);
     }
 
     /**
@@ -533,10 +557,10 @@ public class UserPreferences {
              .apply();
     }
 
-    public static void setNotificationButtons(List<String> items) {
+    public static void setCompactNotificationButtons(List<Integer> items) {
         String str = TextUtils.join(",", items);
         prefs.edit()
-             .putString(PREF_NOTIFICATION_BUTTONS, str)
+             .putString(PREF_COMPACT_NOTIFICATION_BUTTONS, str)
              .apply();
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -194,6 +194,16 @@ public class UserPreferences {
     }
 
     /**
+     * Returns true if additional playback buttons should be shown in the notification even when
+     * on the lockscreen
+     *
+     * @return {@code true} if additional playback buttons should be shown, {@code false}  otherwise
+     */
+    public static boolean showAdditionalNotificationButtons() {
+        return prefs.getBoolean(PREF_EXPANDED_NOTIFICATION, false);
+    }
+
+    /**
      * Returns true if notifications are persistent
      *
      * @return {@code true} if notifications are persistent, {@code false}  otherwise

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -203,9 +203,9 @@ public class UserPreferences {
     }
 
     /**
-     * Returns true if notifications are persistent
+     * Returns true if the lockscreen background should be set to the current episode's image
      *
-     * @return {@code true} if notifications are persistent, {@code false}  otherwise
+     * @return {@code true} if the lockscreen background should be set, {@code false}  otherwise
      */
     public static boolean setLockscreenBackground() {
         return prefs.getBoolean(PREF_LOCKSCREEN_BACKGROUND, true);

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.core.R;
@@ -52,6 +53,7 @@ public class UserPreferences {
     public static final String PREF_DRAWER_FEED_COUNTER = "prefDrawerFeedIndicator";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
+    public static final String PREF_PRIORITISED_NOTIFICATION_BUTTONS = "prefPrioritisedNotificationButtons";
     public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     public static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
     public static final String PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER = "prefShowSubscriptionsInDrawer";
@@ -178,6 +180,10 @@ public class UserPreferences {
 
     public static boolean showSubscriptionsInDrawer() {
         return prefs.getBoolean(PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER, true);
+    }
+
+    public static Set<String> getPrioritisedNotificationButtons() {
+        return prefs.getStringSet(PREF_PRIORITISED_NOTIFICATION_BUTTONS, null);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -30,6 +30,7 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 
 import java.util.List;
+import java.util.Set;
 
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
@@ -858,7 +859,7 @@ public class PlaybackService extends Service {
                             .setPriority(UserPreferences.getNotifyPriority()); // set notification priority
                     IntList compactActionList = new IntList();
 
-
+                    Set<String> prioritisedButtons = UserPreferences.getPrioritisedNotificationButtons();
                     int numActions = 0; // we start and 0 and then increment by 1 for each call to addAction
 
                     // always let them rewind
@@ -867,8 +868,8 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_rew,
                             getString(R.string.rewind_label),
                             rewindButtonPendingIntent);
-                    if(UserPreferences.showAdditionalNotificationButtons()) {
-                        // always show the rewind button (even on the lockscreen)
+                    if(prioritisedButtons.contains("0")) {
+                        // show the rewind button even on the lock screen
                         compactActionList.add(numActions++);
                     } else {
                         numActions++;
@@ -897,8 +898,8 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_ff,
                             getString(R.string.fast_forward_label),
                             ffButtonPendingIntent);
-                    if(UserPreferences.showAdditionalNotificationButtons()) {
-                        // always show the ff button (even on the lockscreen)
+                    if(prioritisedButtons.contains("1")) {
+                        // show the fast forward button even on the lock screen
                         compactActionList.add(numActions++);
                     } else {
                         numActions++;
@@ -910,7 +911,12 @@ public class PlaybackService extends Service {
                         notificationBuilder.addAction(android.R.drawable.ic_media_next,
                                 getString(R.string.skip_episode_label),
                                 skipButtonPendingIntent);
-                        compactActionList.add(numActions++);
+                        if(prioritisedButtons.contains("2")) {
+                            // show the skip button even on the lock screen
+                            compactActionList.add(numActions++);
+                        } else {
+                            numActions++;
+                        }
                     }
 
                     PendingIntent stopButtonPendingIntent = getPendingIntentForMediaAction(

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -867,7 +867,13 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_rew,
                             getString(R.string.rewind_label),
                             rewindButtonPendingIntent);
-                    numActions++;
+                    if(UserPreferences.showAdditionalNotificationButtons()) {
+                        // always show the rewind button (even on the lockscreen)
+                        compactActionList.add(numActions++);
+                    } else {
+                        numActions++;
+                    }
+
 
                     if (playerStatus == PlayerStatus.PLAYING) {
                         PendingIntent pauseButtonPendingIntent = getPendingIntentForMediaAction(
@@ -891,7 +897,12 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_ff,
                             getString(R.string.fast_forward_label),
                             ffButtonPendingIntent);
-                    numActions++;
+                    if(UserPreferences.showAdditionalNotificationButtons()) {
+                        // always show the ff button (even on the lockscreen)
+                        compactActionList.add(numActions++);
+                    } else {
+                        numActions++;
+                    }
 
                     if (UserPreferences.isFollowQueue()) {
                         PendingIntent skipButtonPendingIntent = getPendingIntentForMediaAction(

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -858,7 +858,6 @@ public class PlaybackService extends Service {
                             .setPriority(UserPreferences.getNotifyPriority()); // set notification priority
                     IntList compactActionList = new IntList();
 
-                    final List<String> notificationButtons = UserPreferences.getNotificationButtons();
                     int numActions = 0; // we start and 0 and then increment by 1 for each call to addAction
 
                     // always let them rewind
@@ -867,13 +866,10 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_rew,
                             getString(R.string.rewind_label),
                             rewindButtonPendingIntent);
-                    if(notificationButtons.contains("rewind")) {
-                        // show the rewind button even on the lock screen
-                        compactActionList.add(numActions++);
-                    } else {
-                        numActions++;
+                    if(UserPreferences.showRewindOnCompactNotification()) {
+                        compactActionList.add(numActions);
                     }
-
+                    numActions++;
 
                     if (playerStatus == PlayerStatus.PLAYING) {
                         PendingIntent pauseButtonPendingIntent = getPendingIntentForMediaAction(
@@ -897,12 +893,10 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_ff,
                             getString(R.string.fast_forward_label),
                             ffButtonPendingIntent);
-                    if(notificationButtons.contains("fastforward")) {
-                        // show the fast forward button even on the lock screen
-                        compactActionList.add(numActions++);
-                    } else {
-                        numActions++;
+                    if(UserPreferences.showFastForwardOnCompactNotification()) {
+                        compactActionList.add(numActions);
                     }
+                    numActions++;
 
                     if (UserPreferences.isFollowQueue()) {
                         PendingIntent skipButtonPendingIntent = getPendingIntentForMediaAction(
@@ -910,12 +904,10 @@ public class PlaybackService extends Service {
                         notificationBuilder.addAction(android.R.drawable.ic_media_next,
                                 getString(R.string.skip_episode_label),
                                 skipButtonPendingIntent);
-                        if(notificationButtons.contains("skip")) {
-                            // show the skip button even on the lock screen
-                            compactActionList.add(numActions++);
-                        } else {
-                            numActions++;
+                        if(UserPreferences.showSkipOnCompactNotification()) {
+                            compactActionList.add(numActions);
                         }
+                        numActions++;
                     }
 
                     PendingIntent stopButtonPendingIntent = getPendingIntentForMediaAction(

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -30,7 +30,6 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 
 import java.util.List;
-import java.util.Set;
 
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
@@ -859,7 +858,7 @@ public class PlaybackService extends Service {
                             .setPriority(UserPreferences.getNotifyPriority()); // set notification priority
                     IntList compactActionList = new IntList();
 
-                    Set<String> prioritisedButtons = UserPreferences.getPrioritisedNotificationButtons();
+                    final List<String> notificationButtons = UserPreferences.getNotificationButtons();
                     int numActions = 0; // we start and 0 and then increment by 1 for each call to addAction
 
                     // always let them rewind
@@ -868,7 +867,7 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_rew,
                             getString(R.string.rewind_label),
                             rewindButtonPendingIntent);
-                    if(prioritisedButtons.contains("0")) {
+                    if(notificationButtons.contains("rewind")) {
                         // show the rewind button even on the lock screen
                         compactActionList.add(numActions++);
                     } else {
@@ -898,7 +897,7 @@ public class PlaybackService extends Service {
                     notificationBuilder.addAction(android.R.drawable.ic_media_ff,
                             getString(R.string.fast_forward_label),
                             ffButtonPendingIntent);
-                    if(prioritisedButtons.contains("1")) {
+                    if(notificationButtons.contains("fastforward")) {
                         // show the fast forward button even on the lock screen
                         compactActionList.add(numActions++);
                     } else {
@@ -911,7 +910,7 @@ public class PlaybackService extends Service {
                         notificationBuilder.addAction(android.R.drawable.ic_media_next,
                                 getString(R.string.skip_episode_label),
                                 skipButtonPendingIntent);
-                        if(prioritisedButtons.contains("2")) {
+                        if(notificationButtons.contains("skip")) {
                             // show the skip button even on the lock screen
                             compactActionList.add(numActions++);
                         } else {

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -212,4 +212,18 @@
         <item>500</item>
     </string-array>
 
+    <string-array name="prioritised_notification_buttons_options">
+        <item>@string/rewind_label</item>
+        <item>@string/fast_forward_label</item>
+        <item>@string/skip_episode_label</item>
+    </string-array>
+    <string-array name="prioritised_notification_buttons_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="prioritised_notification_buttons_default_values">
+        <item>2</item>
+    </string-array>
+
 </resources>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -212,18 +212,9 @@
         <item>500</item>
     </string-array>
 
-    <string-array name="notification_buttons_options">
+    <string-array name="compact_notification_buttons_options">
         <item>@string/rewind_label</item>
         <item>@string/fast_forward_label</item>
         <item>@string/skip_episode_label</item>
     </string-array>
-    <string-array name="notification_buttons_values">
-        <item>rewind</item>
-        <item>fastforward</item>
-        <item>skip</item>
-    </string-array>
-    <string-array name="notification_buttons_default_values">
-        <item>skip</item>
-    </string-array>
-
 </resources>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -212,18 +212,18 @@
         <item>500</item>
     </string-array>
 
-    <string-array name="prioritised_notification_buttons_options">
+    <string-array name="notification_buttons_options">
         <item>@string/rewind_label</item>
         <item>@string/fast_forward_label</item>
         <item>@string/skip_episode_label</item>
     </string-array>
-    <string-array name="prioritised_notification_buttons_values">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
+    <string-array name="notification_buttons_values">
+        <item>rewind</item>
+        <item>fastforward</item>
+        <item>skip</item>
     </string-array>
-    <string-array name="prioritised_notification_buttons_default_values">
-        <item>2</item>
+    <string-array name="notification_buttons_default_values">
+        <item>skip</item>
     </string-array>
 
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -385,7 +385,7 @@
     <string name="pref_persistNotify_title">Persistent Playback Controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
     <string name="pref_notification_buttons_title">Select Notification Buttons</string>
-    <string name="pref_notification_buttons_sum">Change the playback buttons on the lock screen notification.</string>
+    <string name="pref_notification_buttons_sum">Change the playback buttons on the lock screen notification. The play/pause button is always included.</string>
     <string name="pref_notification_buttons_dialog_title">Select a maximum of %1$d items</string>
     <string name="pref_notification_buttons_dialog_error">You can only select a maximum of %1$d items.</string>
     <string name="pref_show_subscriptions_in_drawer_title">Show Subscriptions</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -384,6 +384,8 @@
     <string name="pref_expandNotify_sum">Always expand the notification to show playback buttons.</string>
     <string name="pref_persistNotify_title">Persistent Playback Controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
+    <string name="pref_prioritised_notification_buttons_title">Prioritise Notification Buttons</string>
+    <string name="pref_prioritised_notification_buttons_sum">Change the playback buttons on the lock screen notification.</string>
     <string name="pref_show_subscriptions_in_drawer_title">Show Subscriptions</string>
     <string name="pref_show_subscriptions_in_drawer_sum">Show subscription list directly in navigation drawer</string>
     <string name="pref_lockscreen_background_title">Set Lockscreen Background</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -384,8 +384,10 @@
     <string name="pref_expandNotify_sum">Always expand the notification to show playback buttons.</string>
     <string name="pref_persistNotify_title">Persistent Playback Controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
-    <string name="pref_prioritised_notification_buttons_title">Prioritise Notification Buttons</string>
-    <string name="pref_prioritised_notification_buttons_sum">Change the playback buttons on the lock screen notification.</string>
+    <string name="pref_notification_buttons_title">Select Notification Buttons</string>
+    <string name="pref_notification_buttons_sum">Change the playback buttons on the lock screen notification.</string>
+    <string name="pref_notification_buttons_dialog_title">Select a maximum of %1$d items</string>
+    <string name="pref_notification_buttons_dialog_error">You can only select a maximum of %1$d items.</string>
     <string name="pref_show_subscriptions_in_drawer_title">Show Subscriptions</string>
     <string name="pref_show_subscriptions_in_drawer_sum">Show subscription list directly in navigation drawer</string>
     <string name="pref_lockscreen_background_title">Set Lockscreen Background</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -384,10 +384,10 @@
     <string name="pref_expandNotify_sum">Always expand the notification to show playback buttons.</string>
     <string name="pref_persistNotify_title">Persistent Playback Controls</string>
     <string name="pref_persistNotify_sum">Keep notification and lockscreen controls when playback is paused.</string>
-    <string name="pref_notification_buttons_title">Select Notification Buttons</string>
-    <string name="pref_notification_buttons_sum">Change the playback buttons on the lock screen notification. The play/pause button is always included.</string>
-    <string name="pref_notification_buttons_dialog_title">Select a maximum of %1$d items</string>
-    <string name="pref_notification_buttons_dialog_error">You can only select a maximum of %1$d items.</string>
+    <string name="pref_compact_notification_buttons_title">Set Lockscreen Buttons</string>
+    <string name="pref_compact_notification_buttons_sum">Change the playback buttons on the lockscreen. The play/pause button is always included.</string>
+    <string name="pref_compact_notification_buttons_dialog_title">Select a maximum of %1$d items</string>
+    <string name="pref_compact_notification_buttons_dialog_error">You can only select a maximum of %1$d items.</string>
     <string name="pref_show_subscriptions_in_drawer_title">Show Subscriptions</string>
     <string name="pref_show_subscriptions_in_drawer_sum">Show subscription list directly in navigation drawer</string>
     <string name="pref_lockscreen_background_title">Set Lockscreen Background</string>


### PR DESCRIPTION
Currently the lockscreen notification only contains play/pause and skip buttons. This PR makes the rewind and forward buttons appear on the lockscreen if the option `Expand Notification` is selected. The lockscreen then contains the rewind, play/pause and forward buttons, which in my opinion are the most useful buttons on the lockscreen. This has also been requested in #337 and #571.