### PR TITLE
Changes to media player protocol

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -20,6 +20,7 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer;
 import de.danoeh.antennapod.core.service.playback.LocalPSMP;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
@@ -196,10 +197,19 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
             }
 
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
+            }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(PLAYABLE_FILE_URL, null);
@@ -275,8 +285,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -357,8 +377,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -440,8 +470,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
 
         };
@@ -517,8 +557,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
 
         };
@@ -595,8 +645,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -675,8 +735,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -758,8 +828,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -814,8 +894,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         }
 
         @Override
-        public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-            return false;
+        public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+        }
+
+        @Override
+        public Playable getNextInQueue(Playable currentMedia) {
+            return null;
+        }
+
+        @Override
+        public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
         }
     };
 
@@ -896,8 +986,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1012,8 +1112,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1103,8 +1213,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1207,8 +1327,18 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public boolean endPlayback(Playable p, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers) {
-                return false;
+            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
+
+            }
+
+            @Override
+            public Playable getNextInQueue(Playable currentMedia) {
+                return null;
+            }
+
+            @Override
+            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);

--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -1,6 +1,8 @@
 package de.test.antennapod.service.playback;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import android.test.InstrumentationTestCase;
 
 import junit.framework.AssertionFailedError;
@@ -113,7 +115,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
 
     public void testInit() {
         final Context c = getInstrumentation().getTargetContext();
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, defaultCallback);
+        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, new DefaultPSMPCallback());
         psmp.shutdown();
     }
 
@@ -139,7 +141,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectStreamNoStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -159,56 +161,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                     if (assertionError == null)
                         assertionError = e;
                 }
-            }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -227,7 +179,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectStreamStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -247,56 +199,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                     if (assertionError == null)
                         assertionError = e;
                 }
-            }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -316,7 +218,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectStreamNoStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(4);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -340,56 +242,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                         assertionError = e;
                 }
             }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
-            }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(PLAYABLE_FILE_URL, null);
@@ -406,7 +258,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectStreamStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(5);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -433,57 +285,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                         assertionError = e;
                 }
             }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
-            }
-
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(PLAYABLE_FILE_URL, null);
@@ -499,7 +300,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectLocalNoStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -520,57 +321,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                         assertionError = e;
                 }
             }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
-            }
-
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(PLAYABLE_FILE_URL, PLAYABLE_LOCAL_URL);
@@ -587,7 +337,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectLocalStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -607,56 +357,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                     if (assertionError == null)
                         assertionError = e;
                 }
-            }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -674,7 +374,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectLocalNoStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(4);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -698,56 +398,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                         assertionError = e;
                 }
             }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
-            }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(PLAYABLE_FILE_URL, PLAYABLE_LOCAL_URL);
@@ -763,7 +413,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     public void testPlayMediaObjectLocalStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(5);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 try {
@@ -791,56 +441,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                     countDownLatch.countDown();
                 }
             }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
-            public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-                return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
-            }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(PLAYABLE_FILE_URL, PLAYABLE_LOCAL_URL);
@@ -853,68 +453,12 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         psmp.shutdown();
     }
 
-
-    private final PlaybackServiceMediaPlayer.PSMPCallback defaultCallback = new PlaybackServiceMediaPlayer.PSMPCallback() {
-        @Override
-        public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
-            checkPSMPInfo(newInfo);
-        }
-
-        @Override
-        public void shouldStop() {
-
-        }
-
-        @Override
-        public void playbackSpeedChanged(float s) {
-
-        }
-
-        @Override
-        public void setSpeedAbilityChanged() {
-
-        }
-
-        @Override
-        public void onMediaChanged(boolean reloadUI) {
-
-        }
-
-        @Override
-        public void onBufferingUpdate(int percent) {
-
-        }
-
-        @Override
-        public boolean onMediaPlayerInfo(int code, int resourceId) { return false; }
-
-        @Override
-        public boolean onMediaPlayerError(Object inObj, int what, int extra) {
-            return false;
-        }
-
-        @Override
-        public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-        }
-
-        @Override
-        public Playable getNextInQueue(Playable currentMedia) {
-            return null;
-        }
-
-        @Override
-        public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
-        }
-    };
-
     private void pauseTestSkeleton(final PlayerStatus initialState, final boolean stream, final boolean abandonAudioFocus, final boolean reinit, long timeoutSeconds) throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final int latchCount = (stream && reinit) ? 2 : 1;
         final CountDownLatch countDownLatch = new CountDownLatch(latchCount);
 
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 checkPSMPInfo(newInfo);
@@ -954,50 +498,10 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
             public boolean onMediaPlayerError(Object inObj, int what, int extra) {
                 if (assertionError == null)
                     assertionError = new AssertionFailedError("Unexpected call to onMediaPlayerError");
                 return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1055,7 +559,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                 (initialState == PlayerStatus.PREPARED) ? 1 : 0;
         final CountDownLatch countDownLatch = new CountDownLatch(latchCount);
 
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 checkPSMPInfo(newInfo);
@@ -1074,56 +578,11 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
             public boolean onMediaPlayerError(Object inObj, int what, int extra) {
                 if (assertionError == null) {
                     assertionError = new AssertionFailedError("Unexpected call of onMediaPlayerError");
                 }
                 return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1158,7 +617,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         final Context c = getInstrumentation().getTargetContext();
         final int latchCount = 1;
         final CountDownLatch countDownLatch = new CountDownLatch(latchCount);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 checkPSMPInfo(newInfo);
@@ -1172,37 +631,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                         countDownLatch.countDown();
                     }
                 }
-
-            }
-
-            @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
             }
 
             @Override
@@ -1210,21 +638,6 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
                 if (assertionError == null)
                     assertionError = new AssertionFailedError("Unexpected call to onMediaPlayerError");
                 return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1273,7 +686,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         final Context c = getInstrumentation().getTargetContext();
         final int latchCount = 2;
         final CountDownLatch countDownLatch = new CountDownLatch(latchCount);
-        PlaybackServiceMediaPlayer.PSMPCallback callback = new PlaybackServiceMediaPlayer.PSMPCallback() {
+        PlaybackServiceMediaPlayer.PSMPCallback callback = new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
                 checkPSMPInfo(newInfo);
@@ -1290,55 +703,10 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
             }
 
             @Override
-            public void shouldStop() {
-
-            }
-
-            @Override
-            public void playbackSpeedChanged(float s) {
-
-            }
-
-            @Override
-            public void setSpeedAbilityChanged() {
-
-            }
-
-            @Override
-            public void onMediaChanged(boolean reloadUI) {
-
-            }
-
-            @Override
-            public void onBufferingUpdate(int percent) {
-
-            }
-
-            @Override
-            public boolean onMediaPlayerInfo(int code, int resourceId) {
-                return false;
-            }
-
-            @Override
             public boolean onMediaPlayerError(Object inObj, int what, int extra) {
                 if (assertionError == null)
                     assertionError = new AssertionFailedError("Unexpected call to onMediaPlayerError");
                 return false;
-            }
-
-            @Override
-            public void onPostPlayback(Playable media, boolean ended, boolean playingNext) {
-
-            }
-
-            @Override
-            public Playable getNextInQueue(Playable currentMedia) {
-                return null;
-            }
-
-            @Override
-            public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-
             }
         };
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
@@ -1376,6 +744,73 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
     private static class UnexpectedStateChange extends AssertionFailedError {
         public UnexpectedStateChange(PlayerStatus status) {
             super("Unexpected state change: " + status);
+        }
+    }
+
+    private class DefaultPSMPCallback implements PlaybackServiceMediaPlayer.PSMPCallback {
+        @Override
+        public void statusChanged(PlaybackServiceMediaPlayer.PSMPInfo newInfo) {
+
+        }
+
+        @Override
+        public void shouldStop() {
+
+        }
+
+        @Override
+        public void playbackSpeedChanged(float s) {
+
+        }
+
+        @Override
+        public void setSpeedAbilityChanged() {
+
+        }
+
+        @Override
+        public void onBufferingUpdate(int percent) {
+
+        }
+
+        @Override
+        public void onMediaChanged(boolean reloadUI) {
+
+        }
+
+        @Override
+        public boolean onMediaPlayerInfo(int code, @StringRes int resourceId) {
+            return false;
+        }
+
+        @Override
+        public boolean onMediaPlayerError(Object inObj, int what, int extra) {
+            return false;
+        }
+
+        @Override
+        public void onPostPlayback(@NonNull Playable media, boolean ended, boolean playingNext) {
+
+        }
+
+        @Override
+        public void onPlaybackStart(@NonNull Playable playable, int position) {
+
+        }
+
+        @Override
+        public void onPlaybackPause(@NonNull Playable playable, int position) {
+
+        }
+
+        @Override
+        public Playable getNextInQueue(Playable currentMedia) {
+            return null;
+        }
+
+        @Override
+        public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+
         }
     }
 }

--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -799,7 +799,7 @@ public class PlaybackServiceMediaPlayerTest extends InstrumentationTestCase {
         }
 
         @Override
-        public void onPlaybackPause(@NonNull Playable playable, int position) {
+        public void onPlaybackPause(Playable playable, int position) {
 
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -481,7 +481,7 @@ public class FeedMedia extends FeedFile implements Playable {
         setPosition(newPosition);
         setLastPlayedTime(timeStamp);
         if(startPosition>=0 && position > startPosition) {
-            setDuration(playedDurationWhenStarted + position - startPosition);
+            setPlayedDuration(playedDurationWhenStarted + position - startPosition);
         }
         DBWriter.setFeedMediaPlaybackInformation(this);
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -755,7 +755,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
 
     @Override
-    public void endPlayback(final boolean wasSkipped, boolean switchingPlayers) {
+    protected void endPlayback(final boolean wasSkipped) {
         executor.submit(() -> {
             playerLock.lock();
             releaseWifiLockIfNecessary();
@@ -870,7 +870,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             mp -> genericOnCompletion();
 
     private void genericOnCompletion() {
-        endPlayback(false, false);
+        endPlayback(false);
     }
 
     private final MediaPlayer.OnBufferingUpdateListener audioBufferingUpdateListener =

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -316,11 +316,12 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             videoSize = new Pair<>(vp.getVideoWidth(), vp.getVideoHeight());
         }
 
+        // TODO this call has no effect!
         if (media.getPosition() > 0) {
             seekToSync(media.getPosition());
         }
 
-        if (media.getDuration() == 0) {
+        if (media.getDuration() <= 0) {
             Log.d(TAG, "Setting duration of media");
             media.setDuration(mediaPlayer.getDuration());
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -223,7 +223,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 }
                 mediaPlayer.start();
 
-                callback.onPlaybackStart(media, INVALID_TIME);
                 setPlayerStatus(PlayerStatus.PLAYING, media);
                 pausedBecauseOfTransientAudiofocusLoss = false;
             } else {
@@ -253,8 +252,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             if (playerStatus == PlayerStatus.PLAYING) {
                 Log.d(TAG, "Pausing playback.");
                 mediaPlayer.pause();
-                callback.onPlaybackPause(media, getPosition());
-                setPlayerStatus(PlayerStatus.PAUSED, media);
+                setPlayerStatus(PlayerStatus.PAUSED, media, getPosition());
 
                 if (abandonFocus) {
                     audioManager.abandonAudioFocus(audioFocusChangeListener);
@@ -373,8 +371,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
         if (playerStatus == PlayerStatus.PLAYING
                 || playerStatus == PlayerStatus.PAUSED
                 || playerStatus == PlayerStatus.PREPARED) {
-            statusBeforeSeeking = playerStatus;
-            setPlayerStatus(PlayerStatus.SEEKING, media);
             if(seekLatch != null && seekLatch.getCount() > 0) {
                 try {
                     seekLatch.await(3, TimeUnit.SECONDS);
@@ -383,9 +379,8 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 }
             }
             seekLatch = new CountDownLatch(1);
-            if (statusBeforeSeeking == PlayerStatus.PLAYING) {
-                callback.onPlaybackPause(media, getPosition());
-            }
+            statusBeforeSeeking = playerStatus;
+            setPlayerStatus(PlayerStatus.SEEKING, media, getPosition());
             mediaPlayer.seekTo(t);
             try {
                 seekLatch.await(3, TimeUnit.SECONDS);
@@ -934,10 +929,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 callback.onPlaybackStart(media, getPosition());
             }
             if (playerStatus == PlayerStatus.SEEKING) {
-                if (statusBeforeSeeking == PlayerStatus.PLAYING) {
-                    callback.onPlaybackStart(media, getPosition());
-                }
-                setPlayerStatus(statusBeforeSeeking, media);
+                setPlayerStatus(statusBeforeSeeking, media, getPosition());
             }
             playerLock.unlock();
         });

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -786,6 +786,11 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         if (!(playable instanceof FeedMedia)) {
             Log.d(TAG, "Not doing post-playback processing: media not of type FeedMedia");
+            if (ended) {
+                playable.onPlaybackCompleted(getApplicationContext());
+            } else {
+                playable.onPlaybackPause(getApplicationContext());
+            }
             return;
         }
         FeedMedia media = (FeedMedia) playable;
@@ -1587,7 +1592,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         @Override
         public void onStop() {
             Log.d(TAG, "onStop()");
-            mediaPlayer.stop();
+            mediaPlayer.stopPlayback(true);
         }
 
         @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -594,6 +594,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     break;
 
                 case PLAYING:
+                    writePlayerStatusPlaybackPreferences();
                     setupNotification(newInfo);
                     started = true;
                     break;
@@ -675,7 +676,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         @Override
         public void onPlaybackStart(@NonNull Playable playable, int position) {
             taskManager.startWidgetUpdater();
-            writePlayerStatusPlaybackPreferences();
             if (position != PlaybackServiceMediaPlayer.INVALID_TIME) {
                 playable.setPosition(position);
             }
@@ -684,12 +684,14 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
 
         @Override
-        public void onPlaybackPause(@NonNull Playable playable, int position) {
+        public void onPlaybackPause(Playable playable, int position) {
             taskManager.cancelPositionSaver();
-            saveCurrentPosition(position == PlaybackServiceMediaPlayer.INVALID_TIME,
+            saveCurrentPosition(position == PlaybackServiceMediaPlayer.INVALID_TIME || playable == null,
                     playable, position);
             taskManager.cancelWidgetUpdater();
-            playable.onPlaybackPause(getApplicationContext());
+            if (playable != null) {
+                playable.onPlaybackPause(getApplicationContext());
+            }
         }
 
         @Override
@@ -1578,12 +1580,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         public void onPause() {
             Log.d(TAG, "onPause()");
             if (getStatus() == PlayerStatus.PLAYING) {
-                pause(false, true);
-            }
-            if (UserPreferences.isPersistNotify()) {
-                pause(false, true);
-            } else {
-                pause(true, true);
+                pause(!UserPreferences.isPersistNotify(), true);
             }
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -473,7 +473,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                         UserPreferences.shouldHardwareButtonSkip()) {
                     // assume the skip command comes from a notification or the lockscreen
                     // a >| skip button should actually skip
-                    mediaPlayer.endPlayback(true, false);
+                    mediaPlayer.endPlayback();
                 } else {
                     // assume skip command comes from a (bluetooth) media button
                     // user actually wants to fast-forward
@@ -1424,7 +1424,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         public void onReceive(Context context, Intent intent) {
             if (TextUtils.equals(intent.getAction(), ACTION_SKIP_CURRENT_EPISODE)) {
                 Log.d(TAG, "Received SKIP_CURRENT_EPISODE intent");
-                mediaPlayer.endPlayback(true, false);
+                mediaPlayer.endPlayback();
             }
         }
     };
@@ -1656,7 +1656,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         public void onSkipToNext() {
             Log.d(TAG, "onSkipToNext()");
             if(UserPreferences.shouldHardwareButtonSkip()) {
-                mediaPlayer.endPlayback(true, false);
+                mediaPlayer.endPlayback();
             } else {
                 seekDelta(UserPreferences.getFastFowardSecs() * 1000);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -759,7 +759,22 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
     }
 
-    //TODO add javadoc, that is is assumed that the playable object contains info about its position and duration
+    /**
+     * This method processes the media object after its playback ended, either because it completed
+     * or because a different media object was selected for playback.
+     *
+     * Even though these tasks aren't supposed to be resource intensive, a good practice is to
+     * usually call this method on a background thread.
+     *
+     * @param playable the media object that was playing. It is assumed that its position property
+     *                 was updated before this method was called.
+     * @param ended if true, it signals that {@param playable} was played until its end.
+     *              In such case, the position property of the media becomes irrelevant for most of
+     *              the tasks (although it's still a good practice to keep it accurate).
+     * @param playingNext if true, it means another media object is being loaded in place of this one.
+     *                    Instances when we'd set it to false would be when we're not following the
+     *                    queue or when the queue has ended.
+     */
     private void onPostPlayback(final Playable playable, boolean ended, boolean playingNext) {
         if (playable == null) {
             Log.e(TAG, "Cannot do post-playback processing: media was null");

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -301,7 +301,11 @@ public abstract class PlaybackServiceMediaPlayer {
 
         boolean onMediaPlayerError(Object inObj, int what, int extra);
 
-        void onPostPlayback(Playable media, boolean ended, boolean playingNext);
+        void onPostPlayback(@NonNull Playable media, boolean ended, boolean playingNext);
+
+        void onPlaybackStart(@NonNull Playable playable, int position);
+
+        void onPlaybackPause(@NonNull Playable playable, int position);
 
         Playable getNextInQueue(Playable currentMedia);
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -9,10 +9,7 @@ import android.util.Pair;
 import android.view.SurfaceHolder;
 
 import de.danoeh.antennapod.core.feed.Chapter;
-import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
-import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.playback.Playable;
 
 
@@ -291,26 +288,6 @@ public abstract class PlaybackServiceMediaPlayer {
         callback.statusChanged(new PSMPInfo(playerStatus, getPlayable()));
     }
 
-    protected void smartMarkAsPlayed(Playable media) {
-        if(media != null && media instanceof FeedMedia) {
-            FeedMedia oldMedia = (FeedMedia) media;
-            if(oldMedia.hasAlmostEnded()) {
-                Log.d(TAG, "smart mark as read");
-                FeedItem item = oldMedia.getItem();
-                if (item == null) {
-                    return;
-                }
-                DBWriter.markItemPlayed(item, FeedItem.PLAYED, false);
-                DBWriter.removeQueueItem(context, item, false);
-                DBWriter.addItemToPlaybackHistory(oldMedia);
-                if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
-                    Log.d(TAG, "Delete " + oldMedia.toString());
-                    DBWriter.deleteFeedMediaOfItem(context, oldMedia.getId());
-                }
-            }
-        }
-    }
-
     public interface PSMPCallback {
         void statusChanged(PSMPInfo newInfo);
 
@@ -328,7 +305,11 @@ public abstract class PlaybackServiceMediaPlayer {
 
         boolean onMediaPlayerError(Object inObj, int what, int extra);
 
-        boolean endPlayback(Playable media, boolean playNextEpisode, boolean wasSkipped, boolean switchingPlayers);
+        void onPostPlayback(Playable media, boolean ended, boolean playingNext);
+
+        Playable getNextInQueue(Playable currentMedia);
+
+        void onPlaybackEnded(MediaType mediaType, boolean stopPlaying);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -8,7 +8,6 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.SurfaceHolder;
 
-import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.util.playback.Playable;
 
@@ -127,13 +126,6 @@ public abstract class PlaybackServiceMediaPlayer {
     public abstract void seekDelta(int d);
 
     /**
-     * Seek to the start of the specified chapter.
-     */
-    public void seekToChapter(@NonNull Chapter c) {
-        seekTo((int) c.getStart());
-    }
-
-    /**
      * Returns the duration of the current media object or INVALID_TIME if the duration could not be retrieved.
      */
     public abstract int getDuration();
@@ -233,7 +225,7 @@ public abstract class PlaybackServiceMediaPlayer {
 
     protected abstract void setPlayable(Playable playable);
 
-    public void endPlayback() {
+    public void skip() {
         endPlayback(true);
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -233,7 +233,11 @@ public abstract class PlaybackServiceMediaPlayer {
 
     protected abstract void setPlayable(Playable playable);
 
-    public abstract void endPlayback(boolean wasSkipped, boolean switchingPlayers);
+    public void endPlayback() {
+        endPlayback(true);
+    }
+
+    protected abstract void endPlayback(boolean wasSkipped);
 
     /**
      * Moves the PSMP into STOPPED state. This call is only valid if the player is currently in

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.util.playback;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.media.MediaMetadataRetriever;
@@ -205,7 +206,12 @@ public class ExternalMedia implements Playable {
 	}
 
 	@Override
-	public void onPlaybackCompleted() {
+	public void onPlaybackPause(Context context) {
+
+	}
+
+	@Override
+	public void onPlaybackCompleted(Context context) {
 
 	}
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -138,14 +138,27 @@ public interface Playable extends Parcelable,
     void setLastPlayedTime(long lastPlayedTimestamp);
 
     /**
-     * Is called by the PlaybackService when playback starts.
+     * This method should be called every time playback starts on this object.
+     * <p/>
+     * Position held by this Playable should be set accurately before a call to this method is made.
      */
     void onPlaybackStart();
 
     /**
-     * Is called by the PlaybackService when playback is completed.
+     * This method should be called every time playback pauses or stops on this object,
+     * including just before a seeking operation is performed, after which a call to
+     * {@link #onPlaybackStart()} should be made. If playback completes, calling this method is not
+     * necessary, as long as a call to {@link #onPlaybackCompleted(Context)} is made.
+     * <p/>
+     * Position held by this Playable should be set accurately before a call to this method is made.
      */
-    void onPlaybackCompleted();
+    void onPlaybackPause(Context context);
+
+    /**
+     * This method should be called when playback completes for this object.
+     * @param context
+     */
+    void onPlaybackCompleted(Context context);
 
     /**
      * Returns an integer that must be unique among all Playable classes. The

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
@@ -142,7 +142,6 @@ public class CastManager extends BaseCastManager implements OnFailedListener {
             if (ConnectionResult.SUCCESS != GoogleApiAvailability.getInstance()
                     .isGooglePlayServicesAvailable(context)) {
                 Log.e(TAG, "Couldn't find the appropriate version of Google Play Services");
-                //TODO check whether creating an instance without google play services installed actually gives an exception
             }
             INSTANCE = new CastManager(context, castConfiguration);
         }

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.cast;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Parcel;
@@ -255,7 +256,12 @@ public class RemoteMedia implements Playable {
     }
 
     @Override
-    public void onPlaybackCompleted() {
+    public void onPlaybackPause(Context context) {
+        // no-op
+    }
+
+    @Override
+    public void onPlaybackCompleted(Context context) {
         // no-op
     }
 

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -15,6 +15,8 @@ import android.widget.Toast;
 import com.google.android.gms.cast.ApplicationMetadata;
 import com.google.android.libraries.cast.companionlibrary.cast.BaseCastManager;
 
+import java.util.concurrent.ExecutionException;
+
 import de.danoeh.antennapod.core.cast.CastConsumer;
 import de.danoeh.antennapod.core.cast.CastManager;
 import de.danoeh.antennapod.core.cast.DefaultCastConsumer;
@@ -182,8 +184,11 @@ public class PlaybackServiceFlavorHelper {
                                    boolean wasLaunched) {
         PlaybackServiceMediaPlayer mediaPlayer = callback.getMediaPlayer();
         if (mediaPlayer != null) {
-            //TODO change implementation to new protocol
-//            mediaPlayer.endPlayback(true, true);
+            try {
+                mediaPlayer.stopPlayback(false).get();
+            } catch (InterruptedException | ExecutionException e) {
+                Log.e(TAG, "There was a problem stopping playback while switching media players", e);
+            }
             mediaPlayer.shutdownQuietly();
         }
         mediaPlayer = newPlayer;

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -108,7 +108,7 @@ public class PlaybackServiceFlavorHelper {
                 // to the latest position.
                 PlaybackServiceMediaPlayer mediaPlayer = callback.getMediaPlayer();
                 if (mediaPlayer != null) {
-                    callback.saveCurrentPosition(false, 0);
+                    callback.saveCurrentPosition();
                     infoBeforeCastDisconnection = mediaPlayer.getPSMPInfo();
                     if (reason != BaseCastManager.DISCONNECT_REASON_EXPLICIT &&
                             infoBeforeCastDisconnection.playerStatus == PlayerStatus.PLAYING) {
@@ -160,7 +160,7 @@ public class PlaybackServiceFlavorHelper {
                 // could be pause, but this way we make sure the new player will get the correct position,
                 // since pause runs asynchronously and we could be directing the new player to play even before
                 // the old player gives us back the position.
-                callback.saveCurrentPosition(false, 0);
+                callback.saveCurrentPosition();
             }
         }
         if (info == null) {

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -182,7 +182,8 @@ public class PlaybackServiceFlavorHelper {
                                    boolean wasLaunched) {
         PlaybackServiceMediaPlayer mediaPlayer = callback.getMediaPlayer();
         if (mediaPlayer != null) {
-            mediaPlayer.endPlayback(true, true);
+            //TODO change implementation to new protocol
+//            mediaPlayer.endPlayback(true, true);
             mediaPlayer.shutdownQuietly();
         }
         mediaPlayer = newPlayer;

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -108,7 +108,7 @@ public class PlaybackServiceFlavorHelper {
                 // to the latest position.
                 PlaybackServiceMediaPlayer mediaPlayer = callback.getMediaPlayer();
                 if (mediaPlayer != null) {
-                    callback.saveCurrentPosition();
+                    callback.saveCurrentPosition(true, null, PlaybackServiceMediaPlayer.INVALID_TIME);
                     infoBeforeCastDisconnection = mediaPlayer.getPSMPInfo();
                     if (reason != BaseCastManager.DISCONNECT_REASON_EXPLICIT &&
                             infoBeforeCastDisconnection.playerStatus == PlayerStatus.PLAYING) {
@@ -160,7 +160,7 @@ public class PlaybackServiceFlavorHelper {
                 // could be pause, but this way we make sure the new player will get the correct position,
                 // since pause runs asynchronously and we could be directing the new player to play even before
                 // the old player gives us back the position.
-                callback.saveCurrentPosition();
+                callback.saveCurrentPosition(true, null, PlaybackServiceMediaPlayer.INVALID_TIME);
             }
         }
         if (info == null) {

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
@@ -634,11 +634,21 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
             }
         }
         if (shouldContinue || toStoppedState) {
-            if (nextMedia != null) {
-                callback.onPlaybackEnded(null, true);
-                stop();
+            boolean shouldPostProcess = true;
+            if (nextMedia == null) {
+                try {
+                    castMgr.stop();
+                    shouldPostProcess = false;
+                } catch (CastException | TransientNetworkDisconnectionException | NoConnectionException e) {
+                    Log.e(TAG, "Unable to stop playback", e);
+                    callback.onPlaybackEnded(null, true);
+                    stop();
+                }
             }
-            callback.onPostPlayback(currentMedia, !wasSkipped, nextMedia != null);
+            if (shouldPostProcess) {
+                // Otherwise we rely on the chromecast callback to tell us the playback has stopped.
+                callback.onPostPlayback(currentMedia, !wasSkipped, nextMedia != null);
+            }
         } else if (isPlaying) {
             callback.onPlaybackPause(currentMedia,
                     currentMedia != null ? currentMedia.getPosition() : INVALID_TIME);

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
@@ -557,7 +557,7 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
     }
 
     @Override
-    public void endPlayback(boolean wasSkipped, boolean switchingPlayers) {
+    protected void endPlayback(boolean wasSkipped) {
         Log.d(TAG, "endPlayback() called");
         boolean isPlaying = playerStatus == PlayerStatus.PLAYING;
         try {


### PR DESCRIPTION
This PR changes some aspects of how the PlaybackService works and the way it communicates with the media players.

Main changes are:
* Playable types should now implement `onPlaybackStart()`, `onPlaybackPause()` and `onPlaybackCompleted()`, and before each call the current position should be properly updated (or more or less accurate), so that features such as played duration can work (only matters for `FeedMedia` type).
* Flattr and gpodder play action instructions were moved inside `FeedMedia`, to be executed when playback pauses or completes.
* As such, an item is flattr'd only when playback pauses/ends, as opposed to the previous behavior where it would be as soon as it reached the threshold (and we were checking every time we updated the position).
* This also introduces a distinction on the play actions we send to gpodder, as now we don't send the duration as the position when we skipped (unless smart mark as played applied).
* PSMPCallback changed considerably: now it has onPlaybackStart, onPlaybackPause, onPlaybackEnded, getNextInQueue, onPostPlayback.
* PSMP now must implement `skip()` and `stopPlayback()`, while `endPlayback()` becomes an internal method. `stopPlayback()` (and `endPlayback()`) return a `Future`, just for the sake of tracking the method's execution when switching media players (we want to be done with the old one and its callbacks before starting the new one), as it's often run on a separate thread.
* The transition between episodes is now done almost exclusively by the media players, opening the way for future support of chromecast queues (that's why a callback method to fetch the next episode in the queue was introduced).
* changes to RemotePSMP.
* created default PSMPCallback for the tests.

I had tested it mostly before the free/play flavors split, but hopefully still works without a problem after being rebased.