### PR TITLE
Expanding toolbar

### DIFF
--- a/core/src/main/res/values-v23/styles.xml
+++ b/core/src/main/res/values-v23/styles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.AntennaPod.Light.NoTitle" parent="Theme.Base.AntennaPod.Light.NoTitle">
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="colorPrimaryDark">@color/primary_light</item>
+    </style>
+
+    <style name="Theme.AntennaPod.Light" parent="Theme.Base.AntennaPod.Light">
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="colorPrimaryDark">@color/primary_light</item>
+    </style>
+</resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -28,6 +28,7 @@
 
     <!-- Theme colors -->
     <color name="primary_light">#FFFFFF</color>
+    <color name="primary_darktheme">#212121</color>
 
     <color name="highlight_light">#DDDDDD</color>
     <color name="highlight_dark">#414141</color>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -372,6 +372,8 @@
 
     <style name="Theme.AntennaPod.Dark.Splash" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/bg_splash</item>
+        <item name="colorPrimary">@color/ic_launcher_background</item>
+        <item name="colorPrimaryDark">@color/ic_launcher_background</item>
     </style>
 
     <style name="Theme.AntennaPod.VideoPlayer" parent="@style/Theme.AntennaPod.Dark">

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -88,6 +88,8 @@
 
     <style name="Theme.Base.AntennaPod.Dark" parent="Theme.AppCompat">
         <item name="colorAccent">@color/holo_blue_dark</item>
+        <item name="colorPrimary">@color/primary_darktheme</item>
+        <item name="colorPrimaryDark">@color/primary_darktheme</item>
         <item name="colorControlNormal">@color/white</item>
         <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="progressBarTheme">@style/ProgressBarDark</item>
@@ -272,6 +274,8 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="progressBarTheme">@style/ProgressBarDark</item>
         <item name="colorAccent">@color/holo_blue_dark</item>
+        <item name="colorPrimary">@color/primary_darktheme</item>
+        <item name="colorPrimaryDark">@color/primary_darktheme</item>
         <item name="colorControlNormal">@color/white</item>
         <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="alertDialogTheme">@style/AntennaPod.Dialog.Dark</item>


### PR DESCRIPTION
The status bar now has the same color as the toolbar, like most Google apps do it. In my opinion, this looks a bit more modern. I am open to hear other opinions. Looks better on a real device than on the screenshots :)

Before:
<img width="200" src="https://user-images.githubusercontent.com/5811634/50931030-d0dc6a00-1461-11e9-975a-36a5e9ad3c4c.png" /> <img width="200" src="https://user-images.githubusercontent.com/5811634/50931033-d0dc6a00-1461-11e9-8acf-9a77db1be2aa.png" />
After:
<img width="200" src="https://user-images.githubusercontent.com/5811634/50931034-d0dc6a00-1461-11e9-95d4-194abdce9abd.png" /> <img width="200" src="https://user-images.githubusercontent.com/5811634/50931035-d1750080-1461-11e9-9592-83650e67163b.png" />