### PR TITLE
don't pause while casting if headset is disconnected

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1433,7 +1433,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      * Pauses playback if PREF_PAUSE_ON_HEADSET_DISCONNECT was set to true.
      */
     private void pauseIfPauseOnDisconnect() {
-        if (UserPreferences.isPauseOnHeadsetDisconnect()) {
+        if (UserPreferences.isPauseOnHeadsetDisconnect() && !isCasting()) {
             if (mediaPlayer.getPlayerStatus() == PlayerStatus.PLAYING) {
                 transientPause = true;
             }


### PR DESCRIPTION
User was listening to a podcast with headset, then get back home
and want to listen to the rest of the podcast on a chromecast.
If he unplug the headset while the audio is casting, we should not pause.