### PR TITLE
Skip favorite episodes during autodelete

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -128,6 +128,12 @@
             android:summary="@string/pref_skip_keeps_episodes_sum"
             android:title="@string/pref_skip_keeps_episodes_title"/>
         <de.danoeh.antennapod.preferences.SwitchCompatPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="prefFavoriteKeepsEpisode"
+            android:summary="@string/pref_favorite_keeps_episodes_sum"
+            android:title="@string/pref_favorite_keeps_episodes_title"/>
+        <de.danoeh.antennapod.preferences.SwitchCompatPreference
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefAutoDelete"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -67,6 +67,7 @@ public class UserPreferences {
     public static final String PREF_HARDWARE_PREVIOUS_BUTTON_RESTARTS = "prefHardwarePreviousButtonRestarts";
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
     public static final String PREF_SKIP_KEEPS_EPISODE = "prefSkipKeepsEpisode";
+    public static final String PREF_FAVORITE_KEEPS_EPISODE = "prefFavoriteKeepsEpisode";
     public static final String PREF_AUTO_DELETE = "prefAutoDelete";
     public static final String PREF_SMART_MARK_AS_PLAYED_SECS = "prefSmartMarkAsPlayedSecs";
     public static final String PREF_PLAYBACK_SPEED_ARRAY = "prefPlaybackSpeedArray";
@@ -293,6 +294,10 @@ public class UserPreferences {
     }
 
     public static boolean shouldSkipKeepEpisode() { return prefs.getBoolean(PREF_SKIP_KEEPS_EPISODE, true); }
+
+    public static boolean shouldFavoriteKeepEpisode() {
+        return prefs.getBoolean(PREF_FAVORITE_KEEPS_EPISODE, true);
+    }
 
     public static boolean isAutoDelete() {
         return prefs.getBoolean(PREF_AUTO_DELETE, false);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -847,7 +847,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     // isInQueue remains false
                 }
                 // Delete episode if enabled
-                if (item.getFeed().getPreferences().getCurrentAutoDelete()) {
+                if (item.getFeed().getPreferences().getCurrentAutoDelete() &&
+                        !(item.isTagged(FeedItem.TAG_FAVORITE) && UserPreferences.shouldFavoriteKeepEpisode())) {
                     DBWriter.deleteFeedMediaOfItem(PlaybackService.this, media.getId());
                     Log.d(TAG, "Episode Deleted");
                 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -313,6 +313,8 @@
     <string name="pref_smart_mark_as_played_title">Smart mark as played</string>
     <string name="pref_skip_keeps_episodes_sum">Keep episodes when they are skipped</string>
     <string name="pref_skip_keeps_episodes_title">Keep Skipped Episodes</string>
+    <string name="pref_favorite_keeps_episodes_sum">Keep episodes when they are marked Favorite</string>
+    <string name="pref_favorite_keeps_episodes_title">Keep Favorite Episodes</string>
     <string name="playback_pref">Playback</string>
     <string name="network_pref">Network</string>
     <string name="pref_autoUpdateIntervallOrTime_title">Update Interval or Time of Day</string>


### PR DESCRIPTION
This implements "keep episodes marked as favourite from being auto deleted after playback completes".

I find it a bit confusing that there are 2 "auto delete" functionalities:
1. after playback completes
2. Episode Cleanup's auto delete (at new episodes download time)

in case of no. 2, favourites were already kept (issue #1709),
however episodes marked as favourite were still deleted if "auto delete" was enabled, this was mentioned in issue #60.
