### PR TITLE
Render preview for all episodes layout with sample data.

### DIFF
--- a/app/sampledata/episodes.json
+++ b/app/sampledata/episodes.json
@@ -1,0 +1,34 @@
+{
+  "data": [
+    {
+      "title": "FLOSS Weekly 482: PyPI",
+      "status_label": "NEW",
+      "duration": "00:52:40",
+      "published_at": "2. May"
+    },
+    {
+      "title": "FLOSS Weekly 479: Pidgin",
+      "status_label": " ",
+      "duration": "01:08:08",
+      "published_at": "11. Apr"
+    },
+    {
+      "title": "Linux Outlaws 370 - Stay Free, Stay Open Source",
+      "status_label": "NEW",
+      "duration": "02:52:51",
+      "published_at": "29. Dec 2014"
+    },
+    {
+      "title": "Linux Outlaws 368 - The Dark Ages of Free Software",
+      "status_label": " ",
+      "duration": "02:26:54",
+      "published_at": "14. Dec 2014"
+    },
+    {
+      "title": "Linux Outlaws 365 - Last Stand",
+      "status_label": " ",
+      "duration": "00:39:59",
+      "published_at": "3. Nov 2014"
+    }
+  ]
+}

--- a/app/sampledata/inplaylist
+++ b/app/sampledata/inplaylist
@@ -1,0 +1,2 @@
+@null
+@drawable/ic_list_grey600_24dp

--- a/app/sampledata/secondaryaction
+++ b/app/sampledata/secondaryaction
@@ -1,0 +1,3 @@
+@drawable/ic_play_arrow_grey600_36dp
+@drawable/ic_file_download_grey600_24dp
+@drawable/ic_cancel_grey600_24dp

--- a/app/src/main/res/layout/all_episodes_fragment.xml
+++ b/app/src/main/res/layout/all_episodes_fragment.xml
@@ -13,7 +13,9 @@
         android:scrollbarStyle="outsideOverlay"
         android:paddingTop="@dimen/list_vertical_padding"
         android:paddingBottom="@dimen/list_vertical_padding"
-        android:clipToPadding="false"/>
+        android:clipToPadding="false"
+        tools:listitem="@layout/new_episodes_listitem"
+        tools:itemCount="13"/>
 
     <ProgressBar
         android:id="@+id/progLoading"
@@ -22,7 +24,7 @@
         android:layout_gravity="center"
         android:indeterminateOnly="true"
         android:visibility="gone"
-        tools:visibility="visible"
+        tools:visibility="gone"
         tools:layout_width="match_parent"
         tools:layout_height="64dp"
         tools:background="@android:color/holo_red_light"/>

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -13,7 +13,6 @@
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
     android:orientation="horizontal"
-    tools:background="@android:color/darker_gray"
     android:gravity="center_vertical">
 
     <RelativeLayout
@@ -42,8 +41,7 @@
             android:layout_alignRight="@id/txtvPlaceholder"
             android:layout_alignBottom="@id/txtvPlaceholder"
             android:contentDescription="@string/cover_label"
-            tools:src="@drawable/ic_stat_antenna_default"
-            tools:background="@android:color/holo_green_dark" />
+            tools:src="@tools:sample/avatars" />
 
     </RelativeLayout>
 
@@ -54,8 +52,7 @@
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
-        android:layout_weight="1"
-        tools:background="@android:color/white" >
+        android:layout_weight="1">
 
 
         <TextView
@@ -65,7 +62,8 @@
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_alignParentTop="true"
-            android:layout_marginLeft="8dp"/>
+            android:layout_marginLeft="8dp"
+            tools:text="@sample/episodes.json/data/status_label"/>
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -75,8 +73,7 @@
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             android:layout_toLeftOf="@id/statusUnread"
-            tools:text="Episode title"
-            tools:background="@android:color/holo_green_dark" />
+            tools:text="@sample/episodes.json/data/title" />
 
         <RelativeLayout
             android:id="@+id/bottom_bar"
@@ -85,8 +82,7 @@
             android:layout_below="@id/txtvTitle"
             android:layout_alignParentBottom="true"
             android:layout_alignParentLeft="true"
-            android:layout_alignParentRight="true"
-            tools:background="@android:color/holo_red_light" >
+            android:layout_alignParentRight="true">
 
             <TextView
                 android:id="@+id/txtvDuration"
@@ -94,8 +90,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
-                tools:text="00:42:23"
-                tools:background="@android:color/holo_blue_dark" />
+                tools:text="@sample/episodes.json/data/duration" />
 
             <ImageView
                 android:id="@+id/imgvInPlaylist"
@@ -105,8 +100,7 @@
                 android:layout_marginLeft="8dp"
                 android:contentDescription="@string/in_queue_label"
                 android:src="?attr/stat_playlist"
-                tools:src="@drawable/ic_list_grey600_24dp"
-                tools:background="@android:color/black" />
+                tools:src="@sample/inplaylist" />
 
             <TextView
                 android:id="@+id/txtvPublished"
@@ -116,8 +110,7 @@
                 android:layout_alignParentTop="true"
                 android:layout_toLeftOf="@id/imgvInPlaylist"
                 android:ellipsize="end"
-                tools:text="Jan 23"
-                tools:background="@android:color/holo_green_dark" />
+                tools:text="@sample/episodes.json/data/published_at" />
 
             <ProgressBar
                 android:id="@+id/pbar_progress"

--- a/app/src/main/res/layout/secondary_action.xml
+++ b/app/src/main/res/layout/secondary_action.xml
@@ -9,5 +9,4 @@
     android:focusable="false"
     android:focusableInTouchMode="false"
     tools:ignore="ContentDescription"
-    tools:src="@drawable/ic_play_arrow_grey600_36dp"
-    tools:background="@android:color/holo_green_dark" />
+    tools:src="@sample/secondaryaction" />


### PR DESCRIPTION
I make use of the [new sample data feature](https://developer.android.com/studio/write/tool-attributes#toolssample_resources) to render actual data in layouts. With that the background colors in preview mode are no longer needed.
I set the sample data up so that the individual items are rendered with **random** content.

# Before

![before](https://user-images.githubusercontent.com/144518/41378407-489ef8da-6f5f-11e8-939a-4df72546be97.png)

# After

![after](https://user-images.githubusercontent.com/144518/41378411-4c2cda58-6f5f-11e8-8768-d4b912875e0c.png)
