### PR TITLE
Issue #2105 : support optional rewind in lockscreen 

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1004,9 +1004,14 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (useSkipToPreviousForRewindInLockscreen()) {
             // Workaround to fool Android so that Lockscreen will expose a skip-to-previous button,
             // which will be used for rewind.
+            // The workaround is used for pre Lollipop (Androidv5) devices.
+            // For Androidv5+, lockscreen widges are really notifications (compact),
+            // with an independent codepath
             //
             // @see #sessionCallback in the backing callback, skipToPrevious implementation
-            // is actually the same as rewind. So no new inconsistency is created.
+            //   is actually the same as rewind. So no new inconsistency is created.
+            // @see #setupNotification() for the method to create Androidv5+ lockscreen UI
+            //   with notification (compact)
             capabilities = capabilities | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
         }
 
@@ -1017,11 +1022,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     private static boolean useSkipToPreviousForRewindInLockscreen() {
         // showRewindOnCompactNotification() corresponds to the "Set Lockscreen Buttons"
         // Settings in UI.
-        // Hence, from user perspective, he/she is setting the buttons for Loackscreen
-        //
-        // OPEN: it might contain other logic, e.g., the woakround might be applicable
-        // only to prev-Androidv5 devices.
-        return UserPreferences.showRewindOnCompactNotification();
+        // Hence, from user perspective, he/she is setting the buttons for Lockscreen
+        return ( UserPreferences.showRewindOnCompactNotification() &&
+                 (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) );
     }
 
     /**


### PR DESCRIPTION
It addresses #2105 . Behavior:
- if the user selects Rewind in Lockscreen Buttons settings, then the user can rewind in lockscreen 
- the button shown on lockscreen is previous button (Android's own limitation).

Discussion:
- overloading previous button as rewind should not confuse the user: AntennaPood does not support previous. The Lockscreen Buttons settings only provide rewind (no  previous). 
- the change (in `MediaSessionCompat` object) is consistent with the existing logic in the associated  `sessionCallback` object in [`onSkipToPrevious()`](https://github.com/AntennaPod/AntennaPod/blob/1.6.1.2/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java#L1529) method's implementation is actually rewind.
- the fix in PR #2109 addresses hardware previous button. It is still consistent from user's perspective

Open:
- I am not entirely sure the behavior in Android 5+ devices.

Thanks.
