### PR TITLE
Add support for SOCKS proxies

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/ProxyDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/ProxyDialog.java
@@ -75,7 +75,7 @@ public class ProxyDialog {
                     }
                     String type = (String) ((Spinner) dialog1.findViewById(R.id.spType)).getSelectedItem();
                     ProxyConfig proxy;
-                    if(Proxy.Type.valueOf(type) == Proxy.Type.DIRECT) {
+                    if (Proxy.Type.valueOf(type) == Proxy.Type.DIRECT) {
                         proxy = ProxyConfig.direct();
                     } else {
                         String host = etHost.getText().toString();
@@ -92,7 +92,11 @@ public class ProxyDialog {
                         if(!TextUtils.isEmpty(port)) {
                             portValue = Integer.valueOf(port);
                         }
-                        proxy = ProxyConfig.http(host, portValue, username, password);
+                        if (Proxy.Type.valueOf(type) == Proxy.Type.SOCKS) {
+                            proxy = ProxyConfig.socks(host, portValue, username, password);
+                        } else {
+                            proxy = ProxyConfig.http(host, portValue, username, password);
+                        }
                     }
                     UserPreferences.setProxyConfig(proxy);
                     AntennapodHttpClient.reinit();
@@ -103,7 +107,7 @@ public class ProxyDialog {
                 .build();
         View view = dialog.getCustomView();
         spType = view.findViewById(R.id.spType);
-        String[] types = { Proxy.Type.DIRECT.name(), Proxy.Type.HTTP.name() };
+        String[] types = { Proxy.Type.DIRECT.name(), Proxy.Type.SOCKS.name(), Proxy.Type.HTTP.name() };
         ArrayAdapter<String> adapter = new ArrayAdapter<>(context,
             android.R.layout.simple_spinner_item, types);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/ProxyConfig.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/ProxyConfig.java
@@ -5,7 +5,6 @@ import android.support.annotation.Nullable;
 import java.net.Proxy;
 
 public class ProxyConfig {
-
     public final Proxy.Type type;
     @Nullable public final String host;
     public final int port;
@@ -16,6 +15,10 @@ public class ProxyConfig {
 
     public static ProxyConfig direct() {
         return new ProxyConfig(Proxy.Type.DIRECT, null, 0, null, null);
+    }
+
+    public static ProxyConfig socks(String host, int port, String username, String password) {
+        return new ProxyConfig(Proxy.Type.SOCKS, host, port, username, password);
     }
 
     public static ProxyConfig http(String host, int port, String username, String password) {


### PR DESCRIPTION
Helps work around issues like #2703 by enabling use of SOCKS proxies instead of HTTP proxies.

I’m not 100% sure about the authentication test for this one (I don’t have a proxy to test against), but at least this works for unauthenticated proxies like a local Tor gateway.

Automatically negotiates SOCKS5 or SOCKS4.