### PR TITLE
Accept any media content type except for text/*

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -185,8 +185,7 @@ public class HttpDownloader extends Downloader {
             if(request.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                 String contentType = response.header("Content-Type");
                 Log.d(TAG, "content type: " + contentType);
-                if(!contentType.startsWith("audio/") && !contentType.startsWith("video/") &&
-                        !contentType.equals("application/octet-stream")) {
+                if(contentType.startsWith("text/")) {
                     onFail(DownloadError.ERROR_FILE_TYPE, null);
                     return;
                 }


### PR DESCRIPTION
The whole content type thing in podcast is a mess!

I have problems with podcasts using:
> Content-Type: application/force-download

Why is needed to filter any content type, if its for HTML errors, then let's ban only HTML and plain text MIME types.