### PR TITLE
Fix initial gpodder sync

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -111,12 +111,17 @@ public class GpodnetSyncService extends Service {
             stopSelf();
             return;
         }
+        boolean initialSync =  GpodnetPreferences.getLastSubscriptionSyncTimestamp() == 0 &&
+                GpodnetPreferences.getLastEpisodeActionsSyncTimestamp() == 0;
         if(syncSubscriptions) {
             syncSubscriptionChanges();
             syncSubscriptions = false;
         }
         if(syncActions) {
-            syncEpisodeActions();
+            // we only sync episode actions after the subscriptions have been added to the database
+            if(!initialSync) {
+                syncEpisodeActions();
+            }
             syncActions = false;
         }
         stopSelf();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -61,6 +61,7 @@ import de.danoeh.antennapod.core.gpoddernet.model.GpodnetEpisodeAction;
 import de.danoeh.antennapod.core.gpoddernet.model.GpodnetEpisodeAction.Action;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.service.GpodnetSyncService;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -317,6 +318,14 @@ public class DownloadService extends Service {
         feedSyncThread.shutdown();
         cancelNotificationUpdater();
         unregisterReceiver(cancelDownloadReceiver);
+
+        // if this was the initial gpodder sync, i.e. we just synced the feeds successfully,
+        // it is now time to sync the episode actions
+        if(GpodnetPreferences.loggedIn() &&
+                GpodnetPreferences.getLastSubscriptionSyncTimestamp() > 0 &&
+                GpodnetPreferences.getLastEpisodeActionsSyncTimestamp() == 0) {
+            GpodnetSyncService.sendSyncActionsIntent(this);
+        }
 
         // start auto download in case anything new has shown up
         DBTasks.autodownloadUndownloadedItems(getApplicationContext());

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1354,14 +1354,17 @@ public class PodDBAdapter {
     }
 
     public final Cursor getFeedItemCursor(final String podcastUrl, final String episodeUrl) {
-        String downloadUrl = DatabaseUtils.sqlEscapeString(podcastUrl);
-        String itemIdentifier = DatabaseUtils.sqlEscapeString(episodeUrl);
+        String escapedPodcastUrl = DatabaseUtils.sqlEscapeString(podcastUrl);
+        String escapedEpisodeUrl = DatabaseUtils.sqlEscapeString(episodeUrl);
         final String query = ""
                 + "SELECT " + SEL_FI_SMALL_STR + " FROM " + TABLE_NAME_FEED_ITEMS
                 + " INNER JOIN " + TABLE_NAME_FEEDS
                 + " ON " + TABLE_NAME_FEED_ITEMS + "." + KEY_FEED + "=" + TABLE_NAME_FEEDS + "." + KEY_ID
-                + " WHERE " + TABLE_NAME_FEED_ITEMS + "." + KEY_ITEM_IDENTIFIER + "=" + itemIdentifier
-                + " AND " + TABLE_NAME_FEEDS + "." + KEY_DOWNLOAD_URL + "=" + downloadUrl;
+                + " INNER JOIN " + TABLE_NAME_FEED_MEDIA
+                + " ON " + TABLE_NAME_FEED_MEDIA + "." + KEY_FEEDITEM + "=" +  TABLE_NAME_FEED_ITEMS + "." + KEY_ID
+                + " WHERE " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_URL + "=" + escapedEpisodeUrl
+                + " AND " + TABLE_NAME_FEEDS + "." + KEY_DOWNLOAD_URL + "=" + escapedPodcastUrl;
+        Log.d(TAG, "SQL: " + query);
         return db.rawQuery(query, null);
     }
 


### PR DESCRIPTION
For one, the sync was using the item identifier (UUID) to look for episodes which might not be the episode's download url.
Then, we can only sync the episode state when the feeds have been downloaded, parsed and persisted. before, chances were high that the feeds are still downloaded while we tried to find the not yet persisted episodes in the database and set their state according to gpodder.

Resolves #1872