### PR TITLE
Split share intent to embed feed title in EXTRA_SUBJECT rather than EXTRA_TEXT

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -240,7 +240,7 @@ public class ItemDescriptionFragment extends Fragment implements MediaplayerInfo
                     }
                     break;
                 case R.id.share_url_item:
-                    ShareUtils.shareLink(getActivity(), selectedURL);
+                    ShareUtils.shareLink(getActivity(), "", selectedURL);
                     break;
                 case R.id.copy_url_item:
                     ClipData clipData = ClipData.newPlainText(selectedURL,

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -491,7 +491,7 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
                     }
                     break;
                 case R.id.share_url_item:
-                    ShareUtils.shareLink(getActivity(), selectedURL);
+                    ShareUtils.shareLink(getActivity(), "", selectedURL);
                     break;
                 case R.id.copy_url_item:
                     ClipData clipData = ClipData.newPlainText(selectedURL,

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -23,19 +23,20 @@ public class ShareUtils {
 	
 	private ShareUtils() {}
 	
-	public static void shareLink(Context context, String text) {
+	public static void shareLink(Context context, String subject, String text) {
 		Intent i = new Intent(Intent.ACTION_SEND);
 		i.setType("text/plain");
+		i.putExtra(Intent.EXTRA_SUBJECT, subject);
 		i.putExtra(Intent.EXTRA_TEXT, text);
 		context.startActivity(Intent.createChooser(i, context.getString(R.string.share_url_label)));
 	}
 
 	public static void shareFeedlink(Context context, Feed feed) {
-		shareLink(context, feed.getTitle() + ": " + feed.getLink());
+		shareLink(context, feed.getTitle(), feed.getLink());
 	}
 	
 	public static void shareFeedDownloadLink(Context context, Feed feed) {
-		shareLink(context, feed.getTitle() + ": " + feed.getDownload_url());
+		shareLink(context, feed.getTitle(), feed.getDownload_url());
 	}
 
 	public static void shareFeedItemLink(Context context, FeedItem item) {
@@ -55,21 +56,21 @@ public class ShareUtils {
     }
 
 	public static void shareFeedItemLink(Context context, FeedItem item, boolean withPosition) {
-		String text = getItemShareText(item) + " " + FeedItemUtil.getLinkWithFallback(item);
+		String text = FeedItemUtil.getLinkWithFallback(item);
 		if(withPosition) {
 			int pos = item.getMedia().getPosition();
 			text += " [" + Converter.getDurationStringLong(pos) + "]";
 		}
-		shareLink(context, text);
+		shareLink(context, getItemShareText(item), text);
 	}
 
 	public static void shareFeedItemDownloadLink(Context context, FeedItem item, boolean withPosition) {
-		String text = getItemShareText(item) + " " + item.getMedia().getDownload_url();
+		String text =  item.getMedia().getDownload_url();
 		if(withPosition) {
 			int pos = item.getMedia().getPosition();
 			text += " [" + Converter.getDurationStringLong(pos) + "]";
 		}
-		shareLink(context, text);
+		shareLink(context, getItemShareText(item), text);
 	}
 
 	public static void shareFeedItemFile(Context context, FeedMedia media) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -7,8 +7,8 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.support.v4.content.FileProvider;
+import android.text.TextUtils;
 import android.util.Log;
-
 import java.io.File;
 import java.util.List;
 
@@ -26,8 +26,10 @@ public class ShareUtils {
 	public static void shareLink(Context context, String subject, String text) {
 		Intent i = new Intent(Intent.ACTION_SEND);
 		i.setType("text/plain");
-		i.putExtra(Intent.EXTRA_SUBJECT, subject);
 		i.putExtra(Intent.EXTRA_TEXT, text);
+		if (!TextUtils.isEmpty(subject)) {
+			i.putExtra(Intent.EXTRA_SUBJECT, subject);
+		}
 		context.startActivity(Intent.createChooser(i, context.getString(R.string.share_url_label)));
 	}
 


### PR DESCRIPTION
Previously the shared text was in the format of `{title of podcast}:{url of podcast}`

This change makes it so that only the URL of the podcast is in the shared text, but the title of the podcast is sent over in the subject field.

This is useful with SMS, where the intent shared subject is placed as an SMS subject, and the url is the text, allowing to copy+paste the message easier.

Also useful with [zxing app](https://f-droid.org/packages/com.google.zxing.client.android/), only embeds the shared text in a QR code but places the subject line as a label below the QR code.

ISSUES: the timestamp is still placed in the text the same way as before, so any sharing with timestamp will not just be the pure URL