### PR TITLE
change check for wifi connection to metered connection

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -76,7 +76,7 @@ import de.danoeh.antennapod.core.util.InvalidFeedException;
 import de.greenrobot.event.EventBus;
 
 /**
- * Manages the download of feedfiles in the app. Downloads can be enqueued viathe startService intent.
+ * Manages the download of feedfiles in the app. Downloads can be enqueued via the startService intent.
  * The argument of the intent is an instance of DownloadRequest in the EXTRA_REQUEST field of
  * the intent.
  * After the downloads have finished, the downloaded object will be passed on to a specific handler, depending on the
@@ -199,10 +199,10 @@ public class DownloadService extends Service {
                                 if(type == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                                     long id = status.getFeedfileId();
                                     FeedMedia media = DBReader.getFeedMedia(id);
-                                    if(media == null || media.getItem() == null) {
+                                    FeedItem item;
+                                    if(media == null || (item = media.getItem()) == null) {
                                         return;
                                     }
-                                    FeedItem item = media.getItem();
                                     boolean httpNotFound = status.getReason() == DownloadError.ERROR_HTTP_DATA_ERROR
                                             && String.valueOf(HttpURLConnection.HTTP_NOT_FOUND).equals(status.getReasonDetailed());
                                     boolean forbidden = status.getReason() == DownloadError.ERROR_FORBIDDEN
@@ -221,7 +221,11 @@ public class DownloadService extends Service {
                             // so that lists reload that it
                             if(status.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                                 FeedMedia media = DBReader.getFeedMedia(status.getFeedfileId());
-                                EventBus.getDefault().post(FeedItemEvent.updated(media.getItem()));
+                                FeedItem item;
+                                if(media == null || (item = media.getItem()) == null) {
+                                    return;
+                                }
+                                EventBus.getDefault().post(FeedItemEvent.updated(item));
                             }
                         }
                         queryDownloadsAsync();

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
+import android.support.v4.net.ConnectivityManagerCompat;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -80,16 +81,13 @@ public class NetworkUtils {
     }
 
 	public static boolean isDownloadAllowed() {
-		return UserPreferences.isAllowMobileUpdate() || NetworkUtils.connectedToWifi();
+		return UserPreferences.isAllowMobileUpdate() || !NetworkUtils.isNetworkMetered();
 	}
 
-	public static boolean connectedToWifi() {
+	public static boolean isNetworkMetered() {
 		ConnectivityManager connManager = (ConnectivityManager) context
 				.getSystemService(Context.CONNECTIVITY_SERVICE);
-		NetworkInfo mWifi = connManager
-				.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-
-		return mWifi.isConnected();
+        return ConnectivityManagerCompat.isActiveNetworkMetered(connManager);
 	}
 
     /**


### PR DESCRIPTION
This resolves #2017 

https://developer.android.com/reference/android/net/ConnectivityManager.html#isActiveNetworkMetered()

See also:
http://stackoverflow.com/questions/23877476/android-why-connectivitymanager-isactivenetworkmetered-always-returning-true
http://blog.maxaller.name/2012/10/mobile-hotspots-conserving-data/

Overall, this seems like a good improvement. Should we change the strings as well and start calling metered, or keep calling it mobile connection even though it could be some weird wifi connection that charges by the transfer volume (I guess those still exist) and somehow android knows about it?