### PR TITLE
Fix #3028: actually use encodedQuery from URLEncoder to avoid encoding issues

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
@@ -311,8 +311,7 @@ public class ItunesSearchFragment extends Fragment {
                         encodedQuery = query; // failsafe
                     }
 
-                    //Spaces in the query need to be replaced with '+' character.
-                    String formattedUrl = String.format(API_URL, query).replace(' ', '+');
+                    String formattedUrl = String.format(API_URL, encodedQuery);
 
                     OkHttpClient client = AntennapodHttpClient.getHttpClient();
                     Request.Builder httpReq = new Request.Builder()


### PR DESCRIPTION
It seems clear to me that the intent was to use encodedQuery, which avoids issues related to illegal characters by encoding them (so % gets changed into %25, space into +, etc...). The explicit replacement of space with +  is also not needed anymore.

This also makes the `encodedQuery = query; // failsafe` line make sense

This fixes #3028 and maybe other issues