### PR TITLE
Fix possible NPE accessing image.download_url

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -305,8 +305,10 @@ public class Feed extends FeedFile implements FlattrThing, ImageResource {
         if (super.compareWithOther(other)) {
             return true;
         }
-        if(other.image != null && !TextUtils.equals(image.download_url, other.image.download_url)) {
-            return true;
+        if (other.image != null) {
+            if (image == null || !TextUtils.equals(image.download_url, other.image.download_url)) {
+                return true;
+            }
         }
         if (!TextUtils.equals(feedTitle, other.feedTitle)) {
             return true;


### PR DESCRIPTION
May fix #2386. If so, thanks to @cyplo who provided the logcat output
which directed me to that code path.