### PR TITLE
Better feed parser errors

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -317,7 +317,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
                         return handler.parseFeed(feed);
                     } catch (UnsupportedFeedtypeException e) {
                         Log.d(TAG, "Unsupported feed type detected");
-                        if (TextUtils.equals("html", e.getRootElement().toLowerCase())) {
+                        if ("html".equalsIgnoreCase(e.getRootElement())) {
                             showFeedDiscoveryDialog(new File(feed.getFile_url()), feed.getDownload_url());
                             return null;
                         } else {
@@ -342,6 +342,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
                     String errorMsg = DownloadError.ERROR_PARSER_EXCEPTION.getErrorString(
                             OnlineFeedViewActivity.this) + " (" + error.getMessage() + ")";
                     showErrorDialog(errorMsg);
+                    Log.d(TAG, "Feed parser exception: " + Log.getStackTraceString(error));
                 });
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/TypeGetter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/TypeGetter.java
@@ -64,8 +64,9 @@ public class TypeGetter {
 										Log.d(TAG, "Recognized type RSS 0.91/0.92");
 										return Type.RSS091;
 									}
+									throw new UnsupportedFeedtypeException("Unsupported rss version");
 								}
-								throw new UnsupportedFeedtypeException(Type.INVALID);
+								throw new UnsupportedFeedtypeException("No rss version attribute found");
 							default:
 								Log.d(TAG, "Type is invalid");
 								throw new UnsupportedFeedtypeException(Type.INVALID, tag);

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/UnsupportedFeedtypeException.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/UnsupportedFeedtypeException.java
@@ -5,7 +5,8 @@ import de.danoeh.antennapod.core.syndication.handler.TypeGetter.Type;
 public class UnsupportedFeedtypeException extends Exception {
 	private static final long serialVersionUID = 9105878964928170669L;
 	private final TypeGetter.Type type;
-    private String rootElement;
+	private String rootElement;
+	private String message = null;
 	
 	public UnsupportedFeedtypeException(Type type) {
 		super();
@@ -17,6 +18,11 @@ public class UnsupportedFeedtypeException extends Exception {
         this.rootElement = rootElement;
     }
 
+	public UnsupportedFeedtypeException(String message) {
+		this.message = message;
+		type = Type.INVALID;
+	}
+
     public TypeGetter.Type getType() {
 		return type;
 	}
@@ -27,7 +33,9 @@ public class UnsupportedFeedtypeException extends Exception {
 
     @Override
 	public String getMessage() {
-		if (type == TypeGetter.Type.INVALID) {
+		if (message != null) {
+			return message;
+		} else if (type == TypeGetter.Type.INVALID) {
 			return "Invalid type";
 		} else {
 			return "Type " + type + " not supported";


### PR DESCRIPTION
Improves the error message in #2749.

Adds meaningful message and fixes a NPE that occurs if the feed is invalid (`e.getRootElement()` is null).