### PR TITLE
Reload FeedMedia from DB to ensure correct playback position - fixes #2382

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -446,7 +446,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         Log.d(TAG, "OnStartCommand called");
         final int keycode = intent.getIntExtra(MediaButtonReceiver.EXTRA_KEYCODE, -1);
         final boolean castDisconnect = intent.getBooleanExtra(EXTRA_CAST_DISCONNECT, false);
-        final Playable playable = intent.getParcelableExtra(EXTRA_PLAYABLE);
+        Playable playable = intent.getParcelableExtra(EXTRA_PLAYABLE);
         if (keycode == -1 && playable == null && !castDisconnect) {
             Log.e(TAG, "PlaybackService was started with no arguments");
             stopSelf();
@@ -471,6 +471,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);
                 //If the user asks to play External Media, the casting session, if on, should end.
                 flavorHelper.castDisconnect(playable instanceof ExternalMedia);
+                if(playable instanceof FeedMedia){
+                    playable = (Playable) DBReader.getFeedMedia(((FeedMedia)playable).getId());
+                }
                 mediaPlayer.playMediaObject(playable, stream, startWhenPrepared, prepareImmediately);
             }
         }


### PR DESCRIPTION
Changed the implementation of the 'Parcelable' to sync with what is written to the DB.
It could happen that if Android OS deserializes a FeedMedia, that a  playback position is set to the LocalPSMP which is quite old. As described in #2382 this is easily reproducable in Andoid O probably because of the aggressive Background Task management.