### PR TITLE
Fix phantom service notification

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -21,13 +21,14 @@ import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.NetworkUtils;
+import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
 
 /**
  * Default implementation of an ActionButtonCallback
  */
 public class DefaultActionButtonCallback implements ActionButtonCallback {
 
-    private static final String TAG = "DefaultActionButtonCallback";
+    private static final String TAG = "DefaultActionBtnCb";
 
     private final Context context;
 
@@ -81,16 +82,12 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 }
             } else { // media is downloaded
                 if (media.isCurrentlyPlaying()) {
-//                    new PlaybackServiceStarter(context, media) // TODO: [2716] probably not needed but not 100% sure
-//                            .startWhenPrepared(true)
-//                            .shouldStream(false)
-//                            .start();
                     IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE);
                 } else if (media.isCurrentlyPaused()) {
-//                    new PlaybackServiceStarter(context, media) // TODO: [2716] probably not needed but not 100% sure
-//                            .startWhenPrepared(true)
-//                            .shouldStream(false)
-//                            .start();
+                    new PlaybackServiceStarter(context, media) // need to start the service in case it's been stopped by system.
+                            .startWhenPrepared(true)
+                            .shouldStream(false)
+                            .start();
                     IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_RESUME_PLAY_CURRENT_EPISODE);
                 } else {
                     DBTasks.playMedia(context, media, false, true, false);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DefaultActionButtonCallback.java
@@ -1,8 +1,6 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.content.Intent;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -23,7 +21,6 @@ import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.NetworkUtils;
-import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
 
 /**
  * Default implementation of an ActionButtonCallback
@@ -84,16 +81,16 @@ public class DefaultActionButtonCallback implements ActionButtonCallback {
                 }
             } else { // media is downloaded
                 if (media.isCurrentlyPlaying()) {
-                    new PlaybackServiceStarter(context, media)
-                            .startWhenPrepared(true)
-                            .shouldStream(false)
-                            .start();
+//                    new PlaybackServiceStarter(context, media) // TODO: [2716] probably not needed but not 100% sure
+//                            .startWhenPrepared(true)
+//                            .shouldStream(false)
+//                            .start();
                     IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE);
                 } else if (media.isCurrentlyPaused()) {
-                    new PlaybackServiceStarter(context, media)
-                            .startWhenPrepared(true)
-                            .shouldStream(false)
-                            .start();
+//                    new PlaybackServiceStarter(context, media) // TODO: [2716] probably not needed but not 100% sure
+//                            .startWhenPrepared(true)
+//                            .shouldStream(false)
+//                            .start();
                     IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_RESUME_PLAY_CURRENT_EPISODE);
                 } else {
                     DBTasks.playMedia(context, media, false, true, false);

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.KeyEvent;
 
@@ -29,7 +30,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
 			Intent serviceIntent = new Intent(context, PlaybackService.class);
 			serviceIntent.putExtra(EXTRA_KEYCODE, event.getKeyCode());
 			serviceIntent.putExtra(EXTRA_SOURCE, event.getSource());
-			context.startService(serviceIntent); // the service itself will determine if it needs to become a foreground service.
+			ContextCompat.startForegroundService(context, serviceIntent);
 		}
 
 	}

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.core.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.KeyEvent;
 
@@ -30,7 +29,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
 			Intent serviceIntent = new Intent(context, PlaybackService.class);
 			serviceIntent.putExtra(EXTRA_KEYCODE, event.getKeyCode());
 			serviceIntent.putExtra(EXTRA_SOURCE, event.getSource());
-			ContextCompat.startForegroundService(context, serviceIntent);
+			context.startService(serviceIntent); // the service itself will determine if it needs to become a foreground service.
 		}
 
 	}

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -79,10 +79,8 @@ import de.greenrobot.event.EventBus;
  *
  * Callers should connect to the service with either:
  * - .bindService()
- * - .startService(), optionally with arguments such as media to be played.
+ * - ContextCompat.startForegroundService(), optionally with arguments, such as media to be played, in intent extras
  *
- * Caller should not call startForegroundService(). The PlaybackService will make itself foreground
- * when appropriate.
  */
 public class PlaybackService extends MediaBrowserServiceCompat {
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1336,29 +1336,30 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                         Log.v(TAG, "DBG - notificationSetupTask: make service foreground");
                         startForeground(NOTIFICATION_ID, notification);
                     } else if (playerStatus == PlayerStatus.PAUSED) {
-                        // TODO: logic originally in mediaPlayerCallback case PAUSED.
                         if (treatPauseAsStop) {
                             stopForeground(true);
                         } else if ((UserPreferences.isPersistNotify() || isCasting) &&
                                 android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                             // do not remove notification on pause based on user pref and whether android version supports expanded notifications
                             // Change [Play] button to [Pause]
-                            // TODO LATER: logic same as outer else clause: setupNotification(info)
-                            stopForeground(false);
-                            NotificationManager mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-                            mNotificationManager.notify(NOTIFICATION_ID, notification);
+                            leaveNotificationAsBackground(notification);
                         } else if (!UserPreferences.isPersistNotify() && !isCasting) {
                             // remove notification on pause
                             stopForeground(true);
                         }
                     } else {
-                        stopForeground(false);
-                        NotificationManager mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-                        mNotificationManager.notify(NOTIFICATION_ID, notification);
+                        leaveNotificationAsBackground(notification);
                     }
                     Log.d(TAG, "Notification set up");
                 }
             }
+
+            private void leaveNotificationAsBackground(@NonNull Notification notification) {
+                stopForeground(false);
+                NotificationManager mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+                mNotificationManager.notify(NOTIFICATION_ID, notification);
+            }
+
         };
         notificationSetupThread = new Thread(notificationSetupTask);
         notificationSetupThread.start();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -466,30 +466,25 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             return Service.START_NOT_STICKY;
         }
 
-        if ((flags & Service.START_FLAG_REDELIVERY) != 0) {
-            Log.d(TAG, "onStartCommand is a redelivered intent, calling stopForeground now.");
-            stopForeground(true); // TODO: [2716]-RemoveOptional legacy code from v0.9.8.1 that is no longer applicable, which used to return Service.START_REDELIVER_INTENT. See
-        } else {
-            if (keycode != -1) {
-                Log.d(TAG, "Received media button event");
-                boolean handled = handleKeycode(keycode, true);
-                if (!handled) {
-                    serviceManager.stopService(); // TODO: [2716]-RemoveOptional why is it added in the first place in v1.7.0?
-                    return Service.START_NOT_STICKY;
-                }
-            } else if (!flavorHelper.castDisconnect(castDisconnect) && playable != null) {
-                boolean stream = intent.getBooleanExtra(EXTRA_SHOULD_STREAM,
-                        true);
-                boolean startWhenPrepared = intent.getBooleanExtra(EXTRA_START_WHEN_PREPARED, false);
-                boolean prepareImmediately = intent.getBooleanExtra(EXTRA_PREPARE_IMMEDIATELY, false);
-                sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);
-                //If the user asks to play External Media, the casting session, if on, should end.
-                flavorHelper.castDisconnect(playable instanceof ExternalMedia);
-                if (playable instanceof FeedMedia) {
-                    playable = DBReader.getFeedMedia(((FeedMedia) playable).getId());
-                }
-                mediaPlayer.playMediaObject(playable, stream, startWhenPrepared, prepareImmediately);
+        if (keycode != -1) {
+            Log.d(TAG, "Received media button event");
+            boolean handled = handleKeycode(keycode, true);
+            if (!handled) {
+                serviceManager.stopService(); // TODO: [2716]-RemoveOptional why is it added in the first place in v1.7.0?
+                return Service.START_NOT_STICKY;
             }
+        } else if (!flavorHelper.castDisconnect(castDisconnect) && playable != null) {
+            boolean stream = intent.getBooleanExtra(EXTRA_SHOULD_STREAM,
+                    true);
+            boolean startWhenPrepared = intent.getBooleanExtra(EXTRA_START_WHEN_PREPARED, false);
+            boolean prepareImmediately = intent.getBooleanExtra(EXTRA_PREPARE_IMMEDIATELY, false);
+            sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);
+            //If the user asks to play External Media, the casting session, if on, should end.
+            flavorHelper.castDisconnect(playable instanceof ExternalMedia);
+            if (playable instanceof FeedMedia) {
+                playable = DBReader.getFeedMedia(((FeedMedia) playable).getId());
+            }
+            mediaPlayer.playMediaObject(playable, stream, startWhenPrepared, prepareImmediately);
         }
 
         return Service.START_NOT_STICKY;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -605,6 +605,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     public void notifyVideoSurfaceAbandoned() {
+        Log.v(TAG, "notifyVideoSurfaceAbandoned()");
         mediaPlayer.pause(true, false);
         mediaPlayer.resetVideoSurface();
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1932,6 +1932,14 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             try {
                 // Manage the started state of this service.
                 switch (state.getState()) {
+                    case PlaybackStateCompat.STATE_CONNECTING:
+                        // move the service to started, aka, making it foreground
+                        // upon STATE_CONNECTING, i.e., in preparing to play a media.
+                        // This is done so that in case the preparation takes a long time, e.g.,
+                        // streaming over a slow network,
+                        // the service won't be killed by the system prematurely.
+                        moveServiceToStartedState(state);
+                        break;
                     case PlaybackStateCompat.STATE_PLAYING:
                         moveServiceToStartedState(state);
                         break;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -76,7 +76,13 @@ import de.greenrobot.event.EventBus;
 
 /**
  * Controls the MediaPlayer that plays a FeedMedia-file
- * TODO [2716] add some guidelines on how to / not to start / stop the service from callers.
+ *
+ * Callers should connect to the service with either:
+ * - .bindService()
+ * - .startService(), optionally with arguments such as media to be played.
+ *
+ * Caller should not call startForegroundService(). The PlaybackService will make itself foreground
+ * when appropriate.
  */
 public class PlaybackService extends MediaBrowserServiceCompat {
     /**
@@ -463,11 +469,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         final boolean castDisconnect = intent.getBooleanExtra(EXTRA_CAST_DISCONNECT, false);
         Playable playable = intent.getParcelableExtra(EXTRA_PLAYABLE);
         if (keycode == -1 && playable == null && !castDisconnect) {
-            Log.e(TAG, "PlaybackService was started with no arguments");
-            // some code call startService with no arg, causing playback to stop prematurely in typical case
-            // temporarily comment it out for now.
-            // TODO: Next step - find the source of the no-arg service start
-//            stopService(); // TODO: find the source of starting service with no argument that causes me to comment out this line temporarily
+            // Typical cases when the service was started with no argument
+            // - when it is first bound, and then moved to startedState, as in <code>serviceManager.moveServiceToStartedState()</code>
+            // - callers (e.g., Controller) explicitly
+            Log.d(TAG, "PlaybackService was started with no arguments.");
             return Service.START_NOT_STICKY;
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -472,8 +472,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 return Service.START_NOT_STICKY;
             }
         } else if (!flavorHelper.castDisconnect(castDisconnect) && playable != null) {
-            boolean stream = intent.getBooleanExtra(EXTRA_SHOULD_STREAM,
-                    true);
+            boolean stream = intent.getBooleanExtra(EXTRA_SHOULD_STREAM, true);
             boolean startWhenPrepared = intent.getBooleanExtra(EXTRA_START_WHEN_PREPARED, false);
             boolean prepareImmediately = intent.getBooleanExtra(EXTRA_PREPARE_IMMEDIATELY, false);
             sendNotificationBroadcast(NOTIFICATION_TYPE_RELOAD, 0);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1333,7 +1333,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                             playerStatus == PlayerStatus.PREPARING ||
                             playerStatus == PlayerStatus.SEEKING ||
                             isCasting) {
-                        Log.v(TAG, "DBG - notificationSetupTask: make service foreground");
+                        Log.v(TAG, "notificationSetupTask: make service foreground");
                         startForeground(NOTIFICATION_ID, notification);
                     } else if (playerStatus == PlayerStatus.PAUSED) {
                         if (treatPauseAsStop) {
@@ -1848,7 +1848,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         void setIsCasting(boolean isCasting);
 
-        void sendNotificationBroadcast(int type, int code); // TODO: unclear if the broadcast is still needed with ServiceManager
+        void sendNotificationBroadcast(int type, int code);
 
         void saveCurrentPosition(boolean fromMediaPlayer, Playable playable, int position);
 
@@ -1930,7 +1930,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         void onPlaybackStateChange(PlaybackStateCompat state) {
             // Report the state to the MediaSession.
 
-            Log.v(TAG, "DBG - onPlaybackStateChange(" + state + ")");
+            Log.v(TAG, "onPlaybackStateChange(" + (state != null ? state.getState() : "null") + ")");
             try {
                 // Manage the started state of this service.
                 switch (state.getState()) {
@@ -1977,8 +1977,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
 
         private void moveServiceToStartedState(PlaybackStateCompat state) {
-            Log.v(TAG, "DBG - ServiceManager.moveServiceToStartedState() - serviceInStartedState:" + serviceInStartedState);
-
             if (!serviceInStartedState) {
                 ContextCompat.startForegroundService(
                         PlaybackService.this,

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -468,7 +468,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             Log.d(TAG, "Received media button event");
             boolean handled = handleKeycode(keycode, true);
             if (!handled) {
-                serviceManager.stopService(); // TODO: [2716]-RemoveOptional why is it added in the first place in v1.7.0?
+                // Just silently ignores unsupported keycode. Whether the service will
+                // continue to run is solely dependent on whether it is playing some media.
                 return Service.START_NOT_STICKY;
             }
         } else if (!flavorHelper.castDisconnect(castDisconnect) && playable != null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1186,10 +1186,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      */
     private Thread notificationSetupThread;
 
-    private void setupNotification(final Playable playable) {
-        setupNotification(playable, false);
-    }
-
     private synchronized void setupNotification(final Playable playable, boolean treatPauseAsStop) {
         if (notificationSetupThread != null) {
             notificationSetupThread.interrupt();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -672,7 +672,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
                 case STOPPED:
                     //writePlaybackPreferencesNoMediaPlaying();
-                    //serviceManager.stopService();
                     break;
 
                 case PLAYING:

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Optional.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Optional.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package de.danoeh.antennapod.core.util;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+// AntennaPod's stripped-down version of Java/Android platform's java.util.Optional
+// so that it can be used on lower API level (API level 14)
+
+// Android-changed: removed ValueBased paragraph.
+/**
+ * A container object which may or may not contain a non-null value.
+ * If a value is present, {@code isPresent()} will return {@code true} and
+ * {@code get()} will return the value.
+ *
+ * <p>Additional methods that depend on the presence or absence of a contained
+ * value are provided, such as {@link #orElse(java.lang.Object) orElse()}
+ * (return a default value if value not present) and
+ * {@link #ifPresent(java.util.function.Consumer) ifPresent()} (execute a block
+ * of code if the value is present).
+ *
+ * @since 1.8
+ */
+public final class Optional<T> {
+    /**
+     * Common instance for {@code empty()}.
+     */
+    private static final Optional<?> EMPTY = new Optional<>();
+
+    /**
+     * If non-null, the value; if null, indicates no value is present
+     */
+    private final T value;
+
+    /**
+     * Constructs an empty instance.
+     *
+     * @implNote Generally only one empty instance, {@link Optional#EMPTY},
+     * should exist per VM.
+     */
+    private Optional() {
+        this.value = null;
+    }
+
+    /**
+     * Returns an empty {@code Optional} instance.  No value is present for this
+     * Optional.
+     *
+     * @apiNote Though it may be tempting to do so, avoid testing if an object
+     * is empty by comparing with {@code ==} against instances returned by
+     * {@code Option.empty()}. There is no guarantee that it is a singleton.
+     * Instead, use {@link #isPresent()}.
+     *
+     * @param <T> Type of the non-existent value
+     * @return an empty {@code Optional}
+     */
+    public static<T> Optional<T> empty() {
+        @SuppressWarnings("unchecked")
+        Optional<T> t = (Optional<T>) EMPTY;
+        return t;
+    }
+
+    /**
+     * Constructs an instance with the value present.
+     *
+     * @param value the non-null value to be present
+     * @throws NullPointerException if value is null
+     */
+    private Optional(T value) {
+        this.value = Objects.requireNonNull(value);
+    }
+
+    /**
+     * Returns an {@code Optional} with the specified present non-null value.
+     *
+     * @param <T> the class of the value
+     * @param value the value to be present, which must be non-null
+     * @return an {@code Optional} with the value present
+     * @throws NullPointerException if value is null
+     */
+    public static <T> Optional<T> of(T value) {
+        return new Optional<>(value);
+    }
+
+    /**
+     * Returns an {@code Optional} describing the specified value, if non-null,
+     * otherwise returns an empty {@code Optional}.
+     *
+     * @param <T> the class of the value
+     * @param value the possibly-null value to describe
+     * @return an {@code Optional} with a present value if the specified value
+     * is non-null, otherwise an empty {@code Optional}
+     */
+    public static <T> Optional<T> ofNullable(T value) {
+        return value == null ? empty() : of(value);
+    }
+
+    /**
+     * If a value is present in this {@code Optional}, returns the value,
+     * otherwise throws {@code NoSuchElementException}.
+     *
+     * @return the non-null value held by this {@code Optional}
+     * @throws NoSuchElementException if there is no value present
+     *
+     * @see Optional#isPresent()
+     */
+    public T get() {
+        if (value == null) {
+            throw new NoSuchElementException("No value present");
+        }
+        return value;
+    }
+
+    /**
+     * Return {@code true} if there is a value present, otherwise {@code false}.
+     *
+     * @return {@code true} if there is a value present, otherwise {@code false}
+     */
+    public boolean isPresent() {
+        return value != null;
+    }
+
+
+    /**
+     * Return the value if present, otherwise return {@code other}.
+     *
+     * @param other the value to be returned if there is no value present, may
+     * be null
+     * @return the value, if present, otherwise {@code other}
+     */
+    public T orElse(T other) {
+        return value != null ? value : other;
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this Optional. The
+     * other object is considered equal if:
+     * <ul>
+     * <li>it is also an {@code Optional} and;
+     * <li>both instances have no value present or;
+     * <li>the present values are "equal to" each other via {@code equals()}.
+     * </ul>
+     *
+     * @param obj an object to be tested for equality
+     * @return {code true} if the other object is "equal to" this object
+     * otherwise {@code false}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof Optional)) {
+            return false;
+        }
+
+        Optional<?> other = (Optional<?>) obj;
+        return (value == other.value) || (value != null && value.equals(other.value));
+    }
+
+    /**
+     * Returns the hash code value of the present value, if any, or 0 (zero) if
+     * no value is present.
+     *
+     * @return hash code value of the present value or 0 if no value is present
+     */
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+
+    /**
+     * Returns a non-empty string representation of this Optional suitable for
+     * debugging. The exact presentation format is unspecified and may vary
+     * between implementations and versions.
+     *
+     * @implSpec If a value is present the result must include its string
+     * representation in the result. Empty and present Optionals must be
+     * unambiguously differentiable.
+     *
+     * @return the string representation of this instance
+     */
+    @Override
+    public String toString() {
+        return value != null
+                ? String.format("Optional[%s]", value)
+                : "Optional.empty";
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -781,7 +781,7 @@ public abstract class PlaybackController {
     }
 
     private void initServiceNotRunning() {
-        Log.v(TAG, "DBG - initServiceNotRunning()"); // TODO: review it it's still needed
+        Log.v(TAG, "initServiceNotRunning()");
         mediaLoader = Maybe.create((MaybeOnSubscribe<Playable>) emitter -> {
             Playable media = getMedia();
             if (media != null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -192,7 +192,6 @@ public abstract class PlaybackController {
                     if (!PlaybackService.started) {
                         if (intent != null) {
                             Log.d(TAG, "Calling start service");
-                            // ContextCompat.startForegroundService(activity, intent); // TODO: [2716] likely not needed but is not 100% sure
                             bound = activity.bindService(intent, mConnection, 0);
                         } else {
                             status = PlayerStatus.STOPPED;
@@ -587,7 +586,8 @@ public abstract class PlaybackController {
                     .startWhenPrepared(true)
                     .streamIfLastWasStream()
                     .start();
-            Log.w(TAG, "Play/Pause button was pressed, but playbackservice was null!");
+            Log.d(TAG, "Play/Pause button was pressed, but playbackservice was null - " +
+                    "it is likely to have been released by Android system. Restarting it.");
             return;
         }
         switch (status) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -13,7 +13,6 @@ import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
@@ -105,6 +104,7 @@ public abstract class PlaybackController {
     }
 
     private synchronized void initServiceRunning() {
+        Log.v(TAG, "initServiceRunning()");
         if (initialized) {
             return;
         }
@@ -192,7 +192,7 @@ public abstract class PlaybackController {
                     if (!PlaybackService.started) {
                         if (intent != null) {
                             Log.d(TAG, "Calling start service");
-                            ContextCompat.startForegroundService(activity, intent);
+                            // ContextCompat.startForegroundService(activity, intent); // TODO: [2716] likely not needed but is not 100% sure
                             bound = activity.bindService(intent, mConnection, 0);
                         } else {
                             status = PlayerStatus.STOPPED;
@@ -784,6 +784,7 @@ public abstract class PlaybackController {
     }
 
     private void initServiceNotRunning() {
+        Log.v(TAG, "DBG - initServiceNotRunning()"); // TODO: review it it's still needed
         mediaLoader = Maybe.create((MaybeOnSubscribe<Playable>) emitter -> {
             Playable media = getMedia();
             if (media != null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -764,6 +764,7 @@ public abstract class PlaybackController {
     }
 
     public void notifyVideoSurfaceAbandoned() {
+        Log.v(TAG, "notifyVideoSurfaceAbandoned() - hasPlaybackService=" + (playbackService != null));
         if (playbackService != null) {
             playbackService.notifyVideoSurfaceAbandoned();
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.core.util.playback;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
@@ -77,6 +78,6 @@ public class PlaybackServiceStarter {
         if (PlaybackService.isRunning && !callEvenIfRunning) {
             return;
         }
-        context.startService(getIntent()); // the service itself will decide if it needs to become foreground
+        ContextCompat.startForegroundService(context, getIntent());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
@@ -2,9 +2,6 @@ package de.danoeh.antennapod.core.util.playback;
 
 import android.content.Context;
 import android.content.Intent;
-import android.media.MediaPlayer;
-import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
 
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
@@ -73,6 +70,6 @@ public class PlaybackServiceStarter {
         if (PlaybackService.isRunning && !callEvenIfRunning) {
             return;
         }
-        ContextCompat.startForegroundService(context, getIntent());
+        context.startService(getIntent()); // the service itself will decide if it needs to become foreground
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
@@ -2,11 +2,14 @@ package de.danoeh.antennapod.core.util.playback;
 
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 
 public class PlaybackServiceStarter {
+    private static final String TAG = "PlaybackServiceStarter";
+
     private final Context context;
     private final Playable media;
     private boolean startWhenPrepared = false;
@@ -62,6 +65,10 @@ public class PlaybackServiceStarter {
         launchIntent.putExtra(PlaybackService.EXTRA_START_WHEN_PREPARED, startWhenPrepared);
         launchIntent.putExtra(PlaybackService.EXTRA_SHOULD_STREAM, shouldStream);
         launchIntent.putExtra(PlaybackService.EXTRA_PREPARE_IMMEDIATELY, prepareImmediately);
+
+        if (media == null) {
+            Log.e(TAG, "getIntent() - media is unexpectedly null. intent:" + launchIntent);
+        }
 
         return launchIntent;
     }

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -151,7 +151,6 @@ public class PlaybackServiceFlavorHelper {
                 // hardware volume buttons control the local device volume
                 mediaRouter.setMediaSessionCompat(null);
                 unregisterWifiBroadcastReceiver();
-                callback.setupNotification(false, info);
             }
         };
     }
@@ -181,7 +180,6 @@ public class PlaybackServiceFlavorHelper {
         // hardware volume buttons control the remote device volume
         mediaRouter.setMediaSessionCompat(callback.getMediaSession());
         registerWifiBroadcastReceiver();
-        callback.setupNotification(true, info);
     }
 
     private void switchMediaPlayer(@NonNull PlaybackServiceMediaPlayer newPlayer,


### PR DESCRIPTION
Closes #2716. The code is complete, pending reviews requested and testing of cast scenario.

This first cut check-ins definitely solves the phantom service notification in #2716, as it eliminates the source of it (the workaround dummy notification). It is tested with
- existing test suite (note: `VideoPlayerActivityTest` failed, but it has been failing even before the check-in)
- manual testing for typical audio playback: in app, notification controls, lockscreen controls, widgets.
  - devices covered: Android 7 devices, Android 9 and Android 4.4 simulators,

fc0f49f523fd350f4cef9eaa40fa38a476dc59b5 is the crux. It follows the pattern in Google Sample App as explained in https://github.com/AntennaPod/AntennaPod/issues/2716#issuecomment-444282899

Plan:
- [x] Basic first-cut for typical audio playback
- [x] `PENDING REVIEW` https://github.com/AntennaPod/AntennaPod/pull/2954#issuecomment-451313530 - Consider whether existing tests need to be extended - no changes needed.
- [x] Review the other cases
  - [x] `PENDING REVIEW` https://github.com/AntennaPod/AntennaPod/pull/2954#issuecomment-451261293 - Video playback
  - [x] Playback control with headset buttons
  - [x] Playback control with bluetooth - no changes
  - [x] Widgets
  - [x] Casting scenario - @ByteHamster tested it
- [x] Review codes that start / stop `PlaybackService` / notification, ensure they are still relevant / correct with the new model.
- [x] Misc. cleanup

Out of scope:
- Potentially replacing `MediaButtonReceiver` and the associated KeyEvent handling logic in `PlaybackService`. 
It looks like the logic can be replaced by Android Support library's  `android.support.v4.media.session.MediaButtonReceiver`, trimming the code base. Some internal logic, such as `PlaybackService.setupNotification()` and `PlayerWidgetJobService`, will need to migrate to the support's API. There might still be cases such as some customization per `UserPreference` that require some customization beyond Support library provides. 
