### PR TITLE
Fix statistics

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -949,8 +949,12 @@ public final class DBReader {
                     continue;
                 }
 
+                // played duration used to be reset when the item is added to the playback history
+                if(media.getPlaybackCompletionDate() != null) {
+                    feedPlayedTime += media.getDuration() / 1000;
+                }
                 feedPlayedTime += media.getPlayedDuration() / 1000;
-                if(media.getPlayedDuration() > 0) {
+                if (media.getPlaybackCompletionDate() != null || media.getPlayedDuration() > 0) {
                     episodesStarted++;
                 }
                 feedTotalTime += media.getDuration() / 1000;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -272,8 +272,6 @@ public class DBWriter {
         return dbExec.submit(() -> {
             Log.d(TAG, "Adding new item to playback history");
             media.setPlaybackCompletionDate(new Date());
-            // reset played_duration to 0 so that it behaves correctly when the episode is played again
-            media.setPlayedDuration(0);
 
             PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();


### PR DESCRIPTION
Formerly, the played duration was reset when the episode was added to the playback history, i.e. when it completed. Not really sure why that was the case, "so that it behaves correctly" is not really useful. Could have something to do with flattring, but I don't see why it would matter.

We also restore the played duration for episodes where the played duration was already reset. Of course, we have no way of knowing how often the episode was already reset. If the user played the episodes multiple times, most of the information is already lost.

Resolves #1961