### PR TITLE
Expose "Mark as seen" as a context menu item in Episodes screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -300,9 +300,6 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
             };
             FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, null);
 
-            // Currently, Mark as seen only available on Episodes screen.
-            // Hence it is not added to the more generic FeedItemMenuHandler.onPrepareMenu
-            // see AllEpisodesFragment for the actual logic
             contextMenuInterface.setItemVisibility(R.id.mark_as_seen_item, item.isNew());
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -299,6 +299,11 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
                 }
             };
             FeedItemMenuHandler.onPrepareMenu(contextMenuInterface, item, true, null);
+
+            // Currently, Mark as seen only available on Episodes screen.
+            // Hence it is not added to the more generic FeedItemMenuHandler.onPrepareMenu
+            // see AllEpisodesFragment for the actual logic
+            contextMenuInterface.setItemVisibility(R.id.mark_as_seen_item, item.isNew());
         }
 
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -1,8 +1,6 @@
 package de.danoeh.antennapod.fragment;
 
 import android.os.Bundle;
-import android.os.Handler;
-import android.support.design.widget.Snackbar;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.Log;
@@ -16,10 +14,7 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.AllEpisodesRecycleAdapter;
 import de.danoeh.antennapod.core.event.FeedItemEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.feed.FeedMedia;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
-import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 
 
@@ -74,33 +69,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
             @Override
             public void onSwiped(RecyclerView.ViewHolder viewHolder, int swipeDir) {
                 AllEpisodesRecycleAdapter.Holder holder = (AllEpisodesRecycleAdapter.Holder)viewHolder;
-
-                Log.d(TAG, "remove(" + holder.getItemId() + ")");
-                if (subscription != null) {
-                    subscription.unsubscribe();
-                }
-                FeedItem item = holder.getFeedItem();
-                // we're marking it as unplayed since the user didn't actually play it
-                // but they don't want it considered 'NEW' anymore
-                DBWriter.markItemPlayed(FeedItem.UNPLAYED, item.getId());
-
-                final Handler h = new Handler(getActivity().getMainLooper());
-                final Runnable r  = () -> {
-                    FeedMedia media = item.getMedia();
-                    if (media != null && media.hasAlmostEnded() && UserPreferences.isAutoDelete()) {
-                        DBWriter.deleteFeedMediaOfItem(getActivity(), media.getId());
-                    }
-                };
-
-                Snackbar snackbar = Snackbar.make(root, getString(R.string.marked_as_seen_label),
-                        Snackbar.LENGTH_LONG);
-                snackbar.setAction(getString(R.string.undo), v -> {
-                    DBWriter.markItemPlayed(FeedItem.NEW, item.getId());
-                    // don't forget to cancel the thing that's going to remove the media
-                    h.removeCallbacks(r);
-                });
-                snackbar.show();
-                h.postDelayed(r, (int)Math.ceil(snackbar.getDuration() * 1.05f));
+                markItemAsSeenWithUndo(holder.getFeedItem());
             }
 
             @Override

--- a/app/src/main/res/menu/allepisodes_context.xml
+++ b/app/src/main/res/menu/allepisodes_context.xml
@@ -7,6 +7,12 @@
         android:menuCategory="container"
         android:title="@string/skip_episode_label" />
 
+
+    <item
+        android:id="@+id/mark_as_seen_item"
+        android:menuCategory="container"
+        android:title="@string/mark_as_seen_label" />
+
     <item
         android:id="@+id/mark_read_item"
         android:menuCategory="container"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="delete_label">Delete</string>
     <string name="delete_failed">Unable to delete file. Rebooting the device could help.</string>
     <string name="remove_episode_lable">Remove Episode</string>
+    <string name="mark_as_seen_label">Mark as seen</string>
     <string name="marked_as_seen_label">Marked as seen</string>
     <string name="mark_read_label">Mark as played</string>
     <string name="marked_as_read_label">Marked as played</string>


### PR DESCRIPTION
Closes #2580:
Expose "Mark as seen" as a context menu item in Episodes screen, in addition to the existing (somewhat hidden) swipe in Episode > New tab.

What it does not include:  it is not exposed to other type feedItem list UI, e.g., Queue, podcast, etc. (If desired, it can be done by changing `feeditemlist_context.xml` and `FeedItemMenuHandler.java` ( `onPrepareMenu()` and `onMenuItemClicked()`), ``

