### PR TITLE
OPML Import: Check if there is an exported(!) activity for the intents/options

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/IntentUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/IntentUtils.java
@@ -9,10 +9,18 @@ import java.util.List;
 
 public class IntentUtils {
 
+    /*
+     *  Checks if there is at least one exported activity that can be performed for the intent
+     */
     public static boolean isCallable(final Context context, final Intent intent) {
         List<ResolveInfo> list = context.getPackageManager().queryIntentActivities(intent,
                 PackageManager.MATCH_DEFAULT_ONLY);
-        return list.size() > 0;
+        for(ResolveInfo info : list) {
+            if(info.activityInfo.exported) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
Explanation: http://stackoverflow.com/a/11411881/5369600

Currently, ``IntentUtils.isCallable`` is true for an intent, even if none of the intent activities is exported, causing a ``SecurityException``.

Resolves #2004