### PR TITLE
On resume, check if the feeds should be (automatically) refreshed.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -46,6 +46,7 @@ import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBReader;
+import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.Flavors;
@@ -467,6 +468,7 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     protected void onResume() {
         super.onResume();
         StorageUtils.checkStorageAvailability(this);
+        DBTasks.checkShouldRefreshFeeds(getApplicationContext());
 
         Intent intent = getIntent();
         if (intent.hasExtra(EXTRA_FEED_ID) ||

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
@@ -43,6 +43,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
 import de.danoeh.antennapod.core.storage.DBReader;
+import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
@@ -168,6 +169,7 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
             pagerAdapter.onMediaChanged(media);
             pagerAdapter.setController(controller);
         }
+        DBTasks.checkShouldRefreshFeeds(getApplicationContext());
 
         EventDistributor.getInstance().register(contentUpdate);
         loadData();

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -331,7 +331,10 @@ public class UserPreferences {
     }
 
 
-
+    /*
+     * Returns update interval in milliseconds; value 0 means that auto update is disabled
+     * or feeds are updated at a certain time of day
+     */
     public static long getUpdateInterval() {
         String updateInterval = prefs.getString(PREF_UPDATE_INTERVAL, "0");
         if(!updateInterval.contains(":")) {
@@ -743,12 +746,12 @@ public class UserPreferences {
         if (timeOfDay.length == 2) {
             restartUpdateTimeOfDayAlarm(timeOfDay[0], timeOfDay[1]);
         } else {
-            long hours = getUpdateInterval();
-            long startTrigger = hours;
+            long milliseconds = getUpdateInterval();
+            long startTrigger = milliseconds;
             if (now) {
                 startTrigger = TimeUnit.SECONDS.toMillis(10);
             }
-            restartUpdateIntervalAlarm(startTrigger, hours);
+            restartUpdateIntervalAlarm(startTrigger, milliseconds);
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.core.storage;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.util.Log;
 
@@ -16,7 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import de.danoeh.antennapod.core.ClientConfig;
@@ -27,20 +28,28 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.GpodnetSyncService;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
+import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.DownloadError;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 import de.danoeh.antennapod.core.util.exception.MediaFileNotFoundException;
 import de.danoeh.antennapod.core.util.flattr.FlattrUtils;
 
+import static android.content.Context.MODE_PRIVATE;
+import static android.provider.Contacts.SettingsColumns.KEY;
+
 /**
  * Provides methods for doing common tasks that use DBReader and DBWriter.
  */
 public final class DBTasks {
     private static final String TAG = "DBTasks";
+
+    public static final String PREF_NAME = "dbtasks";
+    private static final String PREF_LAST_REFRESH = "last_refresh";
 
     /**
      * Executor service used by the autodownloadUndownloadedEpisodes method.
@@ -161,6 +170,9 @@ public final class DBTasks {
                         refreshFeeds(context, DBReader.getFeedList());
                     }
                     isRefreshing.set(false);
+
+                    SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, MODE_PRIVATE);
+                    prefs.edit().putLong(PREF_LAST_REFRESH, System.currentTimeMillis()).apply();
 
                     if (FlattrUtils.hasToken()) {
                         Log.d(TAG, "Flattring all pending things.");
@@ -311,6 +323,31 @@ public final class DBTasks {
         }
         f.setId(feed.getId());
         DownloadRequester.getInstance().downloadFeed(context, f, loadAllPages, force);
+    }
+
+    /*
+     *  Checks if the app should refresh all feeds, i.e. if the last auto refresh failed.
+     *
+     *  The feeds are only refreshed if an update interval or time of day is set and the last
+     *  (successful) refresh was before the last interval or more than a day ago, respectively.
+     */
+    public static void checkShouldRefreshFeeds(Context context) {
+        long interval = 0;
+        if(UserPreferences.getUpdateInterval() > 0) {
+            interval = UserPreferences.getUpdateInterval();
+        } else if(UserPreferences.getUpdateTimeOfDay().length > 0){
+            interval = TimeUnit.DAYS.toMillis(1);
+        }
+        if(interval == 0) { // auto refresh is disabled
+            return;
+        }
+        SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, MODE_PRIVATE);
+        long lastRefresh = prefs.getLong(PREF_LAST_REFRESH, 0);
+        Log.d(TAG, "last refresh: " + Converter.getDurationStringLocalized(context,
+                System.currentTimeMillis() - lastRefresh) + " ago");
+        if(lastRefresh <= System.currentTimeMillis() - interval) {
+            DBTasks.refreshAllFeeds(context, null);
+        }
     }
 
     /**


### PR DESCRIPTION
When the user resumes the app, we now check if a feed refresh should be performed.
This is the case if the time since the last refresh is larger than the update interval or than 1 day in case of update time of day.

Also fixed documentation, which was plainly wrong.

Resolves #1942