### PR TITLE
Hiding ExternalPlayerFragment onStart

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
@@ -215,7 +215,8 @@ public class ExternalPlayerFragment extends Fragment {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(media -> updateUi((Playable) media),
-                        error -> Log.e(TAG, Log.getStackTraceString(error)));
+                        error -> Log.e(TAG, Log.getStackTraceString(error)),
+                        () -> fragmentLayout.setVisibility(View.GONE));
         return true;
     }
 


### PR DESCRIPTION
If the playback is finished in background, the fragmentLayout is not hidden.
Steps to reproduce (without this commit):
- Start last item in queue
- Leave app using home button
- Finish playback by using notification skip button
- Resume to AntennaPod
- ExternalPlayerFragment is shown (in invalid state) but should be hidden