### PR TITLE
Share link improvement 2579

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -605,16 +605,14 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
     }
 
     private static String getWebsiteLinkWithFallback(Playable media) {
-        String link = null;
-        if (media != null) {
-            link = media.getWebsiteLink();
-            if (link == null) {
-                if (media instanceof FeedMedia) {
-                    link = FeedItemUtil.getLinkWithFallback(((FeedMedia)media).getItem());
-                } // else case not a FeedMedia, return null
-            }
-        } // else no media, return null
-        return link;
+        if (media == null) {
+            return null;
+        } else if (media.getWebsiteLink() != null) {
+            return media.getWebsiteLink();
+        } else if (media instanceof FeedMedia) {
+            return FeedItemUtil.getLinkWithFallback(((FeedMedia)media).getItem());
+        }
+        return null;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -42,6 +42,7 @@ import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.Flavors;
 import de.danoeh.antennapod.core.util.ShareUtils;
 import de.danoeh.antennapod.core.util.StorageUtils;
@@ -320,7 +321,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         ((FeedMedia) media).getItem().getFlattrStatus().flattrable()
         );
 
-        boolean hasWebsiteLink = media != null && media.getWebsiteLink() != null;
+        boolean hasWebsiteLink = ( getWebsiteLinkWithFallback(media) != null );
         menu.findItem(R.id.visit_website_item).setVisible(hasWebsiteLink);
 
         boolean isItemAndHasLink = isFeedMedia &&
@@ -560,7 +561,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         });
                         break;
                     case R.id.visit_website_item:
-                        Uri uri = Uri.parse(media.getWebsiteLink());
+                        Uri uri = Uri.parse(getWebsiteLinkWithFallback(media));
                         startActivity(new Intent(Intent.ACTION_VIEW, uri));
                         break;
                     case R.id.support_item:
@@ -601,6 +602,19 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                 return false;
             }
         }
+    }
+
+    private static String getWebsiteLinkWithFallback(Playable media) {
+        String link = null;
+        if (media != null) {
+            link = media.getWebsiteLink();
+            if (link == null) {
+                if (media instanceof FeedMedia) {
+                    link = FeedItemUtil.getLinkWithFallback(((FeedMedia)media).getItem());
+                } // else case not a FeedMedia, return null
+            }
+        } // else no media, return null
+        return link;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -324,7 +324,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
         menu.findItem(R.id.visit_website_item).setVisible(hasWebsiteLink);
 
         boolean isItemAndHasLink = isFeedMedia &&
-                ((FeedMedia) media).getItem() != null && ((FeedMedia) media).getItem().getLink() != null;
+                ShareUtils.hasLinkToShare(((FeedMedia) media).getItem());
         menu.findItem(R.id.share_link_item).setVisible(isItemAndHasLink);
         menu.findItem(R.id.share_link_with_position_item).setVisible(isItemAndHasLink);
 

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -86,7 +86,7 @@ public class FeedItemMenuHandler {
             mi.setItemVisibility(R.id.add_to_queue_item, false);
         }
 
-        if (!showExtendedMenu || selectedItem.getLink() == null) {
+        if (!showExtendedMenu || !ShareUtils.hasLinkToShare(selectedItem)) {
             mi.setItemVisibility(R.id.visit_website_item, false);
             mi.setItemVisibility(R.id.share_link_item, false);
             mi.setItemVisibility(R.id.share_link_with_position_item, false);

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -17,6 +17,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.ShareUtils;
@@ -216,7 +217,7 @@ public class FeedItemMenuHandler {
                 DBWriter.setFeedItemAutoDownload(selectedItem, false);
                 break;
             case R.id.visit_website_item:
-                Uri uri = Uri.parse(selectedItem.getLink());
+                Uri uri = Uri.parse(FeedItemUtil.getLinkWithFallback(selectedItem));
                 Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                 if(IntentUtils.isCallable(context, intent)) {
                     context.startActivity(intent);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -81,13 +81,16 @@ public class FeedItemUtil {
      * use the feed's link if the named feed item has no link.
      */
     public static String getLinkWithFallback(FeedItem item) {
-	    String link = item.getLink();
-	    if (link == null) {
-	        Feed feed = item.getFeed();
-	        if (feed != null) {
-	            link = feed.getLink();
+	    String link = null;
+	    if (item != null) {
+            link = item.getLink();
+            if (link == null) {
+                Feed feed = item.getFeed();
+                if (feed != null) {
+                    link = feed.getLink();
+                }
             }
-        }
+        } // else null item, can only return null
         return link;
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -2,7 +2,6 @@ package de.danoeh.antennapod.core.util;
 
 import java.util.List;
 
-import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 
 public class FeedItemUtil {
@@ -81,16 +80,13 @@ public class FeedItemUtil {
      * use the feed's link if the named feed item has no link.
      */
     public static String getLinkWithFallback(FeedItem item) {
-	    String link = null;
-	    if (item != null) {
-            link = item.getLink();
-            if (link == null) {
-                Feed feed = item.getFeed();
-                if (feed != null) {
-                    link = feed.getLink();
-                }
-            }
-        } // else null item, can only return null
-        return link;
+        if (item == null) {
+            return null;
+        } else if (item.getLink() != null) {
+            return item.getLink();
+        } else if (item.getFeed() != null) {
+            return item.getFeed().getLink();
+        }
+        return null;
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.core.util;
 
 import java.util.List;
 
+import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 
 public class FeedItemUtil {
@@ -75,4 +76,18 @@ public class FeedItemUtil {
         return false;
     }
 
+    /**
+     * Get the link for the feed item for the purpose of Share. It fallbacks to
+     * use the feed's link if the named feed item has no link.
+     */
+    public static String getLinkWithFallback(FeedItem item) {
+	    String link = item.getLink();
+	    if (link == null) {
+	        Feed feed = item.getFeed();
+	        if (feed != null) {
+	            link = feed.getLink();
+            }
+        }
+        return link;
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -51,7 +51,7 @@ public class ShareUtils {
 	}
 
     public static boolean hasLinkToShare(FeedItem item) {
-	    return ( item != null && FeedItemUtil.getLinkWithFallback(item) != null );
+	    return FeedItemUtil.getLinkWithFallback(item) != null;
     }
 
 	public static void shareFeedItemLink(Context context, FeedItem item, boolean withPosition) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -50,11 +50,30 @@ public class ShareUtils {
 		return item.getFeed().getTitle() + ": " + item.getTitle();
 	}
 
+    /**
+     * Get the link for the feed item for the purpose of Share. It fallbacks to
+     * use the feed's link if the named feed item has no link.
+     */
+    private static String getItemShareLink(FeedItem item) {
+	    String link = item.getLink();
+	    if (link == null) {
+	        Feed feed = item.getFeed();
+	        if (feed != null) {
+	            link = feed.getLink();
+            }
+        }
+        return link;
+    }
+
+    public static boolean hasLinkToShare(FeedItem item) {
+	    return ( item != null && getItemShareLink(item) != null );
+    }
+
 	public static void shareFeedItemLink(Context context, FeedItem item, boolean withPosition) {
-		String text = getItemShareText(item) + " " + item.getLink();
+		String text = getItemShareText(item) + " " + getItemShareLink(item);
 		if(withPosition) {
 			int pos = item.getMedia().getPosition();
-			text = item.getLink() + " [" + Converter.getDurationStringLong(pos) + "]";
+			text += " [" + Converter.getDurationStringLong(pos) + "]";
 		}
 		shareLink(context, text);
 	}

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -50,27 +50,12 @@ public class ShareUtils {
 		return item.getFeed().getTitle() + ": " + item.getTitle();
 	}
 
-    /**
-     * Get the link for the feed item for the purpose of Share. It fallbacks to
-     * use the feed's link if the named feed item has no link.
-     */
-    private static String getItemShareLink(FeedItem item) {
-	    String link = item.getLink();
-	    if (link == null) {
-	        Feed feed = item.getFeed();
-	        if (feed != null) {
-	            link = feed.getLink();
-            }
-        }
-        return link;
-    }
-
     public static boolean hasLinkToShare(FeedItem item) {
-	    return ( item != null && getItemShareLink(item) != null );
+	    return ( item != null && FeedItemUtil.getLinkWithFallback(item) != null );
     }
 
 	public static void shareFeedItemLink(Context context, FeedItem item, boolean withPosition) {
-		String text = getItemShareText(item) + " " + getItemShareLink(item);
+		String text = getItemShareText(item) + " " + FeedItemUtil.getLinkWithFallback(item);
 		if(withPosition) {
 			int pos = item.getMedia().getPosition();
 			text += " [" + Converter.getDurationStringLong(pos) + "]";


### PR DESCRIPTION
For #2579 Provide share Link in episode playback screen even when there is no episode link. 

For the case that a feed item / podcast episode does not have a link (to episode website), the change will fallback to use feed / podcast website link in:
1. share link in FeedItem playback and FeedItem information screens (#2579)
2. visit website menu action for the above two screens (so that visit website and share link have consistent behavior)

It also fixes a (presumably) bug in share link with position, so that the share includes podcast and episode titles in the share text, to be on par with other share variations.

Closes #2579