### PR TITLE
Do not overwrite feed description with item description

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
@@ -47,6 +47,9 @@ public class NSITunes extends Namespace {
         if(state.getContentBuf() == null) {
             return;
         }
+        SyndElement secondElement = state.getSecondTag();
+        String second = secondElement.getName();
+
         if (AUTHOR.equals(localName)) {
             if (state.getFeed() != null) {
                 String author = state.getContentBuf().toString();
@@ -95,10 +98,9 @@ public class NSITunes extends Namespace {
             }
             if (state.getCurrentItem() != null &&
                     (TextUtils.isEmpty(state.getCurrentItem().getDescription()) ||
-                            state.getCurrentItem().getDescription().length() * 1.25 < summary.length())
-            ) {
+                            state.getCurrentItem().getDescription().length() * 1.25 < summary.length())) {
                 state.getCurrentItem().setDescription(summary);
-            } else if (state.getFeed() != null) {
+            } else if (NSRSS20.CHANNEL.equals(second) && state.getFeed() != null) {
                 state.getFeed().setDescription(summary);
             }
         }


### PR DESCRIPTION
Closes #2538

`NSRSS20` uses a check if the parent element (`second`) is the feed or the feed item. This check is not present in `NSITunes`, so every parsed item overwrites the feed's description.

    // NSRSS20.java
    if (CHANNEL.equals(second) && state.getFeed() != null) {
        state.getFeed().setDescription(content);
    }

> https://github.com/AntennaPod/AntennaPod/issues/2538#issuecomment-357874512
> This doesn't happen for each and every feed, does it?

This does not happen for feeds that specify the description on the bottom of the feed (below all item descriptions). In this feeds, the last description that is overwritten is by accident the one we actually want.