### PR TITLE
Fix player stuck due to streaming rather than using downloaded media.

### DIFF
--- a/app/src/androidTest/java/de/danoeh/antennapod/core/service/download/StubDownloader.java
+++ b/app/src/androidTest/java/de/danoeh/antennapod/core/service/download/StubDownloader.java
@@ -1,0 +1,52 @@
+package de.danoeh.antennapod.core.service.download;
+
+import android.support.annotation.NonNull;
+
+import de.danoeh.antennapod.core.util.Consumer;
+
+public class StubDownloader extends Downloader {
+
+    private final long downloadTime;
+
+    @NonNull
+    private final Consumer<DownloadStatus> onDownloadComplete;
+
+    public StubDownloader(@NonNull DownloadRequest request, long downloadTime, @NonNull Consumer<DownloadStatus> onDownloadComplete) {
+        super(request);
+        this.downloadTime = downloadTime;
+        this.onDownloadComplete = onDownloadComplete;
+    }
+
+    @Override
+    protected void download() {
+        try {
+            Thread.sleep(downloadTime);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        onDownloadComplete.accept(result);
+    }
+
+    @NonNull
+    @Override
+    public DownloadRequest getDownloadRequest() {
+        return super.getDownloadRequest();
+    }
+
+    @NonNull
+    @Override
+    public DownloadStatus getResult() {
+        return super.getResult();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return super.isFinished();
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+        result.setCancelled();
+    }
+}

--- a/app/src/androidTest/java/de/test/antennapod/service/download/DownloadServiceTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/download/DownloadServiceTest.java
@@ -6,6 +6,8 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.apache.commons.lang3.StringUtils;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,7 +32,6 @@ import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.Consumer;
-import de.greenrobot.event.EventBus;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -96,6 +97,7 @@ public class DownloadServiceTest {
          * The actual logic in asserting the sequence of DownloadEvents generated,
          * as well as the correspond states in the database.
          */
+        @Subscribe
         public void onEvent(DownloadEvent event) {
             DownloadStatus status = getDownloadStatus(event, FeedMedia.FEEDFILETYPE_FEEDMEDIA, testMedia11.getId());
             trace("DownloadEvent: " + event);

--- a/app/src/androidTest/java/de/test/antennapod/service/download/DownloadServiceTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/download/DownloadServiceTest.java
@@ -1,0 +1,192 @@
+package de.test.antennapod.service.download;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import de.danoeh.antennapod.core.event.DownloadEvent;
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.service.download.DownloadRequest;
+import de.danoeh.antennapod.core.service.download.DownloadService;
+import de.danoeh.antennapod.core.service.download.DownloadStatus;
+import de.danoeh.antennapod.core.service.download.Downloader;
+import de.danoeh.antennapod.core.service.download.StubDownloader;
+import de.danoeh.antennapod.core.storage.DBReader;
+import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.storage.DownloadRequester;
+import de.danoeh.antennapod.core.util.Consumer;
+import de.greenrobot.event.EventBus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @see HttpDownloaderTest for the test of actual download (and saving the file)
+ */
+@RunWith(AndroidJUnit4.class)
+public class DownloadServiceTest {
+
+    private CountDownLatch latch = null;
+    private Feed testFeed = null;
+    private FeedMedia testMedia11 = null;
+
+    private DownloadService.DownloaderFactory origFactory = null;
+
+    @Before
+    public void setUp() throws Exception {
+        origFactory = DownloadService.getDownloaderFactory();
+        testFeed = setUpTestFeeds();
+        testMedia11 = testFeed.getItemAtIndex(0).getMedia();
+    }
+
+    private Feed setUpTestFeeds() throws Exception {
+        Feed feed = new Feed("url", null, "Test Feed title 1");
+        List<FeedItem> items = new ArrayList<>();
+        feed.setItems(items);
+        FeedItem item1 = new FeedItem(0, "Item 1-1", "Item 1-1", "url", new Date(), FeedItem.NEW, feed);
+        items.add(item1);
+        FeedMedia media1 = new FeedMedia(0, item1, 123, 1, 1, "mime_type", null, "download_url", false, null, 0, 0);
+        item1.setMedia(media1);
+
+        DBWriter.setFeedItem(item1).get();
+        trace("feed.id=" + feed.getId() + " , item1.id=" + item1.getId());
+        return feed;
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        DownloadService.setDownloaderFactory(origFactory);
+    }
+
+    private static enum DownloadState {
+        UNKNOWN, IN_PROGRESS, DONE_SUCCESS
+    }
+
+
+    private interface EventsAsserter {
+        int getExpectedNumSignificantEvents();
+    }
+
+    private class DownloadSuccessEventsAsserter implements EventsAsserter {
+        private DownloadState downloadState = DownloadState.UNKNOWN;
+
+        @Override
+        public int getExpectedNumSignificantEvents() {
+            return 2; // in-progress, then an explicit success
+        }
+
+        /**
+         * The actual logic in asserting the sequence of DownloadEvents generated,
+         * as well as the correspond states in the database.
+         */
+        public void onEvent(DownloadEvent event) {
+            DownloadStatus status = getDownloadStatus(event, FeedMedia.FEEDFILETYPE_FEEDMEDIA, testMedia11.getId());
+            trace("DownloadEvent: " + event);
+            trace("  status: " + status);
+            if (status == null) {
+                return; // no relevant update
+                // OPEN: We don't care for cases that the downloader is removed (once it's complete/cancelled)
+            }
+            if (downloadState == DownloadState.UNKNOWN) {
+                if (!status.isDone()) {
+                    downloadState = DownloadState.IN_PROGRESS;
+                    latch.countDown();
+                } else {
+                    fail("Unexpected download status, current state = " + downloadState + " status: " + status);
+                }
+            } else if (downloadState == DownloadState.IN_PROGRESS) {
+                if (status.isSuccessful()) {
+                    FeedMedia fmUpdated = DBReader.getFeedMedia(testMedia11.getId());
+                    // Ensure when media download success message is generated,
+                    // the state in the DB must have been brought up-to-date.
+                    assertTrue("Downloaded state in db should have been set",
+                            fmUpdated.isDownloaded());
+                    assertTrue("Download file path should have been set",
+                            StringUtils.isNotEmpty(fmUpdated.getLocalMediaUrl()));
+                    downloadState = DownloadState.DONE_SUCCESS;
+                    latch.countDown();
+                } else if (!status.isDone()) {
+                    // still in progress, do nothing
+                } else {
+                    fail("Unexpected download status, current state = " + downloadState + " status: " + status);
+                }
+            }
+        }
+    }
+
+    private static DownloadStatus getDownloadStatus(DownloadEvent event, int fileType, long fileId) {
+        for (Downloader downloader : event.update.downloaders) {
+            if (downloader.getDownloadRequest().getFeedfileType() == fileType &&
+                    downloader.getDownloadRequest().getFeedfileId() == fileId) {
+                return downloader.getResult();
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void testDownloadEventsGeneratedCaseDownloadSuccess() throws Exception {
+        // create a stub download that returns successful
+        //
+        // OPEN: Ideally, I'd like the download time long enough so that multiple in-progress DownloadEvents
+        // are generated (to simulate typical download), but it'll make download time quite long (1-2 seconds)
+        // to do so
+        DownloadService.setDownloaderFactory(new StubDownloaderFactory(50, downloadStatus -> {
+           downloadStatus.setSuccessful();
+        }));
+
+        DownloadSuccessEventsAsserter eventsAsserter = new DownloadSuccessEventsAsserter();
+        EventBus.getDefault().register(eventsAsserter);
+        latch = new CountDownLatch(eventsAsserter.getExpectedNumSignificantEvents());
+
+        try {
+            DownloadRequester.getInstance().downloadMedia(InstrumentationRegistry.getTargetContext(),
+                    testMedia11);
+            latch.await(1000, TimeUnit.MILLISECONDS);
+            assertEquals("Ensuring all expected significant events have been generated.",
+                    0, latch.getCount());
+        } finally {
+            EventBus.getDefault().unregister(eventsAsserter);
+        }
+    }
+
+    private static void trace(String msg) {
+//        System.err.println("DBG - " + msg);
+    }
+
+    private static class StubDownloaderFactory implements DownloadService.DownloaderFactory {
+        private final long downloadTime;
+
+        @NonNull
+        private final Consumer<DownloadStatus> onDownloadComplete;
+
+        public StubDownloaderFactory(long downloadTime, @NonNull Consumer<DownloadStatus> onDownloadComplete) {
+            this.downloadTime = downloadTime;
+            this.onDownloadComplete = onDownloadComplete;
+        }
+
+        @Nullable
+        @Override
+        public Downloader create(@NonNull DownloadRequest request) {
+            return new StubDownloader(request, downloadTime, onDownloadComplete);
+        }
+    }
+
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -158,6 +158,10 @@ public class DownloadService extends Service {
     private class DownloadCompletionThread extends Thread {
         private static final String TAG = "downloadCompletionThd";
 
+        DownloadCompletionThread() {
+            super("DownloadCompletionThread");
+        }
+
         @Override
         public void run() {
             Log.d(TAG, "downloadCompletionThread was started");

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -13,6 +13,8 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.NotificationCompat;
 import android.text.TextUtils;
 import android.util.Log;
@@ -465,12 +467,40 @@ public class DownloadService extends Service {
         queryDownloads();
     }
 
-    private Downloader getDownloader(DownloadRequest request) {
-        if (!URLUtil.isHttpUrl(request.getSource()) && !URLUtil.isHttpsUrl(request.getSource())) {
-            Log.e(TAG, "Could not find appropriate downloader for " + request.getSource());
-            return null;
+    @VisibleForTesting
+    public interface DownloaderFactory {
+        @Nullable
+        Downloader create(@NonNull DownloadRequest request);
+    }
+
+    private static class DefaultDownloaderFactory implements DownloaderFactory {
+        @Nullable
+        @Override
+        public Downloader create(@NonNull DownloadRequest request) {
+            if (!URLUtil.isHttpUrl(request.getSource()) && !URLUtil.isHttpsUrl(request.getSource())) {
+                Log.e(TAG, "Could not find appropriate downloader for " + request.getSource());
+                return null;
+            }
+            return new HttpDownloader(request);
         }
-        return new HttpDownloader(request);
+    }
+
+    private static DownloaderFactory downloaderFactory = new DefaultDownloaderFactory();
+
+    @VisibleForTesting
+    public static DownloaderFactory getDownloaderFactory() {
+        return downloaderFactory;
+    }
+
+    // public scope rather than package private,
+    // because androidTest put classes in the non-standard de.test.antennapod hierarchy
+    @VisibleForTesting
+    public static void setDownloaderFactory(DownloaderFactory downloaderFactory) {
+        DownloadService.downloaderFactory = downloaderFactory;
+    }
+
+    private Downloader getDownloader(@NonNull DownloadRequest request) {
+        return downloaderFactory.create(request);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -7,6 +7,9 @@ import android.os.Vibrator;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -17,14 +20,12 @@ import java.util.concurrent.TimeUnit;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.QueueEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.download.Downloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.playback.Playable;
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
 import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
@@ -90,6 +91,7 @@ public class PlaybackServiceTaskManager {
         loadQueue();
     }
 
+    @Subscribe
     public void onEvent(DownloadEvent event) {
         Log.d(TAG, "onEvent(DownloadEvent " + event +")");
         // Refresh the queue, if any of the successful download is in the queue.


### PR DESCRIPTION
Closes #2947

The fix currently narrowly fixes the underlying issue in `DonwloadService` (of not producing events after a FeedMedia has been downloaded, with the states in db updated accordingly).

It'd be great if @mfietz can review it, as the primary author of DownloadEvent (https://github.com/AntennaPod/AntennaPod/commit/d91e9f4d6fb267c65fd228e8e857e550ae5178db#diff-d25b56001b86419b52cdb162a580c9ea)

Issues that require feedback:
1. The fix post one `DownloadEvent` for the single `FeedMedia` successful download. I want to double-check as somehow [in the existing codes](https://github.com/AntennaPod/AntennaPod/blob/1.7.1/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java#L1059) a `DownloadEvent` is posted twice (a workaround for some edge cases?!).
2. The check-in does not generate `DownloadEvent` for other types of download completion, e.g., Feed successful download, download cancelled, etc. Relevant codes have been marked with `TODO-2947` to indicate the codes that needs to be changed to cover the remaining cases. It'd be great if there is some feedback on whether the remaining cases should be covered, and if so, the on the proposed approach.

#2981 can be fixed if the remaining cases are covered (specifically, Feed successful download)
