### PR TITLE
Prepare media on app start/resume and not on playback start

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -383,6 +383,9 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             statusBeforeSeeking = playerStatus;
             setPlayerStatus(PlayerStatus.SEEKING, media, getPosition());
             mediaPlayer.seekTo(t);
+            if (statusBeforeSeeking == PlayerStatus.PREPARED) {
+                media.setPosition(t);
+            }
             try {
                 seekLatch.await(3, TimeUnit.SECONDS);
             } catch (InterruptedException e) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -216,7 +216,7 @@ public abstract class PlaybackController {
                 Intent serviceIntent = new Intent(activity, PlaybackService.class);
                 serviceIntent.putExtra(PlaybackService.EXTRA_PLAYABLE, media);
                 serviceIntent.putExtra(PlaybackService.EXTRA_START_WHEN_PREPARED, false);
-                serviceIntent.putExtra(PlaybackService.EXTRA_PREPARE_IMMEDIATELY, false);
+                serviceIntent.putExtra(PlaybackService.EXTRA_PREPARE_IMMEDIATELY, true);
                 boolean fileExists = media.localFileAvailable();
                 boolean lastIsStream = PlaybackPreferences.getCurrentEpisodeIsStream();
                 if (!fileExists && !lastIsStream && media instanceof FeedMedia) {


### PR DESCRIPTION
I've changed the order in which the last played position is set to right after the media is loaded. This adds a delay (caused by user interaction) between seeking and playback start that should help to solve #1264. I've successfully tested it on my Fairphone 1, but no other phone.