### PR TITLE
Parsing clean up

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -53,14 +53,17 @@ public class NSRSS20 extends Namespace {
 		} else if (ENCLOSURE.equals(localName)) {
 			String type = attributes.getValue(ENC_TYPE);
 			String url = attributes.getValue(ENC_URL);
-			boolean validType;
+			boolean validType = false;
+			boolean validUrl = !TextUtils.isEmpty(url);
+
+			if (type == null) {
+				type = SyndTypeUtils.getMimeTypeFromUrl(url);
+			}
+
 			if(SyndTypeUtils.enclosureTypeValid(type)) {
 				validType = true;
-			} else {
-				type = SyndTypeUtils.getValidMimeTypeFromUrl(url);
-				validType = type != null;
 			}
-            boolean validUrl = !TextUtils.isEmpty(url);
+
 			if (state.getCurrentItem() != null && state.getCurrentItem().getMedia() == null &&
 				validType && validUrl) {
 				long size = 0;

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -95,14 +95,12 @@ public class NSAtom extends Namespace {
                         Log.d(TAG, "Length attribute could not be parsed.");
                     }
                     String type = attributes.getValue(LINK_TYPE);
-                    boolean validType;
-                    if(SyndTypeUtils.enclosureTypeValid(type)) {
-                        validType = true;
-                    } else {
-                        type = SyndTypeUtils.getValidMimeTypeFromUrl(href);
-                        validType = type != null;
+
+                    if (type == null) {
+                        type = SyndTypeUtils.getMimeTypeFromUrl(href);
                     }
-                    if (validType) {
+
+                    if(SyndTypeUtils.enclosureTypeValid(type)) {
                         FeedItem currItem = state.getCurrentItem();
                         if(currItem != null && !currItem.hasMedia()) {
                             currItem.setMedia(new FeedMedia(currItem, href, size, type));

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -206,7 +206,12 @@ public class NSAtom extends Namespace {
                 state.getFeed().setImage(new FeedImage(state.getFeed(), content, null));
             } else if (AUTHOR.equals(second) && state.getFeed() != null) {
                 if (AUTHOR_NAME.equals(top)) {
-                    state.getFeed().setAuthor(content);
+                    String currentName = state.getFeed().getAuthor();
+                    if (currentName == null) {
+                        state.getFeed().setAuthor(content);
+                    } else {
+                        state.getFeed().setAuthor(currentName + ", " + content);
+                    }
                 }
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -45,6 +45,7 @@ public class NSAtom extends Namespace {
     private static final String LINK_LENGTH = "length";
     // rel-values
     private static final String LINK_REL_ALTERNATE = "alternate";
+    private static final String LINK_REL_ARCHIVES = "archives";
     private static final String LINK_REL_ENCLOSURE = "enclosure";
     private static final String LINK_REL_PAYMENT = "payment";
     private static final String LINK_REL_RELATED = "related";
@@ -129,6 +130,17 @@ public class NSAtom extends Namespace {
                             title = href;
                         }
                         state.addAlternateFeedUrl(title, href);
+                    }
+                } else if (LINK_REL_ARCHIVES.equals(rel) && state.getFeed() != null) {
+                    String type = attributes.getValue(LINK_TYPE);
+                    if (LINK_TYPE_ATOM.equals(type) || LINK_TYPE_RSS.equals(type)) {
+                        String title = attributes.getValue(LINK_TITLE);
+                        if (TextUtils.isEmpty(title)) {
+                            title = href;
+                        }
+                        state.addAlternateFeedUrl(title, href);
+                    } else if (LINK_TYPE_HTML.equals(type) || LINK_TYPE_XHTML.equals(type)) {
+                        //A Link such as to a directory such as iTunes
                     }
                 } else if (LINK_REL_PAYMENT.equals(rel) && state.getFeed() != null) {
                     state.getFeed().setPaymentLink(href);

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
@@ -37,16 +37,12 @@ public class SyndTypeUtils {
 	 * the type is not supported, this method will return null.
 	 */
 	public static String getValidMimeTypeFromUrl(String url) {
-		if (url != null) {
-			String extension = FilenameUtils.getExtension(url);
-			if (extension != null) {
-				String type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-				if (type != null && enclosureTypeValid(type)) {
-					return type;
-				}
-			}
+		String type = getMimeTypeFromUrl(url);
+		if (enclosureTypeValid(type)) {
+			return type;
+		} else {
+			return null;
 		}
-		return null;
 	}
 
 	/**
@@ -54,13 +50,14 @@ public class SyndTypeUtils {
 	 * method will return the mime-type of the file extension.
 	 */
 	public static String getMimeTypeFromUrl(String url) {
-		if (url != null) {
-			String extension = FilenameUtils.getExtension(url);
-			if (extension != null) {
-				return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-			}
+		if (url == null) {
+			return null;
 		}
-		return null;
-	}
+		String extension = FilenameUtils.getExtension(url);
+		if (extension == null) {
+			return null;
+		}
 
+		return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+	}
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
@@ -6,8 +6,10 @@ import org.apache.commons.io.FilenameUtils;
 /** Utility class for handling MIME-Types of enclosures */
 public class SyndTypeUtils {
 
-	private static final String VALID_MIMETYPE = "audio/.*" + "|" + "video/.*"
+	private static final String VALID_MEDIA_MIMETYPE = "audio/.*" + "|" + "video/.*"
 			+ "|" + "application/ogg";
+	private static final String VALID_IMAGE_MIMETYPE = "image/.*";
+
 
 	private SyndTypeUtils() {
 
@@ -17,9 +19,17 @@ public class SyndTypeUtils {
 		if (type == null) {
 			return false;
 		} else {
-			return type.matches(VALID_MIMETYPE);
+			return type.matches(VALID_MEDIA_MIMETYPE);
 		}
 	}
+	public static boolean imageTypeValid(String type) {
+		if (type == null) {
+			return false;
+		} else {
+			return type.matches(VALID_IMAGE_MIMETYPE);
+		}
+	}
+
 
 	/**
 	 * Should be used if mime-type of enclosure tag is not supported. This
@@ -38,4 +48,19 @@ public class SyndTypeUtils {
 		}
 		return null;
 	}
+
+	/**
+	 * Should be used if mime-type of enclosure tag is not supported. This
+	 * method will return the mime-type of the file extension.
+	 */
+	public static String getMimeTypeFromUrl(String url) {
+		if (url != null) {
+			String extension = FilenameUtils.getExtension(url);
+			if (extension != null) {
+				return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+			}
+		}
+		return null;
+	}
+
 }


### PR DESCRIPTION
[Alternative feeds](http://podlove.org/alternate-feeds/) is currently against spec, so I added support for it to be done through an archives link. Still supports alternate links as that's what's used and currently still recommended.

Adds images from media:content, if its medium, mime type or file extension indicates an image. I also cleaned up some of the mime type stuff when it is not present in RSS, MRSS or Atom. I've never seen this but it's presumably in their for a reason.

Also adds support for multiple authors.
