### PR TITLE
Mobile updates: Allow images

### DIFF
--- a/app/src/main/res/xml/preferences_network.xml
+++ b/app/src/main/res/xml/preferences_network.xml
@@ -16,10 +16,11 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/download_pref_details">
-        <SwitchPreference
-                android:defaultValue="false"
-                android:enabled="true"
-                android:key="prefMobileUpdate"
+        <ListPreference
+                android:defaultValue="images"
+                android:entries="@array/mobile_update_entries"
+                android:entryValues="@array/mobile_update_values"
+                android:key="prefMobileUpdateAllowed"
                 android:summary="@string/pref_mobileUpdate_sum"
                 android:title="@string/pref_mobileUpdate_title"/>
         <de.danoeh.antennapod.preferences.NumberPickerPreference

--- a/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
@@ -72,7 +72,7 @@ class UpdateManager {
             } // else 0 or special negative values, no change needed
         }
         if (oldVersionCode < 1070197) {
-            if (prefs.getBoolean(UserPreferences.PREF_MOBILE_UPDATE_OLD, false)) {
+            if (prefs.getBoolean("prefMobileUpdate", false)) {
                 prefs.edit().putString(UserPreferences.PREF_MOBILE_UPDATE, "everything").apply();
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/UpdateManager.java
@@ -71,6 +71,11 @@ class UpdateManager {
                 UserPreferences.setEpisodeCleanupValue(oldValueInDays * 24);
             } // else 0 or special negative values, no change needed
         }
+        if (oldVersionCode < 1070197) {
+            if (prefs.getBoolean(UserPreferences.PREF_MOBILE_UPDATE_OLD, false)) {
+                prefs.edit().putString(UserPreferences.PREF_MOBILE_UPDATE, "everything").apply();
+            }
+        }
     }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
@@ -31,6 +31,6 @@ public class ApGlideModule extends AppGlideModule {
 
     @Override
     public void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
-        registry.append(String.class, InputStream.class, new ApOkHttpUrlLoader.Factory());
+        registry.replace(String.class, InputStream.class, new ApOkHttpUrlLoader.Factory());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -113,10 +113,10 @@ class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
                 return chain.proceed(chain.request());
             } else {
                 return new Response.Builder()
-                        .code(420)
                         .protocol(Protocol.HTTP_2)
-                        .message("Dummy response")
-                        .body(new RealResponseBody(null, 0, null))
+                        .code(420)
+                        .message("Policy Not Fulfilled")
+                        .body(ResponseBody.create(null, new byte[0]))
                         .request(chain.request())
                         .build();
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -21,10 +21,8 @@ import de.danoeh.antennapod.core.service.download.AntennapodHttpClient;
 import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.NetworkUtils;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import okhttp3.*;
+import okhttp3.internal.http.RealResponseBody;
 
 /**
  * @see com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
@@ -111,10 +109,16 @@ class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
 
         @Override
         public Response intercept(Chain chain) throws IOException {
-            if (NetworkUtils.isDownloadAllowed()) {
+            if (NetworkUtils.isImageAllowed()) {
                 return chain.proceed(chain.request());
             } else {
-                return null;
+                return new Response.Builder()
+                        .code(420)
+                        .protocol(Protocol.HTTP_2)
+                        .message("Dummy response")
+                        .body(new RealResponseBody(null, 0, null))
+                        .request(chain.request())
+                        .build();
             }
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -77,7 +77,8 @@ public class UserPreferences {
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
     public static final String PREF_UPDATE_INTERVAL = "prefAutoUpdateIntervall";
-    private static final String PREF_MOBILE_UPDATE = "prefMobileUpdate";
+    public static final String PREF_MOBILE_UPDATE_OLD = "prefMobileUpdate";
+    public static final String PREF_MOBILE_UPDATE = "prefMobileUpdateAllowed";
     public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_PARALLEL_DOWNLOADS = "prefParallelDownloads";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
@@ -380,8 +381,16 @@ public class UserPreferences {
         }
     }
 
+    public static String getMobileUpdatesEnabled() {
+        return prefs.getString(PREF_MOBILE_UPDATE, "images");
+    }
+
     public static boolean isAllowMobileUpdate() {
-        return prefs.getBoolean(PREF_MOBILE_UPDATE, false);
+        return getMobileUpdatesEnabled().equals("everything");
+    }
+
+    public static boolean isAllowMobileImages() {
+        return isAllowMobileUpdate() || getMobileUpdatesEnabled().equals("images");
     }
 
     public static int getParallelDownloads() {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -77,7 +77,6 @@ public class UserPreferences {
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
     public static final String PREF_UPDATE_INTERVAL = "prefAutoUpdateIntervall";
-    public static final String PREF_MOBILE_UPDATE_OLD = "prefMobileUpdate";
     public static final String PREF_MOBILE_UPDATE = "prefMobileUpdateAllowed";
     public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_PARALLEL_DOWNLOADS = "prefParallelDownloads";

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -90,9 +90,13 @@ public class NetworkUtils {
         return info != null && info.isConnected();
     }
 
-	public static boolean isDownloadAllowed() {
-		return UserPreferences.isAllowMobileUpdate() || !NetworkUtils.isNetworkMetered();
-	}
+    public static boolean isDownloadAllowed() {
+        return UserPreferences.isAllowMobileUpdate() || !NetworkUtils.isNetworkMetered();
+    }
+
+    public static boolean isImageAllowed() {
+        return UserPreferences.isAllowMobileImages() || !NetworkUtils.isNetworkMetered();
+    }
 
 	private static boolean isNetworkMetered() {
 		ConnectivityManager connManager = (ConnectivityManager) context

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -55,6 +55,18 @@
         <item>-1</item>
     </string-array>
 
+    <string-array name="mobile_update_entries">
+        <item>@string/pref_mobileUpdate_nothing</item>
+        <item>@string/pref_mobileUpdate_images</item>
+        <item>@string/pref_mobileUpdate_everything</item>
+    </string-array>
+
+    <string-array name="mobile_update_values">
+        <item>nothing</item>
+        <item>images</item>
+        <item>everything</item>
+    </string-array>
+
     <string-array name="episode_cleanup_entries">
         <item>@string/episode_cleanup_queue_removal</item>
         <item>0</item>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -373,6 +373,9 @@
     <string name="pref_unpauseOnBluetoothReconnect_title">Bluetooth Reconnect</string>
     <string name="pref_mobileUpdate_title">Mobile Updates</string>
     <string name="pref_mobileUpdate_sum">Allow updates over the mobile data connection</string>
+    <string name="pref_mobileUpdate_nothing">Nothing</string>
+    <string name="pref_mobileUpdate_images">Images only</string>
+    <string name="pref_mobileUpdate_everything">Everything</string>
     <string name="refreshing_label">Refreshing</string>
     <string name="flattr_settings_label">Flattr settings</string>
     <string name="pref_flattr_auth_title">Flattr sign-in</string>


### PR DESCRIPTION
Makes mobile updates setting tri-state (nothing/images/everything). Defaults to `images` to prevent issues like #3079 and #2752

Also fixes some crashes related to image loading on mobile networks.

Closes #2918