### PR TITLE
Parse RSS pubDate fields containing "Sept"

### DIFF
--- a/core/src/androidTest/java/de/danoeh/antennapod/core/tests/util/DateUtilsTest.java
+++ b/core/src/androidTest/java/de/danoeh/antennapod/core/tests/util/DateUtilsTest.java
@@ -130,4 +130,12 @@ public class DateUtilsTest extends AndroidTestCase {
         Date actual = DateUtils.parse("Thu, 8 Oct 2014 09:00:00 GMT"); // actually a Wednesday
         assertEquals(expected, actual);
     }
+
+    public void testParseDateWithBadAbbreviation() {
+        GregorianCalendar exp1 = new GregorianCalendar(2014, 8, 8, 0, 0, 0);
+        exp1.setTimeZone(TimeZone.getTimeZone("GMT"));
+        Date expected = new Date(exp1.getTimeInMillis());
+        Date actual = DateUtils.parse("Mon, 8 Sept 2014 00:00:00 GMT"); // should be Sep
+        assertEquals(expected, actual);
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -31,6 +31,9 @@ public class DateUtils {
         date = date.replaceAll("CEST$", "+02:00");
         date = date.replaceAll("CET$", "+01:00");
 
+        // some generators use "Sept" for September
+        date = date.replaceAll("\\bSept\\b", "Sep");
+
         // if datetime is more precise than seconds, make sure the value is in ms
         if (date.contains(".")) {
             int start = date.indexOf('.');


### PR DESCRIPTION
According to [RFC 2822](https://www.ietf.org/rfc/rfc2822.txt) the correct abbreviation is `Sep`. But [some](https://bugs.eclipse.org/bugs/show_bug.cgi?id=521548) [generators](https://github.com/sparkle-project/Sparkle/issues/217) incorrectly use `Sept` instead. That causes the feed to be displayed out of order, and when logging is enabled, logcat shows `DateUtils: Could not parse date string`. The same feed works in Podcast Addict.