### PR TITLE
bugfix - statistics - inflated actual played duration

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -882,10 +882,6 @@ public final class DBReader {
                     continue;
                 }
 
-                // played duration used to be reset when the item is added to the playback history
-                if (media.getPlaybackCompletionDate() != null) {
-                    feedPlayedTime += media.getDuration() / 1000;
-                }
                 feedPlayedTime += media.getPlayedDuration() / 1000;
 
                 if (item.isPlayed()) {


### PR DESCRIPTION
It fixes the issue https://github.com/AntennaPod/AntennaPod/issues/2162#issuecomment-473173597 raised by @sbadux

- It should also address the inflated played duration reports in 2018 raised in the issue.
- It is unclear if it addresses the original 2016 issue in #2162 . The statistics logic that is fixed was introduced in 2017 (PR #2294) released in `v1.6.1.4` .

