### PR TITLE
Fix "no shownotes" message when contentEncoded is empty but not null

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -372,7 +373,7 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Flattr
             if (contentEncoded == null || description == null) {
                 DBReader.loadExtraInformationOfFeedItem(FeedItem.this);
             }
-            return (contentEncoded != null) ? contentEncoded : description;
+            return !StringUtils.isEmpty(contentEncoded) ? contentEncoded : description;
         };
     }
 


### PR DESCRIPTION
On some feeds (such as http://www.hellointernet.fm/podcast?format=rss), the <content:encoded> tag is empty but present, which makes AntennaPod ignore the <description> tag.