### PR TITLE
Use MIME types in OPML import intent filter (fixes #1758)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -175,16 +175,15 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
 
-                <data
-                    android:host="*"
-                    android:pathPattern=".*\\.opml"
-                    android:scheme="file"
-                    android:mimeType="*/*"/>
-                <data
-                    android:host="*"
-                    android:pathPattern=".*\\.opml"
-                    android:scheme="content"
-                    android:mimeType="*/*"/>
+                <data android:mimeType="text/xml"/>
+                <data android:mimeType="text/x-opml"/>
+                <data android:mimeType="application/xml"/>
+                <data android:mimeType="application/octet-stream"/>
+
+                <data android:scheme="file"/>
+                <data android:scheme="content"/>
+
+                <data android:host="*"/>
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
Using an intent filter based on file extensions is unreliable: for example, K-9 Mail sends out intents with URI's like `content://com.fsck.k9.debug.attachmentprovider/75a212fa-2aa8-473c-ad4d-e4e86eff0bf7/5` when opening attachments, meaning any `intent-filter` relying on catching `*.opml` files will fail; also, extra dots in a file's path will break wildcard characters in `android:pathPattern`.

Using MIME types is currently the best option available. OPML files are often detected as `application/octet-stream` (a catch-all for unknown types) meaning the intent filter will catch files such as `.nomedia` etc., but I think that the amount of such files a user will come across is small enough that it won't really matter.

Fixes #1758