### PR TITLE
Fix #3054: use UTF-8 to encode password and username for gpodder auth 

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
@@ -14,6 +14,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -587,7 +588,7 @@ public class GpodnetService {
         String result = null;
         ResponseBody body = null;
         try {
-            String credential = Credentials.basic(username, password);
+            String credential = Credentials.basic(username, password, Charset.forName("UTF-8"));
             Request authRequest = request.newBuilder().header("Authorization", credential).build();
             Response response = httpClient.newCall(authRequest).execute();
             checkStatusCode(response);


### PR DESCRIPTION
I'm not sure this is the best way to go about this, especially since I had to import the charset library, so please do take a look at it.