### PR TITLE
Fallback to mime type from the URL when the defined is invalid

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -56,7 +56,9 @@ public class NSRSS20 extends Namespace {
 			boolean validType = false;
 			boolean validUrl = !TextUtils.isEmpty(url);
 
-			if (type == null) {
+			if(SyndTypeUtils.enclosureTypeValid(type)) {
+				validType = true;
+			} else {
 				type = SyndTypeUtils.getMimeTypeFromUrl(url);
 			}
 


### PR DESCRIPTION
Fixes https://github.com/AntennaPod/AntennaPod/issues/2190

First checks the attribute, if that is invalid it will pull the mime type based of the file extension in the URL and then check that.

I don't know if this should be merged, because it is an issue with the feed not AntennaPod.

