### PR TITLE
Stop playback service when feed is deleted

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -609,6 +609,9 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     public void shutdown() {
         executor.shutdown();
         if (mediaPlayer != null) {
+            try {
+                mediaPlayer.stop();
+            } catch (Exception ignore) { }
             mediaPlayer.release();
         }
         releaseWifiLockIfNecessary();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -188,6 +188,9 @@ public class DBWriter {
                     if(queue.remove(item)) {
                         removed.add(item);
                     }
+                    if (item.getState() == FeedItem.State.PLAYING && PlaybackService.isRunning) {
+                        context.stopService(new Intent(context, PlaybackService.class));
+                    }
                     if (item.getMedia() != null
                             && item.getMedia().isDownloaded()) {
                         File mediaFile = new File(item.getMedia()


### PR DESCRIPTION
I think it's okay to prevent deletion of the current episode (#2674). When deleting the whole feed, there is already a warning dialog, so we can just stop the service to prevent "stuck" playback

Closes #2425