### PR TITLE
Do not authenticate image without user

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.core.storage;
 
 import android.database.Cursor;
 import android.support.v4.util.ArrayMap;
+import android.text.TextUtils;
 import android.util.Log;
 
 import java.util.ArrayList;
@@ -688,7 +689,7 @@ public final class DBReader {
             if (cursor.moveToFirst()) {
                 String username = cursor.getString(0);
                 String password = cursor.getString(1);
-                if (username != null && password != null) {
+                if (!TextUtils.isEmpty(username) && password != null) {
                     credentials = username + ":" + password;
                 } else {
                     credentials = "";


### PR DESCRIPTION
This could be a fix for #2752

In my case, the icon was not loaded because username and password were not `null`, but `""`. Looks like the server did not like empty credentials. I think it is safe to assume that an empty username is not a valid username (empty password could be).

Not sure how this single feed ended up with non-null credentials, but probably I played around with the feed settings screen.