### PR TITLE
avoid stopping playback after skipping (and changing media type)

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -176,7 +176,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -255,7 +255,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -337,7 +337,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -420,7 +420,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -497,7 +497,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -575,7 +575,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -655,7 +655,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -738,7 +738,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -796,7 +796,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         }
 
         @Override
-        public void reloadUI(boolean onlyMediaSession) {
+        public void onMediaChanged(boolean reloadUI) {
 
         }
 
@@ -874,7 +874,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -989,7 +989,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -1081,7 +1081,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 
@@ -1185,7 +1185,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI(boolean onlyMediaSession) {
+            public void onMediaChanged(boolean reloadUI) {
 
             }
 

--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -176,7 +176,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -255,7 +255,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -337,7 +337,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -420,7 +420,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -497,7 +497,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -575,7 +575,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -655,7 +655,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -738,7 +738,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -796,7 +796,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         }
 
         @Override
-        public void reloadUI() {
+        public void reloadUI(boolean onlyMediaSession) {
 
         }
 
@@ -874,7 +874,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -989,7 +989,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -1081,7 +1081,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 
@@ -1185,7 +1185,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void reloadUI() {
+            public void reloadUI(boolean onlyMediaSession) {
 
             }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -211,11 +211,11 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
 
     @Override
     protected void onPause() {
-        super.onPause();
         if(controller != null) {
             controller.reinitServiceIfPaused();
             controller.pause();
         }
+        super.onPause();
     }
 
     /**
@@ -257,12 +257,12 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
 
     @Override
     protected void onStop() {
-        super.onStop();
         Log.d(TAG, "onStop()");
         if (controller != null) {
             controller.release();
             controller = null; // prevent leak
         }
+        super.onStop();
     }
 
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -158,7 +158,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
         setPlayerStatus(PlayerStatus.INITIALIZING, media);
         try {
             media.loadMetadata();
-            callback.reloadUI(true);
+            callback.onMediaChanged(false);
             if (stream) {
                 mediaPlayer.setDataSource(media.getStreamUrl());
             } else {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -158,7 +158,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
         setPlayerStatus(PlayerStatus.INITIALIZING, media);
         try {
             media.loadMetadata();
-            callback.reloadUI();
+            callback.reloadUI(true);
             if (stream) {
                 mediaPlayer.setDataSource(media.getStreamUrl());
             } else {
@@ -337,6 +337,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     public void reinit() {
         executor.submit(() -> {
             playerLock.lock();
+            Log.d(TAG, "reinit()");
             releaseWifiLockIfNecessary();
             if (media != null) {
                 playMediaObject(media, true, stream, startWhenPrepared.get(), false);
@@ -629,9 +630,13 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     public void resetVideoSurface() {
         executor.submit(() -> {
             playerLock.lock();
-            Log.d(TAG, "Resetting video surface");
-            mediaPlayer.setDisplay(null);
-            reinit();
+            if (mediaType == MediaType.VIDEO) {
+                Log.d(TAG, "Resetting video surface");
+                mediaPlayer.setDisplay(null);
+                reinit();
+            } else {
+                Log.e(TAG, "Resetting video surface for media of Audio type");
+            }
             playerLock.unlock();
         });
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -640,9 +640,9 @@ public class PlaybackService extends Service {
         }
 
         @Override
-        public void reloadUI(boolean onlyMediaSession) {
+        public void onMediaChanged(boolean reloadUI) {
             Log.d(TAG, "reloadUI callback reached");
-            if (!onlyMediaSession) {
+            if (reloadUI) {
                 sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);
             }
             PlaybackService.this.updateMediaSessionMetadata(getPlayable());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -499,7 +499,7 @@ public class PlaybackService extends Service {
     }
 
     public void notifyVideoSurfaceAbandoned() {
-        stopForeground(true);
+        stopForeground(!UserPreferences.isPersistNotify());
         mediaPlayer.resetVideoSurface();
     }
 
@@ -640,9 +640,11 @@ public class PlaybackService extends Service {
         }
 
         @Override
-        public void reloadUI() {
+        public void reloadUI(boolean onlyMediaSession) {
             Log.d(TAG, "reloadUI callback reached");
-            sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);
+            if (!onlyMediaSession) {
+                sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);
+            }
             PlaybackService.this.updateMediaSessionMetadata(getPlayable());
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -322,7 +322,7 @@ public abstract class PlaybackServiceMediaPlayer {
 
         void onBufferingUpdate(int percent);
 
-        void reloadUI();
+        void reloadUI(boolean onlyMediaSession);
 
         boolean onMediaPlayerInfo(int code, @StringRes int resourceId);
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -322,7 +322,7 @@ public abstract class PlaybackServiceMediaPlayer {
 
         void onBufferingUpdate(int percent);
 
-        void reloadUI(boolean onlyMediaSession);
+        void onMediaChanged(boolean reloadUI);
 
         boolean onMediaPlayerInfo(int code, @StringRes int resourceId);
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
@@ -244,7 +244,7 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
                 setPlayerStatus(PlayerStatus.INDETERMINATE, currentMedia);
         }
         if (updateUI) {
-            callback.reloadUI();
+            callback.reloadUI(false);
         }
     }
 
@@ -302,7 +302,7 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
         setPlayerStatus(PlayerStatus.INITIALIZING, media);
         try {
             media.loadMetadata();
-            callback.reloadUI();
+            callback.reloadUI(false);
             setPlayerStatus(PlayerStatus.INITIALIZED, media);
             if (prepareImmediately) {
                 prepare();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
@@ -244,7 +244,7 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
                 setPlayerStatus(PlayerStatus.INDETERMINATE, currentMedia);
         }
         if (updateUI) {
-            callback.reloadUI(false);
+            callback.onMediaChanged(true);
         }
     }
 
@@ -302,7 +302,7 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
         setPlayerStatus(PlayerStatus.INITIALIZING, media);
         try {
             media.loadMetadata();
-            callback.reloadUI(false);
+            callback.onMediaChanged(true);
             setPlayerStatus(PlayerStatus.INITIALIZED, media);
             if (prepareImmediately) {
                 prepare();


### PR DESCRIPTION
Issue is: While playing an episode (locally), on the `MediaPlayerActivity`, and skipping to the next one, the new episode would pause some milliseconds after it started (at least when the media types change). Expected behavior would be, since the previous episode was playing, for the new one to keep playing.

This behavior, in part, was not present before the chromecast implementation, so a quick solution is to make the local PSMP behave exactly as before (so, on start playback, we're only asking to update the media session).

However, when switching from video to audio, this would also occur even before chromecast was implemented, being caused by the video surface being released and calling the media player to reset it. The method to reset the video surface is certainly not meant to be invoked while the current media is of audio type, so a quick fix is to check if the media type is indeed video before resetting the surface and reinitializing the media player.

Final note: gradle was giving me such a hard time today (possibly because I tried upgrading the plugin, which seems to work ok, but then reverted) and so all my tests were not following the changes in the code I was doing, to the point of debugging and the logs not matching and the break points being inside if blocks that tested false. Really driving me nuts...