### PR TITLE
Make app go to player screen if it's currently playing

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -498,11 +498,8 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     }
 
     private void redirectToPlayerActivityIfCurrentlyPlaying() {
-        Log.v(TAG, "DBG - redirectToPlayerActivityIfCurrentlyPlaying()");
-        long startTime = System.currentTimeMillis(); // to measure elapsed time to determine if it's playing
         doIfCurrentlyPlaying(playbackService -> {
-            long playerLaunchTime = System.currentTimeMillis();
-            Log.v(TAG, "    DBG - time to determine it is currently playing(ms)=" + (playerLaunchTime - startTime));
+            Log.v(TAG, "redirectToPlayerActivityIfCurrentlyPlaying() - to redirect");
             Intent playerActivityIntent = PlaybackService.getPlayerActivityIntent(this, playbackService.getPlayable());
             startActivity(playerActivityIntent);
             finish();

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -477,7 +477,10 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     }
 
     private boolean isFromLauncher() {
-        if (Intent.FLAG_ACTIVITY_NEW_TASK == getIntent().getFlags()) {
+        final int flags = getIntent().getFlags();
+        if (Intent.FLAG_ACTIVITY_NEW_TASK == flags || // tested on Android 7, 9
+                0 == flags // tested on Android 4
+                ) {
             // case the activity is launched from launcher, rather than
             // navigating back here from other Player, Settings, etc.
 


### PR DESCRIPTION
Closes #2948.

Notes:
1. On older, slow devices, users might see MainActivity UI (e.g., Queue) a brief moment before being redirected to Player.
Detecting if AntennaPod is playing some media requires connecting to `PlaybackService`. On a 2017 budget phone (Moto E4), the time it took is not noticeable to users (about 60ms). On older budget phones, it will be noticeable: 150 - 300ms on a 2012 budget Samsung phone.

2. There is no official documented way to detect if users have launched the app (as opposed to navigating here from other parts of AntennaPod, e.g., Player, Settings).
The logic used (checking intent flags) are tested quite a few different devices (Android 4, 7, 9; with AOSP, Samsung, Motorola), but there is a chance that it will not work on some phones (or launcher). But even if it doesn't work, it will not cause users any other issues.
