### PR TITLE
Enqueue jobs with a unique job id per class

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -45,6 +45,7 @@ import de.danoeh.antennapod.core.util.gui.NotificationUtils;
  * This class also provides static methods for starting the GpodnetSyncService.
  */
 public class GpodnetSyncService extends JobIntentService {
+
     private static final String TAG = "GpodnetSyncService";
 
     private static final long WAIT_INTERVAL = 5000L;
@@ -61,8 +62,10 @@ public class GpodnetSyncService extends JobIntentService {
     private static boolean syncSubscriptions = false;
     private static boolean syncActions = false;
 
+    private static final int JOB_ID = -17000;
+
     private static void enqueueWork(Context context, Intent intent) {
-        enqueueWork(context, GpodnetSyncService.class, 0, intent);
+        enqueueWork(context, GpodnetSyncService.class, JOB_ID, intent);
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/PlayerWidgetJobService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/PlayerWidgetJobService.java
@@ -26,13 +26,16 @@ import de.danoeh.antennapod.core.receiver.PlayerWidget;
  * Updates the state of the player widget
  */
 public class PlayerWidgetJobService extends JobIntentService {
+
     private static final String TAG = "PlayerWidgetJobService";
 
     private PlaybackService playbackService;
     private final Object waitForService = new Object();
 
+    private static final int JOB_ID = -17001;
+
     public static void updateWidget(Context context) {
-        enqueueWork(context, PlayerWidgetJobService.class, 0, new Intent(context, PlayerWidgetJobService.class));
+        enqueueWork(context, PlayerWidgetJobService.class, JOB_ID, new Intent(context, PlayerWidgetJobService.class));
     }
 
     @Override


### PR DESCRIPTION
Could not reproduce this on the emulator, so I had to rely on documentation.
Resolves #2815 

As Job IDs must be unique per uid (https://commonsware.com/blog/2017/06/07/jobscheduler-job-ids-libraries.html), use IDs that no one else will use...