### PR TITLE
Set video aspect on initial creation

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -152,16 +152,9 @@ public class VideoplayerActivity extends MediaplayerActivity {
 
     @Override
     protected void onAwaitingVideoSurface() {
+        setupVideoAspectRatio();
         if (videoSurfaceCreated && controller != null) {
             Log.d(TAG, "Videosurface already created, setting videosurface now");
-
-            Pair<Integer, Integer> videoSize = controller.getVideoSize();
-            if (videoSize != null && videoSize.first > 0 && videoSize.second > 0) {
-                Log.d(TAG, "Width,height of video: " + videoSize.first + ", " + videoSize.second);
-                videoview.setVideoSize(videoSize.first, videoSize.second);
-            } else {
-                Log.e(TAG, "Could not determine video size");
-            }
             controller.setVideoSurface(videoview.getHolder());
         }
     }
@@ -197,6 +190,18 @@ public class VideoplayerActivity extends MediaplayerActivity {
     void setupVideoControlsToggler() {
         videoControlsHider.stop();
         videoControlsHider.start();
+    }
+
+    private void setupVideoAspectRatio() {
+        if (videoSurfaceCreated && controller != null) {
+            Pair<Integer, Integer> videoSize = controller.getVideoSize();
+            if (videoSize != null && videoSize.first > 0 && videoSize.second > 0) {
+                Log.d(TAG, "Width,height of video: " + videoSize.first + ", " + videoSize.second);
+                videoview.setVideoSize(videoSize.first, videoSize.second);
+            } else {
+                Log.e(TAG, "Could not determine video size");
+            }
+        }
     }
 
     private void toggleVideoControlsVisibility() {
@@ -247,7 +252,7 @@ public class VideoplayerActivity extends MediaplayerActivity {
                     Log.e(TAG, "Couldn't attach surface to mediaplayer - reference to service was null");
                 }
             }
-
+            setupVideoAspectRatio();
         }
 
         @Override


### PR DESCRIPTION
Previously on first start of a video the aspect ratio
was not correct (annoying on a 18:9 phone as
it doesn't match the usual 16:9 aspect ratio). So extract
the code into a setupVideoAspectRatio() helper
and call it from surfaceCreated as well.