### PR TITLE
Do not hold state in fragments

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -239,7 +239,6 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
 
         getWindow().setFormat(PixelFormat.TRANSPARENT);
         setupGUI();
-        loadMediaInfo();
     }
 
     @Override
@@ -283,6 +282,8 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
             controller.release();
         }
         controller = newPlaybackController();
+        controller.init();
+        loadMediaInfo();
         onPositionObserverUpdate();
     }
 
@@ -661,9 +662,6 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
         super.onResume();
         Log.d(TAG, "onResume()");
         StorageUtils.checkStorageAvailability(this);
-        if (controller != null) {
-            controller.init();
-        }
     }
 
     public void onEventMainThread(ServiceEvent event) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -781,6 +781,9 @@ public abstract class PlaybackController {
     }
 
     private void initServiceNotRunning() {
+        if (getPlayButton() == null) {
+            return;
+        }
         Log.v(TAG, "initServiceNotRunning()");
         mediaLoader = Maybe.create((MaybeOnSubscribe<Playable>) emitter -> {
             Playable media = getMedia();


### PR DESCRIPTION
I have another suggestion for fixing the media player screen, just as #3072 and #3095.

> @orionlee: https://github.com/AntennaPod/AntennaPod/pull/3072#issuecomment-480531425
> The current MediaplayerInfoPagerAdapter that tries to keep states are bound to fail in some cases, as Android does its own thing outside the adapter.

I have removed all state from the fragments and the adapter. The fragments create their own connection to the PlaybackService and can be created and restored by the Android system without any problems. The fragments even are no longer dependent on the Activity they are shown in - this makes it easier to implement something like #2353 in the future.

Possible problems: The fragments create their own connection to the PlaybackService. This might be a bit of an overhead because they bind to the service.

Closes #2992, closes #3089.
Replacement for other PRs: closes #3072, closes #3095