### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/EventDistributor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/EventDistributor.java
@@ -96,7 +96,7 @@ public class EventDistributor extends Observable {
 
     public void sendPlayerStatusUpdateBroadcast() { addEvent(PLAYER_STATUS_UPDATE); }
 
-	public static abstract class EventListener implements Observer {
+	public abstract static class EventListener implements Observer {
 
 		@Override
 		public void update(Observable observable, Object data) {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -53,9 +53,9 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
     private long feedId;
 
     private int state;
-    public final static int NEW = -1;
-    public final static int UNPLAYED = 0;
-    public final static int PLAYED = 1;
+    public static final int NEW = -1;
+    public static final int UNPLAYED = 0;
+    public static final int PLAYED = 1;
 
     private String paymentLink;
     private FlattrStatus flattrStatus;

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -68,7 +68,7 @@ public class FeedPreferences {
     /**
      * @return the filter for this feed
      */
-    public @NonNull FeedFilter getFilter() {
+    @NonNull public FeedFilter getFilter() {
         return filter;
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/ProxyConfig.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/ProxyConfig.java
@@ -12,7 +12,7 @@ public class ProxyConfig {
     @Nullable public final String username;
     @Nullable public final String password;
 
-    public final static int DEFAULT_PORT = 8080;
+    public static final int DEFAULT_PORT = 8080;
 
     public static ProxyConfig direct() {
         return new ProxyConfig(Proxy.Type.DIRECT, null, 0, null, null);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -278,7 +278,7 @@ public abstract class PlaybackServiceMediaPlayer {
      * @param newStatus The new PlayerStatus. This must not be null.
      * @param newMedia  The new playable object of the PSMP object. This can be null.
      */
-    protected synchronized final void setPlayerStatus(@NonNull PlayerStatus newStatus, Playable newMedia) {
+    protected final synchronized void setPlayerStatus(@NonNull PlayerStatus newStatus, Playable newMedia) {
         Log.d(TAG, this.getClass().getSimpleName() + ": Setting player status to " + newStatus);
 
         this.playerStatus = newStatus;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -717,7 +717,7 @@ public final class DBTasks {
      * This class automatically creates a PodDBAdapter object and closes it when
      * it is no longer in use.
      */
-    static abstract class QueryTask<T> implements Callable<T> {
+    abstract static class QueryTask<T> implements Callable<T> {
         private T result;
         private Context context;
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1593,7 +1593,7 @@ public class PodDBAdapter {
      */
     private static class PodDBHelper extends SQLiteOpenHelper {
 
-        private final static int VERSION = 1050004;
+        private static final int VERSION = 1050004;
 
         private Context context;
 

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -24,21 +24,21 @@ public class NSRSS20 extends Namespace {
 	public static final String NSTAG = "rss";
 	public static final String NSURI = "";
 
-	public final static String CHANNEL = "channel";
-	public final static String ITEM = "item";
-	public final static String GUID = "guid";
-	public final static String TITLE = "title";
-	public final static String LINK = "link";
-	public final static String DESCR = "description";
-	public final static String PUBDATE = "pubDate";
-	public final static String ENCLOSURE = "enclosure";
-	public final static String IMAGE = "image";
-	public final static String URL = "url";
-	public final static String LANGUAGE = "language";
+	public static final String CHANNEL = "channel";
+	public static final String ITEM = "item";
+	public static final String GUID = "guid";
+	public static final String TITLE = "title";
+	public static final String LINK = "link";
+	public static final String DESCR = "description";
+	public static final String PUBDATE = "pubDate";
+	public static final String ENCLOSURE = "enclosure";
+	public static final String IMAGE = "image";
+	public static final String URL = "url";
+	public static final String LANGUAGE = "language";
 
-	public final static String ENC_URL = "url";
-	public final static String ENC_LEN = "length";
-	public final static String ENC_TYPE = "type";
+	public static final String ENC_URL = "url";
+	public static final String ENC_LEN = "length";
+	public static final String ENC_TYPE = "type";
 
 	@Override
 	public SyndElement handleElementStart(String localName, HandlerState state,

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
@@ -6,7 +6,7 @@ import org.apache.commons.io.FilenameUtils;
 /** Utility class for handling MIME-Types of enclosures */
 public class SyndTypeUtils {
 
-	private final static String VALID_MIMETYPE = "audio/.*" + "|" + "video/.*"
+	private static final String VALID_MIMETYPE = "audio/.*" + "|" + "video/.*"
 			+ "|" + "application/ogg";
 
 	private SyndTypeUtils() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrServiceCreator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/flattr/FlattrServiceCreator.java
@@ -15,14 +15,14 @@ public class FlattrServiceCreator {
 	
 	private static volatile FlattrService flattrService;
 	
-	public synchronized static FlattrService getService(AccessToken token) {
+	public static synchronized FlattrService getService(AccessToken token) {
 		if (flattrService == null) {
 			flattrService = FlattrFactory.getInstance().createFlattrService(token);
 		}
 		return flattrService;
 	}
 	
-	public synchronized static void deleteFlattrService() {
+	public static synchronized void deleteFlattrService() {
 		if (BuildConfig.DEBUG) Log.d(TAG, "Deleting service instance");
 		flattrService = null;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”.

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Soso Tughushi.