### PR TITLE
Build tweak: Speed up debug build by making dexcount optional in debug build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,8 +85,6 @@ android {
             buildConfigField STRING, FLATTR_APP_KEY, mFlattrAppKey
             buildConfigField STRING, FLATTR_APP_SECRET, mFlattrAppSecret            
             dexcount {
-                // Optionally, can disable Dexcount by setting the property
-                // in gradle.properties file or via -P command line argument.
                 if (project.hasProperty("enableDexcountInDebug")) {
                     runOnEachPackage enableDexcountInDebug.toBoolean()
                 } else { // default to not running dexcount

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,7 +89,9 @@ android {
                 // in gradle.properties file or via -P command line argument.
                 if (project.hasProperty("enableDexcountInDebug")) {
                     runOnEachPackage enableDexcountInDebug.toBoolean()
-                } // else default to true
+                } else { // default to not running dexcount
+                    runOnEachPackage false                 
+                }
             }
         }
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,7 +83,14 @@ android {
             applicationIdSuffix ".debug"
             resValue "string", "provider_authority", "de.danoeh.antennapod.debug.provider"
             buildConfigField STRING, FLATTR_APP_KEY, mFlattrAppKey
-            buildConfigField STRING, FLATTR_APP_SECRET, mFlattrAppSecret
+            buildConfigField STRING, FLATTR_APP_SECRET, mFlattrAppSecret            
+            dexcount {
+                // Optionally, can disable Dexcount by setting the property
+                // in gradle.properties file or via -P command line argument.
+                if (project.hasProperty("enableDexcountInDebug")) {
+                    runOnEachPackage enableDexcountInDebug.toBoolean()
+                } // else default to true
+            }
         }
         release {
             resValue "string", "provider_authority", "de.danoeh.antennapod.provider"


### PR DESCRIPTION
Speed up debug build by making `dexcount` plugin optional in debug build, configured with a new gradle property enableDexcountInDebug.