### PR TITLE
Make some static fields final

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
@@ -77,7 +77,7 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
     private static final int POS_CHAPTERS = 2;
     private static final int NUM_CONTENT_FRAGMENTS = 3;
 
-    final String TAG = "MediaplayerInfoActivity";
+    final static String TAG = "MediaplayerInfoActivity";
     private static final String PREFS = "AudioPlayerActivityPreferences";
     private static final String PREF_KEY_SELECTED_FRAGMENT_POSITION = "selectedFragmentPosition";
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
@@ -29,7 +29,7 @@ import de.danoeh.antennapod.core.storage.DownloadRequestException;
 /** Displays a list of DownloadStatus entries. */
 public class DownloadLogAdapter extends BaseAdapter {
 
-	private final String TAG = "DownloadLogAdapter";
+	private static final String TAG = "DownloadLogAdapter";
 
 	private Context context;
 

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -32,7 +32,7 @@ import de.danoeh.antennapod.core.util.LongList;
 
 public class EpisodesApplyActionFragment extends Fragment {
 
-    public String TAG = "EpisodeActionFragment";
+    public static final String TAG = "EpisodeActionFragment";
 
     public static final int ACTION_QUEUE = 1;
     public static final int ACTION_MARK_PLAYED = 2;

--- a/core/src/main/java/de/danoeh/antennapod/core/export/html/HtmlSymbols.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/export/html/HtmlSymbols.java
@@ -22,7 +22,7 @@ class HtmlSymbols extends CommonSymbols {
     static final String ORDERED_LIST = "ol";
     static final String LIST_ITEM = "li";
 
-    static String HEADING = "h1";
+    static final String HEADING = "h1";
 
     static final String LINK = "a";
     static final String LINK_DESTINATION = "href";

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -124,7 +124,7 @@ public class UserPreferences {
     private static final int NOTIFICATION_BUTTON_REWIND = 0;
     private static final int NOTIFICATION_BUTTON_FAST_FORWARD = 1;
     private static final int NOTIFICATION_BUTTON_SKIP = 2;
-    private static int EPISODE_CACHE_SIZE_UNLIMITED = -1;
+    private static final int EPISODE_CACHE_SIZE_UNLIMITED = -1;
     public static final int FEED_ORDER_COUNTER = 0;
     public static final int FEED_ORDER_ALPHABETICAL = 1;
     public static final int FEED_ORDER_LAST_UPDATE = 2;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -127,8 +127,8 @@ public class DownloadService extends Service {
 
 
     private NotificationCompat.Builder notificationCompatBuilder;
-    private int NOTIFICATION_ID = 2;
-    private int REPORT_ID = 3;
+    private static final int NOTIFICATION_ID = 2;
+    private static final int REPORT_ID = 3;
 
     /**
      * Currently running downloads.
@@ -611,7 +611,7 @@ public class DownloadService extends Service {
         private volatile boolean isActive = true;
         private volatile boolean isCollectingRequests = false;
 
-        private final long WAIT_TIMEOUT = 3000;
+        private static final long WAIT_TIMEOUT = 3000;
 
 
         /**


### PR DESCRIPTION
Adding final prohibits modification and allows initialization of
primitive and String fields at compile time instead of runtime in
clinit:

https://developer.android.com/training/articles/perf-tips.html#UseFinal

Found via error-prone.