### PR TITLE
Add configurable behavior of the back button

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -243,4 +243,70 @@ public class MainActivityTest {
         assertEquals(1, hidden.size());
         assertTrue(hidden.contains(DownloadsFragment.TAG));
     }
+
+    @Test
+    public void testBackButtonBehaviorGoToPage() {
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.settings_label));
+        solo.clickOnText(solo.getString(R.string.user_interface_label));
+        solo.clickOnText(solo.getString(R.string.pref_back_button_behavior_title));
+        solo.clickOnText(solo.getString(R.string.back_button_go_to_page));
+        solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.subscriptions_label));
+        solo.clickOnText(solo.getString(R.string.confirm_label));
+        solo.goBackToActivity(MainActivity.class.getSimpleName());
+        solo.goBack();
+        assertEquals(solo.getString(R.string.subscriptions_label), getActionbarTitle());
+    }
+
+    @Test
+    public void testBackButtonBehaviorOpenDrawer() {
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.settings_label));
+        solo.clickOnText(solo.getString(R.string.user_interface_label));
+        solo.clickOnText(solo.getString(R.string.pref_back_button_behavior_title));
+        solo.clickOnText(solo.getString(R.string.back_button_open_drawer));
+        solo.goBackToActivity(MainActivity.class.getSimpleName());
+        solo.goBack();
+        assertTrue(((MainActivity)solo.getCurrentActivity()).isDrawerOpen());
+    }
+
+    @Test
+    public void testBackButtonBehaviorDoubleTap() {
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.settings_label));
+        solo.clickOnText(solo.getString(R.string.user_interface_label));
+        solo.clickOnText(solo.getString(R.string.pref_back_button_behavior_title));
+        solo.clickOnText(solo.getString(R.string.back_button_double_tap));
+        solo.goBackToActivity(MainActivity.class.getSimpleName());
+        solo.goBack();
+        solo.goBack();
+        assertTrue(solo.getCurrentActivity().isFinishing());
+    }
+
+    @Test
+    public void testBackButtonBehaviorPrompt() {
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.settings_label));
+        solo.clickOnText(solo.getString(R.string.user_interface_label));
+        solo.clickOnText(solo.getString(R.string.pref_back_button_behavior_title));
+        solo.clickOnText(solo.getString(R.string.back_button_show_prompt));
+        solo.goBackToActivity(MainActivity.class.getSimpleName());
+        solo.goBack();
+        solo.clickOnText(solo.getString(R.string.yes));
+        solo.waitForDialogToClose();
+        assertTrue(solo.getCurrentActivity().isFinishing());
+    }
+
+    @Test
+    public void testBackButtonBehaviorDefault() {
+        openNavDrawer();
+        solo.clickOnText(solo.getString(R.string.settings_label));
+        solo.clickOnText(solo.getString(R.string.user_interface_label));
+        solo.clickOnText(solo.getString(R.string.pref_back_button_behavior_title));
+        solo.clickOnText(solo.getString(R.string.back_button_default));
+        solo.goBackToActivity(MainActivity.class.getSimpleName());
+        solo.goBack();
+        assertTrue(solo.getCurrentActivity().isFinishing());
+    }
 }

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -466,6 +466,19 @@ public class PreferencesTest {
         }
     }
 
+    @Test
+    public void testBackButtonBehaviorGoToPageSelector() {
+        clickPreference(withText(R.string.user_interface_label));
+        clickPreference(withText(R.string.pref_back_button_behavior_title));
+        solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.back_button_go_to_page));
+        solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.subscriptions_label));
+        solo.clickOnText(solo.getString(R.string.confirm_label));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonBehavior() == UserPreferences.BackButtonBehavior.GO_TO_SUBSCRIPTIONS,
+                Timeout.getLargeTimeout()));
+    }
+
     private void clickPreference(Matcher<View> matcher) {
         onView(withId(R.id.list))
                 .perform(RecyclerViewActions.actionOnItem(hasDescendant(matcher), click()));

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -16,6 +16,10 @@ import de.danoeh.antennapod.core.storage.APCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APNullCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APQueueCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.EpisodeCleanupAlgorithm;
+import de.danoeh.antennapod.fragment.EpisodesFragment;
+import de.danoeh.antennapod.fragment.QueueFragment;
+import de.danoeh.antennapod.fragment.SubscriptionFragment;
+
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
@@ -473,9 +477,31 @@ public class PreferencesTest {
         solo.waitForDialogToOpen();
         solo.clickOnText(solo.getString(R.string.back_button_go_to_page));
         solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.queue_label));
+        solo.clickOnText(solo.getString(R.string.confirm_label));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonBehavior() == UserPreferences.BackButtonBehavior.GO_TO_PAGE,
+                Timeout.getLargeTimeout()));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonGoToPage().equals(QueueFragment.TAG),
+                Timeout.getLargeTimeout()));
+        clickPreference(withText(R.string.pref_back_button_behavior_title));
+        solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.back_button_go_to_page));
+        solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.episodes_label));
+        solo.clickOnText(solo.getString(R.string.confirm_label));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonBehavior() == UserPreferences.BackButtonBehavior.GO_TO_PAGE,
+                Timeout.getLargeTimeout()));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonGoToPage().equals(EpisodesFragment.TAG),
+                Timeout.getLargeTimeout()));
+        clickPreference(withText(R.string.pref_back_button_behavior_title));
+        solo.waitForDialogToOpen();
+        solo.clickOnText(solo.getString(R.string.back_button_go_to_page));
+        solo.waitForDialogToOpen();
         solo.clickOnText(solo.getString(R.string.subscriptions_label));
         solo.clickOnText(solo.getString(R.string.confirm_label));
-        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonBehavior() == UserPreferences.BackButtonBehavior.GO_TO_SUBSCRIPTIONS,
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonBehavior() == UserPreferences.BackButtonBehavior.GO_TO_PAGE,
+                Timeout.getLargeTimeout()));
+        assertTrue(solo.waitForCondition(() -> UserPreferences.getBackButtonGoToPage().equals(SubscriptionFragment.TAG),
                 Timeout.getLargeTimeout()));
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -648,6 +648,8 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     public void onBackPressed() {
         if(isDrawerOpen()) {
             drawerLayout.closeDrawer(navDrawer);
+        } else if(getSupportFragmentManager().getBackStackEntryCount() != 0) {
+            super.onBackPressed();
         } else {
             switch (UserPreferences.getBackButtonBehavior()) {
                 case OPEN_DRAWER:

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -27,6 +27,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 
@@ -122,6 +123,8 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     private ProgressDialog pd;
 
     private Subscription subscription;
+
+    private long lastBackButtonPressTime = 0;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -646,7 +649,33 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
         if(isDrawerOpen()) {
             drawerLayout.closeDrawer(navDrawer);
         } else {
-            super.onBackPressed();
+            switch (UserPreferences.getBackButtonBehavior()) {
+                case OPEN_DRAWER:
+                    drawerLayout.openDrawer(navDrawer);
+                    break;
+                case SHOW_PROMPT:
+                    new AlertDialog.Builder(this)
+                        .setMessage(R.string.close_prompt)
+                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                MainActivity.super.onBackPressed();
+                            }
+                        })
+                        .setNegativeButton(R.string.no, null)
+                        .setCancelable(false)
+                        .show();
+                    break;
+                case DOUBLE_TAP:
+                    if(lastBackButtonPressTime < System.currentTimeMillis() - 2000) {
+                        Toast.makeText(this, R.string.double_tap_toast, Toast.LENGTH_SHORT).show();
+                        lastBackButtonPressTime = System.currentTimeMillis();
+                    } else {
+                        super.onBackPressed();
+                    }
+                    break;
+                default: super.onBackPressed();
+            }
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -656,12 +656,7 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
                 case SHOW_PROMPT:
                     new AlertDialog.Builder(this)
                         .setMessage(R.string.close_prompt)
-                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialogInterface, int i) {
-                                MainActivity.super.onBackPressed();
-                            }
-                        })
+                        .setPositiveButton(R.string.yes, (dialogInterface, i) -> MainActivity.super.onBackPressed())
                         .setNegativeButton(R.string.no, null)
                         .setCancelable(false)
                         .show();
@@ -672,6 +667,27 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
                         lastBackButtonPressTime = System.currentTimeMillis();
                     } else {
                         super.onBackPressed();
+                    }
+                    break;
+                case GO_TO_QUEUE:
+                    if(getLastNavFragment().equals(QueueFragment.TAG)) {
+                        super.onBackPressed();
+                    } else {
+                        loadFragment(QueueFragment.TAG, null);
+                    }
+                    break;
+                case GO_TO_EPISODES:
+                    if(getLastNavFragment().equals(EpisodesFragment.TAG)) {
+                        super.onBackPressed();
+                    } else {
+                        loadFragment(EpisodesFragment.TAG, null);
+                    }
+                    break;
+                case GO_TO_SUBSCRIPTIONS:
+                    if(getLastNavFragment().equals(SubscriptionFragment.TAG)) {
+                        super.onBackPressed();
+                    } else {
+                        loadFragment(SubscriptionFragment.TAG, null);
                     }
                     break;
                 default: super.onBackPressed();

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -669,25 +669,11 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
                         super.onBackPressed();
                     }
                     break;
-                case GO_TO_QUEUE:
-                    if(getLastNavFragment().equals(QueueFragment.TAG)) {
+                case GO_TO_PAGE:
+                    if(getLastNavFragment().equals(UserPreferences.getBackButtonGoToPage())) {
                         super.onBackPressed();
                     } else {
-                        loadFragment(QueueFragment.TAG, null);
-                    }
-                    break;
-                case GO_TO_EPISODES:
-                    if(getLastNavFragment().equals(EpisodesFragment.TAG)) {
-                        super.onBackPressed();
-                    } else {
-                        loadFragment(EpisodesFragment.TAG, null);
-                    }
-                    break;
-                case GO_TO_SUBSCRIPTIONS:
-                    if(getLastNavFragment().equals(SubscriptionFragment.TAG)) {
-                        super.onBackPressed();
-                    } else {
-                        loadFragment(SubscriptionFragment.TAG, null);
+                        loadFragment(UserPreferences.getBackButtonGoToPage(), null);
                     }
                     break;
                 default: super.onBackPressed();

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -646,9 +646,9 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
 
     @Override
     public void onBackPressed() {
-        if(isDrawerOpen()) {
+        if (isDrawerOpen()) {
             drawerLayout.closeDrawer(navDrawer);
-        } else if(getSupportFragmentManager().getBackStackEntryCount() != 0) {
+        } else if (getSupportFragmentManager().getBackStackEntryCount() != 0) {
             super.onBackPressed();
         } else {
             switch (UserPreferences.getBackButtonBehavior()) {
@@ -664,7 +664,7 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
                         .show();
                     break;
                 case DOUBLE_TAP:
-                    if(lastBackButtonPressTime < System.currentTimeMillis() - 2000) {
+                    if (lastBackButtonPressTime < System.currentTimeMillis() - 2000) {
                         Toast.makeText(this, R.string.double_tap_toast, Toast.LENGTH_SHORT).show();
                         lastBackButtonPressTime = System.currentTimeMillis();
                     } else {
@@ -672,7 +672,7 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
                     }
                     break;
                 case GO_TO_PAGE:
-                    if(getLastNavFragment().equals(UserPreferences.getBackButtonGoToPage())) {
+                    if (getLastNavFragment().equals(UserPreferences.getBackButtonGoToPage())) {
                         super.onBackPressed();
                     } else {
                         loadFragment(UserPreferences.getBackButtonGoToPage(), null);

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -232,17 +232,19 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                         if(newValue.equals("page")) {
                             final Context context = ui.getActivity();
                             final String[] navTitles = context.getResources().getStringArray(R.array.back_button_go_to_pages);
-                            final int choice[] = { UserPreferences.getBackButtonGoToPage() };
+                            final String[] navTags = new String[3];
+                            System.arraycopy(MainActivity.NAV_DRAWER_TAGS, 0, navTags, 0, 3);
+                            final String choice[] = { UserPreferences.getBackButtonGoToPage() };
 
                             AlertDialog.Builder builder = new AlertDialog.Builder(context);
                             builder.setTitle(R.string.back_button_go_to_page_title);
-                            builder.setSingleChoiceItems(navTitles, choice[0], (dialogInterface, i) -> {
+                            builder.setSingleChoiceItems(navTitles, ArrayUtils.indexOf(navTags, UserPreferences.getBackButtonGoToPage()), (dialogInterface, i) -> {
                                 if(i >= 0) {
-                                    choice[0] = i;
+                                    choice[0] = navTags[i];
                                 }
                             });
                             builder.setPositiveButton(R.string.confirm_label, (dialogInterface, i) -> {
-                                if (choice[0] != UserPreferences.getBackButtonGoToPage()) {
+                                if (!choice[0].equals(UserPreferences.getBackButtonGoToPage())) {
                                     UserPreferences.setBackButtonGoToPage(choice[0]);
                                 }
                             });

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -229,7 +229,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
 
         ui.findPreference(UserPreferences.PREF_BACK_BUTTON_BEHAVIOR)
                 .setOnPreferenceChangeListener((preference, newValue) -> {
-                        if(newValue.equals("page")) {
+                        if (newValue.equals("page")) {
                             final Context context = ui.getActivity();
                             final String[] navTitles = context.getResources().getStringArray(R.array.back_button_go_to_pages);
                             final String[] navTags = new String[3];
@@ -239,7 +239,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                             AlertDialog.Builder builder = new AlertDialog.Builder(context);
                             builder.setTitle(R.string.back_button_go_to_page_title);
                             builder.setSingleChoiceItems(navTitles, ArrayUtils.indexOf(navTags, UserPreferences.getBackButtonGoToPage()), (dialogInterface, i) -> {
-                                if(i >= 0) {
+                                if (i >= 0) {
                                     choice[0] = navTags[i];
                                 }
                             });

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -227,6 +227,33 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                     return true;
                 });
 
+        ui.findPreference(UserPreferences.PREF_BACK_BUTTON_BEHAVIOR)
+                .setOnPreferenceChangeListener((preference, newValue) -> {
+                        if(newValue.equals("page")) {
+                            final Context context = ui.getActivity();
+                            final String[] navTitles = context.getResources().getStringArray(R.array.back_button_go_to_pages);
+                            final int choice[] = { UserPreferences.getBackButtonGoToPage() };
+
+                            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+                            builder.setTitle(R.string.back_button_go_to_page_title);
+                            builder.setSingleChoiceItems(navTitles, choice[0], (dialogInterface, i) -> {
+                                if(i >= 0) {
+                                    choice[0] = i;
+                                }
+                            });
+                            builder.setPositiveButton(R.string.confirm_label, (dialogInterface, i) -> {
+                                if (choice[0] != UserPreferences.getBackButtonGoToPage()) {
+                                    UserPreferences.setBackButtonGoToPage(choice[0]);
+                                }
+                            });
+                            builder.setNegativeButton(R.string.cancel_label, null);
+                            builder.create().show();
+                            return true;
+                        } else {
+                            return true;
+                        }
+                    });
+
         if (Build.VERSION.SDK_INT >= 26) {
             ui.findPreference(UserPreferences.PREF_EXPANDED_NOTIFICATION).setVisible(false);
         }

--- a/app/src/main/res/xml/preferences_user_interface.xml
+++ b/app/src/main/res/xml/preferences_user_interface.xml
@@ -57,4 +57,14 @@
                 android:summary="@string/pref_lockscreen_background_sum"
                 android:title="@string/pref_lockscreen_background_title"/>
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/behavior">
+        <ListPreference
+                android:entryValues="@array/back_button_behavior_values"
+                android:entries="@array/back_button_behavior_options"
+                android:key="prefBackButtonBehavior"
+                android:title="@string/pref_back_button_behavior_title"
+                android:summary="@string/pref_back_button_behavior_sum"
+                android:defaultValue="default"
+                app:useStockLayout="true"/>
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -52,7 +52,8 @@ public class UserPreferences {
     public static final String PREF_COMPACT_NOTIFICATION_BUTTONS = "prefCompactNotificationButtons";
     public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     private static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
-    private static final String PREF_BACK_BUTTON_BEHAVIOR = "prefBackButtonBehavior";
+    public static final String PREF_BACK_BUTTON_BEHAVIOR = "prefBackButtonBehavior";
+    private static final String PREF_BACK_BUTTON_GO_TO_PAGE = "prefBackButtonGoToPage";
 
     // Queue
     private static final String PREF_QUEUE_ADD_TO_FRONT = "prefQueueAddToFront";
@@ -812,7 +813,7 @@ public class UserPreferences {
     }
 
     public enum BackButtonBehavior {
-        DEFAULT, OPEN_DRAWER, DOUBLE_TAP, SHOW_PROMPT
+        DEFAULT, OPEN_DRAWER, DOUBLE_TAP, SHOW_PROMPT, GO_TO_QUEUE, GO_TO_EPISODES, GO_TO_SUBSCRIPTIONS
     }
 
     public static BackButtonBehavior getBackButtonBehavior() {
@@ -821,7 +822,24 @@ public class UserPreferences {
             case "drawer": return BackButtonBehavior.OPEN_DRAWER;
             case "doubletap": return BackButtonBehavior.DOUBLE_TAP;
             case "prompt": return BackButtonBehavior.SHOW_PROMPT;
+            case "page":
+                switch (UserPreferences.getBackButtonGoToPage()) {
+                    case 0: return BackButtonBehavior.GO_TO_QUEUE;
+                    case 1: return BackButtonBehavior.GO_TO_EPISODES;
+                    case 2: return BackButtonBehavior.GO_TO_SUBSCRIPTIONS;
+                    default: return BackButtonBehavior.GO_TO_QUEUE;
+                }
             default: return BackButtonBehavior.DEFAULT;
         }
+    }
+
+    public static int getBackButtonGoToPage() {
+        return prefs.getInt(PREF_BACK_BUTTON_GO_TO_PAGE, 0);
+    }
+
+    public static void setBackButtonGoToPage(int page) {
+        prefs.edit()
+                .putInt(PREF_BACK_BUTTON_GO_TO_PAGE, page)
+                .apply();
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -813,7 +813,7 @@ public class UserPreferences {
     }
 
     public enum BackButtonBehavior {
-        DEFAULT, OPEN_DRAWER, DOUBLE_TAP, SHOW_PROMPT, GO_TO_QUEUE, GO_TO_EPISODES, GO_TO_SUBSCRIPTIONS
+        DEFAULT, OPEN_DRAWER, DOUBLE_TAP, SHOW_PROMPT, GO_TO_PAGE
     }
 
     public static BackButtonBehavior getBackButtonBehavior() {
@@ -822,24 +822,18 @@ public class UserPreferences {
             case "drawer": return BackButtonBehavior.OPEN_DRAWER;
             case "doubletap": return BackButtonBehavior.DOUBLE_TAP;
             case "prompt": return BackButtonBehavior.SHOW_PROMPT;
-            case "page":
-                switch (UserPreferences.getBackButtonGoToPage()) {
-                    case 0: return BackButtonBehavior.GO_TO_QUEUE;
-                    case 1: return BackButtonBehavior.GO_TO_EPISODES;
-                    case 2: return BackButtonBehavior.GO_TO_SUBSCRIPTIONS;
-                    default: return BackButtonBehavior.GO_TO_QUEUE;
-                }
+            case "page": return BackButtonBehavior.GO_TO_PAGE;
             default: return BackButtonBehavior.DEFAULT;
         }
     }
 
-    public static int getBackButtonGoToPage() {
-        return prefs.getInt(PREF_BACK_BUTTON_GO_TO_PAGE, 0);
+    public static String getBackButtonGoToPage() {
+        return prefs.getString(PREF_BACK_BUTTON_GO_TO_PAGE, "QueueFragment");
     }
 
-    public static void setBackButtonGoToPage(int page) {
+    public static void setBackButtonGoToPage(String tag) {
         prefs.edit()
-                .putInt(PREF_BACK_BUTTON_GO_TO_PAGE, page)
+                .putString(PREF_BACK_BUTTON_GO_TO_PAGE, tag)
                 .apply();
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -52,6 +52,7 @@ public class UserPreferences {
     public static final String PREF_COMPACT_NOTIFICATION_BUTTONS = "prefCompactNotificationButtons";
     public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     private static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
+    private static final String PREF_BACK_BUTTON_BEHAVIOR = "prefBackButtonBehavior";
 
     // Queue
     private static final String PREF_QUEUE_ADD_TO_FRONT = "prefQueueAddToFront";
@@ -808,5 +809,19 @@ public class UserPreferences {
 
     public enum VideoBackgroundBehavior {
         STOP, PICTURE_IN_PICTURE, CONTINUE_PLAYING
+    }
+
+    public enum BackButtonBehavior {
+        DEFAULT, OPEN_DRAWER, DOUBLE_TAP, SHOW_PROMPT
+    }
+
+    public static BackButtonBehavior getBackButtonBehavior() {
+        switch (prefs.getString(PREF_BACK_BUTTON_BEHAVIOR, "default")) {
+            case "default": return BackButtonBehavior.DEFAULT;
+            case "drawer": return BackButtonBehavior.OPEN_DRAWER;
+            case "doubletap": return BackButtonBehavior.DOUBLE_TAP;
+            case "prompt": return BackButtonBehavior.SHOW_PROMPT;
+            default: return BackButtonBehavior.DEFAULT;
+        }
     }
 }

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -277,4 +277,18 @@
         <item>@string/select_all_above</item>
         <item>@string/select_all_below</item>
     </string-array>
+
+    <string-array name="back_button_behavior_options">
+        <item>@string/back_button_default</item>
+        <item>@string/back_button_open_drawer</item>
+        <item>@string/back_button_double_tap</item>
+        <item>@string/back_button_show_prompt</item>
+    </string-array>
+
+    <string-array name="back_button_behavior_values">
+        <item>default</item>
+        <item>drawer</item>
+        <item>doubletap</item>
+        <item>prompt</item>
+    </string-array>
 </resources>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -280,6 +280,7 @@
 
     <string-array name="back_button_behavior_options">
         <item>@string/back_button_default</item>
+        <item>@string/back_button_go_to_page</item>
         <item>@string/back_button_open_drawer</item>
         <item>@string/back_button_double_tap</item>
         <item>@string/back_button_show_prompt</item>
@@ -287,8 +288,15 @@
 
     <string-array name="back_button_behavior_values">
         <item>default</item>
+        <item>page</item>
         <item>drawer</item>
         <item>doubletap</item>
         <item>prompt</item>
+    </string-array>
+
+    <string-array name="back_button_go_to_pages">
+        <item>@string/queue_label</item>
+        <item>@string/episodes_label</item>
+        <item>@string/subscriptions_label</item>
     </string-array>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -470,6 +470,15 @@
     <string name="pref_videoBehavior_sum">Behavior when leaving video playback</string>
     <string name="stop_playback">Stop playback</string>
     <string name="continue_playback">Continue audio playback</string>
+    <string name="behavior">Behavior</string>
+    <string name="pref_back_button_behavior_title">Back button behavior</string>
+    <string name="pref_back_button_behavior_sum">Change behavior of the back button.</string>
+    <string name="back_button_default">Default</string>
+    <string name="back_button_open_drawer">Open navigation drawer</string>
+    <string name="back_button_double_tap">Double tap to exit</string>
+    <string name="back_button_show_prompt">Confirm to exit</string>
+    <string name="close_prompt">Are you sure you want to close AntennaPod?</string>
+    <string name="double_tap_toast">Tap back button again to exit</string>
 
     <!-- Auto-Flattr dialog -->
     <string name="auto_flattr_enable">Enable automatic flattring</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -471,7 +471,7 @@
     <string name="stop_playback">Stop playback</string>
     <string name="continue_playback">Continue audio playback</string>
     <string name="behavior">Behavior</string>
-    <string name="pref_back_button_behavior_title">Back button behavior</string>
+    <string name="pref_back_button_behavior_title">Back Button Behavior</string>
     <string name="pref_back_button_behavior_sum">Change behavior of the back button.</string>
     <string name="back_button_default">Default</string>
     <string name="back_button_open_drawer">Open navigation drawer</string>
@@ -479,6 +479,8 @@
     <string name="back_button_show_prompt">Confirm to exit</string>
     <string name="close_prompt">Are you sure you want to close AntennaPod?</string>
     <string name="double_tap_toast">Tap back button again to exit</string>
+    <string name="back_button_go_to_page">Go to page</string>
+    <string name="back_button_go_to_page_title">Select page</string>
 
     <!-- Auto-Flattr dialog -->
     <string name="auto_flattr_enable">Enable automatic flattring</string>


### PR DESCRIPTION
This PR allows users to change how the back button functions. Closes #2196

Possible choices are following:

 - **Default** - back button functions how it currently functions (closes the app if there is nowhere to go back to)

- **Go to page** - back button opens chosen page (Queue, Episodes or Subscriptions) and closes the app if you're already on that page

 - **Open navigation drawer** - back button always opens the navigation drawer instead of closing the app

 - **Double tap to exit** - like default, but requires two taps to close the app

 - **Confirm to exit** - like default, but prompts user if they really want to exit

---

<img src="https://user-images.githubusercontent.com/6667105/48578378-b67e8800-e919-11e8-94fe-436473af4efd.png" width=128> <img src="https://user-images.githubusercontent.com/6667105/48578439-e9288080-e919-11e8-91d3-354f9f081464.png" width=128> <img src="https://user-images.githubusercontent.com/6667105/48578468-fc3b5080-e919-11e8-9fdd-ac030b79fdf6.png" width=128> <img src="https://user-images.githubusercontent.com/6667105/48578485-078e7c00-e91a-11e8-83ad-7ccac03fafba.png" width=128> <img src="https://user-images.githubusercontent.com/6667105/48578512-19701f00-e91a-11e8-9190-f767ead1705c.png" width=128>


