### PR TITLE
About activity cleanup

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -36,8 +36,6 @@ public class AboutActivity extends AppCompatActivity {
 
     private WebView webview;
     private LinearLayout webviewContainer;
-    private int depth = 0;
-
     private Subscription subscription;
 
     @Override
@@ -60,14 +58,12 @@ public class AboutActivity extends AppCompatActivity {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                if(url.startsWith("http")) {
-                    depth++;
-                    return false;
-                } else {
+                if (!url.startsWith("http")) {
                     url = url.replace("file:///android_asset/", "");
                     loadAsset(url);
                     return true;
                 }
+                return false;
             }
 
         });
@@ -105,9 +101,6 @@ public class AboutActivity extends AppCompatActivity {
                             "    </style>" +
                             "</head><body><p>" + webViewData + "</p></body></html>";
                     webViewData = webViewData.replace("\n", "<br/>");
-                    depth++;
-                } else {
-                    depth = 0;
                 }
                 webViewData = String.format(webViewData, colorString);
                 return webViewData;
@@ -129,10 +122,7 @@ public class AboutActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        Log.d(TAG, "depth: " + depth);
-        if(depth == 1) {
-            loadAsset("about.html");
-        } else if(depth > 1) {
+        if (webview.canGoBack()) {
             webview.goBack();
         } else {
             super.onBackPressed();

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -34,8 +34,8 @@ public class AboutActivity extends AppCompatActivity {
 
     private static final String TAG = AboutActivity.class.getSimpleName();
 
-    private WebView webview;
-    private LinearLayout webviewContainer;
+    private WebView webView;
+    private LinearLayout webViewContainer;
     private Subscription subscription;
 
     @Override
@@ -44,16 +44,16 @@ public class AboutActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
         setContentView(R.layout.about);
-        webviewContainer = (LinearLayout) findViewById(R.id.webvContainer);
-        webview = (WebView) findViewById(R.id.webvAbout);
-        webview.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
+        webViewContainer = (LinearLayout) findViewById(R.id.webViewContainer);
+        webView = (WebView) findViewById(R.id.webViewAbout);
+        webView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         if (UserPreferences.getTheme() == R.style.Theme_AntennaPod_Dark) {
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
-                webview.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+                webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
             }
-            webview.setBackgroundColor(Color.TRANSPARENT);
+            webView.setBackgroundColor(Color.TRANSPARENT);
         }
-        webview.setWebViewClient(new WebViewClient() {
+        webView.setWebViewClient(new WebViewClient() {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
@@ -114,15 +114,15 @@ public class AboutActivity extends AppCompatActivity {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         webviewData ->
-                                webview.loadDataWithBaseURL("file:///android_asset/", webviewData, "text/html", "utf-8", "about:blank"),
+                                webView.loadDataWithBaseURL("file:///android_asset/", webviewData, "text/html", "utf-8", "about:blank"),
                         error -> Log.e(TAG, Log.getStackTraceString(error))
                 );
     }
 
     @Override
     public void onBackPressed() {
-        if (webview.canGoBack()) {
-            webview.goBack();
+        if (webView.canGoBack()) {
+            webView.goBack();
         } else {
             super.onBackPressed();
         }
@@ -144,9 +144,9 @@ public class AboutActivity extends AppCompatActivity {
         if(subscription != null) {
             subscription.unsubscribe();
         }
-        if (webviewContainer != null && webview != null) {
-            webviewContainer.removeAllViews();
-            webview.destroy();
+        if (webViewContainer != null && webView != null) {
+            webViewContainer.removeAllViews();
+            webView.destroy();
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -101,9 +101,7 @@ public class AboutActivity extends AppCompatActivity {
                             "    </style>" +
                             "</head><body><p>" + webViewData + "</p></body></html>";
                     webViewData = webViewData.replace("\n", "<br/>");
-                }
-                else
-                {
+                } else {
                     depth = 0;
                 }
                 webViewData = String.format(webViewData, colorString);

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -75,7 +75,7 @@ public class AboutActivity extends AppCompatActivity {
     }
 
     private void loadAsset(String filename) {
-        subscription = Observable.create((Observable.OnSubscribe<String>) subscriber -> {
+        subscription = Observable.fromCallable(()-> {
             InputStream input = null;
             try {
                 TypedArray res = AboutActivity.this.getTheme().obtainStyledAttributes(
@@ -85,8 +85,7 @@ public class AboutActivity extends AppCompatActivity {
                 res.recycle();
                 input = getAssets().open(filename);
                 String webViewData = IOUtils.toString(input, Charset.defaultCharset());
-                if(!webViewData.startsWith("<!DOCTYPE html>")) {
-                    //webViewData = webViewData.replace("\n\n", "</p><p>");
+                if (!webViewData.startsWith("<!DOCTYPE html>")) {
                     webViewData = webViewData.replace("%", "&#37;");
                     webViewData =
                             "<!DOCTYPE html>" +
@@ -111,13 +110,13 @@ public class AboutActivity extends AppCompatActivity {
                     depth = 0;
                 }
                 webViewData = String.format(webViewData, colorString);
-                subscriber.onNext(webViewData);
+                return webViewData;
             } catch (IOException e) {
-                subscriber.onError(e);
+                Log.e(TAG, Log.getStackTraceString(e));
+                throw e;
             } finally {
                 IOUtils.closeQuietly(input);
             }
-            subscriber.onCompleted();
         })
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -113,7 +113,7 @@ public class AboutActivity extends AppCompatActivity {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         webViewData ->
-                                webView.loadDataWithBaseURL("file:///android_asset/", webViewData.toString(), "text/html", "utf-8", "file:///android_asset/" + webViewData.toString()),
+                                webView.loadDataWithBaseURL("file:///android_asset/", webViewData.toString(), "text/html", "utf-8", "file:///android_asset/" + filename.toString()),
                         error -> Log.e(TAG, Log.getStackTraceString(error))
                 );
     }

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -48,8 +48,7 @@ public class AboutActivity extends AppCompatActivity {
         webview = (WebView) findViewById(R.id.webvAbout);
         webview.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         if (UserPreferences.getTheme() == R.style.Theme_AntennaPod_Dark) {
-            if (Build.VERSION.SDK_INT >= 11
-                    && Build.VERSION.SDK_INT <= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
                 webview.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
             }
             webview.setBackgroundColor(Color.TRANSPARENT);

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -22,7 +22,6 @@ import java.nio.charset.Charset;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import rx.Observable;
-import rx.Subscriber;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -36,6 +36,7 @@ public class AboutActivity extends AppCompatActivity {
     private WebView webView;
     private LinearLayout webViewContainer;
     private Subscription subscription;
+    private int depth = 0;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -56,6 +57,7 @@ public class AboutActivity extends AppCompatActivity {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                depth++;
                 if (!url.startsWith("http")) {
                     url = url.replace("file:///android_asset/", "");
                     loadAsset(url);
@@ -100,6 +102,10 @@ public class AboutActivity extends AppCompatActivity {
                             "</head><body><p>" + webViewData + "</p></body></html>";
                     webViewData = webViewData.replace("\n", "<br/>");
                 }
+                else
+                {
+                    depth = 0;
+                }
                 webViewData = String.format(webViewData, colorString);
                 subscriber.onSuccess(webViewData);
             } catch (IOException e) {
@@ -120,8 +126,9 @@ public class AboutActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (webView.canGoBack()) {
+        if (depth != 0) {
             webView.goBack();
+            depth--;
         } else {
             super.onBackPressed();
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -36,7 +36,6 @@ public class AboutActivity extends AppCompatActivity {
     private WebView webView;
     private LinearLayout webViewContainer;
     private Subscription subscription;
-    private int depth = 0;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -57,7 +56,6 @@ public class AboutActivity extends AppCompatActivity {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                depth++;
                 if (!url.startsWith("http")) {
                     url = url.replace("file:///android_asset/", "");
                     loadAsset(url);
@@ -101,8 +99,6 @@ public class AboutActivity extends AppCompatActivity {
                             "    </style>" +
                             "</head><body><p>" + webViewData + "</p></body></html>";
                     webViewData = webViewData.replace("\n", "<br/>");
-                } else {
-                    depth = 0;
                 }
                 webViewData = String.format(webViewData, colorString);
                 subscriber.onSuccess(webViewData);
@@ -117,16 +113,15 @@ public class AboutActivity extends AppCompatActivity {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         webViewData ->
-                                webView.loadDataWithBaseURL("file:///android_asset/", webViewData.toString(), "text/html", "utf-8", "about:blank"),
+                                webView.loadDataWithBaseURL("file:///android_asset/", webViewData.toString(), "text/html", "utf-8", "file:///android_asset/" + webViewData.toString()),
                         error -> Log.e(TAG, Log.getStackTraceString(error))
                 );
     }
 
     @Override
     public void onBackPressed() {
-        if (depth != 0) {
+        if (webView.canGoBack()) {
             webView.goBack();
-            depth--;
         } else {
             super.onBackPressed();
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/AboutActivity.java
@@ -21,7 +21,7 @@ import java.nio.charset.Charset;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
-import rx.Observable;
+import rx.Single;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
@@ -69,7 +69,7 @@ public class AboutActivity extends AppCompatActivity {
     }
 
     private void loadAsset(String filename) {
-        subscription = Observable.fromCallable(()-> {
+        subscription = Single.create(subscriber -> {
             InputStream input = null;
             try {
                 TypedArray res = AboutActivity.this.getTheme().obtainStyledAttributes(
@@ -101,10 +101,10 @@ public class AboutActivity extends AppCompatActivity {
                     webViewData = webViewData.replace("\n", "<br/>");
                 }
                 webViewData = String.format(webViewData, colorString);
-                return webViewData;
+                subscriber.onSuccess(webViewData);
             } catch (IOException e) {
                 Log.e(TAG, Log.getStackTraceString(e));
-                throw e;
+                subscriber.onError(e);
             } finally {
                 IOUtils.closeQuietly(input);
             }
@@ -112,8 +112,8 @@ public class AboutActivity extends AppCompatActivity {
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        webviewData ->
-                                webView.loadDataWithBaseURL("file:///android_asset/", webviewData, "text/html", "utf-8", "about:blank"),
+                        webViewData ->
+                                webView.loadDataWithBaseURL("file:///android_asset/", webViewData.toString(), "text/html", "utf-8", "about:blank"),
                         error -> Log.e(TAG, Log.getStackTraceString(error))
                 );
     }

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/webvContainer"
+    android:id="@+id/webViewContainer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
     <WebView
-        android:id="@+id/webvAbout"
+        android:id="@+id/webViewAbout"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 


### PR DESCRIPTION
- create((Observable.OnSubscribe<String>) was deprecated, so replaced with fromCallable(())
- Navigating through the Links would latch the depth greater than 1, and so you couldn't leave the About page (replaced depth with webView.canGoBack())
- Code clean-up:
  - Removed unnecessary version check
  - Fixed spelling
  - Removed unnecessary import