### PR TITLE
Share OPML file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -191,6 +191,21 @@
 
                 <data android:host="*"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:mimeType="text/xml"/>
+                <data android:mimeType="text/plain"/>
+                <data android:mimeType="text/x-opml"/>
+                <data android:mimeType="application/xml"/>
+                <data android:mimeType="application/octet-stream"/>
+
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+            </intent-filter>
         </activity>
         <activity
             android:name=".activity.OpmlFeedChooserActivity"
@@ -243,6 +258,7 @@
                 <data android:host="*"/>
                 <data android:pathPattern=".*\\.xml"/>
                 <data android:pathPattern=".*\\.rss"/>
+                <data android:pathPattern=".*\\.atom"/>
             </intent-filter>
 
             <!-- Feedburner URLs -->

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromIntentActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportFromIntentActivity.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.activity;
 
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -18,8 +19,12 @@ public class OpmlImportFromIntentActivity extends OpmlImportBaseActivity {
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         Uri uri = getIntent().getData();
-        if(uri.toString().startsWith("/")) {
-            uri = Uri.parse("file://" + uri.toString());
+        if(uri != null) {
+            if(uri.toString().startsWith("/")) {
+                uri = Uri.parse("file://" + uri.toString());
+            }
+        } else {
+            uri = getIntent().getStringExtra(Intent.EXTRA_TEXT);
         }
         importUri(uri);
     }


### PR DESCRIPTION
When sharing an OPML file, from the browser it's not currently received by AntennaPod. I think it should be received by AntennaPod so I've added another intent-filter.

I haven't tested this, or even built it but I think it should work, sorry, this has been done through GitHub.

Examples for testing, served as [text/plain](https://raw.githubusercontent.com/truecrimereview/truecrimepodcasts/master/true_crime_podcasts.opml) and [application/xml](https://keepawayfromfire.co.uk/linux-podcasts/feeds.opml)