### PR TITLE
Allow choosing between getDuration and getPlayedDuration

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/StatisticsActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/StatisticsActivity.java
@@ -1,14 +1,18 @@
 package de.danoeh.antennapod.activity;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.ProgressBar;
+import android.widget.RadioButton;
 import android.widget.TextView;
 
 import de.danoeh.antennapod.R;
@@ -28,12 +32,16 @@ public class StatisticsActivity extends AppCompatActivity
         implements AdapterView.OnItemClickListener {
 
     private static final String TAG = StatisticsActivity.class.getSimpleName();
+    private static final String PREF_NAME = "StatisticsActivityPrefs";
+    private static final String PREF_COUNT_ALL = "countAll";
 
     private Subscription subscription;
     private TextView totalTimeTextView;
     private ListView feedStatisticsList;
     private ProgressBar progressBar;
     private StatisticsListAdapter listAdapter;
+    private boolean countAll = false;
+    private SharedPreferences prefs;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,10 +50,14 @@ public class StatisticsActivity extends AppCompatActivity
         getSupportActionBar().setDisplayShowHomeEnabled(true);
         setContentView(R.layout.statistics_activity);
 
+        prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE);
+        countAll = prefs.getBoolean(PREF_COUNT_ALL, false);
+
         totalTimeTextView = (TextView) findViewById(R.id.total_time);
         feedStatisticsList = (ListView) findViewById(R.id.statistics_list);
         progressBar = (ProgressBar) findViewById(R.id.progressBar);
         listAdapter = new StatisticsListAdapter(this);
+        listAdapter.setCountAll(countAll);
         feedStatisticsList.setAdapter(listAdapter);
         feedStatisticsList.setOnItemClickListener(this);
     }
@@ -53,10 +65,15 @@ public class StatisticsActivity extends AppCompatActivity
     @Override
     public void onResume() {
         super.onResume();
-        progressBar.setVisibility(View.VISIBLE);
-        totalTimeTextView.setVisibility(View.GONE);
-        feedStatisticsList.setVisibility(View.GONE);
-        loadStats();
+        refreshStats();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.statistics, menu);
+        return true;
     }
 
     @Override
@@ -64,22 +81,54 @@ public class StatisticsActivity extends AppCompatActivity
         if (item.getItemId() == android.R.id.home) {
             finish();
             return true;
+        } else if (item.getItemId() == R.id.calculation_type) {
+            selectCalculationType();
+            return true;
         } else {
             return super.onOptionsItemSelected(item);
         }
     }
 
+    private void selectCalculationType() {
+        View contentView = View.inflate(this, R.layout.calculation_type, null);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setView(contentView);
+        builder.setTitle(R.string.calculation_type);
+
+        if (countAll) {
+            ((RadioButton) contentView.findViewById(R.id.calculation_type_count_all)).setChecked(true);
+        } else {
+            ((RadioButton) contentView.findViewById(R.id.calculation_type_normal)).setChecked(true);
+        }
+
+        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            countAll = ((RadioButton) contentView.findViewById(R.id.calculation_type_count_all)).isChecked();
+            listAdapter.setCountAll(countAll);
+            prefs.edit().putBoolean(PREF_COUNT_ALL, countAll).commit();
+            refreshStats();
+        });
+
+        builder.show();
+    }
+
+    private void refreshStats() {
+        progressBar.setVisibility(View.VISIBLE);
+        totalTimeTextView.setVisibility(View.GONE);
+        feedStatisticsList.setVisibility(View.GONE);
+        loadStats();
+    }
+
     private void loadStats() {
-        if(subscription != null) {
+        if (subscription != null) {
             subscription.unsubscribe();
         }
-        subscription = Observable.fromCallable(() -> DBReader.getStatistics())
+        subscription = Observable.fromCallable(() -> DBReader.getStatistics(countAll))
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     if (result != null) {
                         totalTimeTextView.setText(Converter
-                                .shortLocalizedDuration(this, result.totalTime));
+                                .shortLocalizedDuration(this, countAll ? result.totalTimeCountAll : result.totalTime));
                         listAdapter.update(result.feedTime);
                         progressBar.setVisibility(View.GONE);
                         totalTimeTextView.setVisibility(View.VISIBLE);
@@ -95,9 +144,10 @@ public class StatisticsActivity extends AppCompatActivity
         AlertDialog.Builder dialog = new AlertDialog.Builder(this);
         dialog.setTitle(stats.feed.getTitle());
         dialog.setMessage(getString(R.string.statistics_details_dialog,
-                stats.episodesStarted,
+                countAll ? stats.episodesStartedIncludingMarked : stats.episodesStarted,
                 stats.episodes,
-                Converter.shortLocalizedDuration(this, stats.timePlayed),
+                Converter.shortLocalizedDuration(this, countAll ?
+                        stats.timePlayedCountAll : stats.timePlayed),
                 Converter.shortLocalizedDuration(this, stats.time)));
         dialog.setPositiveButton(android.R.string.ok, null);
         dialog.show();

--- a/app/src/main/java/de/danoeh/antennapod/activity/StatisticsActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/StatisticsActivity.java
@@ -65,7 +65,7 @@ public class StatisticsActivity extends AppCompatActivity
     @Override
     public void onResume() {
         super.onResume();
-        refreshStats();
+        refreshStatistics();
     }
 
     @Override
@@ -81,44 +81,44 @@ public class StatisticsActivity extends AppCompatActivity
         if (item.getItemId() == android.R.id.home) {
             finish();
             return true;
-        } else if (item.getItemId() == R.id.calculation_type) {
-            selectCalculationType();
+        } else if (item.getItemId() == R.id.statistics_mode) {
+            selectStatisticsMode();
             return true;
         } else {
             return super.onOptionsItemSelected(item);
         }
     }
 
-    private void selectCalculationType() {
-        View contentView = View.inflate(this, R.layout.calculation_type, null);
+    private void selectStatisticsMode() {
+        View contentView = View.inflate(this, R.layout.statistics_mode_select_dialog, null);
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setView(contentView);
-        builder.setTitle(R.string.calculation_type);
+        builder.setTitle(R.string.statistics_mode);
 
         if (countAll) {
-            ((RadioButton) contentView.findViewById(R.id.calculation_type_count_all)).setChecked(true);
+            ((RadioButton) contentView.findViewById(R.id.statistics_mode_count_all)).setChecked(true);
         } else {
-            ((RadioButton) contentView.findViewById(R.id.calculation_type_normal)).setChecked(true);
+            ((RadioButton) contentView.findViewById(R.id.statistics_mode_normal)).setChecked(true);
         }
 
         builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-            countAll = ((RadioButton) contentView.findViewById(R.id.calculation_type_count_all)).isChecked();
+            countAll = ((RadioButton) contentView.findViewById(R.id.statistics_mode_count_all)).isChecked();
             listAdapter.setCountAll(countAll);
-            prefs.edit().putBoolean(PREF_COUNT_ALL, countAll).commit();
-            refreshStats();
+            prefs.edit().putBoolean(PREF_COUNT_ALL, countAll).apply();
+            refreshStatistics();
         });
 
         builder.show();
     }
 
-    private void refreshStats() {
+    private void refreshStatistics() {
         progressBar.setVisibility(View.VISIBLE);
         totalTimeTextView.setVisibility(View.GONE);
         feedStatisticsList.setVisibility(View.GONE);
-        loadStats();
+        loadStatistics();
     }
 
-    private void loadStats() {
+    private void loadStatistics() {
         if (subscription != null) {
             subscription.unsubscribe();
         }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/StatisticsListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/StatisticsListAdapter.java
@@ -25,11 +25,15 @@ import de.danoeh.antennapod.core.util.Converter;
 public class StatisticsListAdapter extends BaseAdapter {
     private Context context;
     List<DBReader.StatisticsItem> feedTime = new ArrayList<>();
+    private boolean countAll = true;
 
     public StatisticsListAdapter(Context context) {
         this.context = context;
     }
 
+    public void setCountAll(boolean countAll) {
+        this.countAll = countAll;
+    }
 
     @Override
     public int getCount() {
@@ -77,7 +81,8 @@ public class StatisticsListAdapter extends BaseAdapter {
 
         holder.title.setText(feed.getTitle());
         holder.time.setText(Converter.shortLocalizedDuration(context,
-                feedTime.get(position).timePlayed));
+                countAll ? feedTime.get(position).timePlayedCountAll
+                        : feedTime.get(position).timePlayed));
         return convertView;
     }
 

--- a/app/src/main/res/layout/calculation_type.xml
+++ b/app/src/main/res/layout/calculation_type.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <RadioButton
+        android:id="@+id/calculation_type_normal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/calculation_type_normal" />
+
+    <RadioButton
+        android:id="@+id/calculation_type_count_all"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/calculation_type_count_all" />
+</RadioGroup>

--- a/app/src/main/res/layout/statistics_mode_select_dialog.xml
+++ b/app/src/main/res/layout/statistics_mode_select_dialog.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+    <TextView
+            android:text="@string/statistics_speed_not_counted"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"/>
 
     <RadioButton
-        android:id="@+id/statistics_mode_normal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/statistics_mode_normal" />
+            android:id="@+id/statistics_mode_normal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/statistics_mode_normal"/>
 
     <RadioButton
-        android:id="@+id/statistics_mode_count_all"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/statistics_mode_count_all" />
+            android:id="@+id/statistics_mode_count_all"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/statistics_mode_count_all"/>
 </RadioGroup>

--- a/app/src/main/res/layout/statistics_mode_select_dialog.xml
+++ b/app/src/main/res/layout/statistics_mode_select_dialog.xml
@@ -6,14 +6,14 @@
     android:padding="16dp">
 
     <RadioButton
-        android:id="@+id/calculation_type_normal"
+        android:id="@+id/statistics_mode_normal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/calculation_type_normal" />
+        android:text="@string/statistics_mode_normal" />
 
     <RadioButton
-        android:id="@+id/calculation_type_count_all"
+        android:id="@+id/statistics_mode_count_all"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/calculation_type_count_all" />
+        android:text="@string/statistics_mode_count_all" />
 </RadioGroup>

--- a/app/src/main/res/menu/statistics.xml
+++ b/app/src/main/res/menu/statistics.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:custom="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/calculation_type"
+        android:icon="?attr/ic_filter"
+        android:title="@string/calculation_type"
+        custom:showAsAction="never">
+    </item>
+
+</menu>

--- a/app/src/main/res/menu/statistics.xml
+++ b/app/src/main/res/menu/statistics.xml
@@ -3,9 +3,9 @@
       xmlns:custom="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/calculation_type"
+        android:id="@+id/statistics_mode"
         android:icon="?attr/ic_filter"
-        android:title="@string/calculation_type"
+        android:title="@string/statistics_mode"
         custom:showAsAction="never">
     </item>
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -32,8 +32,8 @@
     <string name="total_time_listened_to_podcasts">Total time of podcasts played:</string>
     <string name="statistics_details_dialog">%1$d out of %2$d episodes started.\n\nPlayed %3$s out of %4$s.</string>
     <string name="statistics_mode">Statistics mode</string>
-    <string name="statistics_mode_normal">The time you actually played podcasts, respecting playback speed</string>
-    <string name="statistics_mode_count_all">Sum up all played podcast durations, including those just marked as played</string>
+    <string name="statistics_mode_normal">Duration that was actually played</string>
+    <string name="statistics_mode_count_all">Include podcasts that are just marked as played</string>
 
     <!-- Main activity -->
     <string name="drawer_open">Open menu</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -32,8 +32,8 @@
     <string name="total_time_listened_to_podcasts">Total time of podcasts played:</string>
     <string name="statistics_details_dialog">%1$d out of %2$d episodes started.\n\nPlayed %3$s out of %4$s.</string>
     <string name="statistics_mode">Statistics mode</string>
-    <string name="statistics_mode_normal">Duration that was actually played</string>
-    <string name="statistics_mode_count_all">Include podcasts that are just marked as played</string>
+    <string name="statistics_mode_normal">Calculate duration that was actually played. Playing twice counts twice, while marking as played does not count.</string>
+    <string name="statistics_mode_count_all">Sum up all podcasts marked as played</string>
 
     <!-- Main activity -->
     <string name="drawer_open">Open menu</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -31,9 +31,9 @@
     <!-- Statistics fragment -->
     <string name="total_time_listened_to_podcasts">Total time of podcasts played:</string>
     <string name="statistics_details_dialog">%1$d out of %2$d episodes started.\n\nPlayed %3$s out of %4$s.</string>
-    <string name="calculation_type">Calculation type</string>
-    <string name="calculation_type_normal">The time you actually played podcasts, respecting playback speed</string>
-    <string name="calculation_type_count_all">Sum up all played podcast durations, including those just marked as played</string>
+    <string name="statistics_mode">Statistics mode</string>
+    <string name="statistics_mode_normal">The time you actually played podcasts, respecting playback speed</string>
+    <string name="statistics_mode_count_all">Sum up all played podcast durations, including those just marked as played</string>
 
     <!-- Main activity -->
     <string name="drawer_open">Open menu</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -31,6 +31,9 @@
     <!-- Statistics fragment -->
     <string name="total_time_listened_to_podcasts">Total time of podcasts played:</string>
     <string name="statistics_details_dialog">%1$d out of %2$d episodes started.\n\nPlayed %3$s out of %4$s.</string>
+    <string name="calculation_type">Calculation type</string>
+    <string name="calculation_type_normal">The time you actually played podcasts, respecting playback speed</string>
+    <string name="calculation_type_count_all">Sum up all played podcast durations, including those just marked as played</string>
 
     <!-- Main activity -->
     <string name="drawer_open">Open menu</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -32,8 +32,9 @@
     <string name="total_time_listened_to_podcasts">Total time of podcasts played:</string>
     <string name="statistics_details_dialog">%1$d out of %2$d episodes started.\n\nPlayed %3$s out of %4$s.</string>
     <string name="statistics_mode">Statistics mode</string>
-    <string name="statistics_mode_normal">Calculate duration that was actually played. Playing twice counts twice, while marking as played does not count.</string>
+    <string name="statistics_mode_normal">Calculate duration that was actually played. Playing twice is counted twice, while marking as played is not counted</string>
     <string name="statistics_mode_count_all">Sum up all podcasts marked as played</string>
+    <string name="statistics_speed_not_counted">Notice: Playback speed is never taken into account.</string>
 
     <!-- Main activity -->
     <string name="drawer_open">Open menu</string>


### PR DESCRIPTION
This new setting makes it easier to keep statistics even when switching podcast clients (by marking as played). It also respects podcasts you listened to before getPlayedDuration was introduced. 
Related discussion: http://www.github.com/AntennaPod/AntennaPod/pull/1841

<img src="https://cloud.githubusercontent.com/assets/5811634/25064149/a8b5a3a4-21f4-11e7-8d84-7464ffddc067.png" width="300" /> <img src="https://cloud.githubusercontent.com/assets/5811634/25064148/a8b45a3a-21f4-11e7-8a81-92cd400dc094.png" width="300" />

Replaces #2111, I changed the branch