### PR TITLE
Improved list items when using a large font size

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -174,7 +174,7 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
                     holder.progress.setVisibility(View.VISIBLE);
                 }
             } else {
-                holder.progress.setVisibility(View.GONE);
+                holder.progress.setVisibility(View.INVISIBLE);
             }
 
             if(media.isCurrentlyPlaying()) {
@@ -183,7 +183,7 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
                 holder.container.setBackgroundColor(normalBackGroundColor);
             }
         } else {
-            holder.progress.setVisibility(View.GONE);
+            holder.progress.setVisibility(View.INVISIBLE);
             holder.txtvDuration.setVisibility(View.GONE);
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -157,7 +157,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
 
             FeedMedia media = item.getMedia();
             if (media == null) {
-                holder.episodeProgress.setVisibility(View.GONE);
+                holder.episodeProgress.setVisibility(View.INVISIBLE);
                 holder.inPlaylist.setVisibility(View.INVISIBLE);
                 holder.type.setVisibility(View.INVISIBLE);
                 holder.lenSize.setVisibility(View.INVISIBLE);
@@ -176,7 +176,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
                     holder.episodeProgress.setProgress(itemAccess.getItemDownloadProgressPercent(item));
                 } else {
                     if(media.getPosition() == 0) {
-                        holder.episodeProgress.setVisibility(View.GONE);
+                        holder.episodeProgress.setVisibility(View.INVISIBLE);
                     }
                 }
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -280,7 +280,7 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                         progressLeft.setText("");
                     }
                     progressRight.setText(Converter.getDurationStringLong(media.getDuration()));
-                    progressBar.setVisibility(View.GONE);
+                    progressBar.setVisibility(View.INVISIBLE);
                 }
 
                 if(media.isCurrentlyPlaying()) {

--- a/app/src/main/res/layout/downloaded_episodeslist_item.xml
+++ b/app/src/main/res/layout/downloaded_episodeslist_item.xml
@@ -3,7 +3,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
     tools:background="@android:color/darker_gray">
 
@@ -18,64 +18,69 @@
         android:contentDescription="@string/cover_label"
         android:scaleType="centerCrop"
         tools:src="@drawable/ic_stat_antenna_default"
-        tools:background="@android:color/holo_green_dark" />
+        tools:background="@android:color/holo_green_dark"/>
 
-    <RelativeLayout
+
+    <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="@dimen/thumbnail_length_downloaded_item"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:layout_weight="1"
+        android:orientation="vertical"
+        android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         tools:background="@android:color/holo_red_dark">
 
         <TextView
             android:id="@+id/txtvTitle"
             style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentTop="true"
-            android:layout_centerVertical="true"
             android:layout_marginBottom="4dp"
             tools:text="Downloaded episode title"
-            tools:background="@android:color/holo_green_dark" />
+            tools:background="@android:color/holo_green_dark"/>
 
-        <TextView
-            android:id="@+id/txtvSize"
-            style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentBottom="true"
-            tools:text="23 MB"
-            tools:background="@android:color/holo_green_dark" />
+            android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
+            tools:background="@android:color/holo_red_dark" >
 
-        <TextView
-            android:id="@+id/txtvPublished"
-            style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentBottom="true"
-            android:layout_marginLeft="8dp"
-            tools:text="Jan 23"
-            tools:background="@android:color/holo_green_dark" />
+            <TextView
+                android:id="@+id/txtvSize"
+                style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="23 MB"
+                tools:background="@android:color/holo_green_dark"/>
 
-        <ImageView
-            android:id="@+id/imgvInPlaylist"
-            android:layout_width="@dimen/enc_icons_size"
-            android:layout_height="@dimen/enc_icons_size"
-            android:layout_toLeftOf="@id/txtvPublished"
-            android:layout_alignParentBottom="true"
-            android:contentDescription="@string/in_queue_label"
-            android:src="?attr/stat_playlist"
-            android:visibility="visible"
-            tools:src="@drawable/ic_list_white_24dp"
-            tools:background="@android:color/holo_red_light" />
+            <View
+                android:layout_width="0dip"
+                android:layout_height="1dip"
+                android:layout_weight="1" />
 
-    </RelativeLayout>
+            <ImageView
+                android:id="@+id/imgvInPlaylist"
+                android:layout_width="@dimen/enc_icons_size"
+                android:layout_height="@dimen/enc_icons_size"
+                android:contentDescription="@string/in_queue_label"
+                android:src="?attr/stat_playlist"
+                android:visibility="visible"
+                tools:src="@drawable/ic_list_white_24dp"
+                tools:background="@android:color/holo_red_light"/>
+
+            <TextView
+                android:id="@+id/txtvPublished"
+                style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                tools:text="Jan 23"
+                tools:background="@android:color/holo_green_dark"/>
+
+        </LinearLayout>
+    </LinearLayout>
 
     <include layout="@layout/vertical_list_divider"/>
 

--- a/app/src/main/res/layout/downloaded_episodeslist_item.xml
+++ b/app/src/main/res/layout/downloaded_episodeslist_item.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -27,9 +26,9 @@
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
+        android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         android:layout_weight="1"
         android:orientation="vertical"
-        android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         tools:background="@android:color/holo_red_dark">
 
         <TextView
@@ -44,7 +43,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
             tools:background="@android:color/holo_red_dark" >
 
             <TextView

--- a/app/src/main/res/layout/downloadlist_item.xml
+++ b/app/src/main/res/layout/downloadlist_item.xml
@@ -2,13 +2,13 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
     tools:background="@android:color/darker_gray">
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="vertical">
 

--- a/app/src/main/res/layout/downloadlog_item.xml
+++ b/app/src/main/res/layout/downloadlog_item.xml
@@ -12,8 +12,8 @@
 
     <com.joanzapata.iconify.widget.IconTextView
         android:id="@+id/txtvIcon"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+        android:layout_width="48sp"
+        android:layout_height="48sp"
         android:layout_alignParentTop="true"
         android:layout_alignParentLeft="true"
         android:textSize="48sp"

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -7,15 +7,15 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    tools:background="@android:color/darker_gray"
-    android:paddingTop="@dimen/listitem_threeline_verticalpadding"
-    android:paddingBottom="@dimen/listitem_threeline_verticalpadding">
+    tools:background="@android:color/darker_gray">
 
     <RelativeLayout
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
         android:layout_weight="1"
+        android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
+        android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         tools:background="@android:color/holo_orange_dark">
 
         <TextView

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -37,7 +37,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="4dp"
             android:layout_toLeftOf="@id/statusUnread"
             tools:text="Episode title"
             tools:background="@android:color/holo_green_dark" />
@@ -101,8 +101,7 @@
             tools:background="@android:color/holo_blue_light"
             android:max="100"
             android:progress="42"
-            android:indeterminate="false"
-            />
+            android:indeterminate="false" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -5,9 +5,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
-    tools:background="@android:color/darker_gray">
+    tools:background="@android:color/darker_gray"
+    android:paddingTop="@dimen/listitem_threeline_verticalpadding"
+    android:paddingBottom="@dimen/listitem_threeline_verticalpadding">
 
     <RelativeLayout
         android:layout_width="0dp"
@@ -23,7 +25,6 @@
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_alignParentTop="true"
-            android:layout_marginTop="16dp"
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
             tools:text="NEW"
@@ -37,7 +38,6 @@
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             android:layout_marginBottom="8dp"
-            android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
             android:layout_toLeftOf="@id/statusUnread"
             tools:text="Episode title"
             tools:background="@android:color/holo_green_dark" />

--- a/app/src/main/res/layout/mediaplayerinfo_activity.xml
+++ b/app/src/main/res/layout/mediaplayerinfo_activity.xml
@@ -152,6 +152,7 @@
                     android:src="?attr/av_fast_forward"
                     android:textSize="@dimen/text_size_medium"
                     android:textAllCaps="false"
+                    android:maxLines="1"
                     tools:visibility="gone"
                     tools:background="@android:color/holo_green_dark" />
 

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -123,7 +123,7 @@
                 android:id="@+id/pbar_progress"
                 style="?android:attr/progressBarStyleHorizontal"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="4dp"
                 android:layout_below="@id/txtvDuration"
                 android:layout_marginTop="-2dp"
                 android:max="100" />

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -121,11 +121,10 @@
 
             <ProgressBar
                 android:id="@+id/pbar_progress"
-                style="?android:attr/progressBarStyleHorizontal"
+                style="?attr/progressBarTheme"
                 android:layout_width="match_parent"
                 android:layout_height="4dp"
                 android:layout_below="@id/txtvDuration"
-                android:layout_marginTop="-2dp"
                 android:max="100" />
 
         </RelativeLayout>

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -10,10 +10,11 @@
 <LinearLayout
     android:id="@+id/content"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height"
+    android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
     android:orientation="horizontal"
-    tools:background="@android:color/darker_gray">
+    tools:background="@android:color/darker_gray"
+    android:gravity="center_vertical">
 
     <RelativeLayout
         android:layout_width="wrap_content"
@@ -48,7 +49,7 @@
 
     <RelativeLayout
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -9,7 +9,7 @@
 
 <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height"
+    android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
     android:orientation="horizontal"
     android:gravity="center_vertical"

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -124,9 +124,8 @@
                 android:id="@+id/progressBar"
                 style="?android:attr/progressBarStyleHorizontal"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="4dp"
                 android:layout_below="@id/txtvProgressLeft"
-                android:layout_marginTop="-2dp"
                 android:max="100"
                 tools:background="@android:color/holo_blue_light" />
 

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -122,7 +122,7 @@
 
             <ProgressBar
                 android:id="@+id/progressBar"
-                style="?android:attr/progressBarStyleHorizontal"
+                style="?attr/progressBarTheme"
                 android:layout_width="match_parent"
                 android:layout_height="4dp"
                 android:layout_below="@id/txtvProgressLeft"

--- a/app/src/main/res/layout/searchlist_item.xml
+++ b/app/src/main/res/layout/searchlist_item.xml
@@ -13,7 +13,6 @@
         android:layout_height="@dimen/thumbnail_length_itemlist"
         android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
-        android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
         android:contentDescription="@string/cover_label"
         android:scaleType="centerCrop"

--- a/app/src/main/res/layout/searchlist_item.xml
+++ b/app/src/main/res/layout/searchlist_item.xml
@@ -2,8 +2,10 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/listitem_threeline_height"
-                tools:background="@android:color/darker_gray">
+                android:layout_height="wrap_content"
+                tools:background="@android:color/darker_gray"
+                android:paddingTop="@dimen/listitem_threeline_verticalpadding"
+                android:paddingBottom="@dimen/listitem_threeline_verticalpadding">
 
     <ImageView
         android:id="@+id/imgvFeedimage"
@@ -13,7 +15,6 @@
         android:layout_centerVertical="true"
         android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
-        android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:contentDescription="@string/cover_label"
         android:scaleType="centerCrop"
         tools:src="@drawable/ic_stat_antenna_default"
@@ -24,7 +25,6 @@
         android:layout_height="match_parent"
         android:layout_marginLeft="@dimen/listitem_iconwithtext_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_verticalpadding"
-        android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:layout_toRightOf="@id/imgvFeedimage"
         android:orientation="vertical"
         tools:background="@android:color/holo_red_dark">

--- a/app/src/main/res/layout/simplechapter_item.xml
+++ b/app/src/main/res/layout/simplechapter_item.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
     tools:background="@android:color/darker_gray">
 

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -23,7 +23,6 @@
     <dimen name="listitem_iconwithtext_textleftpadding">14dp</dimen>
     <dimen name="listitem_iconwithtext_textverticalpadding">16dp</dimen>
 
-    <dimen name="listitem_threeline_height">96dp</dimen>
     <dimen name="listitem_threeline_textleftpadding">14dp</dimen>
     <dimen name="listitem_threeline_textrightpadding">8dp</dimen>
     <dimen name="listitem_threeline_verticalpadding">16dp</dimen>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -20,10 +20,10 @@
     <dimen name="listview_secondary_button_width">48dp</dimen>
     <dimen name="drawer_width">280dp</dimen>
     <dimen name="listitem_iconwithtext_height">48dp</dimen>
-    <dimen name="listitem_iconwithtext_textleftpadding">14dp</dimen>
+    <dimen name="listitem_iconwithtext_textleftpadding">16dp</dimen>
     <dimen name="listitem_iconwithtext_textverticalpadding">16dp</dimen>
 
-    <dimen name="listitem_threeline_textleftpadding">14dp</dimen>
+    <dimen name="listitem_threeline_textleftpadding">16dp</dimen>
     <dimen name="listitem_threeline_textrightpadding">8dp</dimen>
     <dimen name="listitem_threeline_verticalpadding">16dp</dimen>
     <dimen name="listitem_threeline_horizontalpadding">16dp</dimen>


### PR DESCRIPTION
Fixes #1277

### Normal font size (before, after):

<img src="https://cloud.githubusercontent.com/assets/5811634/26245039/96965430-3c92-11e7-9b14-b3d0ce5153e4.png" width="300" /> <img src="https://cloud.githubusercontent.com/assets/5811634/26245040/98e598fe-3c92-11e7-96a4-d50a67e7dacb.png" width="300" />

### Big font size (before, after):
<img src="https://cloud.githubusercontent.com/assets/5811634/26245074/cb3fc720-3c92-11e7-87c9-bc7196618a49.png" width="300" /> <img src="https://cloud.githubusercontent.com/assets/5811634/26245075/cb48b4f2-3c92-11e7-8951-786a4860d3d8.png" width="300" />

