### PR TITLE
Trimming 'pcast:' without '//'

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/URLChecker.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/URLChecker.java
@@ -37,6 +37,9 @@ public final class URLChecker {
         } else if (url.startsWith("pcast://")) {
             if (BuildConfig.DEBUG) Log.d(TAG, "Removing pcast://");
             return prepareURL(url.substring("pcast://".length()));
+        } else if (url.startsWith("pcast:")) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "Removing pcast:");
+            return prepareURL(url.substring("pcast:".length()));
         } else if (url.startsWith("itpc")) {
             if (BuildConfig.DEBUG) Log.d(TAG, "Replacing itpc:// with http://");
             return url.replaceFirst("itpc://", "http://");


### PR DESCRIPTION
Fixes #2284 (subscribtion through podlove 'Let device decide')

`startFeedDownload` was called with 

    pcast:logbuch-netzpolitik.de/feed/mp3

which was converted (using `URLChecker.prepareURL`) to

    http://pcast:logbuch-netzpolitik.de/feed/mp3

Therefore, the invalid port error message