### PR TITLE
Episode: Reload description on swipe

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -352,8 +352,7 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
 
     private void onFragmentLoaded() {
         if (webviewData != null) {
-            webvDescription.loadDataWithBaseURL(null, webviewData, "text/html",
-                    "utf-8", "about:blank");
+            webvDescription.loadDataWithBaseURL(null, webviewData, "text/html", "utf-8", "about:blank");
         }
         updateAppearance();
     }
@@ -573,12 +572,8 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
             .subscribe(result -> {
                 progbarLoading.setVisibility(View.GONE);
                 item = result;
-                if (!itemsLoaded) {
-                    itemsLoaded = true;
-                    onFragmentLoaded();
-                } else {
-                    updateAppearance();
-                }
+                itemsLoaded = true;
+                onFragmentLoaded();
             }, error -> {
                 Log.e(TAG, Log.getStackTraceString(error));
             });


### PR DESCRIPTION
Always calls onFragmentLoaded() because updateAppearance() does not reload the description.

Resolves #1876