### PR TITLE
Fix for restoring scroll position in detail view #1947

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -348,7 +348,7 @@ public class ItemDescriptionFragment extends Fragment implements MediaplayerInfo
     }
 
     private boolean restoreFromPreference() {
-        if (!saveState) {
+        if (saveState) {
             Log.d(TAG, "Restoring from preferences");
             Activity activity = getActivity();
             if (activity != null) {


### PR DESCRIPTION
The scroll position on detail view is now being restored when you are switching back to it. 

On orientation change it doesn't restore on the exact position at the moment. 
But i think that could work with a scroll position relative to the webview height.