### PR TITLE
Show media duration by default on podcast feed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AdapterUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AdapterUtils.java
@@ -46,7 +46,6 @@ class AdapterUtils {
                 txtvPos.setText(Converter.getDurationStringLong(media.getDuration()
                                 - media.getPosition()));
             }
-
         } else {
             txtvPos.setText(Converter.getDurationStringLong(media.getDuration()));
         }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/AdapterUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AdapterUtils.java
@@ -46,27 +46,7 @@ class AdapterUtils {
                 txtvPos.setText(Converter.getDurationStringLong(media.getDuration()
                                 - media.getPosition()));
             }
-        } else if (!media.isDownloaded()) {
-            if (media.getSize() > 0) {
-                txtvPos.setText(Converter.byteToString(media.getSize()));
-            } else if(NetworkUtils.isDownloadAllowed() && !media.checkedOnSizeButUnknown()) {
-                txtvPos.setText("{fa-spinner}");
-                Iconify.addIcons(txtvPos);
-                NetworkUtils.getFeedMediaSizeObservable(media)
-                        .subscribe(
-                                size -> {
-                                    if (size > 0) {
-                                        txtvPos.setText(Converter.byteToString(size));
-                                    } else {
-                                        txtvPos.setText("");
-                                    }
-                                }, error -> {
-                                    txtvPos.setText("");
-                                    Log.e(TAG, Log.getStackTraceString(error));
-                                });
-            } else {
-                txtvPos.setText("");
-            }
+
         } else {
             txtvPos.setText(Converter.getDurationStringLong(media.getDuration()));
         }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -96,8 +96,10 @@ public class FeedItemlistAdapter extends BaseAdapter {
             if(Build.VERSION.SDK_INT >= 23) {
                 holder.title.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
             }
-            holder.lenSize = convertView
+            holder.lenSizeLeft = convertView
                     .findViewById(R.id.txtvLenSize);
+            holder.lenSizeRight = convertView
+                    .findViewById(R.id.txtvLenSizeRight);
             holder.butAction = convertView
                     .findViewById(R.id.butSecondaryAction);
             holder.published = convertView
@@ -153,10 +155,11 @@ public class FeedItemlistAdapter extends BaseAdapter {
                 holder.episodeProgress.setVisibility(View.INVISIBLE);
                 holder.inPlaylist.setVisibility(View.INVISIBLE);
                 holder.type.setVisibility(View.INVISIBLE);
-                holder.lenSize.setVisibility(View.INVISIBLE);
+                holder.lenSizeLeft.setVisibility(View.INVISIBLE);
+                holder.lenSizeRight.setVisibility(View.INVISIBLE);
             } else {
 
-                AdapterUtils.updateEpisodePlaybackProgress(item, holder.lenSize, holder.episodeProgress);
+                AdapterUtils.updateEpisodePlaybackProgress(item, holder.lenSizeLeft, holder.lenSizeRight, holder.episodeProgress);
 
                 if (isInQueue) {
                     holder.inPlaylist.setVisibility(View.VISIBLE);
@@ -222,7 +225,8 @@ public class FeedItemlistAdapter extends BaseAdapter {
         LinearLayout container;
         TextView title;
         TextView published;
-        TextView lenSize;
+        TextView lenSizeLeft;
+        TextView lenSizeRight;
         ImageView type;
         ImageView inPlaylist;
         ImageButton butAction;

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -262,17 +262,17 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                         progressLeft.setText("{fa-spinner}");
                         Iconify.addIcons(progressLeft);
                         NetworkUtils.getFeedMediaSizeObservable(media)
-                            .subscribe(
-                                size -> {
-                                    if (size > 0) {
-                                        progressLeft.setText(Converter.byteToString(size));
-                                    } else {
-                                        progressLeft.setText("");
-                                    }
-                                }, error -> {
-                                    progressLeft.setText("");
-                                    Log.e(TAG, Log.getStackTraceString(error));
-                                });
+                                .subscribe(
+                                        size -> {
+                                            if (size > 0) {
+                                                progressLeft.setText(Converter.byteToString(size));
+                                            } else {
+                                                progressLeft.setText("");
+                                            }
+                                        }, error -> {
+                                            progressLeft.setText("");
+                                            Log.e(TAG, Log.getStackTraceString(error));
+                                        });
                     } else {
                         progressLeft.setText("");
                     }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -117,8 +117,8 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
 
     public class ViewHolder extends RecyclerView.ViewHolder
             implements View.OnClickListener,
-            View.OnCreateContextMenuListener,
-            ItemTouchHelperViewHolder {
+                       View.OnCreateContextMenuListener,
+                       ItemTouchHelperViewHolder {
 
         private final FrameLayout container;
         private final ImageView dragHandle;
@@ -130,7 +130,7 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
         private final TextView progressRight;
         private final ProgressBar progressBar;
         private final ImageButton butSecondary;
-
+        
         private FeedItem item;
 
         public ViewHolder(View v) {
@@ -246,13 +246,13 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                     progressBar.setProgress(itemAccess.getItemDownloadProgressPercent(item));
                     progressBar.setVisibility(View.VISIBLE);
                 } else if (state == FeedItem.State.PLAYING
-                        || state == FeedItem.State.IN_PROGRESS) {
+                    || state == FeedItem.State.IN_PROGRESS) {
                     if (media.getDuration() > 0) {
                         int progress = (int) (100.0 * media.getPosition() / media.getDuration());
                         progressBar.setProgress(progress);
                         progressBar.setVisibility(View.VISIBLE);
                         progressLeft.setText(Converter
-                                .getDurationStringLong(media.getPosition()));
+                            .getDurationStringLong(media.getPosition()));
                         progressRight.setText(Converter.getDurationStringLong(media.getDuration()));
                     }
                 } else {
@@ -262,17 +262,17 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                         progressLeft.setText("{fa-spinner}");
                         Iconify.addIcons(progressLeft);
                         NetworkUtils.getFeedMediaSizeObservable(media)
-                                .subscribe(
-                                        size -> {
-                                            if (size > 0) {
-                                                progressLeft.setText(Converter.byteToString(size));
-                                            } else {
-                                                progressLeft.setText("");
-                                            }
-                                        }, error -> {
-                                            progressLeft.setText("");
-                                            Log.e(TAG, Log.getStackTraceString(error));
-                                        });
+                            .subscribe(
+                                size -> {
+                                    if (size > 0) {
+                                        progressLeft.setText(Converter.byteToString(size));
+                                    } else {
+                                        progressLeft.setText("");
+                                    }
+                                }, error -> {
+                                    progressLeft.setText("");
+                                    Log.e(TAG, Log.getStackTraceString(error));
+                                });
                     } else {
                         progressLeft.setText("");
                     }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -117,8 +117,8 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
 
     public class ViewHolder extends RecyclerView.ViewHolder
             implements View.OnClickListener,
-                       View.OnCreateContextMenuListener,
-                       ItemTouchHelperViewHolder {
+            View.OnCreateContextMenuListener,
+            ItemTouchHelperViewHolder {
 
         private final FrameLayout container;
         private final ImageView dragHandle;
@@ -130,7 +130,7 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
         private final TextView progressRight;
         private final ProgressBar progressBar;
         private final ImageButton butSecondary;
-        
+
         private FeedItem item;
 
         public ViewHolder(View v) {
@@ -246,13 +246,13 @@ public class QueueRecyclerAdapter extends RecyclerView.Adapter<QueueRecyclerAdap
                     progressBar.setProgress(itemAccess.getItemDownloadProgressPercent(item));
                     progressBar.setVisibility(View.VISIBLE);
                 } else if (state == FeedItem.State.PLAYING
-                    || state == FeedItem.State.IN_PROGRESS) {
+                        || state == FeedItem.State.IN_PROGRESS) {
                     if (media.getDuration() > 0) {
                         int progress = (int) (100.0 * media.getPosition() / media.getDuration());
                         progressBar.setProgress(progress);
                         progressBar.setVisibility(View.VISIBLE);
                         progressLeft.setText(Converter
-                            .getDurationStringLong(media.getPosition()));
+                                .getDurationStringLong(media.getPosition()));
                         progressRight.setText(Converter.getDurationStringLong(media.getDuration()));
                     }
                 } else {

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -19,6 +19,7 @@
         android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         tools:background="@android:color/holo_orange_dark">
 
+
         <TextView
             android:id="@+id/statusUnread"
             style="@style/AntennaPod.TextView.UnreadIndicator"
@@ -32,6 +33,22 @@
             tools:text="NEW"
             tools:background="@android:color/white" />
 
+
+        <TextView
+            android:id="@+id/txtvPublished"
+            style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/statusUnread"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
+            android:layout_marginRight="8dp"
+            android:layout_marginEnd="8dp"
+            android:gravity="end|top"
+            tools:text="Jan 23"
+            tools:background="@android:color/holo_green_dark" />
+
+
         <TextView
             android:id="@+id/txtvItemname"
             style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
@@ -41,80 +58,88 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:layout_marginBottom="4dp"
-            android:layout_toLeftOf="@id/statusUnread"
-            android:layout_toStartOf="@id/statusUnread"
+            android:layout_toLeftOf="@id/txtvPublished"
+            android:layout_toStartOf="@id/txtvPublished"
+            android:layout_marginRight="4dp"
             tools:text="Episode title"
             tools:background="@android:color/holo_green_dark" />
 
-        <TextView
-            android:id="@+id/txtvLenSize"
-            style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@id/txtvItemname"
-            tools:text="00:42:23"
-            tools:background="@android:color/holo_green_dark" />
 
-        <ImageView
-            android:id="@+id/imgvInPlaylist"
-            android:layout_width="@dimen/enc_icons_size"
-            android:layout_height="@dimen/enc_icons_size"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"
-            android:layout_below="@id/txtvItemname"
-            android:layout_marginRight="8dp"
-            android:layout_marginEnd="8dp"
-            android:contentDescription="@string/in_queue_label"
-            android:src="?attr/stat_playlist"
-            android:visibility="visible"
-            tools:src="@drawable/ic_list_white_24dp"
-            tools:background="@android:color/holo_red_light" />
-
-        <ImageView
-            android:id="@+id/imgvType"
-            android:layout_width="@dimen/enc_icons_size"
-            android:layout_height="@dimen/enc_icons_size"
-            android:layout_below="@id/txtvItemname"
-            android:layout_marginRight="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_toLeftOf="@id/imgvInPlaylist"
-            android:layout_toStartOf="@id/imgvInPlaylist"
-            tools:ignore="ContentDescription"
-            tools:src="@drawable/ic_hearing_white_18dp"
-            tools:background="@android:color/holo_red_light" />
-
-        <TextView
-            android:id="@+id/txtvPublished"
-            style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/txtvItemname"
-            android:layout_marginRight="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_toLeftOf="@id/imgvType"
-            android:layout_toStartOf="@id/imgvType"
-            tools:text="Jan 23"
-            tools:background="@android:color/holo_green_dark" />
-
-        <ProgressBar
-            android:id="@+id/pbar_episode_progress"
-            style="?android:attr/progressBarStyleHorizontal"
+        <RelativeLayout
+            android:id="@+id/bottom_bar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_alignBottom="@id/txtvPublished"
-            android:layout_marginLeft="8dp"
-            android:layout_marginRight="8dp"
-            android:layout_toStartOf="@id/txtvPublished"
-            android:layout_toLeftOf="@id/txtvPublished"
-            android:layout_toEndOf="@id/txtvLenSize"
-            android:layout_toRightOf="@id/txtvLenSize"
-            android:layoutDirection="ltr"
-            android:indeterminate="false"
-            android:max="100"
-            android:progress="42"
-            tools:background="@android:color/holo_blue_light" />
+            android:layout_below="@id/txtvItemname"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true">
+
+            <TextView
+                android:id="@+id/txtvLenSize"
+                style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                tools:text="00:42:23"
+                tools:background="@android:color/holo_green_dark" />
+
+
+            <TextView
+                android:id="@+id/txtvLenSizeRight"
+                style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                tools:text="00:42:23"
+                tools:background="@android:color/holo_green_dark" />
+
+            <ImageView
+                android:id="@+id/imgvType"
+                android:layout_width="@dimen/enc_icons_size"
+                android:layout_height="@dimen/enc_icons_size"
+                android:layout_marginRight="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_toLeftOf="@id/txtvLenSizeRight"
+                android:layout_toStartOf="@id/txtvLenSizeRight"
+                tools:ignore="ContentDescription"
+                tools:src="@drawable/ic_hearing_white_18dp"
+                tools:background="@android:color/holo_red_light" />
+
+            <ImageView
+                android:id="@+id/imgvInPlaylist"
+                android:layout_width="@dimen/enc_icons_size"
+                android:layout_height="@dimen/enc_icons_size"
+                android:layout_marginRight="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_toLeftOf="@id/imgvType"
+                android:layout_toStartOf="@id/imgvType"
+                android:contentDescription="@string/in_queue_label"
+                android:src="?attr/stat_playlist"
+                android:visibility="visible"
+                tools:src="@drawable/ic_list_white_24dp"
+                tools:background="@android:color/holo_red_light" />
+
+            <ProgressBar
+                android:id="@+id/pbar_episode_progress"
+                style="?attr/progressBarTheme"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                android:layout_below="@id/txtvLenSize"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentLeft="true"
+                android:layout_marginTop="4dp"
+                android:indeterminate="false"
+                android:layoutDirection="ltr"
+                android:max="100"
+                android:progress="42"
+                tools:background="@android:color/holo_blue_light" />
+        </RelativeLayout>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -134,6 +134,8 @@
                 android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_marginTop="4dp"
+                android:layout_marginRight="8dp"
+                android:layout_marginEnd="8dp"
                 android:indeterminate="false"
                 android:layoutDirection="ltr"
                 android:max="100"


### PR DESCRIPTION
#3003
![screenshot_20190123-201002](https://user-images.githubusercontent.com/46357909/51654251-d189fb80-1f4b-11e9-8157-67598b8a0967.png)


Only issue now is that there doesn't seam to be a place where download size is shown, at least not one thats intuitive. My idea would be to implement the size on the individual podcasts item page, so that the download button's text would be: "Download (50mb)"


![screenshot_20190123-201833](https://user-images.githubusercontent.com/46357909/51654347-5aa13280-1f4c-11e9-8e0d-9f270237ef00.png)

