### PR TITLE
Fix gradle free builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,29 @@ android {
 
 dependencies {
     freeCompile project(path: ":core", configuration: "freeRelease")
-    playCompile project(path: ":core", configuration: "playRelease")
+    // free build hack to skip "play" specific dependencies on "free" builds
+    gradle.startParameter.taskRequests.each { taskRequest ->
+        taskRequest.args.each { taskName ->
+            String flavorName = "Free";
+            String[] buildTypes = ["Debug", "Release"];
+            String[] taskTypes = ["", "AndroidTest", "AndroidTestSources", "Annotations", "Classes",
+                                  "JarArtifact", "PlayResources", "Sources", "UnitTest", "UnitTestSources"];
+            boolean skip = taskName == "tasks" || taskName == "assemble" + flavorName;
+            for (int i = 0; i < buildTypes.length && skip == false; ++i) {
+                String buildType = buildTypes[i];
+                for (int j = 0; j < taskTypes.length && skip == false; j++) {
+                    if (taskName.endsWith(flavorName + buildType + taskTypes[j])) {
+                        skip = true;
+                    }
+                }
+            }
+            if (!skip) {
+                playCompile project(path: ":core", configuration: "playRelease")
+            } else if (taskName != "tasks") {
+                System.out.println("app: skipping some dependencies due to free build hack");
+            }
+        }
+    }
     compile "com.android.support:support-v4:$supportVersion"
     compile "com.android.support:appcompat-v7:$supportVersion"
     compile "com.android.support:design:$supportVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,8 @@ dependencies {
             String[] buildTypes = ["Debug", "Release"];
             String[] taskTypes = ["", "AndroidTest", "AndroidTestSources", "Annotations", "Classes",
                                   "JarArtifact", "PlayResources", "Sources", "UnitTest", "UnitTestSources"];
-            boolean skip = taskName == "tasks" || taskName == "assemble" + flavorName;
+            boolean skip = taskName == "tasks" || taskName == "assemble" + flavorName ||
+                    taskName == "clean";
             for (int i = 0; i < buildTypes.length && skip == false; ++i) {
                 String buildType = buildTypes[i];
                 for (int j = 0; j < taskTypes.length && skip == false; j++) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,9 +67,31 @@ dependencies {
     compile "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     // Add casting features
-    playCompile "com.google.android.libraries.cast.companionlibrary:ccl:$castCompanionLibVer"
-    compile "com.android.support:mediarouter-v7:$supportVersion"
-    playCompile "com.google.android.gms:play-services-cast:$playServicesVersion"
+    //// free build hack to skip "play" specific dependencies on "free" builds
+    gradle.startParameter.taskRequests.each { taskRequest ->
+        taskRequest.args.each { taskName ->
+            String flavorName = "Free";
+            String[] buildTypes = ["Debug", "Release"];
+            String[] taskTypes = ["", "AndroidTest", "AndroidTestSources", "Annotations", "Classes",
+                                  "JarArtifact", "PlayResources", "Sources", "UnitTest", "UnitTestSources"];
+            boolean skip = taskName == "tasks" || taskName == "assemble" + flavorName;
+            for (int i = 0; i < buildTypes.length && skip == false; ++i) {
+                String buildType = buildTypes[i];
+                for (int j = 0; j < taskTypes.length && skip == false; j++) {
+                    if (taskName.endsWith(flavorName + buildType + taskTypes[j])) {
+                        skip = true;
+                    }
+                }
+            }
+            if (!skip) {
+                playCompile "com.google.android.libraries.cast.companionlibrary:ccl:$castCompanionLibVer"
+                compile "com.android.support:mediarouter-v7:$supportVersion"
+                playCompile "com.google.android.gms:play-services-cast:$playServicesVersion"
+            } else if (taskName != "tasks") {
+                System.out.println("core: skipping some dependencies due to free build hack");
+            }
+        }
+    }
 }
 
 allprojects {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -74,7 +74,8 @@ dependencies {
             String[] buildTypes = ["Debug", "Release"];
             String[] taskTypes = ["", "AndroidTest", "AndroidTestSources", "Annotations", "Classes",
                                   "JarArtifact", "PlayResources", "Sources", "UnitTest", "UnitTestSources"];
-            boolean skip = taskName == "tasks" || taskName == "assemble" + flavorName;
+            boolean skip = taskName == "tasks" || taskName == "assemble" + flavorName ||
+                    taskName == "clean";
             for (int i = 0; i < buildTypes.length && skip == false; ++i) {
                 String buildType = buildTypes[i];
                 for (int j = 0; j < taskTypes.length && skip == false; j++) {


### PR DESCRIPTION
Follows #1982 to resolve #1959.
As stated in #1959 and https://code.google.com/p/android/issues/detail?id=78997 gradle try to resolve all flavors dependencies before going on, this patch makes gradle skip Google Plays Services dependencies when building "Free" targets and when listing tasks.