### PR TITLE
Add 'back up' to settings title

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -325,7 +325,7 @@
     <string name="flattr_summary">Micropayment service</string>
     <string name="automation">Automation</string>
     <string name="download_pref_details">Details</string>
-    <string name="import_export_pref">Import/Export</string>
+    <string name="import_export_pref">Import, export, back up</string>
     <string name="appearance">Appearance</string>
     <string name="external_elements">External elements</string>
     <string name="interruptions">Interruptions</string>


### PR DESCRIPTION
Users may be searching for this in the settings, adding this phrasal verb to the title hopefully helps.