### PR TITLE
Implemented number picker preference

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/NumberPickerPreference.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/NumberPickerPreference.java
@@ -1,0 +1,106 @@
+package de.danoeh.antennapod.preferences;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.support.v7.preference.Preference;
+import android.text.InputFilter;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.EditText;
+import de.danoeh.antennapod.R;
+
+public class NumberPickerPreference extends Preference {
+    private Context context;
+    private int defaultValue = 0;
+    private int minValue = 0;
+    private int maxValue = Integer.MAX_VALUE;
+
+    public NumberPickerPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs);
+    }
+
+    public NumberPickerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs);
+    }
+
+    public NumberPickerPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs);
+    }
+
+    public NumberPickerPreference(Context context) {
+        super(context);
+        this.context = context;
+    }
+
+    private void init(Context context, AttributeSet attrs) {
+        this.context = context;
+
+        for (int i = 0; i < attrs.getAttributeCount(); i++) {
+            String name = attrs.getAttributeName(i);
+            String value = attrs.getAttributeValue(i);
+            switch (name) {
+                case "defaultValue":
+                    defaultValue = Integer.parseInt(value);
+                    break;
+                case "minValue":
+                    minValue = Integer.parseInt(value);
+                    break;
+                case "maxValue":
+                    maxValue = Integer.parseInt(value);
+                    break;
+            }
+        }
+    }
+
+    @Override
+    protected void onClick() {
+        super.onClick();
+
+        View view = View.inflate(context, R.layout.numberpicker, null);
+        EditText number = view.findViewById(R.id.number);
+        number.setText(getSharedPreferences().getString(getKey(), ""+defaultValue));
+        number.setFilters(new InputFilter[]{(source, start, end, dest, dstart, dend) -> {
+            try {
+                String newVal = dest.toString().substring(0, dstart) + dest.toString().substring(dend);
+                newVal = newVal.substring(0, dstart) + source.toString() + newVal.substring(dstart);
+                int input = Integer.parseInt(newVal);
+                if (input >= minValue && input <= maxValue) {
+                    return null;
+                }
+            } catch (NumberFormatException nfe) {
+                nfe.printStackTrace();
+            }
+            return "";
+        }});
+
+        AlertDialog dialog = new AlertDialog.Builder(context)
+                .setTitle(getTitle())
+                .setView(view)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> {
+                    try {
+                        String numberString = number.getText().toString();
+                        int value = Integer.parseInt(numberString);
+
+                        if (value < minValue || value > maxValue) {
+                            return;
+                        }
+
+                        getSharedPreferences().edit().putString(getKey(), "" + value).apply();
+
+                        if (getOnPreferenceChangeListener() != null) {
+                            getOnPreferenceChangeListener().onPreferenceChange(this, value);
+                        }
+                    } catch (NumberFormatException e) {
+                        // Do not set value
+                    }
+                })
+                .create();
+        dialog.show();
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -462,18 +462,10 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
         ui.findPreference(UserPreferences.PREF_PARALLEL_DOWNLOADS)
                 .setOnPreferenceChangeListener(
                         (preference, o) -> {
-                            if (o instanceof String) {
-                                try {
-                                    int value = Integer.parseInt((String) o);
-                                    if (1 <= value && value <= 50) {
-                                        setParallelDownloadsText(value);
-                                        return true;
-                                    }
-                                } catch (NumberFormatException e) {
-                                    return false;
-                                }
+                            if (o instanceof Integer) {
+                                setParallelDownloadsText((Integer) o);
                             }
-                            return false;
+                            return true;
                         }
                 );
         // validate and set correct value: number of downloads between 1 and 50 (inclusive)

--- a/app/src/main/res/layout/numberpicker.xml
+++ b/app/src/main/res/layout/numberpicker.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:padding="32dp">
+
+    <EditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="numberDecimal"
+            android:ems="10"
+            android:selectAllOnFocus="true"
+            android:id="@+id/number" />
+
+</LinearLayout>

--- a/app/src/main/res/xml/preferences_network.xml
+++ b/app/src/main/res/xml/preferences_network.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
         xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:numberpicker="http://schemas.android.com/apk/de.danoeh.antennapod"
         xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch">
     <PreferenceCategory android:title="@string/automation">
         <Preference
@@ -22,12 +22,12 @@
                 android:key="prefMobileUpdate"
                 android:summary="@string/pref_mobileUpdate_sum"
                 android:title="@string/pref_mobileUpdate_title"/>
-        <EditTextPreference
+        <de.danoeh.antennapod.preferences.NumberPickerPreference
                 android:defaultValue="4"
-                android:inputType="number"
+                numberpicker:minValue="1"
+                numberpicker:maxValue="50"
                 android:key="prefParallelDownloads"
-                android:title="@string/pref_parallel_downloads_title"
-                app:useStockLayout="true"/>
+                android:title="@string/pref_parallel_downloads_title"/>
         <SwitchPreference
                 android:defaultValue="true"
                 android:enabled="true"


### PR DESCRIPTION
Closes #2818

Settings `inputType` does not seem to work. Android still presents the text keyboard. Therefore, this PR creates a new preference that can be used to enter numbers only.

    <EditTextPreference
                android:defaultValue="4"
                android:inputType="number"
                android:digits="0123456789"
                android:key="prefParallelDownloads"
                android:title="@string/pref_parallel_downloads_title"
                app:useStockLayout="true"/>