### PR TITLE
Accept media content type application/octet-stream

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -184,7 +184,9 @@ public class HttpDownloader extends Downloader {
 
             if(request.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                 String contentType = response.header("Content-Type");
-                if(!contentType.startsWith("audio/") && !contentType.startsWith("video/")) {
+                Log.d(TAG, "content type: " + contentType);
+                if(!contentType.startsWith("audio/") && !contentType.startsWith("video/") &&
+                        !contentType.equals("application/octet-stream")) {
                     onFail(DownloadError.ERROR_FILE_TYPE, null);
                     return;
                 }


### PR DESCRIPTION
Instead of returning something useful (audio/*, video/*), the ted talk servers return content type application/octet-stream.
The commit accepts this content type for media. Don't think there are any other mime types anyone would use.

This should probably go into 1.6

Resolves #1937