### PR TITLE
fix cover fragment onMediaChanged

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
@@ -69,16 +69,18 @@ public class ChaptersFragment extends ListFragment implements MediaplayerInfoCon
 
     @Override
     public void onMediaChanged(Playable media) {
-        if(this.media == media || adapter == null) {
+        if(this.media == media) {
             return;
         }
         this.media = media;
-        adapter.setMedia(media);
-        adapter.notifyDataSetChanged();
-        if(media == null || media.getChapters() == null || media.getChapters().size() == 0) {
-            setEmptyText(getString(R.string.no_items_label));
-        } else {
-            setEmptyText(null);
+        if (adapter != null) {
+            adapter.setMedia(media);
+            adapter.notifyDataSetChanged();
+            if(media == null || media.getChapters() == null || media.getChapters().size() == 0) {
+                setEmptyText(getString(R.string.no_items_label));
+            } else {
+                setEmptyText(null);
+            }
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -33,22 +33,15 @@ public class CoverFragment extends Fragment implements MediaplayerInfoContentFra
 
     public static CoverFragment newInstance(Playable item) {
         CoverFragment f = new CoverFragment();
-        if (item != null) {
-            Bundle args = new Bundle();
-            args.putParcelable(ARG_PLAYABLE, item);
-            f.setArguments(args);
-        }
+        f.media = item;
         return f;
     }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Bundle args = getArguments();
-        if (args != null) {
-            media = args.getParcelable(ARG_PLAYABLE);
-        } else {
-            Log.e(TAG, TAG + " was called with invalid arguments");
+        if (media == null) {
+            Log.e(TAG, TAG + " was called without media");
         }
     }
 
@@ -98,11 +91,13 @@ public class CoverFragment extends Fragment implements MediaplayerInfoContentFra
 
     @Override
     public void onMediaChanged(Playable media) {
-        if(!isAdded() || this.media == media) {
+        if(this.media == media) {
             return;
         }
         this.media = media;
-        loadMediaInfo();
+        if (isAdded()) {
+            loadMediaInfo();
+        }
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -185,8 +185,10 @@ public class ItemDescriptionFragment extends Fragment implements MediaplayerInfo
         super.onViewCreated(view, savedInstanceState);
         Bundle args = getArguments();
         if (args.containsKey(ARG_PLAYABLE)) {
-            media = args.getParcelable(ARG_PLAYABLE);
-            shownotesProvider = media;
+            if (media == null) {
+                media = args.getParcelable(ARG_PLAYABLE);
+                shownotesProvider = media;
+            }
             load();
         } else if (args.containsKey(ARG_FEEDITEM_ID)) {
             long id = getArguments().getLong(ARG_FEEDITEM_ID);
@@ -377,12 +379,14 @@ public class ItemDescriptionFragment extends Fragment implements MediaplayerInfo
 
     @Override
     public void onMediaChanged(Playable media) {
-        if(this.media == media || webvDescription == null) {
+        if(this.media == media) {
             return;
         }
         this.media = media;
         this.shownotesProvider = media;
-        load();
+        if (webvDescription != null) {
+            load();
+        }
     }
 
 }


### PR DESCRIPTION
I believe this issue hasn't been reported, but this is the way to reproduce it:
while using `MediaPlayerInfoActivity`, for instance while playing an audio episode, if the episode changes (either it ends or we skip) the next episode shows up. However, if go all the way to the chapters page and back to the cover page, the cover of the previous episode will show instead.
Here's my theory: 2 pages away the fragment gets destroyed, but when it is created again, it fetches the media that was passed to it as an argument on its instantiation, which won't be the same as the current media.