### PR TITLE
Do not reset item "played" flag on media download

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -594,7 +594,7 @@ public class FeedMedia extends FeedFile implements Playable {
     @Override
     public void setDownloaded(boolean downloaded) {
         super.setDownloaded(downloaded);
-        if(item != null && downloaded) {
+        if(item != null && downloaded && !item.isPlayed()) {
             item.setPlayed(false);
         }
     }


### PR DESCRIPTION
If an item has already been played, downloading its media will not
reset that "played" flag.

Fixes: #3067