### PR TITLE
set android:installLocation to auto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.danoeh.antennapod"
+    android:installLocation="auto"
     android:versionCode="1060398"
     android:versionName="1.6.3.0">
     <!--


### PR DESCRIPTION
Allows antennaPod to be movable, can be installed on SD card

Unfortunately, this does not move the podcast location to the card, just the app.
