### PR TITLE
fix horizontal layout (MediaRouteControllerDialog)

### DIFF
--- a/app/src/play/java/de/danoeh/antennapod/config/CastCallbackImpl.java
+++ b/app/src/play/java/de/danoeh/antennapod/config/CastCallbackImpl.java
@@ -1,14 +1,11 @@
 package de.danoeh.antennapod.config;
 
-import android.content.Context;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.MediaRouteControllerDialog;
 import android.support.v7.app.MediaRouteControllerDialogFragment;
 import android.support.v7.app.MediaRouteDialogFactory;
 
-import de.danoeh.antennapod.dialog.CustomMRControllerDialog;
 import de.danoeh.antennapod.core.CastCallbacks;
+import de.danoeh.antennapod.fragment.CustomMRControllerDialogFragment;
 
 public class CastCallbackImpl implements CastCallbacks {
     @Override
@@ -17,12 +14,7 @@ public class CastCallbackImpl implements CastCallbacks {
             @NonNull
             @Override
             public MediaRouteControllerDialogFragment onCreateControllerDialogFragment() {
-                return new MediaRouteControllerDialogFragment() {
-                    @Override
-                    public MediaRouteControllerDialog onCreateControllerDialog(Context context, Bundle savedInstanceState) {
-                        return new CustomMRControllerDialog(context);
-                    }
-                };
+                return new CustomMRControllerDialogFragment();
             }
         };
     }

--- a/app/src/play/java/de/danoeh/antennapod/dialog/CustomMRControllerDialog.java
+++ b/app/src/play/java/de/danoeh/antennapod/dialog/CustomMRControllerDialog.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.dialog;
 
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -14,6 +15,7 @@ import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.support.v4.util.Pair;
+import android.support.v4.view.MarginLayoutParamsCompat;
 import android.support.v4.view.accessibility.AccessibilityEventCompat;
 import android.support.v7.app.MediaRouteControllerDialog;
 import android.support.v7.graphics.Palette;
@@ -104,10 +106,49 @@ public class CustomMRControllerDialog extends MediaRouteControllerDialog {
 
     @Override
     public View onCreateMediaControlView(Bundle savedInstanceState) {
-        rootView = new LinearLayout(getContext());
-        rootView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT));
-        rootView.setOrientation(LinearLayout.VERTICAL);
+        boolean landscape = getContext().getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+        if (landscape) {
+            rootView = new LinearLayout(getContext()) {
+                @Override
+                protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                    // We'd like to find the overall height before adjusting the widths within the LinearLayout
+                    int maxHeight = Integer.MIN_VALUE;
+                    if (MeasureSpec.getMode(heightMeasureSpec) != MeasureSpec.EXACTLY) {
+                        for (int i = 0; i < getChildCount(); i++) {
+                            int height = Integer.MIN_VALUE;
+                            View child = getChildAt(i);
+                            ViewGroup.LayoutParams lp = child.getLayoutParams();
+                            if (lp.height >= 0) {
+                                height = lp.height;
+                            } else if (lp.height == ViewGroup.LayoutParams.WRAP_CONTENT) {
+                                child.measure(widthMeasureSpec, heightMeasureSpec);
+                                height = child.getMeasuredHeight();
+                            }
+                            maxHeight = Math.max(maxHeight, height);
+                        }
+                    }
+                    if (maxHeight > 0) {
+                        super.onMeasure(widthMeasureSpec,
+                                MeasureSpec.makeMeasureSpec(maxHeight, MeasureSpec.EXACTLY));
+                    } else {
+                        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+                    }
+                }
+            };
+        } else {
+            rootView = new LinearLayout(getContext());
+        }
+        FrameLayout.LayoutParams rootParams = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        rootParams.setMargins(0, 0, 0,
+                getContext().getResources().getDimensionPixelSize(R.dimen.media_router_controller_bottom_margin));
+        rootView.setLayoutParams(rootParams);
+        if (landscape) {
+            rootView.setOrientation(LinearLayout.HORIZONTAL);
+        } else {
+            rootView.setOrientation(LinearLayout.VERTICAL);
+        }
 
         // Start the session activity when a content item (album art, title or subtitle) is clicked.
         View.OnClickListener onClickListener = v -> {
@@ -124,38 +165,89 @@ public class CustomMRControllerDialog extends MediaRouteControllerDialog {
             }
         };
 
-        artView = new ImageView(getContext()) {
-            @Override
-            protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-                int desiredHeight = heightMeasureSpec;
-                if (MeasureSpec.getMode(heightMeasureSpec) != MeasureSpec.EXACTLY) {
-                    Drawable drawable = getDrawable();
-                    if (drawable != null) {
-                        int originalWidth = MeasureSpec.getSize(widthMeasureSpec);
-                        int intrHeight = drawable.getIntrinsicHeight();
-                        int intrWidth = drawable.getIntrinsicWidth();
-                        float scale;
-                        if (intrHeight*16 > intrWidth*9) {
-                            // image is taller than 16:9
-                            scale = (float) originalWidth * 9 / 16 / intrHeight;
-                        } else {
-                            // image is more horizontal than 16:9
-                            scale = (float) originalWidth / intrWidth;
+        LinearLayout.LayoutParams artParams;
+        if (landscape) {
+            artView = new ImageView(getContext()) {
+                @Override
+                protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                    int desiredWidth = widthMeasureSpec;
+                    int desiredMeasureMode = MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY ?
+                            MeasureSpec.EXACTLY : MeasureSpec.AT_MOST;
+                    if (MeasureSpec.getMode(widthMeasureSpec) != MeasureSpec.EXACTLY) {
+                        Drawable drawable = getDrawable();
+                        if (drawable != null) {
+                            int intrHeight = drawable.getIntrinsicHeight();
+                            int intrWidth = drawable.getIntrinsicWidth();
+                            int originalHeight = MeasureSpec.getSize(heightMeasureSpec);
+                            if (intrHeight < intrWidth) {
+                                desiredWidth = MeasureSpec.makeMeasureSpec(
+                                        originalHeight, desiredMeasureMode);
+                            } else {
+                                desiredWidth = MeasureSpec.makeMeasureSpec(
+                                        Math.round((float) originalHeight * intrWidth / intrHeight),
+                                        desiredMeasureMode);
+                            }
                         }
-                        desiredHeight = MeasureSpec.makeMeasureSpec((int) (intrHeight * scale + 0.5f), MeasureSpec.EXACTLY);
                     }
+                    super.onMeasure(desiredWidth, heightMeasureSpec);
                 }
+            };
+            artParams = new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT);
+            MarginLayoutParamsCompat.setMarginStart(artParams,
+                    getContext().getResources().getDimensionPixelSize(R.dimen.media_router_controller_playback_control_horizontal_spacing));
+        } else {
+            artView = new ImageView(getContext()) {
+                @Override
+                protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                    int desiredHeight = heightMeasureSpec;
+                    if (MeasureSpec.getMode(heightMeasureSpec) != MeasureSpec.EXACTLY) {
+                        Drawable drawable = getDrawable();
+                        if (drawable != null) {
+                            int originalWidth = MeasureSpec.getSize(widthMeasureSpec);
+                            int intrHeight = drawable.getIntrinsicHeight();
+                            int intrWidth = drawable.getIntrinsicWidth();
+                            float scale;
+                            if (intrHeight*16 > intrWidth*9) {
+                                // image is taller than 16:9
+                                scale = (float) originalWidth * 9 / 16 / intrHeight;
+                            } else {
+                                // image is more horizontal than 16:9
+                                scale = (float) originalWidth / intrWidth;
+                            }
+                            desiredHeight = MeasureSpec.makeMeasureSpec(
+                                    Math.round(intrHeight * scale),
+                                    MeasureSpec.EXACTLY);
+                        }
+                    }
+                    super.onMeasure(widthMeasureSpec, desiredHeight);
+                }
+            };
+            artParams = new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+        artView.setTag(landscape);
 
-                super.onMeasure(widthMeasureSpec, desiredHeight);
-            }
-        };
-        artView.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT));
         artView.setScaleType(ImageView.ScaleType.FIT_CENTER);
         artView.setOnClickListener(onClickListener);
 
+        artView.setLayoutParams(artParams);
         rootView.addView(artView);
-        View playbackControlLayout = View.inflate(getContext(), R.layout.media_router_controller, rootView);
+
+        ViewGroup wrapper = rootView;
+
+        if (landscape) {
+            wrapper = new FrameLayout(getContext());
+            wrapper.setLayoutParams(new LinearLayout.LayoutParams(
+                    0,
+                    ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            rootView.addView(wrapper);
+            rootView.setWeightSum(1f);
+        }
+
+        View playbackControlLayout = View.inflate(getContext(), R.layout.media_router_controller, wrapper);
 
         titleView = (TextView) playbackControlLayout.findViewById(R.id.mrc_control_title);
         subtitleView = (TextView) playbackControlLayout.findViewById(R.id.mrc_control_subtitle);
@@ -179,7 +271,8 @@ public class CustomMRControllerDialog extends MediaRouteControllerDialog {
                     event.setPackageName(getContext().getPackageName());
                     event.setClassName(getClass().getName());
                     int resId = isPlaying ?
-                            android.support.v7.mediarouter.R.string.mr_controller_pause : android.support.v7.mediarouter.R.string.mr_controller_play;
+                            android.support.v7.mediarouter.R.string.mr_controller_pause :
+                            android.support.v7.mediarouter.R.string.mr_controller_play;
                     event.getText().add(getContext().getString(resId));
                     accessibilityManager.sendAccessibilityEvent(event);
                 }
@@ -270,14 +363,20 @@ public class CustomMRControllerDialog extends MediaRouteControllerDialog {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     fetchArtSubscription = null;
+                    if (artView == null) {
+                        return;
+                    }
                     if (result.first != null) {
-                        artView.setBackgroundColor(result.second);
+                        if (!((Boolean) artView.getTag())) {
+                            artView.setBackgroundColor(result.second);
+                        }
                         artView.setImageBitmap(result.first);
                         artView.setVisibility(View.VISIBLE);
                     } else {
                         artView.setVisibility(View.GONE);
                     }
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
+
     }
 
     private void updateState() {

--- a/app/src/play/java/de/danoeh/antennapod/fragment/CustomMRControllerDialogFragment.java
+++ b/app/src/play/java/de/danoeh/antennapod/fragment/CustomMRControllerDialogFragment.java
@@ -1,0 +1,15 @@
+package de.danoeh.antennapod.fragment;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v7.app.MediaRouteControllerDialog;
+import android.support.v7.app.MediaRouteControllerDialogFragment;
+
+import de.danoeh.antennapod.dialog.CustomMRControllerDialog;
+
+public class CustomMRControllerDialogFragment extends MediaRouteControllerDialogFragment {
+    @Override
+    public MediaRouteControllerDialog onCreateControllerDialog(Context context, Bundle savedInstanceState) {
+        return new CustomMRControllerDialog(context);
+    }
+}

--- a/app/src/play/res/layout/media_router_controller.xml
+++ b/app/src/play/res/layout/media_router_controller.xml
@@ -1,50 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
-    <RelativeLayout android:id="@+id/mrc_playback_control"
-        android:layout_width="match_parent"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mrc_playback_control"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/media_router_controller_playback_control_vertical_padding"
+    android:paddingBottom="@dimen/media_router_controller_playback_control_vertical_padding"
+    android:paddingLeft="@dimen/media_router_controller_playback_control_start_padding"
+    android:paddingStart="@dimen/media_router_controller_playback_control_start_padding"
+    android:paddingRight="@dimen/media_router_controller_playback_control_horizontal_spacing"
+    android:paddingEnd="@dimen/media_router_controller_playback_control_horizontal_spacing">
+    <ImageButton android:id="@+id/mrc_control_play_pause"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingTop="16dp"
-        android:paddingBottom="16dp"
-        android:paddingLeft="24dp"
-        android:paddingStart="24dp"
-        android:paddingRight="12dp"
-        android:paddingEnd="12dp">
-        <ImageButton android:id="@+id/mrc_control_play_pause"
+        android:layout_marginLeft="@dimen/media_router_controller_playback_control_horizontal_spacing"
+        android:layout_marginStart="@dimen/media_router_controller_playback_control_horizontal_spacing"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        android:contentDescription="@string/mr_controller_play"
+        android:background="?attr/selectableItemBackgroundBorderless"/>
+
+    <LinearLayout android:id="@+id/mrc_control_title_container"
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_toLeftOf="@id/mrc_control_play_pause"
+        android:layout_toStartOf="@id/mrc_control_play_pause"
+        android:layout_centerVertical="true">
+        <TextView android:id="@+id/mrc_control_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="12dp"
-            android:layout_marginStart="12dp"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"
-            android:contentDescription="@string/mr_controller_play"
-            android:background="?attr/selectableItemBackgroundBorderless"/>
-
-        <LinearLayout android:id="@+id/mrc_control_title_container"
-            android:orientation="vertical"
+            android:textAppearance="?attr/mediaRouteControllerPrimaryTextStyle"/>
+        <TextView android:id="@+id/mrc_control_subtitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_toLeftOf="@id/mrc_control_play_pause"
-            android:layout_toStartOf="@id/mrc_control_play_pause"
-            android:layout_centerVertical="true">
-            <TextView android:id="@+id/mrc_control_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="?attr/mediaRouteControllerPrimaryTextStyle"/>
-            <TextView android:id="@+id/mrc_control_subtitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="?attr/mediaRouteControllerSecondaryTextStyle"
-                android:singleLine="true" />
-        </LinearLayout>
-    </RelativeLayout>
-
-    <View android:id="@+id/mrc_control_divider"
-        android:layout_width="fill_parent"
-        android:layout_height="8dp"/>
-</LinearLayout>
+            android:textAppearance="?attr/mediaRouteControllerSecondaryTextStyle"
+            android:singleLine="true" />
+    </LinearLayout>
+</RelativeLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1024,6 +1024,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 }
             }
             if (!Thread.currentThread().isInterrupted() && started) {
+                //TODO mediaSession.setSessionActivity();
                 mediaSession.setMetadata(builder.build());
             }
         };

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -29,6 +29,7 @@ import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
+import android.support.v4.view.InputDeviceCompat;
 import android.support.v7.app.NotificationCompat;
 import android.text.TextUtils;
 import android.util.Log;
@@ -41,8 +42,8 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.Target;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
@@ -300,7 +301,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         List<MediaSessionCompat.QueueItem> queueItems = new ArrayList<>();
         try {
-            for (FeedItem feedItem: taskManager.getQueue()) {
+            for (FeedItem feedItem : taskManager.getQueue()) {
                 queueItems.add(new MediaSessionCompat.QueueItem(feedItem.getMedia().getMediaItem().getDescription(), feedItem.getId()));
             }
             mediaSession.setQueue(queueItems);
@@ -343,7 +344,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     @Override
-    public BrowserRoot onGetRoot(String clientPackageName, int clientUid, Bundle rootHints) {
+    public BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, Bundle rootHints) {
         Log.d(TAG, "OnGetRoot: clientPackageName=" + clientPackageName +
                 "; clientUid=" + clientUid + " ; rootHints=" + rootHints);
         return new BrowserRoot(
@@ -361,10 +362,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     @Override
-    public void onLoadChildren(String parentId,
-                               Result<List<MediaBrowserCompat.MediaItem>> result) {
+    public void onLoadChildren(@NonNull String parentId,
+                               @NonNull Result<List<MediaBrowserCompat.MediaItem>> result) {
         Log.d(TAG, "OnLoadChildren: parentMediaId=" + parentId);
-        List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<MediaBrowserCompat.MediaItem>();
+        List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
         if (parentId.equals(getResources().getString(R.string.app_name))) {
             // Root List
             mediaItems.add(createBrowsableMediaItemForRoot());
@@ -409,7 +410,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             if (keycode != -1) {
                 Log.d(TAG, "Received media button event");
                 handleKeycode(keycode, intent.getIntExtra(MediaButtonReceiver.EXTRA_SOURCE,
-                        InputDevice.SOURCE_CLASS_NONE));
+                        InputDeviceCompat.SOURCE_CLASS_NONE));
             } else if (!flavorHelper.castDisconnect(castDisconnect)) {
                 started = true;
                 boolean stream = intent.getBooleanExtra(EXTRA_SHOULD_STREAM,
@@ -1024,7 +1025,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 }
             }
             if (!Thread.currentThread().isInterrupted() && started) {
-                //TODO mediaSession.setSessionActivity();
+                mediaSession.setSessionActivity(PendingIntent.getActivity(this, 0,
+                        PlaybackService.getPlayerActivityIntent(this),
+                        PendingIntent.FLAG_UPDATE_CURRENT));
                 mediaSession.setMetadata(builder.build());
             }
         };
@@ -1171,8 +1174,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                             .setShowActionsInCompactView(compactActionList.toArray())
                             .setShowCancelButton(true)
                             .setCancelButtonIntent(stopButtonPendingIntent))
-                            .setVisibility(Notification.VISIBILITY_PUBLIC)
-                            .setColor(Notification.COLOR_DEFAULT);
+                            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                            .setColor(NotificationCompat.COLOR_DEFAULT);
 
                     notification = notificationBuilder.build();
 

--- a/core/src/main/res/values-land/dimens.xml
+++ b/core/src/main/res/values-land/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="media_router_controller_playback_control_start_padding">@dimen/media_router_controller_playback_control_horizontal_spacing</dimen>
+</resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -36,4 +36,9 @@
 
     <dimen name="audioplayer_playercontrols_length">48dp</dimen>
 
+    <dimen name="media_router_controller_playback_control_vertical_padding">16dp</dimen>
+    <dimen name="media_router_controller_playback_control_horizontal_spacing">12dp</dimen>
+    <dimen name="media_router_controller_playback_control_start_padding">24dp</dimen>
+    <dimen name="media_router_controller_bottom_margin">8dp</dimen>
+
 </resources>

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -75,9 +75,8 @@ public class PlaybackServiceFlavorHelper {
     boolean castDisconnect(boolean castDisconnect) {
         if (castDisconnect) {
             castManager.disconnect();
-            return true;
         }
-        return false;
+        return castDisconnect;
     }
 
     boolean onMediaPlayerInfo(Context context, int code, @StringRes int resourceId) {


### PR DESCRIPTION
This was really a pain. Horizontal LinearLayout's behavior is to first resolve the widths of its children and only then figure out any height restrictions. For a child view that imposes a certain aspect ratio, this means that once the height changes, its width is also going to change, but at that point the width is already fixed for all the other children, and LinearLayout doesn't ask them to update their dimensions.
Solution: override onMeasure on the LinearLayout to have a first pass through its children heights.