### PR TITLE
Close cursor before returning

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -905,6 +905,7 @@ public final class DBReader {
         Cursor cursor = adapter.getImageCursor(ids);
         int imageCount = cursor.getCount();
         if (imageCount == 0) {
+            cursor.close();
             return Collections.emptyMap();
         }
         Map<Long, FeedImage> result = new ArrayMap<>(imageCount);


### PR DESCRIPTION
Fixes error when refreshing feeds:

```
10-15 16:21:34.157 885-893/de.danoeh.antennapod E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
                                                              java.lang.Throwable: Explicit termination method 'close' not called
                                                                  at dalvik.system.CloseGuard.open(CloseGuard.java:180)
                                                                  at android.database.CursorWindow.<init>(CursorWindow.java:111)
                                                                  at android.database.AbstractWindowedCursor.clearOrCreateWindow(AbstractWindowedCursor.java:198)
                                                                  at android.database.sqlite.SQLiteCursor.fillWindow(SQLiteCursor.java:138)
                                                                  at android.database.sqlite.SQLiteCursor.getCount(SQLiteCursor.java:132)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.getFeedImages(DBReader.java:906)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.extractItemlistFromCursor(DBReader.java:219)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.getFeedItemList(DBReader.java:179)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.getFeed(DBReader.java:612)
                                                                  at de.danoeh.antennapod.core.storage.DBTasks.searchFeedByIdentifyingValueOrID(DBTasks.java:512)
                                                                  at de.danoeh.antennapod.core.storage.DBTasks.updateFeed(DBTasks.java:564)
                                                                  at de.danoeh.antennapod.core.service.download.DownloadService$FeedSyncThread.lambda$run$0(DownloadService.java:711)
                                                                  at de.danoeh.antennapod.core.service.download.DownloadService$FeedSyncThread$$Lambda$1.run(Unknown Source)
                                                                  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:428)
                                                                  at java.util.concurrent.FutureTask.run(FutureTask.java:237)
                                                                  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
                                                                  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
                                                                  at java.lang.Thread.run(Thread.java:761)
10-15 16:21:34.159 885-893/de.danoeh.antennapod E/StrictMode: Finalizing a Cursor that has not been deactivated or closed. database = /data/user/0/de.danoeh.antennapod/databases/Antennapod.db, table = FeedImages, query = SELECT * FROM FeedImages WHERE id IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                                                              android.database.sqlite.DatabaseObjectNotClosedException: Application did not close the cursor or database object that was opened here
                                                                  at android.database.sqlite.SQLiteCursor.<init>(SQLiteCursor.java:98)
                                                                  at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:50)
                                                                  at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1345)
                                                                  at android.database.sqlite.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1192)
                                                                  at android.database.sqlite.SQLiteDatabase.query(SQLiteDatabase.java:1063)
                                                                  at android.database.sqlite.SQLiteDatabase.query(SQLiteDatabase.java:1231)
                                                                  at de.danoeh.antennapod.core.storage.PodDBAdapter.getImageCursor(PodDBAdapter.java:1196)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.getFeedImages(DBReader.java:905)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.extractItemlistFromCursor(DBReader.java:219)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.getFeedItemList(DBReader.java:179)
                                                                  at de.danoeh.antennapod.core.storage.DBReader.getFeed(DBReader.java:612)
                                                                  at de.danoeh.antennapod.core.storage.DBTasks.searchFeedByIdentifyingValueOrID(DBTasks.java:512)
                                                                  at de.danoeh.antennapod.core.storage.DBTasks.updateFeed(DBTasks.java:564)
                                                                  at de.danoeh.antennapod.core.service.download.DownloadService$FeedSyncThread.lambda$run$0(DownloadService.java:711)
                                                                  at de.danoeh.antennapod.core.service.download.DownloadService$FeedSyncThread$$Lambda$1.run(Unknown Source)
                                                                  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:428)
                                                                  at java.util.concurrent.FutureTask.run(FutureTask.java:237)
                                                                  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
                                                                  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
                                                                  at java.lang.Thread.run(Thread.java:761)
```