### PR TITLE
Re-enable embedded images

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -140,7 +140,7 @@ public class FeedInfoActivity extends ActionBarActivity {
                     Log.d(TAG, "URL is " + feed.getDownload_url());
                     FeedPreferences prefs = feed.getPreferences();
                     imgvCover.post(() -> Glide.with(FeedInfoActivity.this)
-                            .load(feed.getImageUri())
+                            .load(feed.getImageLocation())
                             .placeholder(R.color.light_gray)
                             .error(R.color.light_gray)
                             .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -200,11 +200,11 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         holder.butSecondary.setOnClickListener(secondaryActionListener);
 
         Glide.with(mainActivityRef.get())
-                .load(item.getImageUri())
+                .load(item.getImageLocation())
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                 .fitCenter()
                 .dontAnimate()
-                .into(new CoverTarget(item.getFeed().getImageUri(), holder.placeholder, holder.cover, mainActivityRef.get()));
+                .into(new CoverTarget(item.getFeed().getImageLocation(), holder.placeholder, holder.cover, mainActivityRef.get()));
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/adapter/CoverTarget.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/CoverTarget.java
@@ -18,12 +18,12 @@ import de.danoeh.antennapod.core.glide.ApGlideSettings;
 
 class CoverTarget extends GlideDrawableImageViewTarget {
 
-    private final WeakReference<Uri> fallback;
+    private final WeakReference<String> fallback;
     private final WeakReference<TextView> placeholder;
     private final WeakReference<ImageView> cover;
     private final WeakReference<MainActivity> mainActivity;
 
-    public CoverTarget(Uri fallbackUri, TextView txtvPlaceholder, ImageView imgvCover, MainActivity activity) {
+    public CoverTarget(String fallbackUri, TextView txtvPlaceholder, ImageView imgvCover, MainActivity activity) {
         super(imgvCover);
         fallback = new WeakReference<>(fallbackUri);
         placeholder = new WeakReference<>(txtvPlaceholder);
@@ -33,7 +33,7 @@ class CoverTarget extends GlideDrawableImageViewTarget {
 
     @Override
     public void onLoadFailed(Exception e, Drawable errorDrawable) {
-        Uri fallbackUri = fallback.get();
+        String fallbackUri = fallback.get();
         TextView txtvPlaceholder = placeholder.get();
         ImageView imgvCover = cover.get();
         if (fallbackUri != null && txtvPlaceholder != null && imgvCover != null) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadedEpisodesListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadedEpisodesListAdapter.java
@@ -77,7 +77,7 @@ public class DownloadedEpisodesListAdapter extends BaseAdapter {
         }
 
         Glide.with(context)
-                .load(item.getImageUri())
+                .load(item.getImageLocation())
                 .placeholder(R.color.light_gray)
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -324,7 +324,7 @@ public class NavListAdapter extends BaseAdapter
         }
 
         Glide.with(context)
-                .load(feed.getImageUri())
+                .load(feed.getImageLocation())
                 .placeholder(R.color.light_gray)
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -296,11 +296,11 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
             butSecondary.setOnClickListener(secondaryActionListener);
 
             Glide.with(mainActivity.get())
-                .load(item.getImageUri())
+                .load(item.getImageLocation())
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                 .fitCenter()
                 .dontAnimate()
-                .into(new CoverTarget(item.getFeed().getImageUri(), placeholder, cover, mainActivity.get()));
+                .into(new CoverTarget(item.getFeed().getImageLocation(), placeholder, cover, mainActivity.get()));
         }
 
     }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SearchlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SearchlistAdapter.java
@@ -80,7 +80,7 @@ public class SearchlistAdapter extends BaseAdapter {
             holder.subtitle.setVisibility(View.GONE);
 
             Glide.with(context)
-                    .load(feed.getImageUri())
+                    .load(feed.getImageLocation())
                     .placeholder(R.color.light_gray)
                     .error(R.color.light_gray)
                     .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
@@ -97,7 +97,7 @@ public class SearchlistAdapter extends BaseAdapter {
             }
 
             Glide.with(context)
-                    .load(item.getFeed().getImageUri())
+                    .load(item.getFeed().getImageLocation())
                     .placeholder(R.color.light_gray)
                     .error(R.color.light_gray)
                     .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/StatisticsListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/StatisticsListAdapter.java
@@ -9,11 +9,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
-import com.joanzapata.iconify.widget.IconTextView;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.Feed;
@@ -69,7 +67,7 @@ public class StatisticsListAdapter extends BaseAdapter {
         }
 
         Glide.with(context)
-                .load(feed.getImageUri())
+                .load(feed.getImageLocation())
                 .placeholder(R.color.light_gray)
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
@@ -1,9 +1,7 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
-import android.net.Uri;
 import android.support.v4.app.Fragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -107,7 +105,7 @@ public class SubscriptionsAdapter extends BaseAdapter implements AdapterView.OnI
         holder.count.setPrimaryText(String.valueOf(itemAccess.getFeedCounter(feed.getId())));
         holder.count.setVisibility(View.VISIBLE);
         Glide.with(mainActivityRef.get())
-                .load(feed.getImageUri())
+                .load(feed.getImageLocation())
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                 .fitCenter()

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -67,7 +67,7 @@ public class CoverFragment extends Fragment implements MediaplayerInfoContentFra
             txtvPodcastTitle.setText(media.getFeedTitle());
             txtvEpisodeTitle.setText(media.getEpisodeTitle());
             Glide.with(this)
-                    .load(media.getImageUri())
+                    .load(media.getImageLocation())
                     .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                     .dontAnimate()
                     .fitCenter()

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
@@ -163,7 +163,7 @@ public class ExternalPlayerFragment extends Fragment {
                         ((double) controller.getPosition() / controller.getDuration() * 100));
 
                 Glide.with(getActivity())
-                        .load(media.getImageUri())
+                        .load(media.getImageLocation())
                         .placeholder(R.color.light_gray)
                         .error(R.color.light_gray)
                         .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -44,9 +44,7 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.DefaultActionButtonCallback;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.DownloaderUpdate;
-import de.danoeh.antennapod.core.event.FavoritesEvent;
 import de.danoeh.antennapod.core.event.FeedItemEvent;
-import de.danoeh.antennapod.core.event.QueueEvent;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
@@ -374,7 +372,7 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
         }
 
         Glide.with(getActivity())
-                .load(item.getImageUri())
+                .load(item.getImageLocation())
                 .placeholder(R.color.light_gray)
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -513,7 +513,7 @@ public class ItemlistFragment extends ListFragment {
         imgvBackground.setColorFilter(new LightingColorFilter(0xff828282, 0x000000));
 
         Glide.with(getActivity())
-                .load(feed.getImageUri())
+                .load(feed.getImageLocation())
                 .placeholder(R.color.image_readability_tint)
                 .error(R.color.image_readability_tint)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
@@ -522,7 +522,7 @@ public class ItemlistFragment extends ListFragment {
                 .into(imgvBackground);
 
         Glide.with(getActivity())
-                .load(feed.getImageUri())
+                .load(feed.getImageLocation())
                 .placeholder(R.color.light_gray)
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)

--- a/core/src/main/java/de/danoeh/antennapod/core/asynctask/ImageResource.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/asynctask/ImageResource.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.core.asynctask;
 
-import android.net.Uri;
-
 /**
  * Classes that implement this interface provide access to an image resource that can
  * be loaded by the Picasso library.
@@ -9,29 +7,9 @@ import android.net.Uri;
 public interface ImageResource {
 
     /**
-     * This scheme should be used by PicassoImageResources to
-     * indicate that the image Uri points to a file that is not an image
-     * (e.g. a media file). This workaround is needed so that the Picasso library
-     * loads these Uri with a Downloader instead of trying to load it directly.
+     * Returns the location of the image or null if no image is available.
      * <p/>
-     * For example implementations, see FeedMedia or ExternalMedia.
+     * The location can either be an URL or a local path
      */
-    String SCHEME_MEDIA = "media";
-
-
-    /**
-     * Parameter key for an encoded fallback Uri. This Uri MUST point to a local image file
-     */
-    String PARAM_FALLBACK = "fallback";
-
-    /**
-     * Returns a Uri to the image or null if no image is available.
-     * <p/>
-     * The Uri can either be an HTTP-URL, a URL pointing to a local image file or
-     * a non-image file (see SCHEME_MEDIA for more details).
-     * <p/>
-     * The Uri can also have an optional fallback-URL if loading the default URL
-     * failed (see PARAM_FALLBACK).
-     */
-    Uri getImageUri();
+    String getImageLocation();
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
@@ -4,6 +4,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.android.gms.cast.MediaInfo;
@@ -267,11 +268,9 @@ public class RemoteMedia implements Playable {
     }
 
     @Override
-    public Uri getImageUri() {
-        if (imageUrl != null) {
-            return Uri.parse(imageUrl);
-        }
-        return null;
+    @Nullable
+    public String getImageLocation() {
+        return imageUrl;
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -2,7 +2,6 @@ package de.danoeh.antennapod.core.feed;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -501,9 +500,9 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
     }
 
     @Override
-    public Uri getImageUri() {
+    public String getImageLocation() {
         if (image != null) {
-            return image.getImageUri();
+            return image.getImageLocation();
         } else {
             return null;
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedImage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedImage.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod.core.feed;
 
 import android.database.Cursor;
-import android.net.Uri;
 
 import java.io.File;
 
@@ -81,11 +80,11 @@ public class FeedImage extends FeedFile implements ImageResource {
 	}
 
     @Override
-    public Uri getImageUri() {
+    public String getImageLocation() {
         if (file_url != null && downloaded) {
-            return Uri.fromFile(new File(file_url));
+            return new File(file_url).getAbsolutePath();
         } else if(download_url != null) {
-            return Uri.parse(download_url);
+            return download_url;
         } else {
             return null;
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod.core.feed;
 
 import android.database.Cursor;
-import android.net.Uri;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -374,13 +373,13 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
     }
 
     @Override
-    public Uri getImageUri() {
+    public String getImageLocation() {
         if(media != null && media.hasEmbeddedPicture()) {
-            return media.getImageUri();
+            return media.getImageLocation();
         } else if (image != null) {
-           return image.getImageUri();
+           return image.getImageLocation();
         } else if (feed != null) {
-            return feed.getImageUri();
+            return feed.getImageLocation();
         } else {
             return null;
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -4,7 +4,6 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.database.Cursor;
 import android.media.MediaMetadataRetriever;
-import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
@@ -321,12 +320,10 @@ public class FeedMedia extends FeedFile implements Playable {
     }
 
     public boolean hasEmbeddedPicture() {
-        return false;
-        // TODO: reenable!
-        //if(hasEmbeddedPicture == null) {
-        //    checkEmbeddedPicture();
-        //}
-        //return hasEmbeddedPicture;
+        if(hasEmbeddedPicture == null) {
+            checkEmbeddedPicture();
+        }
+        return hasEmbeddedPicture;
     }
 
     @Override
@@ -514,20 +511,11 @@ public class FeedMedia extends FeedFile implements Playable {
     };
 
     @Override
-    public Uri getImageUri() {
+    public String getImageLocation() {
         if (hasEmbeddedPicture()) {
-            Uri.Builder builder = new Uri.Builder();
-            builder.scheme(SCHEME_MEDIA).encodedPath(getLocalMediaUrl());
-
-            if (item != null && item.getFeed() != null) {
-                final Uri feedImgUri = item.getFeed().getImageUri();
-                if (feedImgUri != null) {
-                    builder.appendQueryParameter(PARAM_FALLBACK, feedImgUri.toString());
-                }
-            }
-            return builder.build();
+            return getLocalMediaUrl();
         } else if(item != null) {
-            return item.getImageUri();
+            return item.getImageLocation();
         } else {
             return null;
         }
@@ -550,7 +538,7 @@ public class FeedMedia extends FeedFile implements Playable {
         super.setFile_url(file_url);
     }
 
-    private void checkEmbeddedPicture() {
+    public void checkEmbeddedPicture() {
         if (!localFileAvailable()) {
             hasEmbeddedPicture = Boolean.FALSE;
             return;

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
@@ -6,7 +6,6 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.GlideBuilder;
 import com.bumptech.glide.load.DecodeFormat;
 import com.bumptech.glide.load.engine.cache.InternalCacheDiskCacheFactory;
-import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.module.GlideModule;
 
 import java.io.InputStream;
@@ -27,7 +26,7 @@ public class ApGlideModule implements GlideModule {
 
     @Override
     public void registerComponents(Context context, Glide glide) {
-        glide.register(GlideUrl.class, InputStream.class, new ApOkHttpUrlLoader.Factory());
+        glide.register(String.class, InputStream.class, new ApOkHttpUrlLoader.Factory());
     }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -26,14 +26,14 @@ import de.danoeh.antennapod.core.util.NetworkUtils;
 /**
  * @see com.bumptech.glide.integration.okhttp.OkHttpUrlLoader
  */
-public class ApOkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
+public class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
 
     private static final String TAG = ApOkHttpUrlLoader.class.getSimpleName();
 
     /**
      * The default factory for {@link ApOkHttpUrlLoader}s.
      */
-    public static class Factory implements ModelLoaderFactory<GlideUrl, InputStream> {
+    public static class Factory implements ModelLoaderFactory<String, InputStream> {
 
         private static volatile OkHttpClient internalClient;
         private OkHttpClient client;
@@ -66,7 +66,7 @@ public class ApOkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
         }
 
         @Override
-        public ModelLoader<GlideUrl, InputStream> build(Context context, GenericLoaderFactory factories) {
+        public ModelLoader<String, InputStream> build(Context context, GenericLoaderFactory factories) {
             return new ApOkHttpUrlLoader(client);
         }
 
@@ -83,8 +83,15 @@ public class ApOkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
     }
 
     @Override
-    public DataFetcher<InputStream> getResourceFetcher(GlideUrl model, int width, int height) {
-        return new OkHttpStreamFetcher(client, model);
+    public DataFetcher<InputStream> getResourceFetcher(String model, int width, int height) {
+        Log.d(TAG, "getResourceFetcher() called with: " + "model = [" + model + "], width = ["
+                + width + "], height = [" + height + "]");
+        if(model.startsWith("/")) {
+            return new AudioCoverFetcher(model);
+        } else {
+            GlideUrl url = new GlideUrl(model);
+            return new OkHttpStreamFetcher(client, url);
+        }
     }
 
     private static class NetworkAllowanceInterceptor implements Interceptor {

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/AudioCoverFetcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/AudioCoverFetcher.java
@@ -1,0 +1,48 @@
+package de.danoeh.antennapod.core.glide;
+
+import android.media.MediaMetadataRetriever;
+import android.util.Log;
+
+import com.bumptech.glide.Priority;
+import com.bumptech.glide.load.data.DataFetcher;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+// see https://github.com/bumptech/glide/issues/699
+class AudioCoverFetcher implements DataFetcher<InputStream> {
+
+    private static final String TAG = "AudioCoverFetcher";
+
+    private final String path;
+
+    public AudioCoverFetcher(String path) {
+        this.path = path;
+    }
+
+    @Override public String getId() {
+        return path;
+    }
+
+    @Override public InputStream loadData(Priority priority) throws Exception {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        try {
+            retriever.setDataSource(path);
+            byte[] picture = retriever.getEmbeddedPicture();
+            if (picture != null) {
+                return new ByteArrayInputStream(picture);
+            }
+        } finally {
+            retriever.release();
+        }
+        throw new IOException("Loading embedded cover did not work");
+    }
+
+    @Override public void cleanup() {
+        // nothing to clean up
+    }
+    @Override public void cancel() {
+        // cannot cancel
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -1009,7 +1009,7 @@ public class DownloadService extends Service {
             }
             media.setDownloaded(true);
             media.setFile_url(request.getDestination());
-            media.setHasEmbeddedPicture(null);
+            media.checkEmbeddedPicture(); // enforce check
 
             // check if file has chapters
             ChapterUtils.loadChaptersFromFileUrl(media);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -988,12 +988,12 @@ public class PlaybackService extends Service {
             builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, p.getEpisodeTitle());
             builder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, p.getFeedTitle());
 
-            if (p.getImageUri() != null && UserPreferences.setLockscreenBackground()) {
-                builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageUri().toString());
+            if (p.getImageLocation() != null && UserPreferences.setLockscreenBackground()) {
+                builder.putString(MediaMetadataCompat.METADATA_KEY_ART_URI, p.getImageLocation().toString());
                 try {
                     if (isCasting) {
                         Bitmap art = Glide.with(this)
-                                .load(p.getImageUri())
+                                .load(p.getImageLocation())
                                 .asBitmap()
                                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                                 .into(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
@@ -1003,7 +1003,7 @@ public class PlaybackService extends Service {
                         WindowManager wm = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
                         Display display = wm.getDefaultDisplay();
                         Bitmap art = Glide.with(this)
-                                .load(p.getImageUri())
+                                .load(p.getImageLocation())
                                 .asBitmap()
                                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                                 .centerCrop()
@@ -1052,7 +1052,7 @@ public class PlaybackService extends Service {
                                 android.R.dimen.notification_large_icon_width);
                         try {
                             icon = Glide.with(PlaybackService.this)
-                                    .load(info.playable.getImageUri())
+                                    .load(info.playable.getImageLocation())
                                     .asBitmap()
                                     .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                                     .centerCrop()

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.core.util.playback;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.media.MediaMetadataRetriever;
-import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -242,9 +241,9 @@ public class ExternalMedia implements Playable {
 	};
 
     @Override
-    public Uri getImageUri() {
+    public String getImageLocation() {
         if (localFileAvailable()) {
-            return new Uri.Builder().scheme(SCHEME_MEDIA).encodedPath(getLocalMediaUrl()).build();
+            return getLocalMediaUrl();
         } else {
             return null;
         }


### PR DESCRIPTION
Re-enables embedded images.

Only tested with a few feeds that I know are using embedded images.
This is kind of a preparation for *virtual* podcasts aka local folders - We probably want embedded images if we ever implement them...

Possible drawbacks: Downloading files will take a bit longer as we check if the file has an embedded picture. Apart from that, hopefully none.