### PR TITLE
Create new adapter to show single item after undo

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -342,19 +342,20 @@ public class AllEpisodesFragment extends Fragment {
     }
 
     private void onFragmentLoaded() {
-        if (listAdapter == null) {
-            MainActivity mainActivity = (MainActivity) getActivity();
-            listAdapter = new AllEpisodesRecycleAdapter(mainActivity, itemAccess,
-                    new DefaultActionButtonCallback(mainActivity), showOnlyNewEpisodes());
-            listAdapter.setHasStableIds(true);
-            recyclerView.setAdapter(listAdapter);
-        }
-        if (episodes == null || episodes.size() == 0) {
-            recyclerView.setVisibility(View.GONE);
-            emptyView.setVisibility(View.VISIBLE);
-        } else {
+        if (episodes != null && episodes.size() > 0) {
+            if (listAdapter == null) {
+                MainActivity mainActivity = (MainActivity) getActivity();
+                listAdapter = new AllEpisodesRecycleAdapter(mainActivity, itemAccess,
+                        new DefaultActionButtonCallback(mainActivity), showOnlyNewEpisodes());
+                listAdapter.setHasStableIds(true);
+                recyclerView.setAdapter(listAdapter);
+            }
             emptyView.setVisibility(View.GONE);
             recyclerView.setVisibility(View.VISIBLE);
+        } else {
+            listAdapter = null;
+            recyclerView.setVisibility(View.GONE);
+            emptyView.setVisibility(View.VISIBLE);
         }
 
         listAdapter.notifyDataSetChanged();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -506,19 +506,20 @@ public class QueueFragment extends Fragment {
     }
 
     private void onFragmentLoaded(final boolean restoreScrollPosition) {
-        if (recyclerAdapter == null) {
-            MainActivity activity = (MainActivity) getActivity();
-            recyclerAdapter = new QueueRecyclerAdapter(activity, itemAccess,
-                new DefaultActionButtonCallback(activity), itemTouchHelper);
-            recyclerAdapter.setHasStableIds(true);
-            recyclerView.setAdapter(recyclerAdapter);
-        }
-        if(queue == null || queue.size() == 0) {
-            recyclerView.setVisibility(View.GONE);
-            emptyView.setVisibility(View.VISIBLE);
-        } else {
+        if (queue != null && queue.size() > 0) {
+            if (recyclerAdapter == null) {
+                MainActivity activity = (MainActivity) getActivity();
+                recyclerAdapter = new QueueRecyclerAdapter(activity, itemAccess,
+                        new DefaultActionButtonCallback(activity), itemTouchHelper);
+                recyclerAdapter.setHasStableIds(true);
+                recyclerView.setAdapter(recyclerAdapter);
+            }
             emptyView.setVisibility(View.GONE);
             recyclerView.setVisibility(View.VISIBLE);
+        } else {
+            recyclerAdapter = null;
+            recyclerView.setVisibility(View.GONE);
+            emptyView.setVisibility(View.VISIBLE);
         }
 
         if (restoreScrollPosition) {


### PR DESCRIPTION
Fixes #3084

Only created the adapter when it is actually necessary and throws it away if not. Not sure why the first item after an undo is not rendered correctly, seems to have something to do with stable ids...