### PR TITLE
Fixed losing media data on rotation

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -235,6 +235,8 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
         StorageUtils.checkStorageAvailability(this);
 
         getWindow().setFormat(PixelFormat.TRANSPARENT);
+        setupGUI();
+        loadMediaInfo();
     }
 
     @Override
@@ -278,8 +280,6 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
             controller.release();
         }
         controller = newPlaybackController();
-        setupGUI();
-        loadMediaInfo();
         onPositionObserverUpdate();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
@@ -278,6 +278,7 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
         butCastDisconnect = findViewById(R.id.butCastDisconnect);
 
         pager = findViewById(R.id.pager);
+        pager.setOffscreenPageLimit(3);
         pagerAdapter = new MediaplayerInfoPagerAdapter(getSupportFragmentManager(), media);
         pagerAdapter.setController(controller);
         pager.setAdapter(pagerAdapter);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -48,6 +48,7 @@ public class CoverFragment extends Fragment implements MediaplayerInfoContentFra
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+        setRetainInstance(true);
         root = inflater.inflate(R.layout.cover_fragment, container, false);
         txtvPodcastTitle = root.findViewById(R.id.txtvPodcastTitle);
         txtvEpisodeTitle = root.findViewById(R.id.txtvEpisodeTitle);


### PR DESCRIPTION
this is a solution to fix the issue of media data disappearing on screen rotation. I had to move the setupGUI method to the onCreate() because there is the issue that the oncreate method is called everytime you rotate. In order to save the fragment data, the ID has to be initialized and if the setupGUI is in onStart() method it throws a null pointer exeption.

An easier solution to this would have been to stop the activity for getting recreated on rotate in the AndroidManifest, but the problem is that MediaplayerActivity isn't a valid activity because it is declared as an abstract class. Also setting it to MediaplayerinfoActivity had no effect and onCreate() was still called.

closes #2992 