### PR TITLE
Allow to focus settings button

### DIFF
--- a/app/src/main/res/layout/nav_list.xml
+++ b/app/src/main/res/layout/nav_list.xml
@@ -15,7 +15,8 @@
         android:layout_alignParentBottom="true"
         android:background="?attr/selectableItemBackground"
         android:contentDescription="@string/settings_label"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:focusable="true">
 
         <ImageView
             android:id="@+id/imgvCover"


### PR DESCRIPTION
Without this change, it seems like the sidebar is not usable
by using arrow keys only.

Related to #445.