### PR TITLE
Enable full hyphenation on Android 6

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -1,8 +1,10 @@
 package de.danoeh.antennapod.adapter;
 
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.Layout;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -81,6 +83,9 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         holder.container = (FrameLayout) view.findViewById(R.id.container);
         holder.placeholder = (TextView) view.findViewById(R.id.txtvPlaceholder);
         holder.title = (TextView) view.findViewById(R.id.txtvTitle);
+        if(Build.VERSION.SDK_INT >= 23) {
+            holder.title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+        }
         holder.pubDate = (TextView) view
                 .findViewById(R.id.txtvPublished);
         holder.statusUnread = view.findViewById(R.id.statusUnread);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
@@ -1,7 +1,9 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
+import android.text.Layout;
 import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -52,6 +54,9 @@ public class DownloadLogAdapter extends BaseAdapter {
 			holder.retry = (IconButton) convertView.findViewById(R.id.btnRetry);
 			holder.date = (TextView) convertView.findViewById(R.id.txtvDate);
 			holder.title = (TextView) convertView.findViewById(R.id.txtvTitle);
+			if(Build.VERSION.SDK_INT >= 23) {
+				holder.title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+			}
 			holder.type = (TextView) convertView.findViewById(R.id.txtvType);
 			holder.reason = (TextView) convertView.findViewById(R.id.txtvReason);
 			convertView.setTag(holder);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadedEpisodesListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadedEpisodesListAdapter.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.os.Build;
+import android.text.Layout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -60,6 +62,9 @@ public class DownloadedEpisodesListAdapter extends BaseAdapter {
                     parent, false);
             holder.imageView = (ImageView) convertView.findViewById(R.id.imgvImage);
             holder.title = (TextView) convertView.findViewById(R.id.txtvTitle);
+            if(Build.VERSION.SDK_INT >= 23) {
+                holder.title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+            }
             holder.txtvSize = (TextView) convertView.findViewById(R.id.txtvSize);
             holder.queueStatus = (ImageView) convertView.findViewById(R.id.imgvInPlaylist);
             holder.pubDate = (TextView) convertView

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -2,7 +2,9 @@ package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
+import android.text.Layout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -95,8 +97,10 @@ public class FeedItemlistAdapter extends BaseAdapter {
             convertView = inflater.inflate(R.layout.feeditemlist_item, parent, false);
             holder.container = (LinearLayout) convertView
                     .findViewById(R.id.container);
-            holder.title = (TextView) convertView
-                    .findViewById(R.id.txtvItemname);
+            holder.title = (TextView) convertView.findViewById(R.id.txtvItemname);
+            if(Build.VERSION.SDK_INT >= 23) {
+                holder.title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+            }
             holder.lenSize = (TextView) convertView
                     .findViewById(R.id.txtvLenSize);
             holder.butAction = (ImageButton) convertView

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -1,10 +1,12 @@
 package de.danoeh.antennapod.adapter;
 
+import android.os.Build;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.MotionEventCompat;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.Layout;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -141,6 +143,9 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
             placeholder = (TextView) v.findViewById(R.id.txtvPlaceholder);
             cover = (ImageView) v.findViewById(R.id.imgvCover);
             title = (TextView) v.findViewById(R.id.txtvTitle);
+            if(Build.VERSION.SDK_INT >= 23) {
+                title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+            }
             pubDate = (TextView) v.findViewById(R.id.txtvPubDate);
             progressLeft = (TextView) v.findViewById(R.id.txtvProgressLeft);
             progressRight = (TextView) v.findViewById(R.id.txtvProgressRight);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SearchlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SearchlistAdapter.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.os.Build;
+import android.text.Layout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -60,6 +62,9 @@ public class SearchlistAdapter extends BaseAdapter {
 
             convertView = inflater.inflate(R.layout.searchlist_item, parent, false);
             holder.title = (TextView) convertView.findViewById(R.id.txtvTitle);
+            if(Build.VERSION.SDK_INT >= 23) {
+                holder.title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+            }
             holder.cover = (ImageView) convertView
                     .findViewById(R.id.imgvFeedimage);
             holder.subtitle = (TextView) convertView

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GestureDetectorCompat;
+import android.text.Layout;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -175,6 +176,9 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
         txtvPodcast = (TextView) layout.findViewById(R.id.txtvPodcast);
         txtvPodcast.setOnClickListener(v -> openPodcast());
         txtvTitle = (TextView) layout.findViewById(R.id.txtvTitle);
+        if(Build.VERSION.SDK_INT >= 23) {
+            txtvTitle.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+        }
         txtvDuration = (TextView) layout.findViewById(R.id.txtvDuration);
         txtvPublished = (TextView) layout.findViewById(R.id.txtvPublished);
         if (Build.VERSION.SDK_INT >= 14) { // ellipsize is causing problems on old versions, see #448


### PR DESCRIPTION
Before & After
![hyphenation](https://cloud.githubusercontent.com/assets/6860662/14523750/9a59d738-0235-11e6-9e1d-31507899f75f.png)

Even though the locale was US and the episode titles are in German, the hyphenation is actually pretty good