### PR TITLE
Hotfix for servers not accepting the Range header

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -93,7 +93,7 @@ public class HttpDownloader extends Downloader {
 
 
             // add range header if necessary
-            if (fileExists) {
+            if (fileExists && destination.length() > 0) {
                 request.setSoFar(destination.length());
                 httpReq.addHeader("Range", "bytes=" + request.getSoFar() + "-");
                 Log.d(TAG, "Adding range header: " + request.getSoFar());


### PR DESCRIPTION
Because of #2339, the file always exists when starting a download.
There is still an issue with the server parsing "Range: bytes=0-"
incorrectly, but this commit should make the error appear less often.

Related to #2539