### PR TITLE
Don't pause directly after starting

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1436,6 +1436,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         @Override
         public void onReceive(Context context, Intent intent) {
+            if (isInitialStickyBroadcast ()) {
+                // Don't pause playback after we just started, just because the receiver
+                // delivers the current headset state (instead of a change)
+                return;
+            }
+
             if (TextUtils.equals(intent.getAction(), Intent.ACTION_HEADSET_PLUG)) {
                 int state = intent.getIntExtra("state", -1);
                 if (state != -1) {


### PR DESCRIPTION
When registering the receiver, it immediately receives
a headset unplugged event (broadcast is sticky) and pauses
playback again in some cases. We are only interested in status
changes, so we can just return.

Fixes #2635