### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
@@ -21,6 +21,7 @@ import de.danoeh.antennapod.core.util.flattr.FlattrStatus;
  */
 public class DBTestUtils {
 
+    private DBTestUtils(){}
     /**
      * Use this method when tests don't involve chapters.
      */

--- a/app/src/androidTest/java/de/test/antennapod/util/syndication/feedgenerator/GeneratorUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/syndication/feedgenerator/GeneratorUtil.java
@@ -8,6 +8,7 @@ import java.io.IOException;
  * Utility methods for FeedGenerator
  */
 public class GeneratorUtil {
+    private GeneratorUtil(){}
 
     public static void addPaymentLink(XmlSerializer xml, String paymentLink, boolean withNamespace) throws IOException {
         String ns = (withNamespace) ? "http://www.w3.org/2005/Atom" : null;

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportHolder.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
  */
 public class OpmlImportHolder {
 
+    private OpmlImportHolder(){}
+
     private static ArrayList<OpmlElement> readElements;
 
     public static ArrayList<OpmlElement> getReadElements() {

--- a/app/src/main/java/de/danoeh/antennapod/config/ClientConfigurator.java
+++ b/app/src/main/java/de/danoeh/antennapod/config/ClientConfigurator.java
@@ -8,6 +8,8 @@ import de.danoeh.antennapod.core.ClientConfig;
  */
 public class ClientConfigurator {
 
+    private ClientConfigurator(){}
+
     static {
         ClientConfig.USER_AGENT = "AntennaPod/" + BuildConfig.VERSION_NAME;
         ClientConfig.applicationCallbacks = new ApplicationCallbacksImpl();

--- a/app/src/main/java/de/danoeh/antennapod/dialog/GpodnetSetHostnameDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/GpodnetSetHostnameDialog.java
@@ -16,6 +16,9 @@ import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
  * Creates a dialog that lets the user change the hostname for the gpodder.net service.
  */
 public class GpodnetSetHostnameDialog {
+
+    private GpodnetSetHostnameDialog(){}
+
     private static final String TAG = "GpodnetSetHostnameDialog";
 
     public static AlertDialog createDialog(final Context context) {

--- a/app/src/main/java/de/danoeh/antennapod/dialog/RatingDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/RatingDialog.java
@@ -17,6 +17,8 @@ import de.danoeh.antennapod.R;
 
 public class RatingDialog {
 
+    private RatingDialog(){}
+
     private static final String TAG = RatingDialog.class.getSimpleName();
     private static final int AFTER_DAYS = 7;
 

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
@@ -30,6 +30,9 @@ import de.danoeh.antennapod.core.util.ShareUtils;
  * Handles interactions with the FeedItemMenu.
  */
 public class FeedMenuHandler {
+
+    private FeedMenuHandler(){ }
+
     private static final String TAG = "FeedMenuHandler";
 
     public static boolean onCreateOptionsMenu(MenuInflater inflater, Menu menu) {

--- a/core/src/main/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -13,6 +13,7 @@ import de.danoeh.antennapod.core.util.NetworkUtils;
  * Apps using the core module of AntennaPod should register implementations of all interfaces here.
  */
 public class ClientConfig {
+    private ClientConfig(){}
 
     /**
      * Should be used when setting User-Agent header for HTTP-requests.

--- a/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
@@ -25,6 +25,8 @@ import de.danoeh.antennapod.core.storage.DBWriter;
  */
 public class UpdateManager {
 
+    private UpdateManager(){}
+
     public static final String TAG = UpdateManager.class.getSimpleName();
 
     private static final String PREF_NAME = "app_version";

--- a/core/src/main/java/de/danoeh/antennapod/core/cast/CastUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/cast/CastUtils.java
@@ -24,6 +24,8 @@ import de.danoeh.antennapod.core.util.playback.Playable;
  * Helper functions for Cast support.
  */
 public class CastUtils {
+    private CastUtils(){}
+
     private static final String TAG = "CastUtils";
 
     public static final String KEY_MEDIA_ID = "de.danoeh.antennapod.core.cast.MediaId";

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideSettings.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideSettings.java
@@ -6,6 +6,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
  * The settings that AntennaPod will use for various Glide options
  */
 public class ApGlideSettings {
+    private ApGlideSettings(){}
 
     public static final DiskCacheStrategy AP_DISK_CACHE_STRATEGY = DiskCacheStrategy.ALL;
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
@@ -23,6 +23,8 @@ import de.danoeh.antennapod.core.service.GpodnetSyncService;
  */
 public class GpodnetPreferences {
 
+    private GpodnetPreferences(){}
+
     private static final String TAG = "GpodnetPreferences";
 
     private static final String PREF_NAME = "gpodder.net";

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -40,6 +40,7 @@ import de.danoeh.antennapod.core.util.Converter;
  * when called.
  */
 public class UserPreferences {
+    private UserPreferences(){}
 
     public static final String IMPORT_DIR = "import/";
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
@@ -35,6 +35,9 @@ import de.danoeh.antennapod.core.storage.DBWriter;
  * Provides access to a HttpClient singleton.
  */
 public class AntennapodHttpClient {
+
+    private AntennapodHttpClient(){}
+
     private static final String TAG = "AntennapodHttpClient";
 
     public static final int CONNECTION_TIMEOUT = 30000;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/FeedSearcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/FeedSearcher.java
@@ -17,6 +17,8 @@ import de.danoeh.antennapod.core.util.comparator.SearchResultValueComparator;
  * Performs search on Feeds and FeedItems
  */
 public class FeedSearcher {
+    private FeedSearcher(){}
+
     private static final String TAG = "FeedSearcher";
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -16,6 +16,7 @@ import java.util.TimeZone;
  * Parses several date formats.
  */
 public class DateUtils {
+    private DateUtils(){}
     
 	private static final String TAG = "DateUtils";
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -5,6 +5,7 @@ import java.util.List;
 import de.danoeh.antennapod.core.feed.FeedItem;
 
 public class FeedItemUtil {
+    private FeedItemUtil(){}
 
     public static int indexOfItemWithDownloadUrl(List<FeedItem> items, String downloadUrl) {
         if(items == null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/IntentUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/IntentUtils.java
@@ -8,6 +8,7 @@ import android.content.pm.ResolveInfo;
 import java.util.List;
 
 public class IntentUtils {
+    private IntentUtils(){}
 
     public static boolean isCallable(final Context context, final Intent intent) {
         List<ResolveInfo> list = context.getPackageManager().queryIntentActivities(intent,

--- a/core/src/main/java/de/danoeh/antennapod/core/util/LangUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/LangUtils.java
@@ -5,6 +5,9 @@ import android.support.v4.util.ArrayMap;
 import java.nio.charset.Charset;
 
 public class LangUtils {
+
+	private LangUtils(){}
+
 	public static final Charset UTF_8 = Charset.forName("UTF-8");
 
 	private static ArrayMap<String, String> languages;

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -27,6 +27,7 @@ import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
 public class NetworkUtils {
+    private NetworkUtils(){}
 
 	private static final String TAG = NetworkUtils.class.getSimpleName();
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/RewindAfterPauseUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/RewindAfterPauseUtils.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
  * Media file should be "rewinded" x seconds after user resumes the playback.
  */
 public class RewindAfterPauseUtils {
+    private RewindAfterPauseUtils(){}
 
     public static final long ELAPSED_TIME_FOR_SHORT_REWIND = TimeUnit.MINUTES.toMillis(1);
     public static final long ELAPSED_TIME_FOR_MEDIUM_REWIND = TimeUnit.HOURS.toMillis(1);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
@@ -14,6 +14,8 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
  * Utility functions for handling storage errors
  */
 public class StorageUtils {
+    private StorageUtils(){}
+
     private static final String TAG = "StorageUtils";
 
     public static boolean storageAvailable() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ThemeUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ThemeUtils.java
@@ -6,6 +6,8 @@ import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 public class ThemeUtils {
+    private ThemeUtils(){}
+
     private static final String TAG = "ThemeUtils";
 
     public static int getSelectionBackgroundColor() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrServiceCreator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrServiceCreator.java
@@ -11,6 +11,8 @@ import de.danoeh.antennapod.core.BuildConfig;
 /** Ensures that only one instance of the FlattrService class exists at a time */
 
 public class FlattrServiceCreator {
+	private FlattrServiceCreator(){}
+
 	public static final String TAG = "FlattrServiceCreator";
 	
 	private static volatile FlattrService flattrService;

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrUtils.java
@@ -36,6 +36,8 @@ import de.danoeh.antennapod.core.storage.DBWriter;
  */
 
 public class FlattrUtils {
+    private FlattrUtils(){}
+
     private static final String TAG = "FlattrUtils";
 
     private static final String HOST_NAME = "de.danoeh.antennapod";

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/MediaPlayerError.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/MediaPlayerError.java
@@ -6,6 +6,7 @@ import de.danoeh.antennapod.core.R;
 
 /** Utility class for MediaPlayer errors. */
 public class MediaPlayerError {
+	private MediaPlayerError(){}
 
 	/** Get a human-readable string for a specific error code. */
 	public static String getErrorString(Context context, int code) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -161,6 +161,8 @@ public interface Playable extends Parcelable,
      * Provides utility methods for Playable objects.
      */
     class PlayableUtils {
+        private PlayableUtils(){}
+
         private static final String TAG = "PlayableUtils";
 
         /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 810 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Soso Tughushi