### PR TITLE
make AntennaPod go to last activity (rather than MainActivity) when launched again

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,10 +47,13 @@
 
         <activity
             android:name=".activity.SplashActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize"
-            android:launchMode="singleTask"
             android:label="@string/app_name"
+            android:configChanges="keyboardHidden|orientation|screenSize"
             android:theme="@style/Theme.AntennaPod.Dark.Splash">
+            <!-- android:launchMode="singleTask"  removed for #2948, so that
+                 when app is launched again, the app will go to the last activity users use
+                 (if the app has been used recently, e.g., last 30 minutes),
+                 rather than always go to MainActivity (launched by SplashActivity here) -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
Closes #2948 - Make AntennaPod go to last activity when launched again [*], per standard Android App behavior.

[*] If AntennaPod has been used recently (approximately last 30 minutes), and has not been explicitly removed by users.

Discussion:
- removing `singleTask` from `SplashActivity` will not cause unwanted side effects in navigation (the task stack), given `SplashActivity` always quickly go away anyway. The actual purpose for `singleTask` is preserved in `MainActivity`.
See [AndroidManifest.xml's history](https://github.com/AntennaPod/AntennaPod/blame/1.7.1/app/src/main/AndroidManifest.xml#L51) for reference.
- `android:alwaysRetainTaskState="true"` could have been set so that AntennaPod *always* go to last activity (e.g., even if users removes it from recent app list), but such behavior might be surprising to users.
