### PR TITLE
Update URLChecker.java

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/URLChecker.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/URLChecker.java
@@ -30,27 +30,31 @@ public final class URLChecker {
      * @return The prepared url
      */
     public static String prepareURL(String url) {
-        url = url.trim();
-        if (url.startsWith("feed://")) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Replacing feed:// with http://");
-            return url.replaceFirst("feed://", "http://");
-        } else if (url.startsWith("pcast://")) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Removing pcast://");
-            return prepareURL(url.substring("pcast://".length()));
-        } else if (url.startsWith("pcast:")) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Removing pcast:");
-            return prepareURL(url.substring("pcast:".length()));
-        } else if (url.startsWith("itpc")) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Replacing itpc:// with http://");
-            return url.replaceFirst("itpc://", "http://");
-        } else if (url.startsWith(AP_SUBSCRIBE)) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Removing antennapod-subscribe://");
-            return prepareURL(url.substring(AP_SUBSCRIBE.length()));
-        } else if (!(url.startsWith("http://") || url.startsWith("https://"))) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "Adding http:// at the beginning of the URL");
-            return "http://" + url;
-        } else {
-            return url;
+        if( url == null) {
+            return "https://antennapod.org/url_not_found_error_1234567890.html";
+        }else{
+            url = url.trim();
+            if (url.startsWith("feed://")) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "Replacing feed:// with http://");
+                return url.replaceFirst("feed://", "http://");
+            } else if (url.startsWith("pcast://")) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "Removing pcast://");
+                return prepareURL(url.substring("pcast://".length()));
+            } else if (url.startsWith("pcast:")) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "Removing pcast:");
+                return prepareURL(url.substring("pcast:".length()));
+            } else if (url.startsWith("itpc")) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "Replacing itpc:// with http://");
+                return url.replaceFirst("itpc://", "http://");
+            } else if (url.startsWith(AP_SUBSCRIBE)) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "Removing antennapod-subscribe://");
+                return prepareURL(url.substring(AP_SUBSCRIBE.length()));
+            } else if (!(url.startsWith("http://") || url.startsWith("https://"))) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "Adding http:// at the beginning of the URL");
+                return "http://" + url;
+            } else {
+                return url;
+            }
         }
     }
 


### PR DESCRIPTION
https://github.com/AntennaPod/AntennaPod/issues/2995
.....................................................................................................................
i noticed just a temporary fix if null is returned instead of an URL; to prevent a crash. looks like a bigger issue
.....................................................................................................................

App version: 1.x (from Google Play/F-Droid/Custom build)
android:versionCode="1070195"
android:versionName="1.7.1

Android version: 5.x [Please mention if you are using a custom rom!]
8.1.0

Device model:
SM-J727U

Expected behaviour:
fetch a podast from URL

Current behaviour:
null returned for podcast url App Crashes

First occured: Version 1.x / about x days/weeks ago
Noticed today

Steps to reproduce:

+Add Podcast
SEARCH FFYD
Type science in the search field get a list of results
Click a podcast result... any result application crash null pointer because there is no URL being returned for some reason.
Environment: [Settings you have changed, e.g. Auto Download. "Unusual" devices you use, e.g. Bluetooth headphones. Do you still use Prestissimo?]
Nothing fancy. Default config...

Stacktrace/Logcat:

[if available]
D/AndroidRuntime: Shutting down VM
E/AndroidRuntime: FATAL EXCEPTION: main

 Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.trim()' on a null object reference
    at de.danoeh.antennapod.core.util.URLChecker.prepareURL(URLChecker.java:33)
    at de.danoeh.antennapod.activity.OnlineFeedViewActivity.startFeedDownload(OnlineFeedViewActivity.java:259)
    at de.danoeh.antennapod.activity.OnlineFeedViewActivity.onCreate(OnlineFeedViewActivity.java:160)