### PR TITLE
Fix app crash in some error cases with ExoPlayer

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -991,7 +991,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
     private final MediaPlayer.OnErrorListener audioErrorListener =
             (mp, what, extra) -> {
-                if(mp.canFallback()) {
+                if(mp != null && mp.canFallback()) {
                     mp.fallback();
                     return true;
                 } else {


### PR DESCRIPTION
It partially addresses #2947, preventing app crash.

The PR does not address the root cause of #2947, on why the player intermittently got stuck to begin with.