### PR TITLE
fix a spelling mistake of chinese translation

### DIFF
--- a/core/src/main/res/values-zh-rCN/strings.xml
+++ b/core/src/main/res/values-zh-rCN/strings.xml
@@ -111,7 +111,7 @@
   <string name="hide_not_downloaded_episodes_label">未下载</string>
   <string name="filtered_label">已过滤的</string>
   <string name="refresh_failed_msg">{fa-exclamation-circle} 上次刷新失败</string>
-  <string name="open_podcast">打开博客</string>
+  <string name="open_podcast">打开播客</string>
   <!--actions on feeditems-->
   <string name="download_label">下载</string>
   <string name="play_label">播放</string>


### PR DESCRIPTION
"podcast" in Chinese should be "播客" rather than "博客". 
I believe it's a mistake in the original translation because the both words have similar pronunciation in Chinese.