### PR TITLE
Fix issue where mini player doesn't show up

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -386,7 +386,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     @Override
     public IBinder onBind(Intent intent) {
         Log.d(TAG, "Received onBind event");
-        if(intent.getAction() != null && intent.getAction().equals("android.media.browse.MediaBrowserService")) {
+        if(intent.getAction() != null && TextUtils.equals(intent.getAction(), MediaBrowserServiceCompat.SERVICE_INTERFACE)) {
             return super.onBind(intent);
         } else {
             return mBinder;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -209,6 +209,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
     private static volatile MediaType currentMediaType = MediaType.UNKNOWN;
 
+    private final IBinder mBinder = new LocalBinder();
+
     public class LocalBinder extends Binder {
         public PlaybackService getService() {
             return PlaybackService.this;
@@ -384,7 +386,11 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     @Override
     public IBinder onBind(Intent intent) {
         Log.d(TAG, "Received onBind event");
-        return super.onBind(intent);
+        if(intent.getAction() != null && intent.getAction().equals("android.media.browse.MediaBrowserService")) {
+            return super.onBind(intent);
+        } else {
+            return mBinder;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix binding issues by only using the MediaBrowserService onBind when the intent's action is MediaBrowserService and otherwise returning the LocalBinder. See issue introduced in https://github.com/AntennaPod/AntennaPod/pull/2053
