### PR TITLE
Improve autodownload in search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,7 +180,7 @@ dependencies {
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     implementation 'com.github.mfietz:fyydlin:v0.3'
-    implementation 'com.github.ByteHamster:SearchPreference:v1.0.3'
+    implementation 'com.github.ByteHamster:SearchPreference:v1.0.8'
 
     androidTestImplementation "com.jayway.android.robotium:robotium-solo:$robotiumSoloVersion"
 }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -37,6 +37,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
+import com.bytehamster.lib.preferencesearch.SearchConfiguration;
 import com.bytehamster.lib.preferencesearch.SearchPreference;
 import de.danoeh.antennapod.activity.AboutActivity;
 import de.danoeh.antennapod.activity.ImportExportActivity;
@@ -561,32 +562,33 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         final AppCompatActivity activity = ui.getActivity();
 
         SearchPreference searchPreference = (SearchPreference) ui.findPreference("searchPreference");
-        searchPreference.setActivity(activity);
-        searchPreference.setFragmentContainerViewId(R.id.content);
-        searchPreference.setBreadcrumbsEnabled(true);
+        SearchConfiguration config = searchPreference.getSearchConfiguration();
+        config.setActivity(activity);
+        config.setFragmentContainerViewId(R.id.content);
+        config.setBreadcrumbsEnabled(true);
 
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_user_interface))
                 .addFile(R.xml.preferences_user_interface);
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_playback))
                 .addFile(R.xml.preferences_playback);
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_network))
                 .addFile(R.xml.preferences_network);
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_storage))
                 .addFile(R.xml.preferences_storage);
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_network))
                 .addBreadcrumb(R.string.automation)
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_autodownload))
                 .addFile(R.xml.preferences_autodownload);
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_integrations))
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_gpodder))
                 .addFile(R.xml.preferences_gpodder);
-        searchPreference.index()
+        config.index()
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_integrations))
                 .addBreadcrumb(getTitleOfPage(R.xml.preferences_flattr))
                 .addFile(R.xml.preferences_flattr);

--- a/app/src/main/res/xml/preferences_autodownload.xml
+++ b/app/src/main/res/xml/preferences_autodownload.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
         xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch">
 
     <de.danoeh.antennapod.preferences.MasterSwitchPreference
             android:key="prefEnableAutoDl"
             android:title="@string/pref_automatic_download_title"
+            search:summary="@string/pref_automatic_download_sum"
             android:defaultValue="false"/>
     <ListPreference
             android:defaultValue="25"

--- a/app/src/main/res/xml/preferences_network.xml
+++ b/app/src/main/res/xml/preferences_network.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
         xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch">
     <PreferenceCategory android:title="@string/automation">
         <Preference
                 android:key="prefAutoUpdateIntervall"
@@ -16,7 +17,8 @@
         <Preference
                 android:summary="@string/pref_automatic_download_sum"
                 android:key="prefAutoDownloadSettings"
-                android:title="@string/pref_automatic_download_title" />
+                android:title="@string/pref_automatic_download_title"
+                search:ignore="true" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/download_pref_details">


### PR DESCRIPTION
Instead of displaying both the autodownload screen and the autodownload checkbox in search, ignore the screen and only display the checkbox (with a summary).

Before / After:
<img width="200" src="https://user-images.githubusercontent.com/5811634/40228852-c36094d4-5a92-11e8-90ff-bab3a873c4c7.png" /> <img width="200" src="https://user-images.githubusercontent.com/5811634/40228851-c342b482-5a92-11e8-955d-ee1b6f4eabf1.png" />
