### PR TITLE
StorageErrorActivity: Prevent NPE

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/StorageErrorActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/StorageErrorActivity.java
@@ -189,6 +189,9 @@ public class StorageErrorActivity extends AppCompatActivity {
             } else {
                 path = getExternalFilesDir(null);
             }
+            if(path == null) {
+                return;
+            }
             String message = null;
 			if(!path.exists()) {
 				message = String.format(getString(R.string.folder_does_not_exist_error), dir);


### PR DESCRIPTION
Maybe would be better to show the user a dialog message, but I have no idea what that would say. 
``getExternalFilesDir`` seems to return null which alone is pretty odd.

I say to wait for users complaining to get an idea under which conditions (steps to reproduce) this even happens.

Resolves #1971