### PR TITLE
Enable configurable history length for PlaybackHistoryFragment

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.fragment;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.ListFragment;
 import android.support.v4.view.MenuItemCompat;
 import android.util.Log;
@@ -287,7 +288,10 @@ public class PlaybackHistoryFragment extends ListFragment {
     }
 
     private List<FeedItem> loadData() {
-        List<FeedItem> history = DBReader.getPlaybackHistory();
+        final String playbackHistorySizeS = PreferenceManager.getDefaultSharedPreferences(getContext())
+                .getString("prefPlaybackHistorySize", "50");
+        final int playbackHistorySize = Integer.parseInt(playbackHistorySizeS);
+        List<FeedItem> history = DBReader.getPlaybackHistory(playbackHistorySize);
         DBReader.loadAdditionalFeedItemListData(history);
         return history;
     }

--- a/app/src/main/res/xml/preferences_storage.xml
+++ b/app/src/main/res/xml/preferences_storage.xml
@@ -25,7 +25,11 @@
             android:key="prefFavoriteKeepsEpisode"
             android:summary="@string/pref_favorite_keeps_episodes_sum"
             android:title="@string/pref_favorite_keeps_episodes_title"/>
-
+    <EditTextPreference
+        android:defaultValue="50"
+        android:key="prefPlaybackHistorySize"
+        android:summary="@string/pref_playback_history_size_sum"
+        android:title="@string/pref_playback_history_size_title"/>
     <PreferenceCategory android:title="@string/import_export_pref">
         <Preference
                 android:key="prefOpmlExport"

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -37,11 +37,6 @@ public final class DBReader {
     private static final String TAG = "DBReader";
 
     /**
-     * Maximum size of the list returned by {@link #getPlaybackHistory()}.
-     */
-    public static final int PLAYBACK_HISTORY_SIZE = 50;
-
-    /**
      * Maximum size of the list returned by {@link #getDownloadLog()}.
      */
     private static final int DOWNLOAD_LOG_SIZE = 200;
@@ -437,9 +432,10 @@ public final class DBReader {
      * has been completed at least once.
      *
      * @return The playback history. The FeedItems are sorted by their media's playbackCompletionDate in descending order.
-     * The size of the returned list is limited by {@link #PLAYBACK_HISTORY_SIZE}.
+     *
+     * @param playbackHistorySize The maximum number of entries to return
      */
-    public static List<FeedItem> getPlaybackHistory() {
+    public static List<FeedItem> getPlaybackHistory(final int playbackHistorySize) {
         Log.d(TAG, "getPlaybackHistory() called");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -448,7 +444,7 @@ public final class DBReader {
         Cursor mediaCursor = null;
         Cursor itemCursor = null;
         try {
-            mediaCursor = adapter.getCompletedMediaCursor(PLAYBACK_HISTORY_SIZE);
+            mediaCursor = adapter.getCompletedMediaCursor(playbackHistorySize);
             String[] itemIds = new String[mediaCursor.getCount()];
             for (int i = 0; i < itemIds.length && mediaCursor.moveToPosition(i); i++) {
                 int index = mediaCursor.getColumnIndex(PodDBAdapter.KEY_FEEDITEM);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -428,7 +428,7 @@ public final class DBReader {
     }
 
     /**
-     * Loads the playback history from the database. A FeedItem is in the playback history if playback of the correpsonding episode
+     * Loads the playback history from the database. A FeedItem is in the playback history if playback of the corresponding episode
      * has been completed at least once.
      *
      * @return The playback history. The FeedItems are sorted by their media's playbackCompletionDate in descending order.

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -349,6 +349,8 @@
     <string name="pref_skip_keeps_episodes_title">Keep Skipped Episodes</string>
     <string name="pref_favorite_keeps_episodes_sum">Keep episodes when they are marked Favorite</string>
     <string name="pref_favorite_keeps_episodes_title">Keep Favorite Episodes</string>
+    <string name="pref_playback_history_size_sum">Playback history size</string>
+    <string name="pref_playback_history_size_title">Playback History Size</string>
     <string name="playback_pref">Playback</string>
     <string name="network_pref">Network</string>
     <string name="pref_autoUpdateIntervallOrTime_title">Update Interval or Time of Day</string>


### PR DESCRIPTION
Allow playback history size to be set in the preferences, for use in PlaybackHistoryFragment.
    
This is a superficial approach to this.  In reality, all history appears to be stored in the database. This merely changes how many items are retrieved when we show the playback history. Perhaps a better approach would be to expose the entire playback history using a RecyclerView which loads in incrementally. But this works well for now.