### PR TITLE
[#2975] Adding highlighting of drawer item functionality

### DIFF
--- a/app/src/main/res/layout/nav_feedlistitem.xml
+++ b/app/src/main/res/layout/nav_feedlistitem.xml
@@ -5,7 +5,8 @@
                 android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/listitem_iconwithtext_height"
-                tools:background="@android:color/darker_gray">
+                tools:background="@android:color/darker_gray"
+                android:background= "?attr/nav_drawer_list_selector">
 
     <ImageView
         android:id="@+id/imgvCover"

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -5,7 +5,8 @@
                 android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/listitem_iconwithtext_height"
-                tools:background="@android:color/darker_gray">
+                tools:background="@android:color/darker_gray"
+                android:background= "?attr/nav_drawer_list_selector">
 
     <ImageView
         android:id="@+id/imgvCover"

--- a/core/src/main/res/drawable/activated_color_dark.xml
+++ b/core/src/main/res/drawable/activated_color_dark.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/highlight_dark"/>
+</shape>

--- a/core/src/main/res/drawable/activated_color_dark.xml
+++ b/core/src/main/res/drawable/activated_color_dark.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/highlight_dark"/>
+    <solid android:color="@color/overlay_dark"/>
 </shape>

--- a/core/src/main/res/drawable/activated_color_light.xml
+++ b/core/src/main/res/drawable/activated_color_light.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/highlight_light"/>
+</shape>

--- a/core/src/main/res/drawable/activated_color_trueblack.xml
+++ b/core/src/main/res/drawable/activated_color_trueblack.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/highlight_trueblack"/>
+</shape>

--- a/core/src/main/res/drawable/drawer_list_selector_dark.xml
+++ b/core/src/main/res/drawable/drawer_list_selector_dark.xml
@@ -1,0 +1,4 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true" android:drawable="@drawable/activated_color_dark" />
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/core/src/main/res/drawable/drawer_list_selector_light.xml
+++ b/core/src/main/res/drawable/drawer_list_selector_light.xml
@@ -1,0 +1,4 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true" android:drawable="@drawable/activated_color_light" />
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/core/src/main/res/drawable/drawer_list_selector_trueblack.xml
+++ b/core/src/main/res/drawable/drawer_list_selector_trueblack.xml
@@ -1,0 +1,4 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true" android:drawable="@drawable/activated_color_trueblack" />
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <attr name="nav_drawer_list_selector" format="reference"/>
     <attr name="action_bar_icon_color" format="reference"/>
     <attr name="action_about" format="reference"/>
     <attr name="action_search" format="reference"/>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -94,6 +94,7 @@
         <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="progressBarTheme">@style/ProgressBarDark</item>
         <item name="alertDialogTheme">@style/AntennaPod.Dialog.Dark</item>
+        <item type="attr" name="nav_drawer_list_selector">@drawable/drawer_list_selector_dark</item>
         <item type="attr" name="action_bar_icon_color">@color/white</item>
         <item type="attr" name="storage">@drawable/ic_sd_white_24dp</item>
         <item type="attr" name="ic_swap">@drawable/ic_swap_vertical_white_24dp</item>
@@ -197,6 +198,7 @@
         <item name="colorAccent">@color/holo_blue_light</item>
         <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="alertDialogTheme">@style/AntennaPod.Dialog.Light</item>
+        <item type="attr" name="nav_drawer_list_selector">@drawable/drawer_list_selector_light</item>
         <item type="attr" name="storage">@drawable/ic_sd_grey600_24dp</item>
         <item type="attr" name="ic_swap">@drawable/ic_swap_vertical_grey600_24dp</item>
         <item type="attr" name="statistics">@drawable/ic_poll_box_grey600_24dp</item>
@@ -270,6 +272,8 @@
     </style>
 
     <style name="Theme.Base.AntennaPod.Dark.NoTitle" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:activatedBackgroundIndicator">@drawable/drawer_list_selector_trueblack</item>
+
         <item name="windowActionBar">false</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="progressBarTheme">@style/ProgressBarDark</item>
@@ -279,6 +283,7 @@
         <item name="colorControlNormal">@color/white</item>
         <item name="buttonStyle">@style/Widget.AntennaPod.Button</item>
         <item name="alertDialogTheme">@style/AntennaPod.Dialog.Dark</item>
+        <item type="attr" name="nav_drawer_list_selector">@drawable/drawer_list_selector_dark</item>
         <item type="attr" name="storage">@drawable/ic_sd_white_24dp</item>
         <item type="attr" name="ic_swap">@drawable/ic_swap_vertical_white_24dp</item>
         <item type="attr" name="statistics">@drawable/ic_poll_box_white_24dp</item>
@@ -372,12 +377,16 @@
 
     <style name="Theme.AntennaPod.Dark.Splash" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/bg_splash</item>
+        <item name="android:activatedBackgroundIndicator">@drawable/drawer_list_selector_trueblack</item>
+
         <item name="colorPrimary">@color/ic_launcher_background</item>
         <item name="colorPrimaryDark">@color/ic_launcher_background</item>
     </style>
 
     <style name="Theme.AntennaPod.VideoPlayer" parent="@style/Theme.AntennaPod.Dark">
         <item name="windowActionBarOverlay">true</item>
+        <item name="android:activatedBackgroundIndicator">@drawable/drawer_list_selector_trueblack</item>
+
     </style>
 
     <style name="AntennaPod.TextView.Heading" parent="@android:style/TextAppearance.Medium">

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -377,16 +377,12 @@
 
     <style name="Theme.AntennaPod.Dark.Splash" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/bg_splash</item>
-        <item name="android:activatedBackgroundIndicator">@drawable/drawer_list_selector_trueblack</item>
-
         <item name="colorPrimary">@color/ic_launcher_background</item>
         <item name="colorPrimaryDark">@color/ic_launcher_background</item>
     </style>
 
     <style name="Theme.AntennaPod.VideoPlayer" parent="@style/Theme.AntennaPod.Dark">
         <item name="windowActionBarOverlay">true</item>
-        <item name="android:activatedBackgroundIndicator">@drawable/drawer_list_selector_trueblack</item>
-
     </style>
 
     <style name="AntennaPod.TextView.Heading" parent="@android:style/TextAppearance.Medium">


### PR DESCRIPTION
![screenshot_20190116-205413](https://user-images.githubusercontent.com/46357909/51296483-4354c900-19d1-11e9-824a-c82ab10e76b8.png)

![screenshot_20190116-205430](https://user-images.githubusercontent.com/46357909/51296488-48197d00-19d1-11e9-9d85-c20200653acf.png)

![screenshot_20190116-205447](https://user-images.githubusercontent.com/46357909/51296493-4bad0400-19d1-11e9-9db5-9b65fbf6a2b4.png)

For the highlighting colors that I chose, I used @color/highlight_trueblack, @color/highlight_light so it is consistent with the rest of the app, however for dark the highlight_dark color didn't really look right so I used @color/overlay_dark, because it looked better. 

Known Issue: I'm using the android:state_active to show which item has been activated. It works once you choose an item and activate it. However when you start the app up without an item that's been activated, the drawer items don't get highlighted.