### PR TITLE
[#2801] (AntennaPod failing to parse date in "Sun 01 Mar 2015 01:00:00 GMT-0400 (EDT)" format)

### DIFF
--- a/core/src/androidTest/java/de/danoeh/antennapod/core/util/DateUtilsTest.java
+++ b/core/src/androidTest/java/de/danoeh/antennapod/core/util/DateUtilsTest.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.util;
 
 import android.test.AndroidTestCase;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -154,6 +155,14 @@ public class DateUtilsTest extends AndroidTestCase {
         exp1.setTimeZone(TimeZone.getTimeZone("GMT"));
         Date expected = new Date(exp1.getTimeInMillis());
         Date actual = DateUtils.parse("Mon, 8 Sept 2014 00:00:00 GMT"); // should be Sep
+        assertEquals(expected, actual);
+    }
+
+    public void testParseDateWithTwoTimezones() {
+        final GregorianCalendar exp1 = new GregorianCalendar(2015, Calendar.MARCH, 1, 1, 0, 0);
+        exp1.setTimeZone(TimeZone.getTimeZone("GMT-4"));
+        final Date expected = new Date(exp1.getTimeInMillis());
+        final Date actual = DateUtils.parse("Sun 01 Mar 2015 01:00:00 GMT-0400 (EDT)");
         assertEquals(expected, actual);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -85,7 +85,8 @@ public class DateUtils {
                 "yyyy-MM-dd'T'HH:mm:ss'Z'",
                 "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
                 "yyyy-MM-ddZ",
-                "yyyy-MM-dd"
+                "yyyy-MM-dd",
+                "EEE d MMM yyyy HH:mm:ss 'GMT'Z (z)"
         };
 
         SimpleDateFormat parser = new SimpleDateFormat("", Locale.US);


### PR DESCRIPTION
Added "EEE d MMM yyyy HH:mm:ss 'GMT'Z (z)"  time format to DateUtils class, so AntennaPod could parse dates like "Sun 01 Mar 2015 01:00:00 GMT-0400 (EDT)"  whish are for example used in "https://s3.us-east-2.amazonaws.com/podcast.intelligence.org/razmedia/razfeed.xml" 
Added new time format to the bottom, because it seems to be used rarely, so there is no sense to keep it higher in the array.

Closes #2801 