### PR TITLE
Prevent app crash during some automatic feed update

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedUpdateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedUpdateUtils.java
@@ -17,15 +17,20 @@ public class FeedUpdateUtils {
     private FeedUpdateUtils() {}
 
     public static void startAutoUpdate(Context context, Runnable callback) {
-        try {
-            with().pollInterval(1, TimeUnit.SECONDS)
-                    .await()
-                    .atMost(10, TimeUnit.SECONDS)
-                    .until(() -> NetworkUtils.networkAvailable() && NetworkUtils.isDownloadAllowed());
-            DBTasks.refreshAllFeeds(context, null, callback);
-        } catch (ConditionTimeoutException ignore) {
-            Log.d(TAG, "Blocking automatic update: no wifi available / no mobile updates allowed");
-        }
+        // the network check is blocking for possibly a long time: so run the logic
+        // in a separate thread to prevent the code blocking the callers
+        final Runnable runnable = () -> {
+            try {
+                with().pollInterval(1, TimeUnit.SECONDS)
+                        .await()
+                        .atMost(10, TimeUnit.SECONDS)
+                        .until(() -> NetworkUtils.networkAvailable() && NetworkUtils.isDownloadAllowed());
+                DBTasks.refreshAllFeeds(context, null, callback);
+            } catch (ConditionTimeoutException ignore) {
+                Log.d(TAG, "Blocking automatic update: no wifi available / no mobile updates allowed");
+            }
+        };
+        new Thread(runnable).start();
     }
 
 }


### PR DESCRIPTION
Closes #2956 

- The fix should also remove some occasional unresponsive UI, as the UI also occasional call automatic feed update.
See: https://github.com/AntennaPod/AntennaPod/search?q=checkShouldRefreshFeeds&unscoped_q=checkShouldRefreshFeeds

- a side effect is for scheduled automatic feed update on Android 7+ devices, it now
spawns an additional thread to check for network availability. It is already being run in a background `JobService` so the additional thread is not necessary.
It can be eliminated with additional logic branching, but I feel the added complexity is not worth the once-in-a-while additional thread.


