### PR TITLE
Fix item tags

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -688,15 +688,13 @@ public class MainActivity extends AppCompatActivity implements NavDrawerActivity
 
     public void onEvent(QueueEvent event) {
         Log.d(TAG, "onEvent(" + event + ")");
-        switch(event.action) {
-            case ADDED:
-            case ADDED_ITEMS:
-            case SET_QUEUE:
-            case REMOVED:
-            case IRREVERSIBLE_REMOVED:
-            case CLEARED:
-                loadData();
+        // we are only interested in the number of queue items, not download status or position
+        if(event.action == QueueEvent.Action.DELETED_MEDIA ||
+                event.action == QueueEvent.Action.SORTED ||
+                event.action == QueueEvent.Action.MOVED) {
+            return;
         }
+        loadData();
     }
 
     public void onEventMainThread(ProgressEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -688,7 +688,15 @@ public class MainActivity extends AppCompatActivity implements NavDrawerActivity
 
     public void onEvent(QueueEvent event) {
         Log.d(TAG, "onEvent(" + event + ")");
-        loadData();
+        switch(event.action) {
+            case ADDED:
+            case ADDED_ITEMS:
+            case SET_QUEUE:
+            case REMOVED:
+            case IRREVERSIBLE_REMOVED:
+            case CLEARED:
+                loadData();
+        }
     }
 
     public void onEventMainThread(ProgressEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -289,8 +289,7 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
                     item1.setVisible(visible);
                 }
             };
-            FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true,
-                    itemAccess.getQueueIds(), itemAccess.getFavoritesIds());
+            FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, null);
         }
 
     }
@@ -306,10 +305,6 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         int getItemDownloadProgressPercent(FeedItem item);
 
         boolean isInQueue(FeedItem item);
-
-        LongList getQueueIds();
-
-        LongList getFavoritesIds();
 
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -147,6 +147,8 @@ public class FeedItemlistAdapter extends BaseAdapter {
             String pubDateStr = DateUtils.formatAbbrev(context, item.getPubDate());
             holder.published.setText(pubDateStr);
 
+            boolean isInQueue = item.isTagged(FeedItem.TAG_QUEUE);
+
             FeedMedia media = item.getMedia();
             if (media == null) {
                 holder.episodeProgress.setVisibility(View.GONE);
@@ -157,7 +159,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
 
                 AdapterUtils.updateEpisodePlaybackProgress(item, holder.lenSize, holder.episodeProgress);
 
-                if (itemAccess.isInQueue(item)) {
+                if (isInQueue) {
                     holder.inPlaylist.setVisibility(View.VISIBLE);
                 } else {
                     holder.inPlaylist.setVisibility(View.INVISIBLE);
@@ -198,7 +200,6 @@ public class FeedItemlistAdapter extends BaseAdapter {
                 }
             }
 
-            boolean isInQueue = itemAccess.isInQueue(item);
             actionButtonUtils.configureActionButton(holder.butAction, item, isInQueue);
             holder.butAction.setFocusable(false);
             holder.butAction.setTag(item);
@@ -231,8 +232,6 @@ public class FeedItemlistAdapter extends BaseAdapter {
     }
 
     public interface ItemAccess {
-
-        boolean isInQueue(FeedItem item);
 
         int getItemDownloadProgressPercent(FeedItem item);
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -188,8 +188,7 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                     item1.setVisible(visible);
                 }
             };
-            FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true,
-                    itemAccess.getQueueIds(), itemAccess.getFavoritesIds());
+            FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, itemAccess.getQueueIds());
         }
 
         @Override
@@ -317,7 +316,6 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
         long getItemDownloadSize(FeedItem item);
         int getItemDownloadProgressPercent(FeedItem item);
         LongList getQueueIds();
-        LongList getFavoritesIds();
     }
 
     /**

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -378,33 +378,6 @@ public class AllEpisodesFragment extends Fragment {
             return item != null && item.isTagged(FeedItem.TAG_QUEUE);
         }
 
-        @Override
-        public LongList getQueueIds() {
-            LongList queueIds = new LongList();
-            if(episodes == null) {
-                return queueIds;
-            }
-            for(FeedItem item : episodes) {
-                if(item.isTagged(FeedItem.TAG_QUEUE)) {
-                    queueIds.add(item.getId());
-                }
-            }
-            return queueIds;
-        }
-
-        @Override
-        public LongList getFavoritesIds() {
-            LongList favoritesIds = new LongList();
-            if(episodes == null) {
-                return favoritesIds;
-            }
-            for(FeedItem item : episodes) {
-                if(item.isTagged(FeedItem.TAG_FAVORITE)) {
-                    favoritesIds.add(item.getId());
-                }
-            }
-            return favoritesIds;
-        }
     };
 
     public void onEventMainThread(FeedItemEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -70,10 +70,10 @@ public class AllEpisodesFragment extends Fragment {
     private static final String PREF_SCROLL_OFFSET = "scroll_offset";
 
     protected RecyclerView recyclerView;
-    private AllEpisodesRecycleAdapter listAdapter;
+    protected AllEpisodesRecycleAdapter listAdapter;
     private ProgressBar progLoading;
 
-    private List<FeedItem> episodes;
+    protected List<FeedItem> episodes;
     private List<Downloader> downloaderList;
 
     private boolean itemsLoaded = false;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -523,18 +523,6 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
         ((MainActivity)getActivity()).loadChildFragment(fragment);
     }
 
-    public void onEventMainThread(QueueEvent event) {
-        if(event.contains(feedItems[feedItemPos])) {
-            load();
-        }
-    }
-
-    public void onEventMainThread(FavoritesEvent event) {
-        if(event.item.getId() == feedItems[feedItemPos]) {
-            load();
-        }
-    }
-
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
         for(FeedItem item : event.items) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -49,7 +49,6 @@ import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.DownloaderUpdate;
 import de.danoeh.antennapod.core.event.FavoritesEvent;
 import de.danoeh.antennapod.core.event.FeedItemEvent;
-import de.danoeh.antennapod.core.event.QueueEvent;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedEvent;
@@ -375,16 +374,6 @@ public class ItemlistFragment extends ListFragment {
         long[] ids = FeedItemUtil.getIds(feed.getItems());
         activity.loadChildFragment(ItemFragment.newInstance(ids, position));
         activity.getSupportActionBar().setTitle(feed.getTitle());
-    }
-
-    public void onEvent(QueueEvent event) {
-        Log.d(TAG, "onEvent() called with: " + "event = [" + event + "]");
-        loadItems();
-    }
-
-    public void onEvent(FavoritesEvent event) {
-        Log.d(TAG, "onEvent() called with: " + "event = [" + event + "]");
-        loadItems();
     }
 
     public void onEvent(FeedEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -47,7 +47,6 @@ import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.dialog.DownloadRequestErrorDialogCreator;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.DownloaderUpdate;
-import de.danoeh.antennapod.core.event.FavoritesEvent;
 import de.danoeh.antennapod.core.event.FeedItemEvent;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.Feed;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -14,12 +14,13 @@ import java.util.List;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.AllEpisodesRecycleAdapter;
-import de.danoeh.antennapod.core.event.QueueEvent;
+import de.danoeh.antennapod.core.event.FeedItemEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.FeedItemUtil;
 
 
 /**
@@ -39,14 +40,24 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
     @Override
     protected String getPrefName() { return PREF_NAME; }
 
-    public void onEvent(QueueEvent event) {
-        Log.d(TAG, "onEvent() called with: " + "event = [" + event + "]");
-        loadItems();
-    }
-
     @Override
     protected void resetViewState() {
         super.resetViewState();
+    }
+
+    @Override
+    public void onEventMainThread(FeedItemEvent event) {
+        Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if(episodes == null) {
+            return;
+        }
+        for(FeedItem item : event.items) {
+            int pos = FeedItemUtil.indexOfItemWithId(episodes, item.getId());
+            if(pos >= 0 && item.isTagged(FeedItem.TAG_QUEUE)) {
+                episodes.remove(pos);
+                listAdapter.notifyItemRemoved(pos);
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
-import android.support.v4.util.Pair;
 import android.support.v4.view.MenuItemCompat;
 import android.util.Log;
 import android.view.Menu;
@@ -29,7 +28,7 @@ import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
-import de.danoeh.antennapod.core.util.LongList;
+
 import de.greenrobot.event.EventBus;
 import rx.Observable;
 import rx.Subscription;
@@ -44,7 +43,6 @@ public class PlaybackHistoryFragment extends ListFragment {
             EventDistributor.PLAYER_STATUS_UPDATE;
 
     private List<FeedItem> playbackHistory;
-    private LongList queue;
     private FeedItemlistAdapter adapter;
 
     private boolean itemsLoaded = false;
@@ -218,10 +216,6 @@ public class PlaybackHistoryFragment extends ListFragment {
     }
 
     private FeedItemlistAdapter.ItemAccess itemAccess = new FeedItemlistAdapter.ItemAccess() {
-        @Override
-        public boolean isInQueue(FeedItem item) {
-            return (queue != null) && queue.contains(item.getId());
-        }
 
         @Override
         public int getItemDownloadProgressPercent(FeedItem item) {
@@ -260,8 +254,7 @@ public class PlaybackHistoryFragment extends ListFragment {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     if (result != null) {
-                        playbackHistory = result.first;
-                        queue = result.second;
+                        playbackHistory = result;
                         itemsLoaded = true;
                         if (viewsCreated) {
                             onFragmentLoaded();
@@ -272,11 +265,10 @@ public class PlaybackHistoryFragment extends ListFragment {
                 });
     }
 
-    private Pair<List<FeedItem>, LongList> loadData() {
+    private List<FeedItem> loadData() {
         List<FeedItem> history = DBReader.getPlaybackHistory();
-        LongList queue = DBReader.getQueueIDList();
         DBReader.loadAdditionalFeedItemListData(history);
-        return Pair.create(history, queue);
+        return history;
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -20,7 +20,7 @@ import de.danoeh.antennapod.adapter.DefaultActionButtonCallback;
 import de.danoeh.antennapod.adapter.FeedItemlistAdapter;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.DownloaderUpdate;
-import de.danoeh.antennapod.core.event.QueueEvent;
+import de.danoeh.antennapod.core.event.FeedItemEvent;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
@@ -28,7 +28,6 @@ import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
-
 import de.greenrobot.event.EventBus;
 import rx.Observable;
 import rx.Subscription;
@@ -185,9 +184,18 @@ public class PlaybackHistoryFragment extends ListFragment {
         }
     }
 
-    public void onEvent(QueueEvent event) {
-        Log.d(TAG, "onEvent(" + event + ")");
-        loadItems();
+    public void onEventMainThread(FeedItemEvent event) {
+        Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if(playbackHistory == null) {
+            return;
+        }
+        for(FeedItem item : event.items) {
+            int pos = FeedItemUtil.indexOfItemWithId(playbackHistory, item.getId());
+            if(pos >= 0) {
+                loadItems();
+                return;
+            }
+        }
     }
 
     private EventDistributor.EventListener contentUpdate = new EventDistributor.EventListener() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -568,20 +568,6 @@ public class QueueFragment extends Fragment {
         public LongList getQueueIds() {
             return queue != null ? LongList.of(FeedItemUtil.getIds(queue)) : new LongList(0);
         }
-
-        @Override
-        public LongList getFavoritesIds() {
-            LongList favoritesIds = new LongList();
-            if(queue == null) {
-                return favoritesIds;
-            }
-            for(FeedItem item : queue) {
-                if(item.isTagged(FeedItem.TAG_FAVORITE)) {
-                    favoritesIds.add(item.getId());
-                }
-            }
-            return favoritesIds;
-        }
     };
 
     private EventDistributor.EventListener contentUpdate = new EventDistributor.EventListener() {

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.menuhandler;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -54,14 +55,14 @@ public class FeedItemMenuHandler {
      * @param showExtendedMenu True if MenuItems that let the user share information about
      *                         the FeedItem and visit its website should be set visible. This
      *                         parameter should be set to false if the menu space is limited.
-     * @param queueAccess      Used for testing if the queue contains the selected item
+     * @param queueAccess      Used for testing if the queue contains the selected item; only used for
+     *                         move to top/bottom in the queue
      * @return Returns true if selectedItem is not null.
      */
     public static boolean onPrepareMenu(MenuInterface mi,
                                         FeedItem selectedItem,
                                         boolean showExtendedMenu,
-                                        LongList queueAccess,
-                                        LongList favorites) {
+                                        @Nullable LongList queueAccess) {
         if (selectedItem == null) {
             return false;
         }
@@ -72,10 +73,7 @@ public class FeedItemMenuHandler {
             mi.setItemVisibility(R.id.skip_episode_item, false);
         }
 
-        boolean isInQueue = false;
-        if(queueAccess != null) {
-            isInQueue = queueAccess.contains(selectedItem.getId());
-        }
+        boolean isInQueue = selectedItem.isTagged(FeedItem.TAG_QUEUE);
         if(queueAccess == null || queueAccess.size() == 0 || queueAccess.get(0) == selectedItem.getId()) {
             mi.setItemVisibility(R.id.move_to_top_item, false);
         }
@@ -126,7 +124,7 @@ public class FeedItemMenuHandler {
             mi.setItemVisibility(R.id.support_item, false);
         }
 
-        boolean isFavorite = favorites != null && favorites.contains(selectedItem.getId());
+        boolean isFavorite = selectedItem.isTagged(FeedItem.TAG_FAVORITE);
         mi.setItemVisibility(R.id.add_to_favorites_item, !isFavorite);
         mi.setItemVisibility(R.id.remove_from_favorites_item, isFavorite);
 
@@ -144,9 +142,8 @@ public class FeedItemMenuHandler {
                                         FeedItem selectedItem,
                                         boolean showExtendedMenu,
                                         LongList queueAccess,
-                                        LongList favorites,
                                         int... excludeIds) {
-        boolean rc = onPrepareMenu(mi, selectedItem, showExtendedMenu, queueAccess, favorites);
+        boolean rc = onPrepareMenu(mi, selectedItem, showExtendedMenu, queueAccess);
         if (rc && excludeIds != null) {
             for (int id : excludeIds) {
                 mi.setItemVisibility(id, false);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -326,6 +326,7 @@ public class DBWriter {
                         adapter.setQueue(queue);
                         item.addTag(FeedItem.TAG_QUEUE);
                         EventBus.getDefault().post(QueueEvent.added(item, index));
+                        EventBus.getDefault().post(FeedItemEvent.updated(item));
                         if (item.isNew()) {
                             DBWriter.markItemPlayed(FeedItem.UNPLAYED, item.getId());
                         }
@@ -349,6 +350,7 @@ public class DBWriter {
             itemIds.add(item.getId());
             item.addTag(FeedItem.TAG_QUEUE);
         }
+        EventBus.getDefault().post(FeedItemEvent.updated(items));
         return addQueueItem(context, false, itemIds.toArray());
     }
 
@@ -448,6 +450,7 @@ public class DBWriter {
                     adapter.setQueue(queue);
                     item.removeTag(FeedItem.TAG_QUEUE);
                     EventBus.getDefault().post(QueueEvent.removed(item));
+                    EventBus.getDefault().post(FeedItemEvent.updated(item));
                 } else {
                     Log.w(TAG, "Queue was not modified by call to removeQueueItem");
                 }
@@ -469,6 +472,7 @@ public class DBWriter {
             adapter.close();
             item.addTag(FeedItem.TAG_FAVORITE);
             EventBus.getDefault().post(FavoritesEvent.added(item));
+            EventBus.getDefault().post(FeedItemEvent.updated(item));
         });
     }
 
@@ -484,6 +488,7 @@ public class DBWriter {
             adapter.close();
             item.addTag(FeedItem.TAG_FAVORITE);
             EventBus.getDefault().post(FavoritesEvent.added(item));
+            EventBus.getDefault().post(FeedItemEvent.updated(item));
         });
     }
 
@@ -494,6 +499,7 @@ public class DBWriter {
             adapter.close();
             item.removeTag(FeedItem.TAG_FAVORITE);
             EventBus.getDefault().post(FavoritesEvent.removed(item));
+            EventBus.getDefault().post(FeedItemEvent.updated(item));
         });
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -350,7 +350,6 @@ public class DBWriter {
             itemIds.add(item.getId());
             item.addTag(FeedItem.TAG_QUEUE);
         }
-        EventBus.getDefault().post(FeedItemEvent.updated(items));
         return addQueueItem(context, false, itemIds.toArray());
     }
 
@@ -374,6 +373,7 @@ public class DBWriter {
                     boolean queueModified = false;
                     LongList markAsUnplayedIds = new LongList();
                     List<QueueEvent> events = new ArrayList<>();
+                    List<FeedItem> updatedItems = new ArrayList<>();
                     for (int i = 0; i < itemIds.length; i++) {
                         if (!itemListContains(queue, itemIds[i])) {
                             final FeedItem item = DBReader.getFeedItem(itemIds[i]);
@@ -389,6 +389,8 @@ public class DBWriter {
                                     queue.add(item);
                                     events.add(QueueEvent.added(item, queue.size() - 1));
                                 }
+                                item.addTag(FeedItem.TAG_QUEUE);
+                                updatedItems.add(item);
                                 queueModified = true;
                                 if (item.isNew()) {
                                     markAsUnplayedIds.add(item.getId());
@@ -401,6 +403,7 @@ public class DBWriter {
                         for (QueueEvent event : events) {
                             EventBus.getDefault().post(event);
                         }
+                        EventBus.getDefault().post(FeedItemEvent.updated(updatedItems));
                         if (markAsUnplayedIds.size() > 0) {
                             DBWriter.markItemPlayed(FeedItem.UNPLAYED, markAsUnplayedIds.toArray());
                         }


### PR DESCRIPTION
Resolves #1831

The problem: The apply actions dialog relied on the feed items tags being loaded

Solution: Load tags, use LongLists with ids less often
QueueEvent is mainly used by the queue fragment, FavoritesEvent by the favorites fragment. All other fragments get notified that feed items(' tags)  changed.