### PR TITLE
Auto feed update fix in airplane mode

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -49,12 +49,12 @@ import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBReader;
-import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.Flavors;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.StorageUtils;
+import de.danoeh.antennapod.core.util.download.AutoUpdateManager;
 import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 import de.danoeh.antennapod.dialog.RatingDialog;
 import de.danoeh.antennapod.dialog.RenameFeedDialog;
@@ -471,7 +471,7 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     protected void onResume() {
         super.onResume();
         StorageUtils.checkStorageAvailability(this);
-        DBTasks.checkShouldRefreshFeeds(getApplicationContext());
+        AutoUpdateManager.checkShouldRefreshFeeds(getApplicationContext());
 
         Intent intent = getIntent();
         if (intent.hasExtra(EXTRA_FEED_ID) ||

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
@@ -46,9 +46,9 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
 import de.danoeh.antennapod.core.storage.DBReader;
-import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.IntentUtils;
+import de.danoeh.antennapod.core.util.download.AutoUpdateManager;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
 import de.danoeh.antennapod.dialog.RenameFeedDialog;
@@ -187,7 +187,7 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
             pagerAdapter.onMediaChanged(media);
             pagerAdapter.setController(controller);
         }
-        DBTasks.checkShouldRefreshFeeds(getApplicationContext());
+        AutoUpdateManager.checkShouldRefreshFeeds(getApplicationContext());
 
         EventDistributor.getInstance().register(contentUpdate);
         EventBus.getDefault().register(this);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -34,6 +34,7 @@ import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.DownloadError;
+import de.danoeh.antennapod.core.util.FeedUpdateUtils;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
@@ -338,7 +339,7 @@ public final class DBTasks {
         Log.d(TAG, "last refresh: " + Converter.getDurationStringLocalized(context,
                 System.currentTimeMillis() - lastRefresh) + " ago");
         if(lastRefresh <= System.currentTimeMillis() - interval) {
-            DBTasks.refreshAllFeeds(context, null);
+            FeedUpdateUtils.startAutoUpdate(context, null);
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import de.danoeh.antennapod.core.ClientConfig;
@@ -28,13 +27,10 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.GpodnetSyncService;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
-import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.DownloadError;
-import de.danoeh.antennapod.core.util.FeedUpdateUtils;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
@@ -208,6 +204,11 @@ public final class DBTasks {
         }).start();
     }
 
+    public static long getLastRefreshAllFeedsTimeMillis(final Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(DBTasks.PREF_NAME, MODE_PRIVATE);
+        return  prefs.getLong(DBTasks.PREF_LAST_REFRESH, 0);
+    }
+
     /**
      * @param context
      * @param feedList the list of feeds to refresh
@@ -316,31 +317,6 @@ public final class DBTasks {
         }
         f.setId(feed.getId());
         DownloadRequester.getInstance().downloadFeed(context, f, loadAllPages, force);
-    }
-
-    /*
-     *  Checks if the app should refresh all feeds, i.e. if the last auto refresh failed.
-     *
-     *  The feeds are only refreshed if an update interval or time of day is set and the last
-     *  (successful) refresh was before the last interval or more than a day ago, respectively.
-     */
-    public static void checkShouldRefreshFeeds(Context context) {
-        long interval = 0;
-        if(UserPreferences.getUpdateInterval() > 0) {
-            interval = UserPreferences.getUpdateInterval();
-        } else if(UserPreferences.getUpdateTimeOfDay().length > 0){
-            interval = TimeUnit.DAYS.toMillis(1);
-        }
-        if(interval == 0) { // auto refresh is disabled
-            return;
-        }
-        SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, MODE_PRIVATE);
-        long lastRefresh = prefs.getLong(PREF_LAST_REFRESH, 0);
-        Log.d(TAG, "last refresh: " + Converter.getDurationStringLocalized(context,
-                System.currentTimeMillis() - lastRefresh) + " ago");
-        if(lastRefresh <= System.currentTimeMillis() - interval) {
-            FeedUpdateUtils.startAutoUpdate(context, null);
-        }
     }
 
     /**


### PR DESCRIPTION
Closes #2906

`DBTasks.checkShouldRefreshFeeds()` is also refactored and moved to `AutoUpdateManager`.

Also, `checkShouldRefreshFeeds()`, a (somewhat) workaround to address #1942, is not really needed for devices with Android 7+ / API 24 anymore. The new (in v1.7.0+) `FeedUpdateJobService` fixes the problem without the workaround. 


