### PR TITLE
add a "rewind" and "fast forward" button for android Wear

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ project.ext {
 
     castCompanionLibVer = "2.8.3"
     playServicesVersion = "8.4.0"
+    wearableSupportVersion = "2.0.3"
 }
 
 task wrapper(type: Wrapper) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -72,6 +72,7 @@ dependencies {
         playCompile "com.google.android.libraries.cast.companionlibrary:ccl:$castCompanionLibVer"
         compile "com.android.support:mediarouter-v7:$supportVersion"
         playCompile "com.google.android.gms:play-services-cast:$playServicesVersion"
+        compile "com.google.android.support:wearable:$wearableSupportVersion"
     } else {
         System.out.println("core: free build hack, skipping some dependencies")
     }

--- a/core/src/free/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -2,6 +2,8 @@ package de.danoeh.antennapod.core.service.playback;
 
 import android.content.Context;
 import android.support.annotation.StringRes;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
 
 /**
  * Class intended to work along PlaybackService and provide support for different flavors.
@@ -40,5 +42,13 @@ public class PlaybackServiceFlavorHelper {
 
     boolean onSharedPreference(String key) {
         return false;
+    }
+
+    void sessionStateAddActionForWear(PlaybackStateCompat.Builder sessionState, String actionName, CharSequence name, int icon) {
+        // no-op
+    }
+
+    void mediaSessionSetExtraForWear(MediaSessionCompat mediaSession) {
+        // no-op
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -133,6 +133,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      */
     public static final String ACTION_RESUME_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.resumePlayCurrentEpisode";
 
+    /**
+     * Custom action used by Android Wear
+     */
+    private static final String CUSTOM_ACTION_FAST_FORWARD = "action.de.danoeh.antennapod.core.service.fastForward";
+    private static final String CUSTOM_ACTION_REWIND = "action.de.danoeh.antennapod.core.service.rewind";
+
 
     /**
      * Used in NOTIFICATION_TYPE_RELOAD.
@@ -1083,6 +1089,14 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
 
         sessionState.setActions(capabilities);
+
+        flavorHelper.sessionStateAddActionForWear(sessionState,
+                CUSTOM_ACTION_REWIND, getString(R.string.rewind_label), android.R.drawable.ic_media_rew);
+        flavorHelper.sessionStateAddActionForWear(sessionState,
+                CUSTOM_ACTION_FAST_FORWARD, getString(R.string.fast_forward_label), android.R.drawable.ic_media_ff);
+
+        flavorHelper.mediaSessionSetExtraForWear(mediaSession);
+
         mediaSession.setPlaybackState(sessionState.build());
     }
 
@@ -1760,6 +1774,16 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 }
             }
             return false;
+        }
+
+        @Override
+        public void onCustomAction(String action, Bundle extra) {
+            Log.d(TAG, "onCustomAction(" + action + ")");
+            if (CUSTOM_ACTION_FAST_FORWARD.equals(action)) {
+                onFastForward();
+            } else if (CUSTOM_ACTION_REWIND.equals(action)) {
+                onRewind();
+            }
         }
     };
 

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -6,9 +6,13 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
 import android.support.v7.media.MediaRouter;
+import android.support.wearable.media.MediaControlConstants;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -254,5 +258,22 @@ public class PlaybackServiceFlavorHelper {
             return true;
         }
         return false;
+    }
+
+    void sessionStateAddActionForWear(PlaybackStateCompat.Builder sessionState, String actionName, CharSequence name, int icon) {
+        PlaybackStateCompat.CustomAction.Builder actionBuilder =
+            new PlaybackStateCompat.CustomAction.Builder(actionName, name, icon);
+        Bundle actionExtras = new Bundle();
+        actionExtras.putBoolean(MediaControlConstants.EXTRA_CUSTOM_ACTION_SHOW_ON_WEAR, true);
+        actionBuilder.setExtras(actionExtras);
+
+        sessionState.addCustomAction(actionBuilder.build());
+    }
+
+    void mediaSessionSetExtraForWear(MediaSessionCompat mediaSession) {
+        Bundle sessionExtras = new Bundle();
+        sessionExtras.putBoolean(MediaControlConstants.EXTRA_RESERVE_SLOT_SKIP_TO_PREVIOUS, true);
+        sessionExtras.putBoolean(MediaControlConstants.EXTRA_RESERVE_SLOT_SKIP_TO_NEXT, true);
+        mediaSession.setExtras(sessionExtras);
     }
 }


### PR DESCRIPTION
This feature is only enabled for "play" build.
It is useful to skip advertisement during a podcast.

Note: I originaly tried to implement this in the "4 ways controller" managed by
the mediaSession (it contains vol up / vol down / skip). This object is linked
to the capabilities of the session and seems to be hard to customise without
changing the capabilities.
This patch simply add 2 new buttons

![rewind](https://user-images.githubusercontent.com/365097/29292909-43193a2e-8149-11e7-8624-d8df041d01da.png)
![forward](https://user-images.githubusercontent.com/365097/29292915-47c4a0c2-8149-11e7-8155-135a7d138a66.png)

