### PR TITLE
fix wifi service mem leak

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -759,7 +759,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
             clearAutodownloadSelectedNetworsPreference();
         }
         // get configured networks
-        WifiManager wifiservice = (WifiManager) activity.getSystemService(Context.WIFI_SERVICE);
+        WifiManager wifiservice = (WifiManager) activity.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         List<WifiConfiguration> networks = wifiservice.getConfiguredNetworks();
 
         if (networks != null) {


### PR DESCRIPTION
The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N.
Try changing activity to activity.getApplicationContext()
[WifiManagerLeak]