### PR TITLE
Fix gradle free builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,9 +109,23 @@ android {
     }
 }
 
+configurations {
+    freeDebugCompile
+    freeReleaseCompile
+    playDebugCompile
+    playReleaseCompile
+}
+
 dependencies {
-    freeCompile project(path: ":core", configuration: "freeRelease")
-    playCompile project(path: ":core", configuration: "playRelease")
+    freeDebugCompile project(path: ":core", configuration: "freeDebug")
+    freeReleaseCompile project(path: ":core", configuration: "freeRelease")
+    // free build hack: skip some dependencies
+    if (!doFreeBuild()) {
+        playDebugCompile project(path: ":core", configuration: "playDebug")
+        playReleaseCompile project(path: ":core", configuration: "playRelease")
+    } else {
+        System.out.println("app: free build hack, skipping some dependencies")
+    }
     compile "com.android.support:support-v4:$supportVersion"
     compile "com.android.support:appcompat-v7:$supportVersion"
     compile "com.android.support:design:$supportVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -70,3 +70,8 @@ project.ext {
 task wrapper(type: Wrapper) {
     gradleVersion = "2.11"
 }
+
+// free build hack: common functions
+def doFreeBuild() {
+    return System.properties["freeBuildHackDoFreeBuild"] == "true"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -73,5 +73,5 @@ task wrapper(type: Wrapper) {
 
 // free build hack: common functions
 def doFreeBuild() {
-    return System.properties["freeBuildHackDoFreeBuild"] == "true"
+    return hasProperty("freeBuild")
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,9 +67,14 @@ dependencies {
     compile "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     // Add casting features
-    playCompile "com.google.android.libraries.cast.companionlibrary:ccl:$castCompanionLibVer"
-    compile "com.android.support:mediarouter-v7:$supportVersion"
-    playCompile "com.google.android.gms:play-services-cast:$playServicesVersion"
+    // free build hack: skip some dependencies
+    if (!doFreeBuild()) {
+        playCompile "com.google.android.libraries.cast.companionlibrary:ccl:$castCompanionLibVer"
+        compile "com.android.support:mediarouter-v7:$supportVersion"
+        playCompile "com.google.android.gms:play-services-cast:$playServicesVersion"
+    } else {
+        System.out.println("core: free build hack, skipping some dependencies")
+    }
 }
 
 allprojects {


### PR DESCRIPTION
Replaces #1996, follows #1982 to resolve #1959.
Here is a new solution that fix the flavor and build variants build under gradle and seems to integrate better with android studio.
To make a free build `-DfreeBuildHackDoFreeBuild=true` must be passed to gradle, ex:`./gradlew clean assembleFreeRelease -DfreeBuildHackDoFreeBuild=true`

@mvdan and @mfietz : are you ok with this solution?

This solution is better that #1996 cause the build variants are correctly linked on Android Studio.

For the record:

- Using different build files was not possible due to: [GRADLE-2624](https://issues.gradle.org/browse/GRADLE-2624)

- build variants fix from: http://stackoverflow.com/a/29661804