### PR TITLE
Fix AMOLED chapter currently playing highlight color

### DIFF
--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -31,7 +31,7 @@
 
     <color name="highlight_light">#DDDDDD</color>
     <color name="highlight_dark">#414141</color>
-    <color name="highlight_trueblack">#000000</color>
+    <color name="highlight_trueblack">#414141</color>
 
     <color name="antennapod_blue">#147BAF</color>
 


### PR DESCRIPTION
Didn't see an issue for this minor issue, but found this while looking at the AMOLED theme.

On the standard AMOLED theme, you couldn't see which chapter was currently playing because the highlight color was the same color as the background:

Current `develop` branch:

![screen shot 2018-10-22 at 9 17 05 pm](https://user-images.githubusercontent.com/611354/47331136-83a9e280-d640-11e8-9897-ccb6adaf8d4e.png)

So changed the color so that it was lighter, and recognizable as a highlight.

My PR: 

![screen shot 2018-10-22 at 9 19 51 pm](https://user-images.githubusercontent.com/611354/47331146-96241c00-d640-11e8-9f01-b3a3655ec144.png)
