### PR TITLE
Change Timecode Regex

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/util/ConverterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/ConverterTest.java
@@ -17,8 +17,8 @@ public class ConverterTest extends AndroidTestCase {
 
     public void testGetDurationStringShort() throws Exception {
         String expected = "13:05";
-        int input = 785000;
-        assertEquals(expected, Converter.getDurationStringShort(input));
+        assertEquals(expected, Converter.getDurationStringShort(47110000, true));
+        assertEquals(expected, Converter.getDurationStringShort(785000, false));
     }
 
     public void testDurationStringLongToMs() throws Exception {
@@ -29,7 +29,7 @@ public class ConverterTest extends AndroidTestCase {
 
     public void testDurationStringShortToMs() throws Exception {
         String input = "8:30";
-        long expected = 510000;
-        assertEquals(expected, Converter.durationStringShortToMs(input));
+        assertEquals(30600000, Converter.durationStringShortToMs(input, true));
+        assertEquals(510000, Converter.durationStringShortToMs(input, false));
     }
 }

--- a/app/src/androidTest/java/de/test/antennapod/util/ConverterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/ConverterTest.java
@@ -17,7 +17,7 @@ public class ConverterTest extends AndroidTestCase {
 
     public void testGetDurationStringShort() throws Exception {
         String expected = "13:05";
-        int input = 47110000;
+        int input = 785000;
         assertEquals(expected, Converter.getDurationStringShort(input));
     }
 
@@ -29,7 +29,7 @@ public class ConverterTest extends AndroidTestCase {
 
     public void testDurationStringShortToMs() throws Exception {
         String input = "8:30";
-        long expected = 30600000;
+        long expected = 510000;
         assertEquals(expected, Converter.durationStringShortToMs(input));
     }
 }

--- a/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
@@ -110,12 +110,14 @@ public class TimelineTest extends InstrumentationTestCase {
     }
 
     public void testProcessShownotesAddTimecodeMultipleShortFormatNoChapters() throws Exception {
+
+        // One of these timecodes fits as HH:MM and one does not so both should be parsed as MM:SS.
         final String[] timeStrings = new String[]{ "10:12", "2:12" };
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode " + timeStrings[0] + " here. Hey look another one " + timeStrings[1] + " here!</p>", 3 * 60 * 60 * 1000);
         Timeline t = new Timeline(context, p);
         String res = t.processShownotes(true);
-        checkLinkCorrect(res, new long[]{ 10 * 60 * 1000 + 12 * 1000, 2 * 60 * 60 * 1000 + 12 * 60 * 1000 }, timeStrings);
+        checkLinkCorrect(res, new long[]{ 10 * 60 * 1000 + 12 * 1000, 2 * 60 * 1000 + 12 * 1000 }, timeStrings);
     }
 
     public void testProcessShownotesAddTimecodeParentheses() throws Exception {

--- a/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
@@ -151,9 +151,15 @@ public class TimelineTest extends InstrumentationTestCase {
     }
 
     public void testProcessShownotesAndInvalidTimecode() throws Exception {
-        final String timeStr = "2:1";
+        final String[] timeStrs = new String[] {"2:1", "0:0", "000", "00", "00:000"};
 
-        Playable p = newTestPlayable(null, "<p> Some test text with a timecode <" + timeStr + "> here.</p>", Integer.MAX_VALUE);
+        StringBuilder shownotes = new StringBuilder("<p> Some test text with timecodes ");
+        for (String timeStr : timeStrs) {
+            shownotes.append(timeStr).append(" ");
+        }
+        shownotes.append("here.</p>");
+
+        Playable p = newTestPlayable(null, shownotes.toString(), Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
         String res = t.processShownotes(true);
         checkLinkCorrect(res, new long[0], new String[0]);

--- a/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
@@ -50,6 +50,16 @@ public class TimelineTest extends InstrumentationTestCase {
         checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
+    public void testProcessShownotesAddTimecodeHHMMSSMoreThen24HoursNoChapters() throws Exception {
+        final String timeStr = "25:00:00";
+        final long time = 25 * 60 * 60 * 1000;
+
+        Playable p = newTestPlayable(null, "<p> Some test text with a timecode " + timeStr + " here.</p>", Integer.MAX_VALUE);
+        Timeline t = new Timeline(context, p);
+        String res = t.processShownotes(true);
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+    }
+
     public void testProcessShownotesAddTimecodeHHMMNoChapters() throws Exception {
         final String timeStr = "10:11";
         final long time = 3600 * 1000 * 10 + 60 * 1000 * 11;

--- a/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
@@ -50,9 +50,29 @@ public class TimelineTest extends InstrumentationTestCase {
         checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
-    public void testProcessShownotesAddTimecodeHHMMNoChapters() throws Exception {
+    public void testProcessShownotesAddTimecodeHMMSSNoChapters() throws Exception {
+        final String timeStr = "2:11:12";
+        final long time = 2 * 60 * 60 * 1000 + 11 * 60 * 1000 + 12 * 1000;
+
+        Playable p = newTestPlayable(null, "<p> Some test text with a timecode " + timeStr + " here.</p>");
+        Timeline t = new Timeline(context, p);
+        String res = t.processShownotes(true);
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+    }
+
+    public void testProcessShownotesAddTimecodeMSSNoChapters() throws Exception {
+        final String timeStr = "1:12";
+        final long time = 60 * 1000 + 12 * 1000;
+
+        Playable p = newTestPlayable(null, "<p> Some test text with a timecode " + timeStr + " here.</p>");
+        Timeline t = new Timeline(context, p);
+        String res = t.processShownotes(true);
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+    }
+
+    public void testProcessShownotesAddTimecodeMMSSNoChapters() throws Exception {
         final String timeStr = "10:11";
-        final long time = 3600 * 1000 * 10 + 60 * 1000 * 11;
+        final long time = 60 * 1000 * 10 + 1000 * 11;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode " + timeStr + " here.</p>");
         Timeline t = new Timeline(context, p);
@@ -61,7 +81,7 @@ public class TimelineTest extends InstrumentationTestCase {
     }
 
     public void testProcessShownotesAddTimecodeParentheses() throws Exception {
-        final String timeStr = "10:11";
+        final String timeStr = "10:11:00";
         final long time = 3600 * 1000 * 10 + 60 * 1000 * 11;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode (" + timeStr + ") here.</p>");
@@ -71,7 +91,7 @@ public class TimelineTest extends InstrumentationTestCase {
     }
 
     public void testProcessShownotesAddTimecodeBrackets() throws Exception {
-        final String timeStr = "10:11";
+        final String timeStr = "10:11:00";
         final long time = 3600 * 1000 * 10 + 60 * 1000 * 11;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode [" + timeStr + "] here.</p>");
@@ -81,7 +101,7 @@ public class TimelineTest extends InstrumentationTestCase {
     }
 
     public void testProcessShownotesAddTimecodeAngleBrackets() throws Exception {
-        final String timeStr = "10:11";
+        final String timeStr = "10:11:00";
         final long time = 3600 * 1000 * 10 + 60 * 1000 * 11;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode <" + timeStr + "> here.</p>");

--- a/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/playback/TimelineTest.java
@@ -150,6 +150,15 @@ public class TimelineTest extends InstrumentationTestCase {
         checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
+    public void testProcessShownotesAndInvalidTimecode() throws Exception {
+        final String timeStr = "2:1";
+
+        Playable p = newTestPlayable(null, "<p> Some test text with a timecode <" + timeStr + "> here.</p>", Integer.MAX_VALUE);
+        Timeline t = new Timeline(context, p);
+        String res = t.processShownotes(true);
+        checkLinkCorrect(res, new long[0], new String[0]);
+    }
+
     private void checkLinkCorrect(String res, long[] timecodes, String[] timecodeStr) {
         assertNotNull(res);
         Document d = Jsoup.parse(res);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -76,11 +76,11 @@ public final class Converter {
     
     /** Converts milliseconds to a string containing hours and minutes */
     public static String getDurationStringShort(int duration) {
-    	int h = duration / HOURS_MIL;
-    	int rest = duration - h * HOURS_MIL;
-    	int m = rest / MINUTES_MIL;
+    	int minutes = duration / MINUTES_MIL;
+    	int rest = duration - minutes * MINUTES_MIL;
+    	int seconds = rest / SECONDS_MIL;
     	
-    	return String.format(Locale.getDefault(), "%02d:%02d", h, m);
+    	return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds);
     }
 
     /** Converts long duration string (HH:MM:SS) to milliseconds. */
@@ -100,8 +100,8 @@ public final class Converter {
         if (parts.length != 2) {
             return 0;
         }
-        return Integer.parseInt(parts[0]) * 3600 * 1000 +
-                Integer.parseInt(parts[1]) * 1000 * 60;
+        return Integer.parseInt(parts[0]) * 60 * 1000 +
+                Integer.parseInt(parts[1]) * 1000;
     }
 
     /** Converts milliseconds to a localized string containing hours and minutes */

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -74,13 +74,14 @@ public final class Converter {
     	return String.format(Locale.getDefault(), "%02d:%02d:%02d", h, m, s);
     }
     
-    /** Converts milliseconds to a string containing hours and minutes */
-    public static String getDurationStringShort(int duration) {
-    	int minutes = duration / MINUTES_MIL;
-    	int rest = duration - minutes * MINUTES_MIL;
-    	int seconds = rest / SECONDS_MIL;
-    	
-    	return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds);
+    /** Converts milliseconds to a string containing hours and minutes or minutes and seconds*/
+    public static String getDurationStringShort(int duration, boolean durationIsInHours) {
+        int firstPartBase = durationIsInHours ?  HOURS_MIL : MINUTES_MIL;
+        int firstPart = duration / firstPartBase;
+        int leftoverFromFirstPart = duration - firstPart * firstPartBase;
+        int secondPart = leftoverFromFirstPart / (durationIsInHours ? MINUTES_MIL : SECONDS_MIL);
+
+    	return String.format(Locale.getDefault(), "%02d:%02d", firstPart, secondPart);
     }
 
     /** Converts long duration string (HH:MM:SS) to milliseconds. */
@@ -94,14 +95,20 @@ public final class Converter {
                 Integer.parseInt(parts[2]) * 1000;
     }
 
-    /** Converts short duration string (HH:MM) to milliseconds. */
-    public static int durationStringShortToMs(String input) {
+    /**
+     * Converts short duration string (XX:YY) to milliseconds. If durationIsInHours is true then the
+     * format is HH:MM, otherwise it's MM:SS.
+     * */
+    public static int durationStringShortToMs(String input, boolean durationIsInHours) {
         String[] parts = input.split(":");
         if (parts.length != 2) {
             return 0;
         }
-        return Integer.parseInt(parts[0]) * 60 * 1000 +
-                Integer.parseInt(parts[1]) * 1000;
+
+        int modifier = durationIsInHours ? 60 : 1;
+
+        return Integer.parseInt(parts[0]) * 60 * 1000 * modifier+
+                Integer.parseInt(parts[1]) * 1000 * modifier;
     }
 
     /** Converts milliseconds to a localized string containing hours and minutes */

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -70,7 +70,7 @@ public class Timeline {
 
     private static final Pattern TIMECODE_LINK_REGEX = Pattern.compile("antennapod://timecode/((\\d+))");
     private static final String TIMECODE_LINK = "<a class=\"timecode\" href=\"antennapod://timecode/%d\">%s</a>";
-    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(\\d*):)?([0-5]?\\d):)?([0-5][0-9]?\\d)\\b");
+    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(\\d*):)?([0-5]?\\d))?:([0-5]\\d)\\b");
     private static final Pattern LINE_BREAK_REGEX = Pattern.compile("<br */?>");
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -68,7 +68,7 @@ public class Timeline {
 
     private static final Pattern TIMECODE_LINK_REGEX = Pattern.compile("antennapod://timecode/((\\d+))");
     private static final String TIMECODE_LINK = "<a class=\"timecode\" href=\"antennapod://timecode/%d\">%s</a>";
-    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(([0-9][0-9])):))?(([0-9][0-9])):(([0-9][0-9]))\\b");
+    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:([01]?\\d|2[0-3]):)?([0-5]?\\d):)?([0-5]?\\d)\\b");
     private static final Pattern LINE_BREAK_REGEX = Pattern.compile("<br */?>");
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -70,7 +70,7 @@ public class Timeline {
 
     private static final Pattern TIMECODE_LINK_REGEX = Pattern.compile("antennapod://timecode/((\\d+))");
     private static final String TIMECODE_LINK = "<a class=\"timecode\" href=\"antennapod://timecode/%d\">%s</a>";
-    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(\\d*):)?([0-5]?\\d):)?([0-5]?\\d)\\b");
+    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(\\d*):)?([0-5]?\\d):)?([0-5][0-9]?\\d)\\b");
     private static final Pattern LINE_BREAK_REGEX = Pattern.compile("<br */?>");
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -70,7 +70,7 @@ public class Timeline {
 
     private static final Pattern TIMECODE_LINK_REGEX = Pattern.compile("antennapod://timecode/((\\d+))");
     private static final String TIMECODE_LINK = "<a class=\"timecode\" href=\"antennapod://timecode/%d\">%s</a>";
-    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:([01]?\\d|2[0-3]):)?([0-5]?\\d):)?([0-5]?\\d)\\b");
+    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(\\d*):)?([0-5]?\\d):)?([0-5]?\\d)\\b");
     private static final Pattern LINE_BREAK_REGEX = Pattern.compile("<br */?>");
 
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -70,7 +70,7 @@ public class Timeline {
 
     private static final Pattern TIMECODE_LINK_REGEX = Pattern.compile("antennapod://timecode/((\\d+))");
     private static final String TIMECODE_LINK = "<a class=\"timecode\" href=\"antennapod://timecode/%d\">%s</a>";
-    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b(?:(?:(\\d*):)?([0-5]?\\d))?:([0-5]\\d)\\b");
+    private static final Pattern TIMECODE_REGEX = Pattern.compile("\\b((\\d+):)?(\\d+):(\\d{2})\\b");
     private static final Pattern LINE_BREAK_REGEX = Pattern.compile("<br */?>");
 
 


### PR DESCRIPTION
Fixes #3031.

This changes the definition of 'short' and 'long' timecode when parsing the shownotes. A  'short' timecode has the format of MM:SS instead of HH:MM. A long timecode is HH:MM:SS. In addition the first part of a timecode can contain one or two digits.

Tests were updated to reflect this new definition and some new ones were added as well.

If there is anything else that needs to be done or changed please let me know.