### PR TITLE
Validate that the item state is only changed when needed

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     }
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -594,7 +594,7 @@ public class FeedMedia extends FeedFile implements Playable {
     @Override
     public void setDownloaded(boolean downloaded) {
         super.setDownloaded(downloaded);
-        if(item != null && downloaded && !item.isPlayed()) {
+        if(item != null && downloaded && item.isNew()) {
             item.setPlayed(false);
         }
     }

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/FeedItemTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/FeedItemTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static de.danoeh.antennapod.core.feed.FeedItemMother.anyFeedItemWithImage;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class FeedItemTest {
 
@@ -37,6 +38,28 @@ public class FeedItemTest {
         setNewFeedItemImageDownloadUrl();
         original.updateFromOther(changedFeedItem);
         assertFeedItemImageWasUpdated();
+    }
+
+    /**
+     * Test that a played item loses that state after being marked as new.
+     */
+    @Test
+    public void testMarkPlayedItemAsNew_itemNotPlayed() {
+        original.setPlayed(true);
+        original.setNew();
+
+        assertFalse(original.isPlayed());
+    }
+
+    /**
+     * Test that a new item loses that state after being marked as played.
+     */
+    @Test
+    public void testMarkNewItemAsPlayed_itemNotNew() {
+        original.setNew();
+        original.setPlayed(true);
+
+        assertFalse(original.isNew());
     }
 
     private void setNewFeedItemImageDownloadUrl() {

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/FeedItemTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/FeedItemTest.java
@@ -62,6 +62,17 @@ public class FeedItemTest {
         assertFalse(original.isNew());
     }
 
+    /**
+     * Test that a new item loses that state after being marked as not played.
+     */
+    @Test
+    public void testMarkNewItemAsNotPlayed_itemNotNew() {
+        original.setNew();
+        original.setPlayed(false);
+
+        assertFalse(original.isNew());
+    }
+
     private void setNewFeedItemImageDownloadUrl() {
         changedFeedItem.setImageUrl("http://example.com/new_picture");
     }

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/FeedMediaMother.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/FeedMediaMother.java
@@ -1,0 +1,13 @@
+package de.danoeh.antennapod.core.feed;
+
+class FeedMediaMother {
+
+    private static final String EPISODE_URL = "http://example.com/episode";
+    private static final long SIZE = 42;
+    private static final String MIME_TYPE = "audio/mp3";
+
+    static FeedMedia anyFeedMedia() {
+        return new FeedMedia(null, EPISODE_URL, SIZE, MIME_TYPE);
+    }
+
+}

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/FeedMediaTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/FeedMediaTest.java
@@ -1,0 +1,72 @@
+package de.danoeh.antennapod.core.feed;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static de.danoeh.antennapod.core.feed.FeedMediaMother.anyFeedMedia;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FeedMediaTest {
+
+    private FeedMedia media;
+
+    @Before
+    public void setUp() {
+        media = anyFeedMedia();
+    }
+
+    /**
+     * Downloading a media from a not new and not played item should not change the item state.
+     */
+    @Test
+    public void testDownloadMediaOfNotNewAndNotPlayedItem_unchangedItemState() {
+        FeedItem item = mock(FeedItem.class);
+        when(item.isNew()).thenReturn(false);
+        when(item.isPlayed()).thenReturn(false);
+
+        media.setItem(item);
+        media.setDownloaded(true);
+
+        verify(item, never()).setNew();
+        verify(item, never()).setPlayed(true);
+        verify(item, never()).setPlayed(false);
+    }
+
+    /**
+     * Downloading a media from a played item (thus not new) should not change the item state.
+     */
+    @Test
+    public void testDownloadMediaOfPlayedItem_unchangedItemState() {
+        FeedItem item = mock(FeedItem.class);
+        when(item.isNew()).thenReturn(false);
+        when(item.isPlayed()).thenReturn(true);
+
+        media.setItem(item);
+        media.setDownloaded(true);
+
+        verify(item, never()).setNew();
+        verify(item, never()).setPlayed(true);
+        verify(item, never()).setPlayed(false);
+    }
+
+    /**
+     * Downloading a media from a new item (thus not played) should change the item to not played.
+     */
+    @Test
+    public void testDownloadMediaOfNewItem_changedToNotPlayedItem() {
+        FeedItem item = mock(FeedItem.class);
+        when(item.isNew()).thenReturn(true);
+        when(item.isPlayed()).thenReturn(false);
+
+        media.setItem(item);
+        media.setDownloaded(true);
+
+        verify(item).setPlayed(false);
+        verify(item, never()).setNew();
+        verify(item, never()).setPlayed(true);
+    }
+
+}


### PR DESCRIPTION
A follow-up to PR #3068 that adds tests for issue #3067.

As discussed previously in PR #3068, the condition on which the `FeedItem` state is changed has been updated to be clearer (use `FeedItem.isNew()` instead of `!FeedItem.isPlayed()`). *This is a bonus from the explicit tests added by this commit which would otherwise fail.*