### PR TITLE
Actually return instance in getInstance

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -308,26 +308,22 @@ public class PodDBAdapter {
             KEY_CONTENT_ENCODED, KEY_FEED};
 
     private static Context context;
-    private static PodDBHelper dbHelper;
 
     private static volatile SQLiteDatabase db;
     private static int counter = 0;
-    private static PodDBAdapter instance;
 
     public static void init(Context context) {
         PodDBAdapter.context = context.getApplicationContext();
     }
 
-    private static class PodDBHelperholder {
-        public static final PodDBHelper dbHelper = new PodDBHelper(PodDBAdapter.context, DATABASE_NAME, null);
+    // Bill Pugh Singleton Implementation
+    private static class SingletonHolder {
+        private static final PodDBHelper dbHelper = new PodDBHelper(PodDBAdapter.context, DATABASE_NAME, null);
+        private static final PodDBAdapter dbAdapter = new PodDBAdapter();
     }
 
     public static PodDBAdapter getInstance() {
-        if (instance == null) {
-            instance = new PodDBAdapter();
-        }
-        dbHelper = PodDBHelperholder.dbHelper;
-        return instance;
+        return SingletonHolder.dbAdapter;
     }
 
     private PodDBAdapter() {
@@ -346,11 +342,11 @@ public class PodDBAdapter {
     private SQLiteDatabase openDb() {
         SQLiteDatabase newDb;
         try {
-            newDb = dbHelper.getWritableDatabase();
+            newDb = SingletonHolder.dbHelper.getWritableDatabase();
             newDb.enableWriteAheadLogging();
         } catch (SQLException ex) {
             Log.e(TAG, Log.getStackTraceString(ex));
-            newDb = dbHelper.getReadableDatabase();
+            newDb = SingletonHolder.dbHelper.getReadableDatabase();
         }
         return newDb;
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -312,6 +312,7 @@ public class PodDBAdapter {
 
     private static volatile SQLiteDatabase db;
     private static int counter = 0;
+    private static PodDBAdapter instance;
 
     public static void init(Context context) {
         PodDBAdapter.context = context.getApplicationContext();
@@ -322,8 +323,11 @@ public class PodDBAdapter {
     }
 
     public static PodDBAdapter getInstance() {
+        if (instance == null) {
+            instance = new PodDBAdapter();
+        }
         dbHelper = PodDBHelperholder.dbHelper;
-        return new PodDBAdapter();
+        return instance;
     }
 
     private PodDBAdapter() {


### PR DESCRIPTION
This probably fixes all those "db deleted" issues and mysterious NPEs

Previously, the synchronized keyword on open() and close() was useless
because it was synchronizing on different objects in each thread.

Might fix various bugs like:
#1945 #2270 #2463 #2571