### PR TITLE
Resolve file type errors

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -208,7 +208,8 @@ public class DownloadService extends Service {
                                     boolean forbidden = status.getReason() == DownloadError.ERROR_FORBIDDEN
                                             && String.valueOf(HttpURLConnection.HTTP_FORBIDDEN).equals(status.getReasonDetailed());
                                     boolean notEnoughSpace = status.getReason() == DownloadError.ERROR_NOT_ENOUGH_SPACE;
-                                    if (httpNotFound || forbidden || notEnoughSpace) {
+                                    boolean wrongFileType = status.getReason() == DownloadError.ERROR_FILE_TYPE;
+                                    if (httpNotFound || forbidden || notEnoughSpace || wrongFileType) {
                                         DBWriter.saveFeedItemAutoDownloadFailed(item).get();
                                     }
                                     // to make lists reload the failed item, we fake an item update

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -182,10 +182,20 @@ public class HttpDownloader extends Downloader {
                 return;
             }
 
+            // fail with a file type error when the content type is text and
+            // the reported content length is less than 100kb (or no length is given)
             if(request.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                 String contentType = response.header("Content-Type");
                 Log.d(TAG, "content type: " + contentType);
-                if(contentType.startsWith("text/")) {
+                int contentLength = -1;
+                String contentLen = response.header("Content-Length");
+                if(contentLen != null) {
+                    try {
+                        contentLength = Integer.parseInt(contentLen);
+                    } catch(NumberFormatException e) {}
+                }
+                Log.d(TAG, "content length: " + contentLength);
+                if(contentType.startsWith("text/") && contentLength < 100 * 1024) {
                     onFail(DownloadError.ERROR_FILE_TYPE, null);
                     return;
                 }


### PR DESCRIPTION
Add exponential backoff for file type errors and check content length before assuming a file type error

I'm hopeful this resolves #2017