### PR TITLE
squid:S1118 - Utility classes should not have public constructors (part 2)

### DIFF
--- a/core/src/free/java/de/danoeh/antennapod/core/feed/FeedMediaFlavorHelper.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/feed/FeedMediaFlavorHelper.java
@@ -4,6 +4,7 @@ package de.danoeh.antennapod.core.feed;
  * Implements methods for FeedMedia that are flavor dependent.
  */
 public class FeedMediaFlavorHelper {
+    private FeedMediaFlavorHelper(){}
     static boolean instanceOfRemoteMedia(Object o) {
         return false;
     }

--- a/core/src/play/java/de/danoeh/antennapod/core/feed/FeedMediaFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/feed/FeedMediaFlavorHelper.java
@@ -6,6 +6,7 @@ import de.danoeh.antennapod.core.cast.RemoteMedia;
  * Implements methods for FeedMedia that are flavor dependent.
  */
 public class FeedMediaFlavorHelper {
+    private FeedMediaFlavorHelper(){}
     static boolean instanceOfRemoteMedia(Object o) {
         return o instanceof RemoteMedia;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 60 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Soso Tughushi