### PR TITLE
set minSdkVersion to 14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
 project.ext {
     compileSdkVersion = 25
     buildToolsVersion = "25.0.3"
-    minSdkVersion = 10
+    minSdkVersion = 14
     targetSdkVersion = 25
 
     supportVersion = "25.3.1"


### PR DESCRIPTION
According to https://developer.android.com/about/dashboards/index.html
API levels of 14 and lower are only on less than 0.5% of the devices.
IMHO it is time to move on, and allow for some compat code cleanup.

Example cleanup included, but there is a lot to remove (extra resources,
various conditionals in the code)