### PR TITLE
Layout improvements

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -109,7 +109,6 @@ public class QueueFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        recyclerView.setAdapter(recyclerAdapter);
         loadItems(true);
         EventDistributor.getInstance().register(contentUpdate);
         EventBus.getDefault().registerSticky(this);

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -38,6 +38,7 @@
             android:maxLines="2"
             android:ellipsize="end"
             android:text="Podcast"
+            android:textIsSelectable="true"
             android:textColor="?android:attr/textColorSecondary" />
 
     </LinearLayout>
@@ -61,6 +62,7 @@
             android:maxLines="2"
             android:ellipsize="end"
             android:text="Episode"
+            android:textIsSelectable="true"
             android:textColor="?android:attr/textColorPrimary" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/external_player_fragment.xml
+++ b/app/src/main/res/layout/external_player_fragment.xml
@@ -1,91 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/fragmentLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
+    android:layout_height="@dimen/external_player_height"
     android:visibility="gone"
     android:background="?attr/selectableItemBackground">
 
-    <RelativeLayout
+    <ImageView
+        android:id="@+id/imgvCover"
+        android:contentDescription="@string/cover_label"
+        android:layout_width="@dimen/external_player_height"
+        android:layout_height="@dimen/external_player_height"
+        android:adjustViewBounds="true"
+        android:cropToPadding="true"
+        android:scaleType="centerCrop"
+        tools:src="@drawable/ic_drag_vertical_white_48dp"
+        tools:background="@android:color/holo_green_dark"
+        android:transitionName="coverTransition"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"/>
+
+    <ProgressBar
+        android:id="@+id/episodeProgress"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/external_player_height">
+        android:layout_height="4dp"
+        android:layout_toRightOf="@id/imgvCover"
+        android:layout_toEndOf="@id/imgvCover"
+        android:layout_alignParentTop="true"
+        style="?attr/progressBarTheme"
+        android:indeterminate="false"
+        tools:progress="100"/>
 
-        <ImageView
-            android:id="@+id/imgvCover"
-            android:contentDescription="@string/cover_label"
-            android:layout_width="@dimen/external_player_height"
-            android:layout_height="@dimen/external_player_height"
-            android:adjustViewBounds="true"
-            android:cropToPadding="true"
-            android:scaleType="centerCrop"
-            tools:src="@drawable/ic_drag_vertical_white_48dp"
-            tools:background="@android:color/holo_green_dark"
-            android:transitionName="coverTransition"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"/>
+    <ImageButton
+        android:id="@+id/butPlay"
+        android:layout_width="52dp"
+        android:layout_height="52dp"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@id/episodeProgress"
+        android:layout_centerVertical="true"
+        android:contentDescription="@string/pause_label"
+        android:background="?attr/selectableItemBackground"
+        tools:src="@drawable/ic_play_arrow_white_36dp"/>
 
-        <ProgressBar
-            android:id="@+id/episodeProgress"
-            android:layout_width="match_parent"
-            android:layout_height="4dp"
-            android:layout_toRightOf="@id/imgvCover"
-            android:layout_toEndOf="@id/imgvCover"
-            android:layout_alignParentTop="true"
-            style="?attr/progressBarTheme"
-            android:indeterminate="false"
-            tools:progress="100"/>
+    <TextView
+        android:id="@+id/txtvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="26dp"
+        android:layout_toRightOf="@id/imgvCover"
+        android:layout_toEndOf="@id/imgvCover"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_toLeftOf="@id/butPlay"
+        android:layout_toStartOf="@id/butPlay"
+        style="@style/Base.TextAppearance.AppCompat.Body1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        tools:text="Episode title that is too long and will cause the text to wrap"/>
 
-        <ImageButton
-            android:id="@+id/butPlay"
-            android:layout_width="52dp"
-            android:layout_height="52dp"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"
-            android:layout_below="@id/episodeProgress"
-            android:layout_centerVertical="true"
-            android:contentDescription="@string/pause_label"
-            android:background="?attr/selectableItemBackground"
-            tools:src="@drawable/ic_play_arrow_white_36dp"/>
+    <TextView
+        android:id="@+id/txtvAuthor"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/episodeProgress"
+        android:layout_marginTop="26dp"
+        android:layout_toRightOf="@id/imgvCover"
+        android:layout_toEndOf="@id/imgvCover"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_toLeftOf="@id/butPlay"
+        android:layout_toStartOf="@id/butPlay"
+        style="@style/TextAppearance.AppCompat.Body1"
+        android:textColor="?android:attr/textColorSecondary"
+        android:ellipsize="end"
+        android:maxLines="1"
+        tools:text="Episode author that is too long and will cause the text to wrap"/>
 
-        <TextView
-            android:id="@+id/txtvTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_marginBottom="26dp"
-            android:layout_toRightOf="@id/imgvCover"
-            android:layout_toEndOf="@id/imgvCover"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_toLeftOf="@id/butPlay"
-            android:layout_toStartOf="@id/butPlay"
-            style="@style/Base.TextAppearance.AppCompat.Body1"
-            android:ellipsize="end"
-            android:maxLines="1"
-            tools:text="Episode title that is too long and will cause the text to wrap"/>
-
-        <TextView
-            android:id="@+id/txtvAuthor"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/episodeProgress"
-            android:layout_marginTop="26dp"
-            android:layout_toRightOf="@id/imgvCover"
-            android:layout_toEndOf="@id/imgvCover"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_toLeftOf="@id/butPlay"
-            android:layout_toStartOf="@id/butPlay"
-            style="@style/TextAppearance.AppCompat.Body1"
-            android:textColor="?android:attr/textColorSecondary"
-            android:ellipsize="end"
-            android:maxLines="1"
-            tools:text="Episode author that is too long and will cause the text to wrap"/>
-
-    </RelativeLayout>
-
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/external_player_fragment.xml
+++ b/app/src/main/res/layout/external_player_fragment.xml
@@ -6,7 +6,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:visibility="gone">
+    android:visibility="gone"
+    android:background="?attr/selectableItemBackground">
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="#5000"
+    android:background="@color/feed_image_bg"
     tools:context="de.danoeh.antennapod.activity.MainActivity"
     tools:background="@android:color/darker_gray">
 

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="#5000"
     tools:context="de.danoeh.antennapod.activity.MainActivity"
     tools:background="@android:color/darker_gray">
 

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <RelativeLayout
         android:id="@+id/content"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -16,7 +16,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:background="?attr/colorPrimary"
             tools:layout_height="64dp"
             tools:background="@android:color/holo_green_light" />
 
@@ -42,6 +41,7 @@
             android:layout_height="0px"
             android:layout_above="@id/playerFragment"
             android:layout_below="@id/toolbar"
+            android:foreground="?android:windowContentOverlay"
             tools:background="@android:color/holo_red_dark" />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -16,6 +16,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
+            android:background="?attr/colorPrimary"
             tools:layout_height="64dp"
             tools:background="@android:color/holo_green_light" />
 
@@ -41,7 +42,6 @@
             android:layout_height="0px"
             android:layout_above="@id/playerFragment"
             android:layout_below="@id/toolbar"
-            android:foreground="?android:windowContentOverlay"
             tools:background="@android:color/holo_red_dark" />
 
     </RelativeLayout>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -20,6 +20,7 @@
     <color name="swipe_refresh_secondary_color_dark">#060708</color>
     <color name="new_indicator_green">#669900</color>
     <color name="image_readability_tint">#80000000</color>
+    <color name="feed_image_bg">#50000000</color>
 
     <color name="selection_background_color_dark">#286E8A</color>
     <color name="selection_background_color_light">#81CFEA</color>


### PR DESCRIPTION
This fixes that awful flickering when returning back to the queue:

![ezgif-4-8d51e687f6](https://user-images.githubusercontent.com/5811634/36127179-5038e64e-105c-11e8-821e-25501d2f0e8d.gif)

Feed header background color:

<img src="https://user-images.githubusercontent.com/5811634/36127235-a19cc0dc-105c-11e8-9e6c-377b885dc73f.png" width="310" /> <img src="https://user-images.githubusercontent.com/5811634/36127234-a17e28d4-105c-11e8-9474-05abdb0233ef.png" width="310" />

Closes #2565