### PR TITLE
Add delete option to episode's context menu

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -505,6 +505,20 @@ public class PreferencesTest {
                 Timeout.getLargeTimeout()));
     }
 
+    @Test
+    public void testDeleteRemovesFromQueue() {
+        clickPreference(withText(R.string.storage_pref));
+        if (!UserPreferences.shouldDeleteRemoveFromQueue()) {
+            clickPreference(withText(R.string.pref_delete_removes_from_queue_title));
+            assertTrue(solo.waitForCondition(UserPreferences::shouldDeleteRemoveFromQueue, Timeout.getLargeTimeout()));
+        }
+        final boolean deleteRemovesFromQueue = UserPreferences.shouldDeleteRemoveFromQueue();
+        solo.clickOnText(solo.getString(R.string.pref_delete_removes_from_queue_title));
+        assertTrue(solo.waitForCondition(() -> deleteRemovesFromQueue != UserPreferences.shouldDeleteRemoveFromQueue(), Timeout.getLargeTimeout()));
+        solo.clickOnText(solo.getString(R.string.pref_delete_removes_from_queue_title));
+        assertTrue(solo.waitForCondition(() -> deleteRemovesFromQueue == UserPreferences.shouldDeleteRemoveFromQueue(), Timeout.getLargeTimeout()));
+    }
+
     private void clickPreference(Matcher<View> matcher) {
         onView(withId(R.id.list))
                 .perform(RecyclerViewActions.actionOnItem(hasDescendant(matcher), click()));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -17,6 +17,7 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.DownloadedEpisodesListAdapter;
 import de.danoeh.antennapod.core.feed.EventDistributor;
 import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
@@ -169,6 +170,9 @@ public class CompletedDownloadsFragment extends ListFragment {
         @Override
         public void onFeedItemSecondaryAction(FeedItem item) {
             DBWriter.deleteFeedMediaOfItem(getActivity(), item.getMedia().getId());
+            if (UserPreferences.shouldDeleteRemoveFromQueue()) {
+                DBWriter.removeQueueItem(getActivity(), item, false);
+            }
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -101,7 +101,8 @@ public class FeedItemMenuHandler {
             mi.setItemVisibility(R.id.share_download_url_with_position_item, false);
         }
 
-        mi.setItemVisibility(R.id.share_file, hasMedia && selectedItem.getMedia().fileExists());
+        boolean fileDownloaded = hasMedia && selectedItem.getMedia().fileExists();
+        mi.setItemVisibility(R.id.share_file, fileDownloaded);
 
         if (selectedItem.isPlayed()) {
             mi.setItemVisibility(R.id.mark_read_item, false);
@@ -129,6 +130,8 @@ public class FeedItemMenuHandler {
         boolean isFavorite = selectedItem.isTagged(FeedItem.TAG_FAVORITE);
         mi.setItemVisibility(R.id.add_to_favorites_item, !isFavorite);
         mi.setItemVisibility(R.id.remove_from_favorites_item, isFavorite);
+
+        mi.setItemVisibility(R.id.remove_item, fileDownloaded);
 
         return true;
     }
@@ -162,6 +165,9 @@ public class FeedItemMenuHandler {
                 break;
             case R.id.remove_item:
                 DBWriter.deleteFeedMediaOfItem(context, selectedItem.getMedia().getId());
+                if (UserPreferences.shouldDeleteRemoveFromQueue()) {
+                    DBWriter.removeQueueItem(context, selectedItem, false);
+                }
                 break;
             case R.id.mark_read_item:
                 selectedItem.setPlayed(true);

--- a/app/src/main/res/menu/feeditemlist_context.xml
+++ b/app/src/main/res/menu/feeditemlist_context.xml
@@ -47,6 +47,10 @@
         android:id="@+id/deactivate_auto_download"
         android:menuCategory="container"
         android:title="@string/deactivate_auto_download" />
+    <item
+        android:id="@+id/remove_item"
+        android:menuCategory="container"
+        android:title="@string/delete_label" />
 
     <item
         android:id="@+id/visit_website_item"

--- a/app/src/main/res/menu/queue_context.xml
+++ b/app/src/main/res/menu/queue_context.xml
@@ -48,6 +48,10 @@
         android:id="@+id/deactivate_auto_download"
         android:menuCategory="container"
         android:title="@string/deactivate_auto_download" />
+    <item
+        android:id="@+id/remove_item"
+        android:menuCategory="container"
+        android:title="@string/delete_label" />
 
     <item
         android:id="@+id/visit_website_item"

--- a/app/src/main/res/xml/preferences_storage.xml
+++ b/app/src/main/res/xml/preferences_storage.xml
@@ -25,6 +25,12 @@
             android:key="prefFavoriteKeepsEpisode"
             android:summary="@string/pref_favorite_keeps_episodes_sum"
             android:title="@string/pref_favorite_keeps_episodes_title"/>
+    <SwitchPreference
+        android:defaultValue="false"
+        android:enabled="true"
+        android:key="prefDeleteRemovesFromQueue"
+        android:summary="@string/pref_delete_removes_from_queue_sum"
+        android:title="@string/pref_delete_removes_from_queue_title"/>
 
     <PreferenceCategory android:title="@string/import_export_pref">
         <Preference

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -100,6 +100,7 @@ public class UserPreferences {
     // Other
     private static final String PREF_DATA_FOLDER = "prefDataFolder";
     public static final String PREF_IMAGE_CACHE_SIZE = "prefImageCacheSize";
+    public static final String PREF_DELETE_REMOVES_FROM_QUEUE = "prefDeleteRemovesFromQueue";
 
     // Mediaplayer
     public static final String PREF_MEDIA_PLAYER = "prefMediaPlayer";
@@ -307,6 +308,10 @@ public class UserPreferences {
 
     public static int getSmartMarkAsPlayedSecs() {
         return Integer.parseInt(prefs.getString(PREF_SMART_MARK_AS_PLAYED_SECS, "30"));
+    }
+
+    public static boolean shouldDeleteRemoveFromQueue() {
+        return prefs.getBoolean(PREF_DELETE_REMOVES_FROM_QUEUE, false);
     }
 
     public static boolean isAutoFlattr() {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -481,6 +481,8 @@
     <string name="double_tap_toast">Tap back button again to exit</string>
     <string name="back_button_go_to_page">Go to page</string>
     <string name="back_button_go_to_page_title">Select page</string>
+    <string name="pref_delete_removes_from_queue_title">Delete Removes From Queue</string>
+    <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from queue when it is deleted.</string>
 
     <!-- Auto-Flattr dialog -->
     <string name="auto_flattr_enable">Enable automatic flattring</string>


### PR DESCRIPTION
Closes #2548. This PR makes following changes:

 - Adds delete option to episode's context menus in queue and feed list

 - Adds a storage preference that allows episodes to be automatically removed from queue when they are deleted (by clicking delete in context menu, or pressing trash can icon on `Completed` tab of `Downloads` page)

 - Adds a test for the aforementioned preference

---

<img src="https://user-images.githubusercontent.com/6667105/49251643-2b75b580-f422-11e8-9566-5748ad99d003.png" width=128> <img src="https://user-images.githubusercontent.com/6667105/49251692-4cd6a180-f422-11e8-93f9-37e12cb308de.png" width=128> <img src="https://user-images.githubusercontent.com/6667105/49251694-4ea06500-f422-11e8-9197-66e7a205209d.png" width=128>


