### PR TITLE
treat showing the subscriptions list like other drawer items.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AudioplayerActivity.java
@@ -83,7 +83,8 @@ public class AudioplayerActivity extends MediaplayerActivity implements NavDrawe
             SubscriptionFragment.TAG,
             DownloadsFragment.TAG,
             PlaybackHistoryFragment.TAG,
-            AddFeedFragment.TAG
+            AddFeedFragment.TAG,
+            NavListAdapter.SUBSCRIPTION_LIST_TAG
     };
 
     private AtomicBoolean isSetup = new AtomicBoolean(false);

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -96,7 +96,8 @@ public class MainActivity extends AppCompatActivity implements NavDrawerActivity
             SubscriptionFragment.TAG,
             DownloadsFragment.TAG,
             PlaybackHistoryFragment.TAG,
-            AddFeedFragment.TAG
+            AddFeedFragment.TAG,
+            NavListAdapter.SUBSCRIPTION_LIST_TAG
     };
 
     private Toolbar toolbar;

--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -50,11 +50,18 @@ public class NavListAdapter extends BaseAdapter
     public static final int VIEW_TYPE_SECTION_DIVIDER = 1;
     public static final int VIEW_TYPE_SUBSCRIPTION = 2;
 
+    /**
+     * a tag used as a placeholder to indicate if the subscription list should be displayed or not
+     * This tag doesn't correspond to any specific activity.
+     */
+    public static final String SUBSCRIPTION_LIST_TAG = "SubscriptionList";
+
     private static List<String> tags;
     private static String[] titles;
 
     private ItemAccess itemAccess;
     private Context context;
+    private boolean showSubscriptionList = true;
 
     public NavListAdapter(ItemAccess itemAccess, Context context) {
         this.itemAccess = itemAccess;
@@ -79,6 +86,18 @@ public class NavListAdapter extends BaseAdapter
         for(String hidden : hiddenFragments) {
             newTags.remove(hidden);
         }
+
+        if (newTags.contains(SUBSCRIPTION_LIST_TAG)) {
+            // we never want SUBSCRIPTION_LIST_TAG to be in 'tags'
+            // since it doesn't actually correspond to a position in the list, but is
+            // a placeholder that indicates if we should show the subscription list in the
+            // nav drawer at all.
+            showSubscriptionList = true;
+            newTags.remove(SUBSCRIPTION_LIST_TAG);
+        } else {
+            showSubscriptionList = false;
+        }
+
         tags = newTags;
         notifyDataSetChanged();
     }
@@ -132,7 +151,7 @@ public class NavListAdapter extends BaseAdapter
     @Override
     public int getCount() {
         int baseCount = getSubscriptionOffset();
-        if (UserPreferences.showSubscriptionsInDrawer()) {
+        if (showSubscriptionList) {
             baseCount += itemAccess.getCount();
         }
         return baseCount;

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -36,12 +36,6 @@
                 android:summary="@string/pref_nav_drawer_feed_counter_sum"
                 android:defaultValue="0"
                 app:useStockLayout="true"/>
-            <de.danoeh.antennapod.preferences.SwitchCompatPreference
-                android:defaultValue="true"
-                android:enabled="true"
-                android:key="prefShowSubscriptionsInDrawer"
-                android:summary="@string/pref_show_subscriptions_in_drawer_sum"
-                android:title="@string/pref_show_subscriptions_in_drawer_title"/>
         </PreferenceScreen>
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="false"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -54,7 +54,6 @@ public class UserPreferences {
     public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
     public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     public static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
-    public static final String PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER = "prefShowSubscriptionsInDrawer";
 
 
     // Queue
@@ -174,10 +173,6 @@ public class UserPreferences {
     public static int getFeedCounterSetting() {
         String value = prefs.getString(PREF_DRAWER_FEED_COUNTER, "0");
         return Integer.parseInt(value);
-    }
-
-    public static boolean showSubscriptionsInDrawer() {
-        return prefs.getBoolean(PREF_SHOW_SUBSCRIPTIONS_IN_DRAWER, true);
     }
 
     /**

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -150,6 +150,7 @@
         <item>@string/downloads_label</item>
         <item>@string/playback_history_label</item>
         <item>@string/add_feed_label</item>
+        <item>@string/subscriptions_list_label</item>
     </string-array>
 
     <string-array name="nav_drawer_feed_order_options">

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="downloads_completed_label">Completed</string>
     <string name="downloads_log_label">Log</string>
     <string name="subscriptions_label">Subscriptions</string>
+    <string name="subscriptions_list_label">Subscriptions List</string>
     <string name="cancel_download_label">Cancel\nDownload</string>
     <string name="playback_history_label">Playback History</string>
     <string name="gpodnet_main_label">gpodder.net</string>


### PR DESCRIPTION
Addresses one of the issues from #1838 

Subscription List is now shown in the drawer options instead of having it's own thing.