### PR TITLE
add an option to archive media file when playback completes

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -119,7 +119,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     private Playable writeTestPlayable(String downloadUrl, String fileUrl) {
         final Context c = getInstrumentation().getTargetContext();
         Feed f = new Feed(0, null, "f", "l", "d", null, null, null, null, "i", null, null, "l", false);
-        FeedPreferences prefs = new FeedPreferences(f.getId(), false, FeedPreferences.AutoDeleteAction.NO, null, null);
+        FeedPreferences prefs = new FeedPreferences(f.getId(), false, FeedPreferences.PlayedAction.NONE, null, null);
         f.setPreferences(prefs);
         f.setItems(new ArrayList<>());
         FeedItem i = new FeedItem(0, "t", "i", "l", new Date(), FeedItem.UNPLAYED, f);

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.PreferenceActivity;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APNullCleanupAlgorithm;
@@ -162,12 +163,20 @@ public class PreferencesTest extends ActivityInstrumentationTestCase2<Preference
         assertTrue(solo.waitForCondition(() -> continuousPlayback == UserPreferences.isFollowQueue(), Timeout.getLargeTimeout()));
     }
 
-    public void testAutoDelete() {
-        final boolean autoDelete = UserPreferences.isAutoDelete();
-        solo.clickOnText(solo.getString(R.string.pref_auto_delete_title));
-        assertTrue(solo.waitForCondition(() -> autoDelete != UserPreferences.isAutoDelete(), Timeout.getLargeTimeout()));
-        solo.clickOnText(solo.getString(R.string.pref_auto_delete_title));
-        assertTrue(solo.waitForCondition(() -> autoDelete == UserPreferences.isAutoDelete(), Timeout.getLargeTimeout()));
+    public void testPlayedAction() {
+        UserPreferences.setPlayedAction(FeedPreferences.PlayedAction.NONE);
+        solo.clickOnText(solo.getString(R.string.pref_played_action_title));
+        solo.waitForDialogToOpen(1000);
+        solo.clickOnText(solo.getString(R.string.feed_played_action_archive));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getPlayedAction() == FeedPreferences.PlayedAction.ARCHIVE , Timeout.getLargeTimeout()));
+        solo.clickOnText(solo.getString(R.string.pref_played_action_title));
+        solo.waitForDialogToOpen(1000);
+        solo.clickOnText(solo.getString(R.string.feed_played_action_delete));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getPlayedAction() == FeedPreferences.PlayedAction.DELETE , Timeout.getLargeTimeout()));
+        solo.clickOnText(solo.getString(R.string.pref_played_action_title));
+        solo.waitForDialogToOpen(1000);
+        solo.clickOnText(solo.getString(R.string.feed_played_action_none));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getPlayedAction() == FeedPreferences.PlayedAction.NONE , Timeout.getLargeTimeout()));
     }
 
     public void testPlaybackSpeeds() {

--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -67,7 +67,7 @@ public class FeedInfoActivity extends ActionBarActivity {
     private RadioButton rdoFilterExclude;
     private CheckBox cbxAutoDownload;
     private CheckBox cbxKeepUpdated;
-    private Spinner spnAutoDelete;
+    private Spinner spnPlayedAction;
     private boolean filterInclude = true;
 
     private final View.OnClickListener copyUrlToClipboard = new View.OnClickListener() {
@@ -107,7 +107,7 @@ public class FeedInfoActivity extends ActionBarActivity {
         txtvUrl = (TextView) findViewById(R.id.txtvUrl);
         cbxAutoDownload = (CheckBox) findViewById(R.id.cbxAutoDownload);
         cbxKeepUpdated = (CheckBox) findViewById(R.id.cbxKeepUpdated);
-        spnAutoDelete = (Spinner) findViewById(R.id.spnAutoDelete);
+        spnPlayedAction = (Spinner) findViewById(R.id.spnFeedPlayedAction);
         etxtUsername = (EditText) findViewById(R.id.etxtUsername);
         etxtPassword = (EditText) findViewById(R.id.etxtPassword);
         etxtFilterText = (EditText) findViewById(R.id.etxtEpisodeFilterText);
@@ -176,27 +176,33 @@ public class FeedInfoActivity extends ActionBarActivity {
                         feed.getPreferences().setKeepUpdated(checked);
                         feed.savePreferences(FeedInfoActivity.this);
                     });
-                    spnAutoDelete.setOnItemSelectedListener(new OnItemSelectedListener() {
+                    spnPlayedAction.setOnItemSelectedListener(new OnItemSelectedListener() {
                         @Override
                         public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
-                            FeedPreferences.AutoDeleteAction auto_delete_action;
+                            FeedPreferences.PlayedAction played_action;
                             switch (parent.getSelectedItemPosition()) {
                                 case 0:
-                                    auto_delete_action = FeedPreferences.AutoDeleteAction.GLOBAL;
+                                    played_action = FeedPreferences.PlayedAction.GLOBAL;
                                     break;
 
                                 case 1:
-                                    auto_delete_action = FeedPreferences.AutoDeleteAction.YES;
+                                    played_action = FeedPreferences.PlayedAction.DELETE;
                                     break;
 
                                 case 2:
-                                    auto_delete_action = FeedPreferences.AutoDeleteAction.NO;
+                                    played_action = FeedPreferences.PlayedAction.NONE;
                                     break;
 
-                                default: // TODO - add exceptions here
+                                case 3:
+                                    played_action = FeedPreferences.PlayedAction.ARCHIVE;
+                                    break;
+
+                                default:
+                                    Log.e(TAG, "spnPlayedAction: unhandled case = " +
+                                            parent.getSelectedItemPosition());
                                     return;
                             }
-                            feed.getPreferences().setAutoDeleteAction(auto_delete_action);// p
+                            feed.getPreferences().setPlayedAction(played_action);// p
                             autoDeleteChanged = true;
                         }
 
@@ -205,7 +211,7 @@ public class FeedInfoActivity extends ActionBarActivity {
                             // Another interface callback
                         }
                     });
-                    spnAutoDelete.setSelection(prefs.getAutoDeleteAction().ordinal());
+                    spnPlayedAction.setSelection(prefs.getPlayedAction().ordinal());
 
                     etxtUsername.setText(prefs.getUsername());
                     etxtPassword.setText(prefs.getPassword());

--- a/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/FeedInfoActivity.java
@@ -180,21 +180,29 @@ public class FeedInfoActivity extends ActionBarActivity {
                         @Override
                         public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
                             FeedPreferences.PlayedAction played_action;
+                            TextView playedActionTxt = (TextView) findViewById(R.id.txtFeedPlayedActionText);
+
                             switch (parent.getSelectedItemPosition()) {
                                 case 0:
                                     played_action = FeedPreferences.PlayedAction.GLOBAL;
+                                    playedActionTxt.setVisibility(View.GONE);
                                     break;
 
                                 case 1:
                                     played_action = FeedPreferences.PlayedAction.DELETE;
+                                    playedActionTxt.setVisibility(View.GONE);
                                     break;
 
                                 case 2:
                                     played_action = FeedPreferences.PlayedAction.NONE;
+                                    playedActionTxt.setVisibility(View.GONE);
                                     break;
 
                                 case 3:
                                     played_action = FeedPreferences.PlayedAction.ARCHIVE;
+                                    playedActionTxt.setVisibility(View.VISIBLE);
+                                    playedActionTxt.setText(getResources().getString(R.string.to) +
+                                            " " + UserPreferences.getArchiveFolder(null).toString());
                                     break;
 
                                 default:

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -259,7 +259,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         url = URLChecker.prepareURL(url);
         feed = new Feed(url, null);
         if (username != null && password != null) {
-            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, username, password));
+            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.PlayedAction.GLOBAL, username, password));
         }
         String fileUrl = new File(getExternalCacheDir(),
                 FileNameGenerator.generateFileName(feed.getDownload_url())).toString();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -21,6 +21,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
+import de.danoeh.antennapod.core.util.PlayedActionUtils;
 
 
 /**
@@ -87,8 +88,8 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
                 final Handler h = new Handler(getActivity().getMainLooper());
                 final Runnable r  = () -> {
                     FeedMedia media = item.getMedia();
-                    if (media != null && media.hasAlmostEnded() && UserPreferences.isAutoDelete()) {
-                        DBWriter.deleteFeedMediaOfItem(getActivity(), media.getId());
+                    if (media != null && media.hasAlmostEnded()) {
+                        PlayedActionUtils.performPlayedAction(getActivity(), media);
                     }
                 };
 

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -824,7 +824,9 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                 val = context.getString(R.string.feed_played_action_none);
                 break;
             case ARCHIVE:
-                val = context.getString(R.string.feed_played_action_archive);
+                val = context.getString(R.string.feed_played_action_archive) + "\n" +
+                        context.getString(R.string.to) + " " +
+                        UserPreferences.getArchiveFolder(null).toString();
                 break;
             default:
                 Log.e(TAG, "setPlayedActionText: unhandled case = " + played_action);

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -56,6 +56,7 @@ import de.danoeh.antennapod.activity.PreferenceActivity;
 import de.danoeh.antennapod.activity.PreferenceActivityGingerbread;
 import de.danoeh.antennapod.activity.StatisticsActivity;
 import de.danoeh.antennapod.asynctask.OpmlExportWorker;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.GpodnetSyncService;
@@ -428,6 +429,9 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
             }
             return true;
         });
+        ui.findPreference(UserPreferences.PREF_PLAYED_ACTION).setOnPreferenceChangeListener(
+                (preference, o) -> setPlayedActionText(FeedPreferences.PlayedAction.values()[Integer.parseInt((String) o)])
+        );
         buildEpisodeCleanupPreference();
         buildSmartMarkAsPlayedPreference();
         buildAutodownloadSelectedNetworsPreference();
@@ -450,6 +454,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         setParallelDownloadsText(UserPreferences.getParallelDownloads());
         setEpisodeCacheSizeText(UserPreferences.getEpisodeCacheSize());
         setDataFolderText();
+        setPlayedActionText(UserPreferences.getPlayedAction());
         updateGpodnetPreferenceScreen();
     }
 
@@ -805,6 +810,31 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         });
         builder.setNegativeButton(R.string.cancel_label, null);
         builder.create().show();
+    }
+
+    private boolean setPlayedActionText(FeedPreferences.PlayedAction played_action) {
+        boolean rc = true;
+        final Context context = ui.getActivity();
+        String val;
+        switch (played_action) {
+            case DELETE:
+                val = context.getString(R.string.feed_played_action_delete);
+                break;
+            case NONE:
+                val = context.getString(R.string.feed_played_action_none);
+                break;
+            case ARCHIVE:
+                val = context.getString(R.string.feed_played_action_archive);
+                break;
+            default:
+                Log.e(TAG, "setPlayedActionText: unhandled case = " + played_action);
+                val = "";
+                rc = false;
+        }
+        String summary = context.getString(R.string.pref_played_action_sum) + "\n"
+                + String.format(context.getString(R.string.pref_current_value), val);
+        ui.findPreference(UserPreferences.PREF_PLAYED_ACTION).setSummary(summary);
+        return rc;
     }
 
     // CHOOSE DATA FOLDER

--- a/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
+++ b/app/src/main/java/de/danoeh/antennapod/service/PlayerWidgetService.java
@@ -22,6 +22,7 @@ import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.PlayedActionUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.fragment.QueueFragment;
 import de.danoeh.antennapod.receiver.PlayerWidget;
@@ -69,10 +70,7 @@ public class PlayerWidgetService extends Service {
                     DBWriter.markItemPlayed(item, FeedItem.PLAYED, false);
                     DBWriter.removeQueueItem(this, item, false);
                     DBWriter.addItemToPlaybackHistory(media);
-                    if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
-                        Log.d(TAG, "Delete " + media.toString());
-                        DBWriter.deleteFeedMediaOfItem(this, media.getId());
-                    }
+                    PlayedActionUtils.performPlayedAction(this, media);
                 }
             }
         }

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -158,10 +158,10 @@
                 app:rowCount="1">
 
                 <TextView
-                    android:id="@+id/txtvFeedAutoDelete"
+                    android:id="@+id/txtvFeedPlayedAction"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/auto_delete_label"
+                    android:text="@string/played_action_label"
                     app:layout_row="0"
                     app:layout_column="0"
                     app:layout_gravity="center_vertical"
@@ -170,8 +170,8 @@
                 <Spinner
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-                    android:id="@+id/spnAutoDelete"
-                    android:entries="@array/spnAutoDeleteItems"
+                    android:id="@+id/spnFeedPlayedAction"
+                    android:entries="@array/spnFeedPlayedActionItems"
                     android:layout_marginTop="8dp"
                     app:layout_row="0"
                     app:layout_column="1"

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -155,10 +155,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 app:columnCount="2"
-                app:rowCount="1">
+                app:rowCount="2">
 
                 <TextView
-                    android:id="@+id/txtvFeedPlayedAction"
+                    android:id="@+id/txtFeedPlayedAction"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/played_action_label"
@@ -169,16 +169,23 @@
 
                 <Spinner
                     android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:id="@+id/spnFeedPlayedAction"
                     android:entries="@array/spnFeedPlayedActionItems"
-                    android:layout_marginTop="8dp"
                     app:layout_row="0"
                     app:layout_column="1"
                     android:spinnerMode="dropdown"
                     app:layout_gravity="center"
                     android:dropDownWidth="wrap_content"
                     android:clickable="true" />
+
+                <TextView
+                    android:id="@+id/txtFeedPlayedActionText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_row="1"
+                    app:layout_column="0"
+                    app:layout_columnSpan="2"/>
             </android.support.v7.widget.GridLayout>
 
             <CheckBox

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -122,12 +122,14 @@
             android:key="prefSkipKeepsEpisode"
             android:summary="@string/pref_skip_keeps_episodes_sum"
             android:title="@string/pref_skip_keeps_episodes_title"/>
-        <de.danoeh.antennapod.preferences.SwitchCompatPreference
-            android:defaultValue="false"
-            android:enabled="true"
-            android:key="prefAutoDelete"
-            android:summary="@string/pref_auto_delete_sum"
-            android:title="@string/pref_auto_delete_title"/>
+        <com.afollestad.materialdialogs.prefs.MaterialListPreference
+            android:defaultValue="2"
+            android:entries="@array/pref_played_action_entries"
+            android:entryValues="@array/pref_played_action_values"
+            android:key="prefPlayedAction"
+            android:summary="@string/pref_played_action_sum"
+            android:title="@string/pref_played_action_title"
+            app:useStockLayout="true"/>
         <com.afollestad.materialdialogs.prefs.MaterialListPreference
             android:defaultValue="30"
             android:entries="@array/smart_mark_as_played_values"

--- a/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.antennapod.audio.MediaPlayer;
@@ -16,6 +17,7 @@ import java.util.List;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedImage;
 import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -91,6 +93,12 @@ public class UpdateManager {
             if(MediaPlayer.isPrestoLibraryInstalled(context) && Build.VERSION.SDK_INT >= 16) {
                 UserPreferences.enableSonic(true);
             }
+        }
+        if(oldVersionCode < 1070000) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            UserPreferences.setPlayedAction(prefs.getBoolean("prefAutoDelete", false) ?
+                    FeedPreferences.PlayedAction.DELETE : FeedPreferences.PlayedAction.NONE);
+            prefs.edit().remove("prefAutoDelete").commit();
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -165,7 +165,7 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
      */
     public Feed(String url, String lastUpdate, String title, String username, String password) {
         this(url, lastUpdate, title);
-        preferences = new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL, username, password);
+        preferences = new FeedPreferences(0, true, FeedPreferences.PlayedAction.GLOBAL, username, password);
     }
 
     public static Feed fromCursor(Cursor cursor) {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -20,24 +20,25 @@ public class FeedPreferences {
     private boolean autoDownload;
     private boolean keepUpdated;
 
-    public enum AutoDeleteAction {
+    public enum PlayedAction {
         GLOBAL,
-        YES,
-        NO
+        DELETE,
+        NONE,
+        ARCHIVE
     }
-    private AutoDeleteAction auto_delete_action;
+    private PlayedAction played_action;
     private String username;
     private String password;
 
-    public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String username, String password) {
-        this(feedID, autoDownload, true, auto_delete_action, username, password, new FeedFilter());
+    public FeedPreferences(long feedID, boolean autoDownload, PlayedAction played_action, String username, String password) {
+        this(feedID, autoDownload, true, played_action, username, password, new FeedFilter());
     }
 
-    public FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter) {
+    public FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, PlayedAction played_action, String username, String password, @NonNull FeedFilter filter) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
         this.keepUpdated = keepUpdated;
-        this.auto_delete_action = auto_delete_action;
+        this.played_action = played_action;
         this.username = username;
         this.password = password;
         this.filter = filter;
@@ -47,7 +48,7 @@ public class FeedPreferences {
         int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
         int indexAutoDownload = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DOWNLOAD);
         int indexAutoRefresh = cursor.getColumnIndex(PodDBAdapter.KEY_KEEP_UPDATED);
-        int indexAutoDeleteAction = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DELETE_ACTION);
+        int indexPlayedAction = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DELETE_ACTION);
         int indexUsername = cursor.getColumnIndex(PodDBAdapter.KEY_USERNAME);
         int indexPassword = cursor.getColumnIndex(PodDBAdapter.KEY_PASSWORD);
         int indexIncludeFilter = cursor.getColumnIndex(PodDBAdapter.KEY_INCLUDE_FILTER);
@@ -56,13 +57,13 @@ public class FeedPreferences {
         long feedId = cursor.getLong(indexId);
         boolean autoDownload = cursor.getInt(indexAutoDownload) > 0;
         boolean autoRefresh = cursor.getInt(indexAutoRefresh) > 0;
-        int autoDeleteActionIndex = cursor.getInt(indexAutoDeleteAction);
-        AutoDeleteAction autoDeleteAction = AutoDeleteAction.values()[autoDeleteActionIndex];
+        int playedActionIndex = cursor.getInt(indexPlayedAction);
+        PlayedAction playedAction = PlayedAction.values()[playedActionIndex];
         String username = cursor.getString(indexUsername);
         String password = cursor.getString(indexPassword);
         String includeFilter = cursor.getString(indexIncludeFilter);
         String excludeFilter = cursor.getString(indexExcludeFilter);
-        return new FeedPreferences(feedId, autoDownload, autoRefresh, autoDeleteAction, username, password, new FeedFilter(includeFilter, excludeFilter));
+        return new FeedPreferences(feedId, autoDownload, autoRefresh, playedAction, username, password, new FeedFilter(includeFilter, excludeFilter));
     }
 
     /**
@@ -134,26 +135,22 @@ public class FeedPreferences {
         this.autoDownload = autoDownload;
     }
 
-    public AutoDeleteAction getAutoDeleteAction() {
-        return auto_delete_action;
+    public PlayedAction getPlayedAction() {
+        return played_action;
     }
 
-    public void setAutoDeleteAction(AutoDeleteAction auto_delete_action) {
-        this.auto_delete_action = auto_delete_action;
+    public void setPlayedAction(PlayedAction played_action) {
+        this.played_action = played_action;
     }
 
-    public boolean getCurrentAutoDelete() {
-        switch (auto_delete_action) {
+    public PlayedAction getCurrentPlayedAction() {
+        switch (played_action) {
             case GLOBAL:
-                return UserPreferences.isAutoDelete();
+                return UserPreferences.getPlayedAction();
 
-            case YES:
-                return true;
-
-            case NO:
-                return false;
+            default:
+                return played_action;
         }
-        return false; // TODO - add exceptions here
     }
 
     public void save(Context context) {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.core.R;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.receiver.FeedUpdateReceiver;
 import de.danoeh.antennapod.core.service.download.ProxyConfig;
 import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
@@ -41,6 +42,7 @@ import de.danoeh.antennapod.core.util.Converter;
  */
 public class UserPreferences {
 
+    public static final String ARCHIVE_DIR = "archive";
     public static final String IMPORT_DIR = "import/";
 
     private static final String TAG = "UserPreferences";
@@ -67,7 +69,7 @@ public class UserPreferences {
     public static final String PREF_HARDWARE_FOWARD_BUTTON_SKIPS = "prefHardwareForwardButtonSkips";
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
     public static final String PREF_SKIP_KEEPS_EPISODE = "prefSkipKeepsEpisode";
-    public static final String PREF_AUTO_DELETE = "prefAutoDelete";
+    public static final String PREF_PLAYED_ACTION = "prefPlayedAction";
     public static final String PREF_SMART_MARK_AS_PLAYED_SECS = "prefSmartMarkAsPlayedSecs";
     public static final String PREF_PLAYBACK_SPEED_ARRAY = "prefPlaybackSpeedArray";
     public static final String PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS = "prefPauseForFocusLoss";
@@ -288,8 +290,12 @@ public class UserPreferences {
 
     public static boolean shouldSkipKeepEpisode() { return prefs.getBoolean(PREF_SKIP_KEEPS_EPISODE, true); }
 
-    public static boolean isAutoDelete() {
-        return prefs.getBoolean(PREF_AUTO_DELETE, false);
+    public static FeedPreferences.PlayedAction getPlayedAction() {
+        return FeedPreferences.PlayedAction.values()[Integer.parseInt(prefs.getString(PREF_PLAYED_ACTION, "2"))];
+    }
+
+    public static void setPlayedAction(FeedPreferences.PlayedAction played_action) {
+        prefs.edit().putString(PREF_PLAYED_ACTION, String.valueOf(played_action.ordinal())).apply();
     }
 
     public static int getSmartMarkAsPlayedSecs() {
@@ -807,5 +813,17 @@ public class UserPreferences {
      */
     public static boolean isCastEnabled() {
         return prefs.getBoolean(PREF_CAST_ENABLED, false);
+    }
+
+    /**
+     * Return the archive folder.
+     *
+     * @param type The name of the folder inside the archive folder. May be null
+     *             when accessing the root of the archive folder.
+     * @return The archive folder that has been requested or null if the folder
+     * could not be created.
+     */
+    public static File getArchiveFolder(String type) {
+        return getDataFolder(type == null ? ARCHIVE_DIR : ARCHIVE_DIR + File.separator + type);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -805,7 +805,7 @@ public class DownloadService extends Service {
             feed.setFile_url(request.getDestination());
             feed.setId(request.getFeedfileId());
             feed.setDownloaded(true);
-            feed.setPreferences(new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL,
+            feed.setPreferences(new FeedPreferences(0, true, FeedPreferences.PlayedAction.GLOBAL,
                     request.getUsername(), request.getPassword()));
             feed.setPageNr(request.getArguments().getInt(DownloadRequester.REQUEST_ARG_PAGE_NR, 0));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -66,6 +66,7 @@ import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.IntList;
 import de.danoeh.antennapod.core.util.NetworkUtils;
+import de.danoeh.antennapod.core.util.PlayedActionUtils;
 import de.danoeh.antennapod.core.util.QueueAccess;
 import de.danoeh.antennapod.core.util.flattr.FlattrUtils;
 import de.danoeh.antennapod.core.util.playback.ExternalMedia;
@@ -725,11 +726,8 @@ public class PlaybackService extends Service {
                         DBWriter.removeQueueItem(PlaybackService.this, item, true);
                     }
 
-                    // Delete episode if enabled
-                    if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
-                        DBWriter.deleteFeedMediaOfItem(PlaybackService.this, media.getId());
-                        Log.d(TAG, "Episode Deleted");
-                    }
+                    // Perform episode played action if one
+                    PlayedActionUtils.performPlayedAction(PlaybackService.this, media);
                 }
             }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -13,6 +13,7 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.PlayedActionUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
 
 
@@ -303,10 +304,7 @@ public abstract class PlaybackServiceMediaPlayer {
                 DBWriter.markItemPlayed(item, FeedItem.PLAYED, false);
                 DBWriter.removeQueueItem(context, item, false);
                 DBWriter.addItemToPlaybackHistory(oldMedia);
-                if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
-                    Log.d(TAG, "Delete " + oldMedia.toString());
-                    DBWriter.deleteFeedMediaOfItem(context, oldMedia.getId());
-                }
+                PlayedActionUtils.performPlayedAction(context, oldMedia);
             }
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -8,6 +8,7 @@ import android.database.Cursor;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import org.apache.commons.io.FilenameUtils;
 import org.shredzone.flattr4j.model.Flattr;
 
 import java.io.File;
@@ -73,6 +74,57 @@ public class DBWriter {
     }
 
     /**
+     * Moves a downloaded FeedMedia file to the archives directory.
+     *
+     * @param context A context that is used for opening a database connection.
+     * @param mediaId ID of the FeedMedia object whose downloaded file should be archived.
+     */
+    public static Future<?> archiveFeedMediaOfItem(final Context context,
+                                                  final long mediaId) {
+        return dbExec.submit(() -> {
+            final FeedMedia media = DBReader.getFeedMedia(mediaId);
+            if (media != null) {
+                Log.i(TAG, String.format("Requested to archive FeedMedia [id=%d, title=%s, downloaded=%s",
+                        media.getId(), media.getEpisodeTitle(), String.valueOf(media.isDownloaded())));
+                boolean result = false;
+                if (media.isDownloaded()) {
+                    // archive downloaded media file
+                    File mediaFile = new File(media.getFile_url());
+                    if (mediaFile.exists()) {
+                        File dest = getNonExistingFile(UserPreferences.getArchiveFolder(media.getItem().getFeed().getTitle())
+                                + File.separator + mediaFile.getName());
+                        Log.i(TAG, "Archiving file to: " + dest);
+                        result = mediaFile.renameTo(dest);
+                    }
+                    cleanMediaFile(context, media);
+                }
+                Log.d(TAG, "Archiving file result: " + result);
+                EventBus.getDefault().post(FeedItemEvent.deletedMedia(Collections.singletonList(media.getItem())));
+                EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
+            }
+        });
+    }
+
+    /**
+     * Gets a file that doesn't already exists on the filesystem, renames it if needed.
+     *
+     * @param filename Desired filename.
+     * @return a previously non existing file
+     */
+    private static File getNonExistingFile(final String filename) {
+        File dest = new File(filename);
+        if (dest.exists()) {
+            String basename = FilenameUtils.getBaseName(dest.getName());
+            String extension = FilenameUtils.getExtension(dest.getName());
+            for (int i = 1; i < Integer.MAX_VALUE && dest.exists(); ++i) {
+                dest = new File(dest.getParent() + File.separator
+                        + basename + "-" + i + FilenameUtils.EXTENSION_SEPARATOR + extension);
+            }
+        }
+        return dest;
+    }
+
+    /**
      * Deletes a downloaded FeedMedia file from the storage device.
      *
      * @param context A context that is used for opening a database connection.
@@ -92,49 +144,59 @@ public class DBWriter {
                     if (mediaFile.exists()) {
                         result = mediaFile.delete();
                     }
-                    media.setDownloaded(false);
-                    media.setFile_url(null);
-                    media.setHasEmbeddedPicture(false);
-                    PodDBAdapter adapter = PodDBAdapter.getInstance();
-                    adapter.open();
-                    adapter.setMedia(media);
-                    adapter.close();
-
-                    // If media is currently being played, change playback
-                    // type to 'stream' and shutdown playback service
-                    SharedPreferences prefs = PreferenceManager
-                            .getDefaultSharedPreferences(context);
-                    if (PlaybackPreferences.getCurrentlyPlayingMedia() == FeedMedia.PLAYABLE_TYPE_FEEDMEDIA) {
-                        if (media.getId() == PlaybackPreferences
-                                .getCurrentlyPlayingFeedMediaId()) {
-                            SharedPreferences.Editor editor = prefs.edit();
-                            editor.putBoolean(
-                                    PlaybackPreferences.PREF_CURRENT_EPISODE_IS_STREAM,
-                                    true);
-                            editor.commit();
-                        }
-                        if (PlaybackPreferences
-                                .getCurrentlyPlayingFeedMediaId() == media
-                                .getId()) {
-                            context.sendBroadcast(new Intent(
-                                    PlaybackService.ACTION_SHUTDOWN_PLAYBACK_SERVICE));
-                        }
-                    }
-                    // Gpodder: queue delete action for synchronization
-                    if(GpodnetPreferences.loggedIn()) {
-                        FeedItem item = media.getItem();
-                        GpodnetEpisodeAction action = new GpodnetEpisodeAction.Builder(item, GpodnetEpisodeAction.Action.DELETE)
-                                .currentDeviceId()
-                                .currentTimestamp()
-                                .build();
-                        GpodnetPreferences.enqueueEpisodeAction(action);
-                    }
+                    cleanMediaFile(context, media);
                 }
                 Log.d(TAG, "Deleting File. Result: " + result);
                 EventBus.getDefault().post(FeedItemEvent.deletedMedia(Collections.singletonList(media.getItem())));
                 EventDistributor.getInstance().sendUnreadItemsUpdateBroadcast();
             }
         });
+    }
+
+    /**
+     * Cleans things after a downloaded FeedMedia file has been removed from its storage device location.
+     *
+     * @param context A context that is used for opening a database connection.
+     * @param media FeedMedia object whose downloaded file has been deleted.
+     */
+    private static void cleanMediaFile(final Context context, final FeedMedia media) {
+        media.setDownloaded(false);
+        media.setFile_url(null);
+        media.setHasEmbeddedPicture(false);
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setMedia(media);
+        adapter.close();
+
+        // If media is currently being played, change playback
+        // type to 'stream' and shutdown playback service
+        SharedPreferences prefs = PreferenceManager
+                .getDefaultSharedPreferences(context);
+        if (PlaybackPreferences.getCurrentlyPlayingMedia() == FeedMedia.PLAYABLE_TYPE_FEEDMEDIA) {
+            if (media.getId() == PlaybackPreferences
+                    .getCurrentlyPlayingFeedMediaId()) {
+                SharedPreferences.Editor editor = prefs.edit();
+                editor.putBoolean(
+                        PlaybackPreferences.PREF_CURRENT_EPISODE_IS_STREAM,
+                        true);
+                editor.commit();
+            }
+            if (PlaybackPreferences
+                    .getCurrentlyPlayingFeedMediaId() == media
+                    .getId()) {
+                context.sendBroadcast(new Intent(
+                        PlaybackService.ACTION_SHUTDOWN_PLAYBACK_SERVICE));
+            }
+        }
+        // Gpodder: queue delete action for synchronization
+        if(GpodnetPreferences.loggedIn()) {
+            FeedItem item = media.getItem();
+            GpodnetEpisodeAction action = new GpodnetEpisodeAction.Builder(item, GpodnetEpisodeAction.Action.DELETE)
+                    .currentDeviceId()
+                    .currentTimestamp()
+                    .build();
+            GpodnetPreferences.enqueueEpisodeAction(action);
+        }
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -95,7 +95,7 @@ public class PodDBAdapter {
     public static final String KEY_PLAYBACK_COMPLETION_DATE = "playback_completion_date";
     public static final String KEY_AUTO_DOWNLOAD = "auto_download";
     public static final String KEY_KEEP_UPDATED = "keep_updated";
-    public static final String KEY_AUTO_DELETE_ACTION = "auto_delete_action";
+    public static final String KEY_AUTO_DELETE_ACTION = "auto_delete_action"; // used as "played action" since version 1070000
     public static final String KEY_PLAYED_DURATION = "played_duration";
     public static final String KEY_USERNAME = "username";
     public static final String KEY_PASSWORD = "password";
@@ -413,7 +413,7 @@ public class PodDBAdapter {
         ContentValues values = new ContentValues();
         values.put(KEY_AUTO_DOWNLOAD, prefs.getAutoDownload());
         values.put(KEY_KEEP_UPDATED, prefs.getKeepUpdated());
-        values.put(KEY_AUTO_DELETE_ACTION,prefs.getAutoDeleteAction().ordinal());
+        values.put(KEY_AUTO_DELETE_ACTION,prefs.getPlayedAction().ordinal());
         values.put(KEY_USERNAME, prefs.getUsername());
         values.put(KEY_PASSWORD, prefs.getPassword());
         values.put(KEY_INCLUDE_FILTER, prefs.getFilter().getIncludeFilter());

--- a/core/src/main/java/de/danoeh/antennapod/core/util/PlayedActionUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/PlayedActionUtils.java
@@ -1,0 +1,31 @@
+package de.danoeh.antennapod.core.util;
+
+import android.content.Context;
+import android.util.Log;
+
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.storage.DBWriter;
+
+public class PlayedActionUtils {
+    private static final String TAG = "PlayedActionUtils";
+
+    public static void performPlayedAction(final Context context, final FeedMedia media) {
+        switch (media.getItem().getFeed().getPreferences().getCurrentPlayedAction()) {
+            case DELETE:
+                Log.d(TAG, "Delete: " + media.toString());
+                DBWriter.deleteFeedMediaOfItem(context, media.getId());
+                break;
+            case ARCHIVE:
+                Log.d(TAG, "Archive: " + media.toString());
+                DBWriter.archiveFeedMediaOfItem(context, media.getId());
+                break;
+            case NONE:
+                Log.d(TAG, "No action: " + media.toString());
+                break;
+            default:
+                Log.e(TAG, "performPlayedAction: unhandled case = "
+                        + media.getItem().getFeed().getPreferences().getCurrentPlayedAction());
+                break;
+        }
+    }
+}

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -1,10 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string-array name="spnAutoDeleteItems">
-        <item>@string/feed_auto_download_global</item>
-        <item>@string/feed_auto_download_always</item>
-        <item>@string/feed_auto_download_never</item>
+    <string-array name="spnFeedPlayedActionItems">
+        <item>@string/feed_played_action_global</item>
+        <item>@string/feed_played_action_delete</item>
+        <item>@string/feed_played_action_none</item>
+        <item>@string/feed_played_action_archive</item>
+    </string-array>
+
+    <string-array name="pref_played_action_entries">
+        <item>@string/feed_played_action_none</item>
+        <item>@string/feed_played_action_delete</item>
+        <item>@string/feed_played_action_archive</item>
+    </string-array>
+
+    <string-array name="pref_played_action_values">
+        <!-- map the values from FeedPreferences.PlayedAction
+             "GLOBAL" is omitted has it makes no sense here -->
+        <item>2</item>
+        <item>1</item>
+        <item>3</item>
     </string-array>
 
     <string-array name="smart_mark_as_played_values">

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="feed_played_action_delete">Delete</string>
     <string name="feed_played_action_none">None</string>
     <string name="feed_played_action_archive">Archive</string>
+    <string name="to">to</string>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="auto_download_label">Include in auto downloads</string>
     <string name="auto_download_apply_to_items_title">Apply to Previous Episodes</string>
     <string name="auto_download_apply_to_items_message">The new <i>Auto Download</i> setting will automatically be applied to new episodes.\nDo you also want to apply it to previously published episodes?</string>
-    <string name="auto_delete_label">Auto Delete Episode</string>
+    <string name="played_action_label">Episode Played Action</string>
     <string name="parallel_downloads_suffix">\u0020parallel downloads</string>
     <string name="feed_auto_download_global">Global default</string>
     <string name="feed_auto_download_always">Always</string>
@@ -96,6 +96,10 @@
         <item quantity="one">1 day after finishing</item>
         <item quantity="other">%d days after finishing</item>
     </plurals>
+    <string name="feed_played_action_global">Global default</string>
+    <string name="feed_played_action_delete">Delete</string>
+    <string name="feed_played_action_none">None</string>
+    <string name="feed_played_action_archive">Archive</string>
 
     <!-- 'Add Feed' Activity labels -->
     <string name="feedurl_label">Feed URL</string>
@@ -296,8 +300,8 @@
     <string name="pref_hardwareForwardButtonSkips_title">Forward button skips</string>
     <string name="pref_hardwareForwardButtonSkips_sum">When pressing a hardware forward button skip to the next episode instead of fast-forwarding</string>
     <string name="pref_followQueue_sum">Jump to next queue item when playback completes</string>
-    <string name="pref_auto_delete_sum">Delete episode when playback completes</string>
-    <string name="pref_auto_delete_title">Auto Delete</string>
+    <string name="pref_played_action_sum">Perform an action when playback completes</string>
+    <string name="pref_played_action_title">Played Action</string>
     <string name="pref_smart_mark_as_played_sum">Mark episodes as played even if less than a certain amount of seconds of playing time is still left</string>
     <string name="pref_smart_mark_as_played_title">Smart mark as played</string>
     <string name="pref_skip_keeps_episodes_sum">Keep episodes when they are skipped</string>


### PR DESCRIPTION
Hi.

I developped a feature that I miss on Antennapod and I'd like it to be integrated.

The feature is about adding an option to move the media file to an "archive" folder instead of deleting it when the playback completes. The file will still be marked as deleted on Antennapod but then the user can safely move/delete the files from the "archive" directory.

If you are willing to add such feature here are the key points of the proposed implementation:
- Change the user preferences "auto delete" check box into a "played action" list (none, delete, archive).
- Replace the "prefAutoDelete" shared preference by a "prefPlayedAction" shared preference (1.7.0.0 migration).
- Change the feed preference "auto delete" list to a "played action" list (global, none, delete, archive), no database migration needed as the old values will still be valid.<br>
  It reuse the database Feeds "auto_delete_action" field as the played action value, there is no renaming/migration :-/ as there's no easy way to rename or drop a column in SQlite. Adding a new "played_action" column will make the "auto_delete_action" one obsolete and imho keeping an unused field with values should be avoided.
