### PR TITLE
Executing all ExoPlayer methods on main thread

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -776,15 +776,6 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
         loadData();
     }
 
-    public void onEventMainThread(ServiceEvent event) {
-        Log.d(TAG, "onEvent(" + event + ")");
-        switch(event.action) {
-            case SERVICE_STARTED:
-                externalPlayerFragment.connectToPlaybackService();
-                break;
-        }
-    }
-
     public void onEventMainThread(ProgressEvent event) {
         Log.d(TAG, "onEvent(" + event + ")");
         switch(event.action) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -165,6 +165,7 @@ public class ExoPlayerWrapper implements IPlayer {
     @Override
     public void seekTo(int i) throws IllegalStateException {
         mExoPlayer.seekTo(i);
+        audioSeekCompleteListener.onSeekComplete(null);
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -57,16 +58,42 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     private final ReentrantLock playerLock;
     private CountDownLatch seekLatch;
 
-    private final ThreadPoolExecutor executor;
+    private final PlayerExecutor executor;
+
+    /**
+     * All ExoPlayer methods must be executed on the same thread.
+     * We use the main application thread. This class allows to
+     * "fake" an executor that just calls the method instead of
+     * submitting to another thread. Other players are still
+     * executed in a background thread.
+     */
+    private class PlayerExecutor {
+        private boolean useMainThread = true;
+        private ThreadPoolExecutor threadPool;
+
+        public Future<?> submit(Runnable r) {
+            if (useMainThread) {
+                r.run();
+                return new FutureTask<Void>(() -> {}, null);
+            } else {
+                return threadPool.submit(r);
+            }
+        }
+
+        public void shutdown() {
+            threadPool.shutdown();
+        }
+    }
 
     public LocalPSMP(@NonNull Context context,
                      @NonNull PSMPCallback callback) {
         super(context, callback);
-
         this.audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         this.playerLock = new ReentrantLock();
         this.startWhenPrepared = new AtomicBoolean(false);
-        executor = new ThreadPoolExecutor(1, 1, 5, TimeUnit.MINUTES, new LinkedBlockingDeque<>(),
+
+        executor = new PlayerExecutor();
+        executor.threadPool = new ThreadPoolExecutor(1, 1, 5, TimeUnit.MINUTES, new LinkedBlockingDeque<>(),
                 (r, executor) -> Log.d(TAG, "Rejected execution of runnable"));
 
         mediaPlayer = null;
@@ -105,6 +132,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     @Override
     public void playMediaObject(@NonNull final Playable playable, final boolean stream, final boolean startWhenPrepared, final boolean prepareImmediately) {
         Log.d(TAG, "playMediaObject(...)");
+        executor.useMainThread = true; // ExoPlayer needs to be initialized in main thread
         executor.submit(() -> {
             playerLock.lock();
             try {
@@ -755,10 +783,13 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
         if (UserPreferences.useExoplayer()) {
             mediaPlayer = new ExoPlayerWrapper(context);
+            executor.useMainThread = true;
         } else if (media.getMediaType() == MediaType.VIDEO) {
             mediaPlayer = new VideoPlayer();
+            executor.useMainThread = false;
         } else {
             mediaPlayer = new AudioPlayer(context);
+            executor.useMainThread = false;
         }
 
         mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
@@ -1012,7 +1043,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             mp -> genericSeekCompleteListener();
 
     private void genericSeekCompleteListener() {
-        Thread t = new Thread(() -> {
+        Runnable r = () -> {
             Log.d(TAG, "genericSeekCompleteListener");
             if(seekLatch != null) {
                 seekLatch.countDown();
@@ -1025,7 +1056,12 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 setPlayerStatus(statusBeforeSeeking, media, getPosition());
             }
             playerLock.unlock();
-        });
-        t.start();
+        };
+
+        if (mediaPlayer instanceof ExoPlayerWrapper) {
+            r.run();
+        } else {
+            new Thread(r).start();
+        }
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.core.service.playback;
 
 import android.content.Context;
+import android.os.Handler;
 import android.os.Vibrator;
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -125,7 +126,8 @@ public class PlaybackServiceTaskManager {
      */
     public synchronized void startPositionSaver() {
         if (!isPositionSaverActive()) {
-            Runnable positionSaver = callback::positionSaverTick;
+            Handler handler = new Handler(); // Execute on main thread
+            Runnable positionSaver = () -> handler.post(callback::positionSaverTick);
             positionSaverFuture = schedExecutor.scheduleWithFixedDelay(positionSaver, POSITION_SAVER_WAITING_INTERVAL,
                     POSITION_SAVER_WAITING_INTERVAL, TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
After much noise in #3087 (sorry), I finally managed to get a responsive ExoPlayer in the main thread!. Apparently, ExoPlayer does not call `onSeekProcessed` and therefore, AntennaPod waited until the 3 seconds timeout every time a seek happened. When calling `audioSeekCompleteListener` directly, everything is fine.

Closes #3025