### PR TITLE
Use generic export message instead of OPML

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -474,8 +474,8 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         subscription = observable.subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(output -> {
-                    alert.setTitle(R.string.opml_export_success_title);
-                    String message = context.getString(R.string.opml_export_success_sum) + output.toString();
+                    alert.setTitle(R.string.export_success_title);
+                    String message = context.getString(R.string.export_success_sum, output.toString());
                     alert.setMessage(message);
                     alert.setPositiveButton(R.string.send_label, (dialog, which) -> {
                         Uri fileUri = FileProvider.getUriForFile(context.getApplicationContext(),

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -475,8 +475,8 @@
     <string name="html_export_label">HTML export</string>
     <string name="exporting_label">Exporting&#8230;</string>
     <string name="export_error_label">Export error</string>
-    <string name="opml_export_success_title">OPML Export successful.</string>
-    <string name="opml_export_success_sum">The .opml file was written to:\u0020</string>
+    <string name="export_success_title">Export successful</string>
+    <string name="export_success_sum">The exported file was written to:\n\n%1$s</string>
     <string name="opml_import_ask_read_permission">Access to external storage is required to read the OPML file</string>
 
     <!-- Sleep timer -->


### PR DESCRIPTION
The same message is shown for HTML and OPML. Fixes #2462.
Additionally, using string formatting now instead of just "+"