### PR TITLE
Make gpodnet sync error notifications optional

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -118,5 +118,14 @@ public class PreferenceActivity extends AppCompatActivity {
                 activity.preferenceController.onResume();
             }
         }
+
+        @Override
+        public void onPause() {
+            PreferenceActivity activity = instance.get();
+            if(activity != null && activity.preferenceController != null) {
+                activity.preferenceController.onPause();
+            }
+            super.onPause();
+        }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivityGingerbread.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivityGingerbread.java
@@ -55,6 +55,12 @@ public class PreferenceActivityGingerbread extends android.preference.Preference
     }
 
     @Override
+    protected void onPause() {
+        preferenceController.onPause();
+        super.onPause();
+    }
+
+    @Override
     protected void onApplyThemeResource(Theme theme, int resid, boolean first) {
         theme.applyStyle(UserPreferences.getTheme(), true);
     }

--- a/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
@@ -6,7 +6,7 @@ import android.content.res.Configuration;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -40,7 +40,7 @@ import de.danoeh.antennapod.core.service.GpodnetSyncService;
  * Step 2: Choose device from a list of available devices or create a new one
  * Step 3: Choose from a list of actions
  */
-public class GpodnetAuthenticationActivity extends ActionBarActivity {
+public class GpodnetAuthenticationActivity extends AppCompatActivity {
     private static final String TAG = "GpodnetAuthActivity";
 
     private static final String CURRENT_STEP = "current_step";

--- a/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
@@ -11,6 +11,8 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -113,6 +115,9 @@ public class GpodnetAuthenticationActivity extends AppCompatActivity {
         final TextView txtvError = (TextView) view.findViewById(R.id.txtvError);
         final ProgressBar progressBar = (ProgressBar) view.findViewById(R.id.progBarLogin);
 
+        password.setOnEditorActionListener((v, actionID, event) ->
+            actionID == EditorInfo.IME_ACTION_GO && login.performClick());
+
         login.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -131,6 +136,11 @@ public class GpodnetAuthenticationActivity extends AppCompatActivity {
                         login.setEnabled(false);
                         progressBar.setVisibility(View.VISIBLE);
                         txtvError.setVisibility(View.GONE);
+                        // hide the keyboard
+                        InputMethodManager inputManager = (InputMethodManager)
+                                getSystemService(Context.INPUT_METHOD_SERVICE);
+                        inputManager.hideSoftInputFromWindow(login.getWindowToken(),
+                                InputMethodManager.HIDE_NOT_ALWAYS);
 
                     }
 

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -123,6 +123,14 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         }
     }
 
+    private final SharedPreferences.OnSharedPreferenceChangeListener gpoddernetListener =
+            (sharedPreferences, key) -> {
+                if (GpodnetPreferences.PREF_LAST_SYNC_ATTEMPT_TIMESTAMP.equals(key)) {
+                    updateLastGpodnetSyncReport(GpodnetPreferences.getLastSyncAttemptResult(),
+                            GpodnetPreferences.getLastSyncAttemptTimestamp());
+                }
+            };
+
     /**
      * Returns the preference activity that should be used on this device.
      *
@@ -436,15 +444,12 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         setParallelDownloadsText(UserPreferences.getParallelDownloads());
         setEpisodeCacheSizeText(UserPreferences.getEpisodeCacheSize());
         setDataFolderText();
-        GpodnetPreferences.setSyncAttemptListener(() -> ui.getActivity().runOnUiThread(
-                () -> updateLastGpodnetSyncReport(
-                        GpodnetPreferences.getLastSyncAttemptResult(),
-                        GpodnetPreferences.getLastSyncAttemptTimestamp())));
+        GpodnetPreferences.registerOnSharedPreferenceChangeListener(gpoddernetListener);
         updateGpodnetPreferenceScreen();
     }
 
     public void onPause() {
-        GpodnetPreferences.setSyncAttemptListener(null);
+        GpodnetPreferences.unregisterOnSharedPreferenceChangeListener(gpoddernetListener);
     }
 
     @SuppressLint("NewApi")

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -91,7 +91,6 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
     public static final String PREF_GPODNET_LOGOUT = "pref_gpodnet_logout";
     public static final String PREF_GPODNET_HOSTNAME = "pref_gpodnet_hostname";
     public static final String PREF_GPODNET_NOTIFICATIONS = "pref_gpodnet_notifications";
-    public static final String PREF_GPODNET_SYNC_REPORT = "pref_gpodnet_sync_report";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_PROXY = "prefProxy";
     public static final String PREF_KNOWN_ISSUES = "prefKnownIssues";
@@ -510,24 +509,20 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
     }
 
     private void updateLastGpodnetSyncReport(boolean successful, long lastTime) {
-        Preference syncReport = ui.findPreference(PREF_GPODNET_SYNC_REPORT);
+        Preference sync = ui.findPreference(PREF_GPODNET_SYNC);
         if (lastTime != 0) {
-            syncReport.setTitle(ui.getActivity().getString(R.string.pref_gpodnet_last_sync_title,
-                    ui.getActivity().getString(successful ?
-                            R.string.gpodnetsync_pref_report_successful :
-                            R.string.gpodnetsync_pref_report_failed)));
-            syncReport.setSummary(DateUtils.getRelativeDateTimeString(
-                    ui.getActivity(),
-                    lastTime,
-                    DateUtils.MINUTE_IN_MILLIS,
-                    DateUtils.WEEK_IN_MILLIS,
-                    DateUtils.FORMAT_SHOW_TIME));
-            syncReport.setEnabled(true);
+            sync.setSummary(ui.getActivity().getString(R.string.pref_gpodnet_sync_sum) + "\n" +
+                    ui.getActivity().getString(R.string.pref_gpodnet_sync_sum_last_sync_line,
+                            ui.getActivity().getString(successful ?
+                                    R.string.gpodnetsync_pref_report_successful :
+                                    R.string.gpodnetsync_pref_report_failed),
+                            DateUtils.getRelativeDateTimeString(ui.getActivity(),
+                                    lastTime,
+                                    DateUtils.MINUTE_IN_MILLIS,
+                                    DateUtils.WEEK_IN_MILLIS,
+                                    DateUtils.FORMAT_SHOW_TIME)));
         } else {
-            syncReport.setTitle(ui.getActivity().getString(R.string.pref_gpodnet_last_sync_title,
-                    ui.getActivity().getString(R.string.gpodnetsync_pref_report_undetermined)));
-            syncReport.setSummary(null);
-            syncReport.setEnabled(false);
+            sync.setSummary(ui.getActivity().getString(R.string.pref_gpodnet_sync_sum));
         }
     }
 

--- a/app/src/main/res/layout/gpodnetauth_credentials.xml
+++ b/app/src/main/res/layout/gpodnetauth_credentials.xml
@@ -33,7 +33,11 @@
         android:layout_margin="8dp"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:cursorVisible="true"/>
+        android:cursorVisible="true"
+        android:maxLines="1"
+        android:inputType="text"
+        android:imeOptions="actionNext"
+        android:nextFocusForward="@id/etxtPassword"/>
 
     <EditText
         android:id="@+id/etxtPassword"
@@ -45,7 +49,9 @@
         android:layout_margin="8dp"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:cursorVisible="true"/>
+        android:cursorVisible="true"
+        android:imeOptions="actionGo"
+        android:imeActionLabel="@string/gpodnetauth_login_butLabel"/>
 
     <Button
         android:id="@+id/butLogin"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -74,7 +74,6 @@
             android:key="prefQueueAddToFront"
             android:summary="@string/pref_queueAddToFront_sum"
             android:title="@string/pref_queueAddToFront_title"/>
-        />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/playback_pref">
@@ -233,7 +232,7 @@
                 android:title="@string/pref_revokeAccess_title"/>
         </PreferenceScreen>
         <PreferenceScreen
-            android:key="prefFlattrSettings"
+            android:key="prefGpodderSettings"
             android:title="@string/gpodnet_main_label">
 
             <PreferenceScreen
@@ -256,6 +255,16 @@
             <Preference
                 android:key="pref_gpodnet_hostname"
                 android:title="@string/pref_gpodnet_sethostname_title"/>
+            <de.danoeh.antennapod.preferences.SwitchCompatPreference
+                android:key="pref_gpodnet_notifications"
+                android:title="@string/pref_gpodnet_notifications_title"
+                android:summary="@string/pref_gpodnet_notifications_sum"
+                android:defaultValue="true"/>
+            <Preference android:key="pref_gpodnet_sync_report"
+                android:title="@string/pref_gpodnet_last_sync_title"
+                android:selectable="false"
+                android:enabled="false"
+                android:shouldDisableView="true"/>
         </PreferenceScreen>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/storage_pref">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -249,6 +249,11 @@
                 android:key="pref_gpodnet_sync"
                 android:title="@string/pref_gpodnet_sync_title"
                 android:summary="@string/pref_gpodnet_sync_sum"/>
+            <Preference android:key="pref_gpodnet_sync_report"
+                android:title="@string/pref_gpodnet_last_sync_title"
+                android:selectable="false"
+                android:enabled="false"
+                android:shouldDisableView="true"/>
             <Preference
                 android:key="pref_gpodnet_logout"
                 android:title="@string/pref_gpodnet_logout_title"/>
@@ -260,11 +265,6 @@
                 android:title="@string/pref_gpodnet_notifications_title"
                 android:summary="@string/pref_gpodnet_notifications_sum"
                 android:defaultValue="true"/>
-            <Preference android:key="pref_gpodnet_sync_report"
-                android:title="@string/pref_gpodnet_last_sync_title"
-                android:selectable="false"
-                android:enabled="false"
-                android:shouldDisableView="true"/>
         </PreferenceScreen>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/storage_pref">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -251,7 +251,6 @@
                 android:summary="@string/pref_gpodnet_sync_sum"/>
             <Preference android:key="pref_gpodnet_sync_report"
                 android:title="@string/pref_gpodnet_last_sync_title"
-                android:selectable="false"
                 android:enabled="false"
                 android:shouldDisableView="true"/>
             <Preference

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -249,10 +249,6 @@
                 android:key="pref_gpodnet_sync"
                 android:title="@string/pref_gpodnet_sync_title"
                 android:summary="@string/pref_gpodnet_sync_sum"/>
-            <Preference android:key="pref_gpodnet_sync_report"
-                android:title="@string/pref_gpodnet_last_sync_title"
-                android:enabled="false"
-                android:shouldDisableView="true"/>
             <Preference
                 android:key="pref_gpodnet_logout"
                 android:title="@string/pref_gpodnet_logout_title"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
@@ -62,12 +62,20 @@ public class GpodnetPreferences {
 
     private static boolean lastSyncAttemptResult;
 
-    private static Runnable syncAttemptListener;
-
     private static boolean preferencesLoaded = false;
 
     private static SharedPreferences getPreferences() {
         return ClientConfig.applicationCallbacks.getApplicationInstance().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static void registerOnSharedPreferenceChangeListener(
+            SharedPreferences.OnSharedPreferenceChangeListener listener) {
+        getPreferences().registerOnSharedPreferenceChangeListener(listener);
+    }
+
+    public static void unregisterOnSharedPreferenceChangeListener(
+            SharedPreferences.OnSharedPreferenceChangeListener listener) {
+        getPreferences().unregisterOnSharedPreferenceChangeListener(listener);
     }
 
     private static synchronized void ensurePreferencesLoaded() {
@@ -178,9 +186,6 @@ public class GpodnetPreferences {
         GpodnetPreferences.lastSyncAttemptTimestamp = timestamp;
         writePreference(PREF_LAST_SYNC_ATTEMPT_RESULT, result);
         writePreference(PREF_LAST_SYNC_ATTEMPT_TIMESTAMP, timestamp);
-        if (timestamp != 0 && syncAttemptListener != null) {
-            syncAttemptListener.run();
-        }
     }
 
     public static String getHostname() {
@@ -307,10 +312,6 @@ public class GpodnetPreferences {
         setLastSubscriptionSyncTimestamp(0);
         setLastSyncAttempt(false, 0);
         UserPreferences.setGpodnetNotificationsEnabled();
-    }
-
-    public static void setSyncAttemptListener(Runnable listener) {
-        syncAttemptListener = listener;
     }
 
     private static Set<String> readListFromString(String s) {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -92,6 +92,7 @@ public class UserPreferences {
     // Services
     public static final String PREF_AUTO_FLATTR = "pref_auto_flattr";
     public static final String PREF_AUTO_FLATTR_PLAYED_DURATION_THRESHOLD = "prefAutoFlattrPlayedDurationThreshold";
+    public static final String PREF_GPODNET_NOTIFICATIONS = "pref_gpodnet_notifications";
 
     // Other
     public static final String PREF_DATA_FOLDER = "prefDataFolder";
@@ -544,6 +545,16 @@ public class UserPreferences {
              .putBoolean(PREF_AUTO_FLATTR, enabled)
              .putFloat(PREF_AUTO_FLATTR_PLAYED_DURATION_THRESHOLD, autoFlattrThreshold)
              .apply();
+    }
+
+    public static boolean gpodnetNotificationsEnabled() {
+        return prefs.getBoolean(PREF_GPODNET_NOTIFICATIONS, true);
+    }
+
+    public static void setGpodnetNotificationsEnabled() {
+        prefs.edit()
+                .putBoolean(PREF_GPODNET_NOTIFICATIONS, true)
+                .apply();
     }
 
     public static void setHiddenDrawerItems(List<String> items) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -301,6 +301,7 @@ public class GpodnetSyncService extends Service {
 
     private void updateErrorNotification(GpodnetServiceException exception) {
      Log.d(TAG, "Posting error notification");
+        GpodnetPreferences.setLastSyncAttempt(false, System.currentTimeMillis());
 
         final String title;
         final String description;
@@ -310,7 +311,6 @@ public class GpodnetSyncService extends Service {
             description = getString(R.string.gpodnetsync_auth_error_descr);
             id = R.id.notification_gpodnet_sync_autherror;
         } else {
-            GpodnetPreferences.setLastSyncAttempt(false, System.currentTimeMillis());
             if (UserPreferences.gpodnetNotificationsEnabled()) {
                 title = getString(R.string.gpodnetsync_error_title);
                 description = getString(R.string.gpodnetsync_error_descr) + exception.getMessage();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -30,6 +30,7 @@ import de.danoeh.antennapod.core.gpoddernet.model.GpodnetEpisodeActionPostRespon
 import de.danoeh.antennapod.core.gpoddernet.model.GpodnetSubscriptionChange;
 import de.danoeh.antennapod.core.gpoddernet.model.GpodnetUploadChangesResponse;
 import de.danoeh.antennapod.core.preferences.GpodnetPreferences;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -107,7 +108,7 @@ public class GpodnetSyncService extends Service {
 
 
     private synchronized void sync() {
-        if (GpodnetPreferences.loggedIn() == false || NetworkUtils.networkAvailable() == false) {
+        if (!GpodnetPreferences.loggedIn() || !NetworkUtils.networkAvailable()) {
             stopSelf();
             return;
         }
@@ -161,6 +162,7 @@ public class GpodnetSyncService extends Service {
                 GpodnetPreferences.removeRemovedFeeds(localRemoved);
             }
             GpodnetPreferences.setLastSubscriptionSyncTimestamp(newTimeStamp);
+            GpodnetPreferences.setLastSyncAttempt(true, System.currentTimeMillis());
             clearErrorNotifications();
         } catch (GpodnetServiceException e) {
             e.printStackTrace();
@@ -177,15 +179,15 @@ public class GpodnetSyncService extends Service {
         // local changes are always superior to remote changes!
         // add subscription if (1) not already subscribed and (2) not just unsubscribed
         for (String downloadUrl : changes.getAdded()) {
-            if (false == localSubscriptions.contains(downloadUrl) &&
-                    false == localRemoved.contains(downloadUrl)) {
+            if (!localSubscriptions.contains(downloadUrl) &&
+                    !localRemoved.contains(downloadUrl)) {
                 Feed feed = new Feed(downloadUrl, null);
                 DownloadRequester.getInstance().downloadFeed(this, feed);
             }
         }
         // remove subscription if not just subscribed (again)
         for (String downloadUrl : changes.getRemoved()) {
-            if(false == localAdded.contains(downloadUrl)) {
+            if(!localAdded.contains(downloadUrl)) {
                 DBTasks.removeFeedWithDownloadUrl(GpodnetSyncService.this, downloadUrl);
             }
         }
@@ -215,6 +217,7 @@ public class GpodnetSyncService extends Service {
                 GpodnetPreferences.removeQueuedEpisodeActions(localActions);
             }
             GpodnetPreferences.setLastEpisodeActionsSyncTimestamp(lastUpdate);
+            GpodnetPreferences.setLastSyncAttempt(true, System.currentTimeMillis());
             clearErrorNotifications();
         } catch (GpodnetServiceException e) {
             e.printStackTrace();
@@ -299,7 +302,6 @@ public class GpodnetSyncService extends Service {
     private void updateErrorNotification(GpodnetServiceException exception) {
      Log.d(TAG, "Posting error notification");
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
         final String title;
         final String description;
         final int id;
@@ -308,18 +310,24 @@ public class GpodnetSyncService extends Service {
             description = getString(R.string.gpodnetsync_auth_error_descr);
             id = R.id.notification_gpodnet_sync_autherror;
         } else {
-            title = getString(R.string.gpodnetsync_error_title);
-            description = getString(R.string.gpodnetsync_error_descr) + exception.getMessage();
-            id = R.id.notification_gpodnet_sync_error;
+            GpodnetPreferences.setLastSyncAttempt(false, System.currentTimeMillis());
+            if (UserPreferences.gpodnetNotificationsEnabled()) {
+                title = getString(R.string.gpodnetsync_error_title);
+                description = getString(R.string.gpodnetsync_error_descr) + exception.getMessage();
+                id = R.id.notification_gpodnet_sync_error;
+            } else {
+                return;
+            }
         }
 
         PendingIntent activityIntent = ClientConfig.gpodnetCallbacks.getGpodnetSyncServiceErrorNotificationPendingIntent(this);
-        Notification notification = builder.setContentTitle(title)
+        Notification notification = new NotificationCompat.Builder(this)
+                .setContentTitle(title)
                 .setContentText(description)
                 .setContentIntent(activityIntent)
                 .setSmallIcon(R.drawable.stat_notify_sync_error)
                 .setAutoCancel(true)
-                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .build();
         NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         nm.notify(id, notification);

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -365,12 +365,12 @@
     <string name="pref_gpodnet_setlogin_information_title">Change login information</string>
     <string name="pref_gpodnet_setlogin_information_sum">Change the login information for your gpodder.net account.</string>
     <string name="pref_gpodnet_sync_title">Sync now</string>
-    <string name="pref_gpodnet_sync_sum">Sync subscriptions and episode states with gpodder.net</string>
+    <string name="pref_gpodnet_sync_sum">Sync subscriptions and episode states with gpodder.net.</string>
+    <string name="pref_gpodnet_sync_sum_last_sync_line">Last sync attempt: %1$s (%2$s)</string>
     <string name="pref_gpodnet_sync_started">Sync started</string>
     <string name="pref_gpodnet_login_status"><![CDATA[Logged in as <i>%1$s</i> with device <i>%2$s</i>]]></string>
     <string name="pref_gpodnet_notifications_title">Show sync error notifications</string>
     <string name="pref_gpodnet_notifications_sum">This setting does not apply to authentication errors.</string>
-    <string name="pref_gpodnet_last_sync_title">Last sync attempt: %1$s</string>
     <string name="pref_playback_speed_title">Playback Speeds</string>
     <string name="pref_playback_speed_sum">Customize the speeds available for variable speed audio playback</string>
     <string name="pref_fast_forward">Fast forward time</string>
@@ -507,7 +507,6 @@
     <string name="gpodnetsync_error_descr">An error occurred during syncing:\u0020</string>
     <string name="gpodnetsync_pref_report_successful">Successful</string>
     <string name="gpodnetsync_pref_report_failed">Failed</string>
-    <string name="gpodnetsync_pref_report_undetermined">Never</string>
 
     <!-- Directory chooser -->
     <string name="selected_folder_label">Selected folder:</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -368,6 +368,9 @@
     <string name="pref_gpodnet_sync_sum">Sync subscriptions and episode states with gpodder.net</string>
     <string name="pref_gpodnet_sync_started">Sync started</string>
     <string name="pref_gpodnet_login_status"><![CDATA[Logged in as <i>%1$s</i> with device <i>%2$s</i>]]></string>
+    <string name="pref_gpodnet_notifications_title">Show sync error notifications</string>
+    <string name="pref_gpodnet_notifications_sum">This setting does not apply to authentication errors.</string>
+    <string name="pref_gpodnet_last_sync_title">Last sync attempt: %1$s</string>
     <string name="pref_playback_speed_title">Playback Speeds</string>
     <string name="pref_playback_speed_sum">Customize the speeds available for variable speed audio playback</string>
     <string name="pref_fast_forward">Fast forward time</string>
@@ -502,6 +505,9 @@
     <string name="gpodnetsync_auth_error_descr">Wrong username or password</string>
     <string name="gpodnetsync_error_title">gpodder.net sync error</string>
     <string name="gpodnetsync_error_descr">An error occurred during syncing:\u0020</string>
+    <string name="gpodnetsync_pref_report_successful">Successful</string>
+    <string name="gpodnetsync_pref_report_failed">Failed</string>
+    <string name="gpodnetsync_pref_report_undetermined">Undetermined</string>
 
     <!-- Directory chooser -->
     <string name="selected_folder_label">Selected folder:</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -507,7 +507,7 @@
     <string name="gpodnetsync_error_descr">An error occurred during syncing:\u0020</string>
     <string name="gpodnetsync_pref_report_successful">Successful</string>
     <string name="gpodnetsync_pref_report_failed">Failed</string>
-    <string name="gpodnetsync_pref_report_undetermined">Undetermined</string>
+    <string name="gpodnetsync_pref_report_undetermined">Never</string>
 
     <!-- Directory chooser -->
     <string name="selected_folder_label">Selected folder:</string>


### PR DESCRIPTION
on the gpodnet preferences, it adds an option that prevents sync error notifications from being shown. It does not apply to authentication errors.
It also includes another item that all it does is to show the result of the last sync attempt and when it occurred.