### PR TITLE
Improve MRSS support

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -25,6 +25,9 @@ public class NSMedia extends Namespace {
 	private static final String DURATION = "duration";
 	private static final String DEFAULT = "isDefault";
 
+	private static final String IMAGE = "thumbnail";
+	private static final String IMAGE_URL = "url";
+
 	@Override
 	public SyndElement handleElementStart(String localName, HandlerState state,
 										  Attributes attributes) {
@@ -70,6 +73,22 @@ public class NSMedia extends Namespace {
 					media.setDuration(durationMs);
 				}
 				state.getCurrentItem().setMedia(media);
+			}
+		} else if (IMAGE.equals(localName)) {
+			String url = attributes.getValue(IMAGE_URL);
+			if (url != null) {
+				FeedImage image = new FeedImage();
+				image.setDownload_url(url);
+
+				if (state.getCurrentItem() != null) {
+					image.setOwner(state.getCurrentItem());
+					state.getCurrentItem().setImage(image);
+				} else {
+					if (state.getFeed().getImage() == null) {
+						image.setOwner(state.getFeed());
+						state.getFeed().setImage(image);
+					}
+				}
 			}
 		}
 		return new SyndElement(localName, this);

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -7,8 +7,10 @@ import org.xml.sax.Attributes;
 
 import java.util.concurrent.TimeUnit;
 
+import de.danoeh.antennapod.core.feed.FeedImage;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.syndication.handler.HandlerState;
+import de.danoeh.antennapod.core.syndication.namespace.atom.AtomText;
 import de.danoeh.antennapod.core.syndication.util.SyndTypeUtils;
 
 /** Processes tags from the http://search.yahoo.com/mrss/ namespace. */
@@ -27,6 +29,9 @@ public class NSMedia extends Namespace {
 
 	private static final String IMAGE = "thumbnail";
 	private static final String IMAGE_URL = "url";
+
+	private static final String DESCRIPTION = "description";
+	private static final String DESCRIPTION_TYPE = "type";
 
 	@Override
 	public SyndElement handleElementStart(String localName, HandlerState state,
@@ -90,13 +95,22 @@ public class NSMedia extends Namespace {
 					}
 				}
 			}
+		} else if (DESCRIPTION.equals(localName)) {
+			String type = attributes.getValue(DESCRIPTION_TYPE);
+			return new AtomText(localName, this, type);
 		}
 		return new SyndElement(localName, this);
 	}
 
 	@Override
 	public void handleElementEnd(String localName, HandlerState state) {
-
+		if (DESCRIPTION.equals(localName)) {
+			String content = state.getContentBuf().toString();
+			if (state.getCurrentItem() != null && content != null &&
+				state.getCurrentItem().getDescription() == null) {
+					state.getCurrentItem().setDescription(content);
+			}
+		}
 	}
 }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -26,19 +26,19 @@ public class NSMedia extends Namespace {
 
 	@Override
 	public SyndElement handleElementStart(String localName, HandlerState state,
-			Attributes attributes) {
+										  Attributes attributes) {
 		if (CONTENT.equals(localName)) {
 			String url = attributes.getValue(DOWNLOAD_URL);
 			String type = attributes.getValue(MIME_TYPE);
-            boolean validType;
-            if(SyndTypeUtils.enclosureTypeValid(type)) {
-                validType = true;
-            } else {
-                type = SyndTypeUtils.getValidMimeTypeFromUrl(url);
-                validType = type != null;
-            }
-            if (state.getCurrentItem() != null && state.getCurrentItem().getMedia() == null &&
-                url != null && validType) {
+			boolean validType;
+			if (SyndTypeUtils.enclosureTypeValid(type)) {
+				validType = true;
+			} else {
+				type = SyndTypeUtils.getValidMimeTypeFromUrl(url);
+				validType = type != null;
+			}
+			if (state.getCurrentItem() != null && state.getCurrentItem().getMedia() == null &&
+					url != null && validType) {
 				long size = 0;
 				String sizeStr = attributes.getValue(SIZE);
 				try {
@@ -51,14 +51,14 @@ public class NSMedia extends Namespace {
 				String durationStr = attributes.getValue(DURATION);
 				if (!TextUtils.isEmpty(durationStr)) {
 					try {
-                        long duration = Long.parseLong(durationStr);
+						long duration = Long.parseLong(durationStr);
 						durationMs = (int) TimeUnit.MILLISECONDS.convert(duration, TimeUnit.SECONDS);
 					} catch (NumberFormatException e) {
 						Log.e(TAG, "Duration \"" + durationStr + "\" could not be parsed");
 					}
 				}
 				FeedMedia media = new FeedMedia(state.getCurrentItem(), url, size, type);
-				if(durationMs > 0) {
+				if (durationMs > 0) {
 					media.setDuration(durationMs);
 				}
 				state.getCurrentItem().setMedia(media);
@@ -71,5 +71,4 @@ public class NSMedia extends Namespace {
 	public void handleElementEnd(String localName, HandlerState state) {
 
 	}
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -41,16 +41,15 @@ public class NSMedia extends Namespace {
 			String type = attributes.getValue(MIME_TYPE);
 			String defaultStr = attributes.getValue(DEFAULT);
 			boolean validType;
-			boolean isDefault = false;
+
+			boolean isDefault = "true".equals(defaultStr);
+
 			if (SyndTypeUtils.enclosureTypeValid(type)) {
 				validType = true;
 			} else {
 				type = SyndTypeUtils.getValidMimeTypeFromUrl(url);
 				validType = type != null;
 			}
-
-			if (defaultStr == "true")
-				isDefault = true;
 
 			if (state.getCurrentItem() != null &&
 					(state.getCurrentItem().getMedia() == null || isDefault) &&

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -23,6 +23,7 @@ public class NSMedia extends Namespace {
 	private static final String SIZE = "fileSize";
 	private static final String MIME_TYPE = "type";
 	private static final String DURATION = "duration";
+	private static final String DEFAULT = "isDefault";
 
 	@Override
 	public SyndElement handleElementStart(String localName, HandlerState state,
@@ -30,14 +31,21 @@ public class NSMedia extends Namespace {
 		if (CONTENT.equals(localName)) {
 			String url = attributes.getValue(DOWNLOAD_URL);
 			String type = attributes.getValue(MIME_TYPE);
+			String defaultStr = attributes.getValue(DEFAULT);
 			boolean validType;
+			boolean isDefault = false;
 			if (SyndTypeUtils.enclosureTypeValid(type)) {
 				validType = true;
 			} else {
 				type = SyndTypeUtils.getValidMimeTypeFromUrl(url);
 				validType = type != null;
 			}
-			if (state.getCurrentItem() != null && state.getCurrentItem().getMedia() == null &&
+
+			if (defaultStr == "true")
+				isDefault = true;
+
+			if (state.getCurrentItem() != null &&
+					(state.getCurrentItem().getMedia() == null || isDefault) &&
 					url != null && validType) {
 				long size = 0;
 				String sizeStr = attributes.getValue(SIZE);
@@ -72,3 +80,4 @@ public class NSMedia extends Namespace {
 
 	}
 }
+


### PR DESCRIPTION
Add support for one mrss thumbnail, and description. Closes https://github.com/AntennaPod/AntennaPod/issues/1699

If an enclosure (content) is marked as default it can override an actual enclosure. For feeds that use mrss' content, they usually have the default one also be the enclosure, but if they don't this will still honor the default attribute.