### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/nav_list.xml
+++ b/app/src/main/res/layout/nav_list.xml
@@ -1,80 +1,73 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/nav_layout"
+  android:layout_width="@dimen/drawer_width"
+  android:layout_height="match_parent"
+  android:layout_gravity="start"
+  android:background="?attr/nav_drawer_background"
+  android:orientation="vertical">
 
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/nav_layout"
+  <LinearLayout android:id="@+id/nav_settings"
     android:layout_width="@dimen/drawer_width"
-    android:layout_height="match_parent"
-    android:layout_gravity="start"
-    android:background="?attr/nav_drawer_background"
-    android:orientation="vertical">
+    android:layout_height="@dimen/listitem_iconwithtext_height"
+    android:layout_alignParentBottom="true"
+    android:background="?attr/selectableItemBackground"
+    android:contentDescription="@string/settings_label"
+    android:orientation="horizontal">
 
-    <LinearLayout
-        android:id="@+id/nav_settings"
-        android:layout_width="@dimen/drawer_width"
-        android:layout_height="@dimen/listitem_iconwithtext_height"
-        android:layout_alignParentBottom="true"
-        android:background="?attr/selectableItemBackground"
-        android:contentDescription="@string/settings_label"
-        android:orientation="horizontal">
+    <ImageView android:id="@+id/imgvCover"
+      android:layout_width="@dimen/thumbnail_length_navlist"
+      android:layout_height="@dimen/thumbnail_length_navlist"
+      android:layout_marginBottom="4dp"
+      android:layout_marginLeft="@dimen/listitem_icon_leftpadding"
+      android:layout_marginTop="4dp"
+      android:adjustViewBounds="true"
+      android:contentDescription="@string/cover_label"
+      android:cropToPadding="true"
+      android:padding="8dp"
+      android:scaleType="centerCrop"
+      android:src="?attr/ic_settings"
+      tools:src="@android:drawable/sym_def_app_icon"
+      tools:background="@android:color/holo_orange_dark">
+      <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+    </ImageView>
 
-        <ImageView
-            android:id="@+id/imgvCover"
-            android:layout_width="@dimen/thumbnail_length_navlist"
-            android:layout_height="@dimen/thumbnail_length_navlist"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:layout_marginBottom="4dp"
-            android:layout_marginLeft="@dimen/listitem_icon_leftpadding"
-            android:layout_marginTop="4dp"
-            android:adjustViewBounds="true"
-            android:contentDescription="@string/cover_label"
-            android:cropToPadding="true"
-            android:padding="8dp"
-            android:scaleType="centerCrop"
-            android:src="?attr/ic_settings"
-            tools:src="@android:drawable/sym_def_app_icon"
-            tools:background="@android:color/holo_orange_dark" />
+    <TextView android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      android:layout_marginLeft="16dp"
+      android:layout_weight="1"
+      android:gravity="center_vertical"
+      android:text="@string/settings_label"
+      android:textColor="?android:attr/textColorPrimary"
+      android:textSize="@dimen/text_size_navdrawer"
+      tools:background="@android:color/holo_green_light"/>
+  </LinearLayout>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginLeft="16dp"
-            android:layout_weight="1"
-            android:gravity="center_vertical"
-            android:text="@string/settings_label"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textSize="@dimen/text_size_navdrawer"
-            tools:background="@android:color/holo_green_light"/>
+  <View android:id="@+id/divider"
+    android:layout_width="@dimen/drawer_width"
+    android:layout_height="1dp"
+    android:layout_centerVertical="true"
+    android:layout_above="@id/nav_settings"
+    android:background="?android:attr/listDivider"
+    tools:background="@android:color/holo_red_dark"/>
 
-    </LinearLayout>
-
-    <View
-        android:id="@+id/divider"
-        android:layout_width="@dimen/drawer_width"
-        android:layout_height="1dp"
-        android:layout_centerVertical="true"
-        android:layout_above="@id/nav_settings"
-        android:background="?android:attr/listDivider"
-        tools:background="@android:color/holo_red_dark" />
-
-    <ListView
-        android:id="@+id/nav_list"
-        android:layout_width="@dimen/drawer_width"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_above="@id/divider"
-        android:layout_alignParentTop="true"
-        android:choiceMode="singleChoice"
-        android:clipToPadding="false"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="0dp"
-        android:paddingBottom="@dimen/list_vertical_padding"
-        android:paddingTop="@dimen/list_vertical_padding"
-        android:scrollbarStyle="outsideOverlay"
-        tools:listitem="@layout/nav_listitem"
-        tools:background="@android:color/holo_purple" />
-
+  <ListView android:id="@+id/nav_list"
+    android:layout_width="@dimen/drawer_width"
+    android:layout_height="wrap_content"
+    android:layout_above="@id/divider"
+    android:layout_alignParentTop="true"
+    android:choiceMode="singleChoice"
+    android:clipToPadding="false"
+    android:divider="@android:color/transparent"
+    android:dividerHeight="0dp"
+    android:paddingBottom="@dimen/list_vertical_padding"
+    android:paddingTop="@dimen/list_vertical_padding"
+    android:scrollbarStyle="outsideOverlay"
+    tools:listitem="@layout/nav_listitem"
+    tools:background="@android:color/holo_purple">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </ListView>
 </RelativeLayout>

--- a/app/src/main/res/layout/subscription_item.xml
+++ b/app/src/main/res/layout/subscription_item.xml
@@ -1,40 +1,38 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<?xml version='1.0' encoding='utf-8'?>
+  <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="horizontal">
+
+  <de.danoeh.antennapod.view.SquareImageView android:id="@+id/imgvCover"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:scaleType="centerCrop"
+    tools:src="@drawable/ic_launcher">
+    <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+    <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+  </de.danoeh.antennapod.view.SquareImageView>
+
+  <com.joanzapata.iconify.widget.IconTextView android:id="@+id/txtvTitle"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:ellipsize="end"
+    android:gravity="center"
+    android:background="@color/light_gray"
+    tools:text="@string/app_name"/>
 
-    <de.danoeh.antennapod.view.SquareImageView
-        android:id="@+id/imgvCover"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:scaleType="centerCrop"
-        tools:src="@drawable/ic_launcher" />
-
-    <com.joanzapata.iconify.widget.IconTextView
-        android:id="@+id/txtvTitle"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:ellipsize="end"
-        android:gravity="center"
-        android:background="@color/light_gray"
-        tools:text="@string/app_name" />
-
-    <jp.shts.android.library.TriangleLabelView
-        android:id="@+id/triangleCountView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
-        app:backgroundColor="@color/antennapod_blue"
-        app:corner="rightTop"
-        app:primaryText="Test"
-        app:primaryTextColor="@color/white"
-        app:primaryTextSize="12sp"
-        android:layout_gravity="right|top"/>
-
+  <jp.shts.android.library.TriangleLabelView android:id="@+id/triangleCountView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:backgroundColor="@color/antennapod_blue"
+    app:corner="rightTop"
+    app:primaryText="Test"
+    app:primaryTextColor="@color/white"
+    app:primaryTextSize="12sp"
+    android:layout_gravity="right|top">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentRight-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+  </jp.shts.android.library.TriangleLabelView>
 </FrameLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis