### PR TITLE
Removed large icon from notification

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -339,12 +339,9 @@ public class DownloadService extends Service {
     }
 
     private void setupNotificationBuilders() {
-        Bitmap icon = BitmapFactory.decodeResource(getResources(), R.drawable.stat_notify_sync);
-
         notificationCompatBuilder = new NotificationCompat.Builder(this)
                 .setOngoing(true)
                 .setContentIntent(ClientConfig.downloadServiceCallbacks.getNotificationContentIntent(this))
-                .setLargeIcon(icon)
                 .setSmallIcon(R.drawable.stat_notify_sync);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             notificationCompatBuilder.setVisibility(Notification.VISIBILITY_PUBLIC);
@@ -511,10 +508,6 @@ public class DownloadService extends Service {
                                     successfulDownloads, failedDownloads)
                     )
                     .setSmallIcon(R.drawable.stat_notify_sync_error)
-                    .setLargeIcon(
-                            BitmapFactory.decodeResource(getResources(),
-                                    R.drawable.stat_notify_sync_error)
-                    )
                     .setContentIntent(
                             ClientConfig.downloadServiceCallbacks.getReportNotificationContentIntent(this)
                     )
@@ -565,7 +558,6 @@ public class DownloadService extends Service {
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(getText(R.string.authentication_notification_msg)
                             + ": " + resourceTitle))
                     .setSmallIcon(R.drawable.ic_stat_authentication)
-                    .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.drawable.ic_stat_authentication))
                     .setAutoCancel(true)
                     .setContentIntent(ClientConfig.downloadServiceCallbacks.getAuthentificationNotificationContentIntent(DownloadService.this, downloadRequest));
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
Closes #2541.

We do not need the same icon twice.
As the icon is displayed white-on-white, it is not visible anyways.
This also gives more space to the notification text