### PR TITLE
fixes CastManager.addMediaRouterButton NPE

### DIFF
--- a/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
+++ b/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
@@ -67,9 +67,16 @@ public abstract class CastEnabledActivity extends AppCompatActivity
     @CallSuper
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        mediaRouteActionProvider = castManager
-                .addMediaRouterButton(menu.findItem(R.id.media_route_menu_item));
-        mediaRouteActionProvider.setEnabled(castButtonVisibilityManager.shouldEnable());
+        MenuItem mediaRouteButton = menu.findItem(R.id.media_route_menu_item);
+        if (mediaRouteButton == null) {
+            Log.wtf(TAG, "MediaRoute item could not be found on the menu!");
+            mediaRouteActionProvider = null;
+            return true;
+        }
+        mediaRouteActionProvider = castManager.addMediaRouterButton(mediaRouteButton);
+        if (mediaRouteActionProvider != null) {
+            mediaRouteActionProvider.setEnabled(castButtonVisibilityManager.shouldEnable());
+        }
         return true;
     }
 

--- a/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
+++ b/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
@@ -69,7 +69,7 @@ public abstract class CastEnabledActivity extends AppCompatActivity
         super.onPrepareOptionsMenu(menu);
         MenuItem mediaRouteButton = menu.findItem(R.id.media_route_menu_item);
         if (mediaRouteButton == null) {
-            Log.wtf(TAG, "MediaRoute item could not be found on the menu!");
+            Log.wtf(TAG, "MediaRoute item could not be found on the menu!", new Exception());
             mediaRouteActionProvider = null;
             return true;
         }

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
@@ -1746,7 +1746,8 @@ public class CastManager extends BaseCastManager implements OnFailedListener {
         if (!(actionProvider instanceof SwitchableMediaRouteActionProvider)) {
             Log.wtf(TAG, "MenuItem provided to addMediaRouterButton() is not compatible with " +
                     "SwitchableMediaRouteActionProvider." +
-                    ((actionProvider == null) ? " Its action provider is null!" : ""));
+                    ((actionProvider == null) ? " Its action provider is null!" : ""),
+                    new ClassCastException());
             return null;
         }
         SwitchableMediaRouteActionProvider mediaRouteActionProvider =

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
@@ -24,6 +24,8 @@ package de.danoeh.antennapod.core.cast;
 
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.v4.view.ActionProvider;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.media.MediaRouter;
 import android.util.Log;
@@ -1739,9 +1741,16 @@ public class CastManager extends BaseCastManager implements OnFailedListener {
      *
      * @param menuItem MenuItem of the Media Router cast button.
      */
-    public final SwitchableMediaRouteActionProvider addMediaRouterButton(MenuItem menuItem) {
-        SwitchableMediaRouteActionProvider mediaRouteActionProvider = (SwitchableMediaRouteActionProvider)
-                MenuItemCompat.getActionProvider(menuItem);
+    public final SwitchableMediaRouteActionProvider addMediaRouterButton(@NonNull MenuItem menuItem) {
+        ActionProvider actionProvider = MenuItemCompat.getActionProvider(menuItem);
+        if (!(actionProvider instanceof SwitchableMediaRouteActionProvider)) {
+            Log.wtf(TAG, "MenuItem provided to addMediaRouterButton() is not compatible with " +
+                    "SwitchableMediaRouteActionProvider." +
+                    ((actionProvider == null) ? " Its action provider is null!" : ""));
+            return null;
+        }
+        SwitchableMediaRouteActionProvider mediaRouteActionProvider =
+                (SwitchableMediaRouteActionProvider) actionProvider;
         mediaRouteActionProvider.setRouteSelector(mMediaRouteSelector);
         if (mCastConfiguration.getMediaRouteDialogFactory() != null) {
             mediaRouteActionProvider.setDialogFactory(mCastConfiguration.getMediaRouteDialogFactory());


### PR DESCRIPTION
This fixes #1974.

I have no clue as what could have caused this problem.

If on one hand this PR prevents NPE to be thrown for this reason, it also prevents us from ever finding its cause as users will be more unlikely to report it in the future (who can tell if the cast button didn't show one particular time? more likely we assume it's some temporary connectivity issue).