### PR TITLE
Add auto download on mobile connection option

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -219,6 +219,11 @@
                 android:summary="@string/pref_automatic_download_on_battery_sum"
                 android:defaultValue="true"/>
             <de.danoeh.antennapod.preferences.SwitchCompatPreference
+                android:key="prefEnableAutoDownloadOnMobile"
+                android:title="@string/pref_autodl_allow_on_mobile_title"
+                android:summary="@string/pref_autodl_allow_on_mobile_sum"
+                android:defaultValue="false"/>
+            <de.danoeh.antennapod.preferences.SwitchCompatPreference
                 android:key="prefEnableAutoDownloadWifiFilter"
                 android:title="@string/pref_autodl_wifi_filter_title"
                 android:summary="@string/pref_autodl_wifi_filter_sum"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -83,6 +83,7 @@ public class UserPreferences {
     public static final String PREF_ENABLE_AUTODL = "prefEnableAutoDl";
     public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
     public static final String PREF_ENABLE_AUTODL_WIFI_FILTER = "prefEnableAutoDownloadWifiFilter";
+    public static final String PREF_ENABLE_AUTODL_ON_MOBILE = "prefEnableAutoDownloadOnMobile";
     public static final String PREF_AUTODL_SELECTED_NETWORKS = "prefAutodownloadSelectedNetworks";
     public static final String PREF_PROXY_TYPE = "prefProxyType";
     public static final String PREF_PROXY_HOST = "prefProxyHost";
@@ -395,6 +396,11 @@ public class UserPreferences {
     public static boolean isEnableAutodownloadWifiFilter() {
         return prefs.getBoolean(PREF_ENABLE_AUTODL_WIFI_FILTER, false);
     }
+
+    public static boolean isEnableAutodownloadOnMobile() {
+        return prefs.getBoolean(PREF_ENABLE_AUTODL_ON_MOBILE, false);
+    }
+
 
     public static int getImageCacheSize() {
         String cacheSizeString = prefs.getString(PREF_IMAGE_CACHE_SIZE, IMAGE_CACHE_DEFAULT_VALUE);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -66,6 +66,18 @@ public class NetworkUtils {
 						}
 					}
 				}
+			} else {
+				if (!UserPreferences.isEnableAutodownloadOnMobile())
+				{
+					Log.d(TAG, "Auto Download not enabled on Mobile");
+					return false;
+				}
+				if (networkInfo.isRoaming())
+				{
+					Log.d(TAG, "Roaming on foreign network");
+					return false;
+				}
+				return true;
 			}
 		}
 		Log.d(TAG, "Network for auto-dl is not available");

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -67,13 +67,11 @@ public class NetworkUtils {
 					}
 				}
 			} else {
-				if (!UserPreferences.isEnableAutodownloadOnMobile())
-				{
+				if (!UserPreferences.isEnableAutodownloadOnMobile()) {
 					Log.d(TAG, "Auto Download not enabled on Mobile");
 					return false;
 				}
-				if (networkInfo.isRoaming())
-				{
+				if (networkInfo.isRoaming()) {
 					Log.d(TAG, "Roaming on foreign network");
 					return false;
 				}

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -363,6 +363,8 @@
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes.</string>
     <string name="pref_autodl_wifi_filter_title">Enable Wi-Fi filter</string>
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
+    <string name="pref_autodl_allow_on_mobile_title">Download on mobile connection</string>
+    <string name="pref_autodl_allow_on_mobile_sum">Allow automatic download over the mobile data connection.</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>
     <string name="pref_automatic_download_on_battery_sum">Allow automatic download when the battery is not charging</string>
     <string name="pref_parallel_downloads_title">Parallel Downloads</string>


### PR DESCRIPTION
As I got "unlimited" data on my mobile I switched off wifi and found AntennaPod no longer did auto updates. I therefore downloaded the source, got android-studio and added the option to auto download even when you are not on wifi, even though I haven't done any android development before.

I've run with my changes for a few months without any problems and though it may be helpful for others.

I now see there is issue #2005 where this change is suggested already.