### PR TITLE
Fix subscription view loading

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
@@ -107,6 +107,10 @@ public class SubscriptionsAdapter extends BaseAdapter implements AdapterView.OnI
             holder.count.setPrimaryText("");
             // make it go away, we don't need it for add feed
             holder.count.setVisibility(View.INVISIBLE);
+
+            // when this holder is reused, we could else end up with a cover image
+            Glide.clear(holder.imageView);
+
             return convertView;
         }
 
@@ -135,7 +139,7 @@ public class SubscriptionsAdapter extends BaseAdapter implements AdapterView.OnI
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        if (position == ADD_POSITION) {
+        if (position == getAddTilePosition()) {
             mainActivityRef.get().loadChildFragment(new AddFeedFragment());
         } else {
             Fragment fragment = ItemlistFragment.newInstance(getItemId(position));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -27,6 +27,7 @@ import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 import rx.Observable;
+import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
@@ -46,6 +47,7 @@ public class SubscriptionFragment extends Fragment {
 
     private int mPosition = -1;
 
+    private Subscription subscription;
 
     public SubscriptionFragment() {
     }
@@ -88,8 +90,19 @@ public class SubscriptionFragment extends Fragment {
         EventDistributor.getInstance().register(contentUpdate);
     }
 
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if(subscription != null) {
+            subscription.unsubscribe();
+        }
+    }
+
     private void loadSubscriptions() {
-        Observable.fromCallable(() -> DBReader.getNavDrawerData())
+        if(subscription != null) {
+            subscription.unsubscribe();
+        }
+        subscription = Observable.fromCallable(() -> DBReader.getNavDrawerData())
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {


### PR DESCRIPTION
The subscription view had three issues: 
* When the former add tile holder was reused, we could end up with a cover in the add tile when the grid is reloaded, usually the cover of the top left feed
* Clicking the add tile did not work
* We need to unsubscribe, else rx could cause a "IllegalStateException: Activity has been destroyed" error