### PR TITLE
Avoid duplicate chapters

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/ChaptersListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ChaptersListAdapter.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.text.Layout;
 import android.text.Selection;
@@ -42,8 +43,9 @@ public class ChaptersListAdapter extends ArrayAdapter<Chapter> {
         this.media = media;
     }
 
+    @NonNull
     @Override
-    public View getView(final int position, View convertView, ViewGroup parent) {
+    public View getView(final int position, View convertView, @NonNull ViewGroup parent) {
         Holder holder;
 
         Chapter sc = getItem(position);
@@ -120,7 +122,7 @@ public class ChaptersListAdapter extends ArrayAdapter<Chapter> {
                     if (link.length != 0) {
                         if (action == MotionEvent.ACTION_UP) {
                             link[0].onClick(widget);
-                        } else if (action == MotionEvent.ACTION_DOWN){
+                        } else if (action == MotionEvent.ACTION_DOWN) {
                             Selection.setSelection(buffer,
                                     buffer.getSpanStart(link[0]),
                                     buffer.getSpanEnd(link[0]));
@@ -139,23 +141,17 @@ public class ChaptersListAdapter extends ArrayAdapter<Chapter> {
                 callback.onPlayChapterButtonClicked(position);
             }
         });
+
         Chapter current = ChapterUtils.getCurrentChapter(media);
-        if (current != null) {
-            if (current == sc) {
-                int playingBackGroundColor;
-                if(UserPreferences.getTheme() == R.style.Theme_AntennaPod_Dark) {
-                    playingBackGroundColor = ContextCompat.getColor(getContext(), R.color.highlight_dark);
-                } else {
-                    playingBackGroundColor = ContextCompat.getColor(getContext(), R.color.highlight_light);
-                }
-                holder.view.setBackgroundColor(playingBackGroundColor);
-            } else {
-                holder.view.setBackgroundColor(ContextCompat.getColor(getContext(), android.R.color.transparent));
-                holder.title.setTextColor(defaultTextColor);
-                holder.start.setTextColor(defaultTextColor);
-            }
+        if (current == sc) {
+            boolean darkTheme = UserPreferences.getTheme() == R.style.Theme_AntennaPod_Dark;
+            int highlight = darkTheme ? R.color.highlight_dark : R.color.highlight_light;
+            int playingBackGroundColor = ContextCompat.getColor(getContext(), highlight);
+            holder.view.setBackgroundColor(playingBackGroundColor);
         } else {
-            Log.w(TAG, "Could not find out what the current chapter is.");
+            holder.view.setBackgroundColor(ContextCompat.getColor(getContext(), android.R.color.transparent));
+            holder.title.setTextColor(defaultTextColor);
+            holder.start.setTextColor(defaultTextColor);
         }
 
         return convertView;
@@ -172,7 +168,7 @@ public class ChaptersListAdapter extends ArrayAdapter<Chapter> {
 
     @Override
     public int getCount() {
-        if(media == null || media.getChapters() == null) {
+        if (media == null || media.getChapters() == null) {
             return 0;
         }
         // ignore invalid chapters

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
@@ -27,11 +27,13 @@ public abstract class Chapter extends FeedComponent {
 	}
 
 	public static Chapter fromCursor(Cursor cursor, FeedItem item) {
+		int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
 		int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
 		int indexStart = cursor.getColumnIndex(PodDBAdapter.KEY_START);
 		int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
 		int indexChapterType = cursor.getColumnIndex(PodDBAdapter.KEY_CHAPTER_TYPE);
 
+		long id = cursor.getLong(indexId);
 		String title = cursor.getString(indexTitle);
 		long start = cursor.getLong(indexStart);
 		String link = cursor.getString(indexLink);
@@ -49,6 +51,7 @@ public abstract class Chapter extends FeedComponent {
 				chapter = new VorbisCommentChapter(start, title, item, link);
 				break;
 		}
+		chapter.setId(id);
 		return chapter;
 	}
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.core.feed;
 
 import android.database.Cursor;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -389,16 +389,19 @@ public class FeedMedia extends FeedFile implements Playable {
         if (item == null && itemID != 0) {
             item = DBReader.getFeedItem(itemID);
         }
+        if (item == null || item.getChapters() != null) {
+            return;
+        }
         // check if chapters are stored in db and not loaded yet.
-        if (item != null && item.hasChapters() && item.getChapters() == null) {
+        if (item.hasChapters()) {
             DBReader.loadChaptersOfFeedItem(item);
-        } else if (item != null && item.getChapters() == null) {
+        } else {
             if(localFileAvailable()) {
                 ChapterUtils.loadChaptersFromFileUrl(this);
             } else {
                 ChapterUtils.loadChaptersFromStreamUrl(this);
             }
-            if (getChapters() != null && item != null) {
+            if (item.getChapters() != null) {
                 DBWriter.setFeedItem(item);
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -976,7 +976,9 @@ public class DownloadService extends Service {
             media.checkEmbeddedPicture(); // enforce check
 
             // check if file has chapters
-            ChapterUtils.loadChaptersFromFileUrl(media);
+            if(media.getItem() != null && !media.getItem().hasChapters()) {
+                ChapterUtils.loadChaptersFromFileUrl(media);
+            }
 
             // Get duration
             MediaMetadataRetriever mmr = new MediaMetadataRetriever();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -811,31 +811,8 @@ public final class DBReader {
             }
             item.setChapters(new ArrayList<>(chaptersCount));
             while (cursor.moveToNext()) {
-                int indexType = cursor.getColumnIndex(PodDBAdapter.KEY_CHAPTER_TYPE);
-                int indexStart = cursor.getColumnIndex(PodDBAdapter.KEY_START);
-                int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
-                int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
-
-                int chapterType = cursor.getInt(indexType);
-                Chapter chapter = null;
-                long start = cursor.getLong(indexStart);
-                String title = cursor.getString(indexTitle);
-                String link = cursor.getString(indexLink);
-
-                switch (chapterType) {
-                    case SimpleChapter.CHAPTERTYPE_SIMPLECHAPTER:
-                        chapter = new SimpleChapter(start, title, item, link);
-                        break;
-                    case ID3Chapter.CHAPTERTYPE_ID3CHAPTER:
-                        chapter = new ID3Chapter(start, title, item, link);
-                        break;
-                    case VorbisCommentChapter.CHAPTERTYPE_VORBISCOMMENT_CHAPTER:
-                        chapter = new VorbisCommentChapter(start, title, item, link);
-                        break;
-                }
+                Chapter chapter = Chapter.fromCursor(cursor, item);
                 if (chapter != null) {
-                    int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
-                    chapter.setId(cursor.getLong(indexId));
                     item.getChapters().add(chapter);
                 }
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -1,5 +1,7 @@
 package de.danoeh.antennapod.core.util;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
@@ -14,7 +16,6 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
-import de.danoeh.antennapod.core.BuildConfig;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.util.comparator.ChapterStartTimeComparator;
 import de.danoeh.antennapod.core.util.id3reader.ChapterReader;
@@ -27,55 +28,74 @@ import de.danoeh.antennapod.core.util.vorbiscommentreader.VorbisCommentReaderExc
  * Utility class for getting chapter data from media files.
  */
 public class ChapterUtils {
+
     private static final String TAG = "ChapterUtils";
 
     private ChapterUtils() {
+    }
+
+    @Nullable
+    public static Chapter getCurrentChapter(Playable media) {
+        if (media.getChapters() == null) {
+            return null;
+        }
+        List<Chapter> chapters = media.getChapters();
+        if (chapters == null) {
+            return null;
+        }
+        Chapter current = chapters.get(0);
+        for (Chapter sc : chapters) {
+            if (sc.getStart() > media.getPosition()) {
+                break;
+            } else {
+                current = sc;
+            }
+        }
+        return current;
+    }
+
+    public static void loadChaptersFromStreamUrl(Playable media) {
+        ChapterUtils.readID3ChaptersFromPlayableStreamUrl(media);
+        if (media.getChapters() == null) {
+            ChapterUtils.readOggChaptersFromPlayableStreamUrl(media);
+        }
+    }
+
+    public static void loadChaptersFromFileUrl(Playable media) {
+        if (!media.localFileAvailable()) {
+            Log.e(TAG, "Could not load chapters from file url: local file not available");
+            return;
+        }
+        ChapterUtils.readID3ChaptersFromPlayableFileUrl(media);
+        if (media.getChapters() == null) {
+            ChapterUtils.readOggChaptersFromPlayableFileUrl(media);
+        }
     }
 
     /**
      * Uses the download URL of a media object of a feeditem to read its ID3
      * chapters.
      */
-    public static void readID3ChaptersFromPlayableStreamUrl(Playable p) {
-        if (p != null && p.getStreamUrl() != null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
-            InputStream in = null;
-            try {
-                URL url = new URL(p.getStreamUrl());
-                ChapterReader reader = new ChapterReader();
+    private static void readID3ChaptersFromPlayableStreamUrl(Playable p) {
+        if (p == null || p.getStreamUrl() == null) {
+            Log.e(TAG, "Unable to read ID3 chapters: media or download URL was null");
+            return;
+        }
+        Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
+        InputStream in = null;
+        try {
+            URL url = new URL(p.getStreamUrl());
 
-                in = url.openStream();
-                reader.readInputStream(in);
-                List<Chapter> chapters = reader.getChapters();
-
-                if (chapters != null) {
-                    Collections
-                            .sort(chapters, new ChapterStartTimeComparator());
-                    processChapters(chapters, p);
-                    if (chaptersValid(chapters)) {
-                        p.setChapters(chapters);
-                        Log.i(TAG, "Chapters loaded");
-                    } else {
-                        Log.e(TAG, "Chapter data was invalid");
-                    }
-                } else {
-                    Log.i(TAG, "ChapterReader could not find any ID3 chapters");
-                }
-            } catch (IOException | ID3ReaderException e) {
-                e.printStackTrace();
-            } finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
+            in = url.openStream();
+            List<Chapter> chapters = readChaptersFrom(in);
+            if(!chapters.isEmpty()) {
+                p.setChapters(chapters);
             }
-        } else {
-            Log.e(TAG,
-                    "Unable to read ID3 chapters: media or download URL was null");
+            Log.i(TAG, "Chapters loaded");
+        } catch (IOException | ID3ReaderException e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+        } finally {
+            IOUtils.closeQuietly(in);
         }
     }
 
@@ -83,107 +103,104 @@ public class ChapterUtils {
      * Uses the file URL of a media object of a feeditem to read its ID3
      * chapters.
      */
-    public static void readID3ChaptersFromPlayableFileUrl(Playable p) {
-        if (p != null && p.localFileAvailable() && p.getLocalMediaUrl() != null) {
-            if (BuildConfig.DEBUG)
-                Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
-            File source = new File(p.getLocalMediaUrl());
-            if (source.exists()) {
-                ChapterReader reader = new ChapterReader();
-                InputStream in = null;
+    private static void readID3ChaptersFromPlayableFileUrl(Playable p) {
+        if (p == null || !p.localFileAvailable() || p.getLocalMediaUrl() == null) {
+            return;
+        }
+        Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
+        File source = new File(p.getLocalMediaUrl());
+        if (!source.exists()) {
+            Log.e(TAG, "Unable to read id3 chapters: Source doesn't exist");
+            return;
+        }
 
-                try {
-                    in = new BufferedInputStream(new FileInputStream(source));
-                    reader.readInputStream(in);
-                    List<Chapter> chapters = reader.getChapters();
-
-                    if (chapters != null) {
-                        Collections.sort(chapters,
-                                new ChapterStartTimeComparator());
-                        processChapters(chapters, p);
-                        if (chaptersValid(chapters)) {
-                            p.setChapters(chapters);
-                            Log.i(TAG, "Chapters loaded");
-                        } else {
-                            Log.e(TAG, "Chapter data was invalid");
-                        }
-                    } else {
-                        Log.i(TAG,
-                                "ChapterReader could not find any ID3 chapters");
-                    }
-                } catch (IOException | ID3ReaderException e) {
-                    e.printStackTrace();
-                } finally {
-                    if (in != null) {
-                        try {
-                            in.close();
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-            } else {
-                Log.e(TAG, "Unable to read id3 chapters: Source doesn't exist");
+        InputStream in = null;
+        try {
+            in = new BufferedInputStream(new FileInputStream(source));
+            List<Chapter> chapters = readChaptersFrom(in);
+            if (!chapters.isEmpty()) {
+                p.setChapters(chapters);
             }
+            Log.i(TAG, "Chapters loaded");
+        } catch (IOException | ID3ReaderException e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+        } finally {
+            IOUtils.closeQuietly(in);
         }
     }
 
-    public static void readOggChaptersFromPlayableStreamUrl(Playable media) {
-        if (media != null && media.streamAvailable()) {
+    @NonNull
+    private static List<Chapter> readChaptersFrom(InputStream in) throws IOException, ID3ReaderException {
+        ChapterReader reader = new ChapterReader();
+        reader.readInputStream(in);
+        List<Chapter> chapters = reader.getChapters();
+
+        if (chapters == null) {
+            Log.i(TAG, "ChapterReader could not find any ID3 chapters");
+            return Collections.emptyList();
+        }
+        Collections.sort(chapters, new ChapterStartTimeComparator());
+        enumerateEmptyChapterTitles(chapters);
+        if (!chaptersValid(chapters)) {
+            Log.e(TAG, "Chapter data was invalid");
+            return Collections.emptyList();
+        }
+        return chapters;
+    }
+
+    private static void readOggChaptersFromPlayableStreamUrl(Playable media) {
+        if (media == null || !media.streamAvailable()) {
+            return;
+        }
+        InputStream input = null;
+        try {
+            URL url = new URL(media.getStreamUrl());
+            input = url.openStream();
+            if (input != null) {
+                readOggChaptersFromInputStream(media, input);
+            }
+        } catch (IOException e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+        } finally {
+            IOUtils.closeQuietly(input);
+        }
+    }
+
+    private static void readOggChaptersFromPlayableFileUrl(Playable media) {
+        if (media == null || media.getLocalMediaUrl() == null) {
+            return;
+        }
+        File source = new File(media.getLocalMediaUrl());
+        if (source.exists()) {
             InputStream input = null;
             try {
-                URL url = new URL(media.getStreamUrl());
-                input = url.openStream();
-                if (input != null) {
-                    readOggChaptersFromInputStream(media, input);
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
+                input = new BufferedInputStream(new FileInputStream(source));
+                readOggChaptersFromInputStream(media, input);
+            } catch (FileNotFoundException e) {
+                Log.e(TAG, Log.getStackTraceString(e));
             } finally {
                 IOUtils.closeQuietly(input);
             }
         }
     }
 
-    public static void readOggChaptersFromPlayableFileUrl(Playable media) {
-        if (media != null && media.getLocalMediaUrl() != null) {
-            File source = new File(media.getLocalMediaUrl());
-            if (source.exists()) {
-                InputStream input = null;
-                try {
-                    input = new BufferedInputStream(new FileInputStream(source));
-                    readOggChaptersFromInputStream(media, input);
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                } finally {
-                    IOUtils.closeQuietly(input);
-                }
-            }
-        }
-    }
-
-    private static void readOggChaptersFromInputStream(Playable p,
-                                                       InputStream input) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG,
-                    "Trying to read chapters from item with title "
-                            + p.getEpisodeTitle());
+    private static void readOggChaptersFromInputStream(Playable p, InputStream input) {
+        Log.d(TAG, "Trying to read chapters from item with title " + p.getEpisodeTitle());
         try {
             VorbisCommentChapterReader reader = new VorbisCommentChapterReader();
             reader.readInputStream(input);
             List<Chapter> chapters = reader.getChapters();
-            if (chapters != null) {
-                Collections.sort(chapters, new ChapterStartTimeComparator());
-                processChapters(chapters, p);
-                if (chaptersValid(chapters)) {
-                    p.setChapters(chapters);
-                    Log.i(TAG, "Chapters loaded");
-                } else {
-                    Log.e(TAG, "Chapter data was invalid");
-                }
+            if (chapters == null) {
+                Log.i(TAG, "ChapterReader could not find any Ogg vorbis chapters");
+                return;
+            }
+            Collections.sort(chapters, new ChapterStartTimeComparator());
+            enumerateEmptyChapterTitles(chapters);
+            if (chaptersValid(chapters)) {
+                p.setChapters(chapters);
+                Log.i(TAG, "Chapters loaded");
             } else {
-                Log.i(TAG,
-                        "ChapterReader could not find any Ogg vorbis chapters");
+                Log.e(TAG, "Chapter data was invalid");
             }
         } catch (VorbisCommentReaderException e) {
             e.printStackTrace();
@@ -193,7 +210,7 @@ public class ChapterUtils {
     /**
      * Makes sure that chapter does a title and an item attribute.
      */
-    private static void processChapters(List<Chapter> chapters, Playable p) {
+    private static void enumerateEmptyChapterTitles(List<Chapter> chapters) {
         for (int i = 0; i < chapters.size(); i++) {
             Chapter c = chapters.get(i);
             if (c.getTitle() == null) {
@@ -207,9 +224,6 @@ public class ChapterUtils {
             return false;
         }
         for (Chapter c : chapters) {
-            if (c.getTitle() == null) {
-                return false;
-            }
             if (c.getStart() < 0) {
                 return false;
             }
@@ -217,49 +231,4 @@ public class ChapterUtils {
         return true;
     }
 
-    /**
-     * Calls getCurrentChapter with current position.
-     */
-    public static Chapter getCurrentChapter(Playable media) {
-        if (media.getChapters() != null) {
-            List<Chapter> chapters = media.getChapters();
-            Chapter current = null;
-            if (chapters != null) {
-                current = chapters.get(0);
-                for (Chapter sc : chapters) {
-                    if (sc.getStart() > media.getPosition()) {
-                        break;
-                    } else {
-                        current = sc;
-                    }
-                }
-            }
-            return current;
-        } else {
-            return null;
-        }
-    }
-
-    public static void loadChaptersFromStreamUrl(Playable media) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Starting chapterLoader thread");
-        ChapterUtils.readID3ChaptersFromPlayableStreamUrl(media);
-        if (media.getChapters() == null) {
-            ChapterUtils.readOggChaptersFromPlayableStreamUrl(media);
-        }
-
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "ChapterLoaderThread has finished");
-    }
-
-    public static void loadChaptersFromFileUrl(Playable media) {
-        if (media.localFileAvailable()) {
-            ChapterUtils.readID3ChaptersFromPlayableFileUrl(media);
-            if (media.getChapters() == null) {
-                ChapterUtils.readOggChaptersFromPlayableFileUrl(media);
-            }
-        } else {
-            Log.e(TAG, "Could not load chapters from file url: local file not available");
-        }
-    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
@@ -27,20 +27,20 @@ public class ChapterReader extends ID3Reader {
 	@Override
 	public int onStartTagHeader(TagHeader header) {
 		chapters = new ArrayList<>();
-		System.out.println(header.toString());
+		Log.d(TAG, "header: " + header);
 		return ID3Reader.ACTION_DONT_SKIP;
 	}
 
 	@Override
 	public int onStartFrameHeader(FrameHeader header, InputStream input)
 			throws IOException, ID3ReaderException {
-		System.out.println(header.toString());
+		Log.d(TAG, "header: " + header);
 		switch (header.getId()) {
 			case FRAME_ID_CHAPTER:
 				if (currentChapter != null) {
 					if (!hasId3Chapter(currentChapter)) {
 						chapters.add(currentChapter);
-						if (BuildConfig.DEBUG) Log.d(TAG, "Found chapter: " + currentChapter);
+						Log.d(TAG, "Found chapter: " + currentChapter);
 						currentChapter = null;
 					}
 				}
@@ -59,7 +59,7 @@ public class ChapterReader extends ID3Reader {
 					readString(title, input, header.getSize());
 					currentChapter
 							.setTitle(title.toString());
-					if (BuildConfig.DEBUG) Log.d(TAG, "Found title: " + currentChapter.getTitle());
+					Log.d(TAG, "Found title: " + currentChapter.getTitle());
 
 					return ID3Reader.ACTION_DONT_SKIP;
 				}
@@ -74,7 +74,7 @@ public class ChapterReader extends ID3Reader {
 
 					currentChapter.setLink(decodedLink);
 
-					if (BuildConfig.DEBUG) Log.d(TAG, "Found link: " + currentChapter.getLink());
+					Log.d(TAG, "Found link: " + currentChapter.getLink());
 					return ID3Reader.ACTION_DONT_SKIP;
 				}
 				break;
@@ -102,17 +102,17 @@ public class ChapterReader extends ID3Reader {
 				chapters.add(currentChapter);
 			}
 		}
-		System.out.println("Reached end of tag");
+		Log.d(TAG, "Reached end of tag");
 		if (chapters != null) {
 			for (Chapter c : chapters) {
-				System.out.println(c.toString());
+				Log.d(TAG, "chapter: " + c);
 			}
 		}
 	}
 
 	@Override
 	public void onNoTagHeaderFound() {
-		System.out.println("No tag header found");
+		Log.d(TAG, "No tag header found");
 		super.onNoTagHeaderFound();
 	}
 


### PR DESCRIPTION
Problem was that the chapters were read from the just downloaded file and persisted even if the database already contained chapters read from the feed.

Resolves #2397 