### PR TITLE
OpmlImportFromPathActivity: Prevent onActivityResult NPE

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromPathActivity.java
@@ -135,7 +135,7 @@ public class OpmlImportFromPathActivity extends OpmlImportBaseActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if (resultCode == RESULT_OK && requestCode == CHOOSE_OPML_FILE) {
             Uri uri = data.getData();
-            if(uri.toString().startsWith("/")) {
+            if(uri != null && uri.toString().startsWith("/")) {
                 uri = Uri.parse("file://" + uri.toString());
             }
             importUri(uri);


### PR DESCRIPTION
``importUri(@Nullable uri)``should not be an issue.
We only must not call ``toString()`` on a null object reference.

Resolves #1999