### PR TITLE
Set current position to the begining on 'Previous' button

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -110,6 +110,12 @@
             android:summary="@string/pref_hardwareForwardButtonSkips_sum"
             android:title="@string/pref_hardwareForwardButtonSkips_title"/>
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefHardwarePreviousButtonRestarts"
+            android:summary="@string/pref_hardwarePreviousButtonRestarts_sum"
+            android:title="@string/pref_hardwarePreviousButtonRestarts_title"/>
+        <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefFollowQueue"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -65,6 +65,7 @@ public class UserPreferences {
     public static final String PREF_UNPAUSE_ON_HEADSET_RECONNECT = "prefUnpauseOnHeadsetReconnect";
     public static final String PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT = "prefUnpauseOnBluetoothReconnect";
     public static final String PREF_HARDWARE_FOWARD_BUTTON_SKIPS = "prefHardwareForwardButtonSkips";
+    public static final String PREF_HARDWARE_PREVIOUS_BUTTON_RESTARTS = "prefHardwarePreviousButtonRestarts";
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
     public static final String PREF_SKIP_KEEPS_EPISODE = "prefSkipKeepsEpisode";
     public static final String PREF_AUTO_DELETE = "prefAutoDelete";
@@ -280,6 +281,10 @@ public class UserPreferences {
 
     public static boolean shouldHardwareButtonSkip() {
         return prefs.getBoolean(PREF_HARDWARE_FOWARD_BUTTON_SKIPS, false);
+    }
+
+    public static boolean shouldHardwarePreviousButtonRestart() {
+        return prefs.getBoolean(PREF_HARDWARE_PREVIOUS_BUTTON_RESTARTS, false);
     }
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -478,6 +478,14 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 mediaPlayer.seekDelta(UserPreferences.getFastFowardSecs() * 1000);
                 break;
             case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                if(UserPreferences.shouldHardwarePreviousButtonRestart()) {
+                    // user wants to restart current episode
+                    mediaPlayer.seekTo(0);
+                } else {
+                    //  user wants to rewind current episode
+                    mediaPlayer.seekDelta(-UserPreferences.getRewindSecs() * 1000);
+                }
+                break;
             case KeyEvent.KEYCODE_MEDIA_REWIND:
                 mediaPlayer.seekDelta(-UserPreferences.getRewindSecs() * 1000);
                 break;

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -298,6 +298,8 @@
     <string name="pref_unpauseOnBluetoothReconnect_sum">Resume playback when bluetooth reconnects</string>
     <string name="pref_hardwareForwardButtonSkips_title">Forward button skips</string>
     <string name="pref_hardwareForwardButtonSkips_sum">When pressing a hardware forward button skip to the next episode instead of fast-forwarding</string>
+    <string name="pref_hardwarePreviousButtonRestarts_title">Previous button restarts</string>
+    <string name="pref_hardwarePreviousButtonRestarts_sum">When pressing a hardware previous button restart playing the current episode instead of rewinding</string>
     <string name="pref_followQueue_sum">Jump to next queue item when playback completes</string>
     <string name="pref_auto_delete_sum">Delete episode when playback completes</string>
     <string name="pref_auto_delete_title">Auto Delete</string>


### PR DESCRIPTION
If the user enables 'shouldHardwareButtonSkip' is likely there exist separate hardware buttons for 'Next' and 'Forward' functions. In this case, it's likely there exist also separate 'Previous' and 'Rewind' hardware buttons (as in my car stereo connected by bluetooth).  If that is the case, it is useless both buttons have the same function, it is more intuitive that the 'Previous' button restart the current track from its beginning as most players do. This patch does that.