### PR TITLE
avoid unused context parameter

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
@@ -176,8 +176,8 @@ public class DownloadRequester {
             args.putInt(REQUEST_ARG_PAGE_NR, feed.getPageNr());
             args.putBoolean(REQUEST_ARG_LOAD_ALL_PAGES, loadAllPages);
 
-            download(context, feed, null, new File(getFeedfilePath(context),
-                    getFeedfileName(feed)), true, username, password, lastModified, true, args);
+            download(context, feed, null, new File(getFeedfilePath(), getFeedfileName(feed)),
+                    true, username, password, lastModified, true, args);
         }
     }
 
@@ -203,8 +203,7 @@ public class DownloadRequester {
             if (feedmedia.getFile_url() != null) {
                 dest = new File(feedmedia.getFile_url());
             } else {
-                dest = new File(getMediafilePath(context, feedmedia),
-                        getMediafilename(feedmedia));
+                dest = new File(getMediafilePath(feedmedia), getMediafilename(feedmedia));
             }
             download(context, feedmedia, feed,
                     dest, false, username, password, null, false, null);
@@ -305,10 +304,8 @@ public class DownloadRequester {
         return downloads.size();
     }
 
-    private synchronized String getFeedfilePath(Context context)
-            throws DownloadRequestException {
-        return getExternalFilesDirOrThrowException(context, FEED_DOWNLOADPATH)
-                .toString() + "/";
+    private synchronized String getFeedfilePath() throws DownloadRequestException {
+        return getExternalFilesDirOrThrowException(FEED_DOWNLOADPATH).toString() + "/";
     }
 
     private synchronized String getFeedfileName(Feed feed) {
@@ -319,10 +316,8 @@ public class DownloadRequester {
         return "feed-" + FileNameGenerator.generateFileName(filename);
     }
 
-    private synchronized String getMediafilePath(Context context, FeedMedia media)
-            throws DownloadRequestException {
+    private synchronized String getMediafilePath(FeedMedia media) throws DownloadRequestException {
         File externalStorage = getExternalFilesDirOrThrowException(
-                context,
                 MEDIA_DOWNLOADPATH
                         + FileNameGenerator.generateFileName(media.getItem()
                         .getFeed().getTitle()) + "/"
@@ -330,8 +325,7 @@ public class DownloadRequester {
         return externalStorage.toString();
     }
 
-    private File getExternalFilesDirOrThrowException(Context context,
-                                                     String type) throws DownloadRequestException {
+    private File getExternalFilesDirOrThrowException(String type) throws DownloadRequestException {
         File result = UserPreferences.getDataFolder(type);
         if (result == null) {
             throw new DownloadRequestException(


### PR DESCRIPTION
While working on the changes for https://github.com/AntennaPod/AntennaPod/pull/2697 I was reading over the `DownloadRequester.java` code and noticed the `context` parameter is unused in several places. This PR simply removes the unnecessary parameter, which cleans up the code a bit. I was able to unwrap some lines and still stay under the 100 char limit