### PR TITLE
Add progress bar with space information to data folder selection dialog

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
@@ -27,12 +27,14 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
     private final ChooseDataFolderDialog.RunnableWithString selectionHandler;
     private final String currentPath;
     private final List<StoragePath> entries;
+    private final String freeSpaceString;
     private Dialog dialog;
 
     public DataFolderAdapter(Context context, ChooseDataFolderDialog.RunnableWithString selectionHandler) {
         this.entries = getStorageEntries(context);
         this.currentPath = getCurrentPath();
         this.selectionHandler = selectionHandler;
+        this.freeSpaceString = context.getString(R.string.choose_data_directory_available_space);
     }
 
     @NonNull
@@ -46,8 +48,10 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         StoragePath storagePath = entries.get(position);
+        String freeSpace = Converter.byteToString(storagePath.getAvailableSpace());
+
         holder.path.setText(storagePath.getShortPath());
-        holder.size.setText(Converter.byteToString(storagePath.getAvailableSpace()));
+        holder.size.setText(String.format(freeSpaceString, freeSpace));
         holder.progressBar.setProgress(storagePath.getUsagePercentage());
         holder.root.setOnClickListener((View v) -> selectAndDismiss(storagePath));
         holder.radioButton.setOnClickListener((View v) -> selectAndDismiss(storagePath));

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
@@ -20,6 +20,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.StorageUtils;
 import de.danoeh.antennapod.dialog.ChooseDataFolderDialog;
+import me.zhanghai.android.materialprogressbar.MaterialProgressBar;
 
 
 public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.ViewHolder> {
@@ -47,6 +48,7 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
         StoragePath storagePath = entries.get(position);
         holder.path.setText(storagePath.getShortPath());
         holder.size.setText(Converter.byteToString(storagePath.getAvailableSpace()));
+        holder.progressBar.setProgress(storagePath.getUsagePercentage());
         holder.root.setOnClickListener((View v) -> selectAndDismiss(storagePath));
         holder.radioButton.setOnClickListener((View v) -> selectAndDismiss(storagePath));
         if (storagePath.getFullPath().equals(currentPath)) {
@@ -98,6 +100,7 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
         private TextView path;
         private TextView size;
         private RadioButton radioButton;
+        private MaterialProgressBar progressBar;
 
         ViewHolder(View itemView) {
             super(itemView);
@@ -105,6 +108,7 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
             path = itemView.findViewById(R.id.path);
             size = itemView.findViewById(R.id.size);
             radioButton = itemView.findViewById(R.id.radio_button);
+            progressBar = itemView.findViewById(R.id.used_space);
         }
     }
 
@@ -126,6 +130,14 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
 
         long getAvailableSpace() {
             return StorageUtils.getFreeSpaceAvailable(path);
+        }
+
+        long getTotalSpace() {
+            return StorageUtils.getTotalSpaceAvailable(path);
+        }
+
+        int getUsagePercentage() {
+            return 100 - (int) (100 * getAvailableSpace() / (float) getTotalSpace());
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
@@ -1,0 +1,131 @@
+package de.danoeh.antennapod.adapter;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.RadioButton;
+import android.widget.TextView;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.util.Converter;
+import de.danoeh.antennapod.core.util.StorageUtils;
+import de.danoeh.antennapod.dialog.ChooseDataFolderDialog;
+
+
+public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.ViewHolder> {
+    private final ChooseDataFolderDialog.RunnableWithString selectionHandler;
+    private final String currentPath;
+    private final List<StoragePath> entries;
+    private Dialog dialog;
+
+    public DataFolderAdapter(Context context, ChooseDataFolderDialog.RunnableWithString selectionHandler) {
+        this.entries = getStorageEntries(context);
+        this.currentPath = getCurrentPath();
+        this.selectionHandler = selectionHandler;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        View entryView = inflater.inflate(R.layout.choose_data_folder_dialog_entry, parent, false);
+        return new ViewHolder(entryView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        StoragePath storagePath = entries.get(position);
+        holder.path.setText(storagePath.getShortPath());
+        holder.size.setText(Converter.byteToString(storagePath.getAvailableSpace()));
+        holder.root.setOnClickListener((View v) -> selectAndDismiss(storagePath));
+        holder.radioButton.setOnClickListener((View v) -> selectAndDismiss(storagePath));
+        if (storagePath.getFullPath().equals(currentPath)) {
+            holder.radioButton.toggle();
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        if (currentPath == null) {
+            return 0;
+        } else {
+            return entries.size();
+        }
+    }
+
+    public void setDialog(Dialog dialog) {
+        this.dialog = dialog;
+    }
+
+    private String getCurrentPath() {
+        File dataFolder = UserPreferences.getDataFolder(null);
+        if (dataFolder != null) return dataFolder.getAbsolutePath();
+        return null;
+    }
+
+    private List<StoragePath> getStorageEntries(Context context) {
+        File[] mediaDirs = ContextCompat.getExternalFilesDirs(context, null);
+        final List<StoragePath> entries = new ArrayList<>(mediaDirs.length);
+        for (File dir : mediaDirs) {
+            if (isNotWritable(dir)) continue;
+
+            entries.add(new StoragePath(dir.getAbsolutePath()));
+        }
+        return entries;
+    }
+
+    private boolean isNotWritable(File dir) {
+        return dir == null || !dir.exists() || !dir.canRead() || !dir.canWrite();
+    }
+
+    private void selectAndDismiss(StoragePath storagePath) {
+        selectionHandler.run(storagePath.getFullPath());
+        dialog.dismiss();
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder {
+        private View root;
+        private TextView path;
+        private TextView size;
+        private RadioButton radioButton;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+            root = itemView.findViewById(R.id.root);
+            path = itemView.findViewById(R.id.path);
+            size = itemView.findViewById(R.id.size);
+            radioButton = itemView.findViewById(R.id.radio_button);
+        }
+    }
+
+    class StoragePath {
+        private final String path;
+
+        StoragePath(String path) {
+            this.path = path;
+        }
+
+        String getShortPath() {
+            int prefixIndex = path.indexOf("Android");
+            return (prefixIndex > 0) ? path.substring(0, prefixIndex) : path;
+        }
+
+        String getFullPath() {
+            return this.path;
+        }
+
+        long getAvailableSpace() {
+            return StorageUtils.getFreeSpaceAvailable(path);
+        }
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/dialog/ChooseDataFolderDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/ChooseDataFolderDialog.java
@@ -1,21 +1,11 @@
 package de.danoeh.antennapod.dialog;
 
 import android.content.Context;
-import android.os.Build;
-import android.support.v4.content.ContextCompat;
-import android.text.Html;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
-import de.danoeh.antennapod.core.util.Converter;
-import de.danoeh.antennapod.core.util.StorageUtils;
+import de.danoeh.antennapod.adapter.DataFolderAdapter;
 
 public class ChooseDataFolderDialog {
 
@@ -32,12 +22,9 @@ public class ChooseDataFolderDialog {
     private ChooseDataFolderDialog() {}
 
     public static void showDialog(final Context context, RunnableWithString handlerFunc) {
-        File dataFolder = UserPreferences.getDataFolder(null);
-        HashMap<String, List<String>> options = getStorageOptions(context);
-        final List<String> entries = options.get("entries");
-        final List<String> folders = options.get("folders");
+        DataFolderAdapter adapter = new DataFolderAdapter(context, handlerFunc);
 
-        if (dataFolder == null || entries.isEmpty()) {
+        if (adapter.getItemCount() == 0) {
             new MaterialDialog.Builder(context)
                     .title(R.string.error_label)
                     .content(R.string.external_storage_error_msg)
@@ -46,66 +33,15 @@ public class ChooseDataFolderDialog {
             return;
         }
 
-        int selectedIndex = folders.indexOf(dataFolder.getAbsolutePath());
         MaterialDialog dialog = new MaterialDialog.Builder(context)
                 .title(R.string.choose_data_directory)
                 .content(R.string.choose_data_directory_message)
-                .items(entries)
-                .itemsCallbackSingleChoice(selectedIndex, (dialog1, itemView, which, text) -> {
-                    String folder = folders.get(which);
-                    handlerFunc.run(folder);
-                    return true;
-                })
+                .adapter(adapter, null)
                 .negativeText(R.string.cancel_label)
                 .cancelable(true)
                 .build();
+        adapter.setDialog(dialog);
         dialog.show();
-    }
-
-    private static HashMap<String, List<String>> getStorageOptions(Context context) {
-        File[] mediaDirs = ContextCompat.getExternalFilesDirs(context, null);
-        final List<String> folders = new ArrayList<>(mediaDirs.length);
-        final List<String> entries = new ArrayList<>(mediaDirs.length);
-        for (File dir : mediaDirs) {
-            if (isNotWritable(dir)) continue;
-
-            String path = dir.getAbsolutePath();
-            String location = getStorageLocation(path);
-            String availableSpace = getAvailableSpace(path);
-            folders.add(path);
-            entries.add(storageEntry(location, availableSpace));
-        }
-        return new HashMap<String, List<String>>() {{
-            put("folders", folders);
-            put("entries", entries);
-        }};
-    }
-
-    private static String storageEntry(String location, String availableSpace) {
-        String html = String.format("<small>%1$s [%2$s]</small>", location, availableSpace);
-        return fromHtmlVersioned(html).toString();
-    }
-
-    private static String getAvailableSpace(String path) {
-        long spaceAvailable = StorageUtils.getFreeSpaceAvailable(path);
-        return Converter.byteToString(spaceAvailable);
-    }
-
-    private static String getStorageLocation(String path) {
-        int prefixIndex = path.indexOf("Android");
-        return (prefixIndex > 0) ? path.substring(0, prefixIndex) : path;
-    }
-
-    private static boolean isNotWritable(File dir) {
-        return dir == null || !dir.exists() || !dir.canRead() || !dir.canWrite();
-    }
-
-    @SuppressWarnings("deprecation")
-    private static CharSequence fromHtmlVersioned(final String html) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            return Html.fromHtml(html);
-        }
-        return Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY);
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/ChooseDataFolderDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/ChooseDataFolderDialog.java
@@ -9,6 +9,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
@@ -32,7 +33,11 @@ public class ChooseDataFolderDialog {
 
     public static void showDialog(final Context context, RunnableWithString handlerFunc) {
         File dataFolder = UserPreferences.getDataFolder(null);
-        if (dataFolder == null) {
+        HashMap<String, List<String>> options = getStorageOptions(context);
+        final List<String> entries = options.get("entries");
+        final List<String> folders = options.get("folders");
+
+        if (dataFolder == null || entries.isEmpty()) {
             new MaterialDialog.Builder(context)
                     .title(R.string.error_label)
                     .content(R.string.external_storage_error_msg)
@@ -40,41 +45,12 @@ public class ChooseDataFolderDialog {
                     .show();
             return;
         }
-        String dataFolderPath = dataFolder.getAbsolutePath();
-        int selectedIndex = -1;
-        int index = 0;
-        File[] mediaDirs = ContextCompat.getExternalFilesDirs(context, null);
-        final List<String> folders = new ArrayList<>(mediaDirs.length);
-        final List<CharSequence> choices = new ArrayList<>(mediaDirs.length);
-        for (File dir : mediaDirs) {
-            if(dir == null || !dir.exists() || !dir.canRead() || !dir.canWrite()) {
-                continue;
-            }
-            String path = dir.getAbsolutePath();
-            folders.add(path);
-            if(dataFolderPath.equals(path)) {
-                selectedIndex = index;
-            }
-            int prefixIndex = path.indexOf("Android");
-            String choice = (prefixIndex > 0) ? path.substring(0, prefixIndex) : path;
-            long bytes = StorageUtils.getFreeSpaceAvailable(path);
-            String item = String.format(
-                    "<small>%1$s [%2$s]</small>", choice, Converter.byteToString(bytes));
-            choices.add(fromHtmlVersioned(item));
-            index++;
-        }
-        if (choices.isEmpty()) {
-            new MaterialDialog.Builder(context)
-                    .title(R.string.error_label)
-                    .content(R.string.external_storage_error_msg)
-                    .neutralText(android.R.string.ok)
-                    .show();
-            return;
-        }
+
+        int selectedIndex = folders.indexOf(dataFolder.getAbsolutePath());
         MaterialDialog dialog = new MaterialDialog.Builder(context)
                 .title(R.string.choose_data_directory)
                 .content(R.string.choose_data_directory_message)
-                .items(choices)
+                .items(entries)
                 .itemsCallbackSingleChoice(selectedIndex, (dialog1, itemView, which, text) -> {
                     String folder = folders.get(which);
                     handlerFunc.run(folder);
@@ -84,6 +60,44 @@ public class ChooseDataFolderDialog {
                 .cancelable(true)
                 .build();
         dialog.show();
+    }
+
+    private static HashMap<String, List<String>> getStorageOptions(Context context) {
+        File[] mediaDirs = ContextCompat.getExternalFilesDirs(context, null);
+        final List<String> folders = new ArrayList<>(mediaDirs.length);
+        final List<String> entries = new ArrayList<>(mediaDirs.length);
+        for (File dir : mediaDirs) {
+            if (isNotWritable(dir)) continue;
+
+            String path = dir.getAbsolutePath();
+            String location = getStorageLocation(path);
+            String availableSpace = getAvailableSpace(path);
+            folders.add(path);
+            entries.add(storageEntry(location, availableSpace));
+        }
+        return new HashMap<String, List<String>>() {{
+            put("folders", folders);
+            put("entries", entries);
+        }};
+    }
+
+    private static String storageEntry(String location, String availableSpace) {
+        String html = String.format("<small>%1$s [%2$s]</small>", location, availableSpace);
+        return fromHtmlVersioned(html).toString();
+    }
+
+    private static String getAvailableSpace(String path) {
+        long spaceAvailable = StorageUtils.getFreeSpaceAvailable(path);
+        return Converter.byteToString(spaceAvailable);
+    }
+
+    private static String getStorageLocation(String path) {
+        int prefixIndex = path.indexOf("Android");
+        return (prefixIndex > 0) ? path.substring(0, prefixIndex) : path;
+    }
+
+    private static boolean isNotWritable(File dir) {
+        return dir == null || !dir.exists() || !dir.canRead() || !dir.canWrite();
     }
 
     @SuppressWarnings("deprecation")

--- a/app/src/main/res/layout/choose_data_folder_dialog_entry.xml
+++ b/app/src/main/res/layout/choose_data_folder_dialog_entry.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/diag_content_side_padding"
+    android:background="?attr/selectableItemBackground">
+
+    <RadioButton
+        android:id="@+id/radio_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:padding="4dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:layout_toEndOf="@+id/radio_button"
+        android:layout_toRightOf="@+id/radio_button"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/path"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="/storage/sdcard0" />
+
+        <TextView
+            android:id="@+id/size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="2 GB" />
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/choose_data_folder_dialog_entry.xml
+++ b/app/src/main/res/layout/choose_data_folder_dialog_entry.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
@@ -35,6 +36,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="2 GB" />
+
+        <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+            android:id="@+id/used_space"
+            style="@style/Widget.MaterialProgressBar.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:mpb_progressStyle="horizontal" />
     </LinearLayout>
 
 </RelativeLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/StorageUtils.java
@@ -74,4 +74,18 @@ public class StorageUtils {
         }
         return availableBlocks * blockSize;
     }
+
+    public static long getTotalSpaceAvailable(String path) {
+        StatFs stat = new StatFs(path);
+        long blockCount;
+        long blockSize;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            blockCount = stat.getBlockCountLong();
+            blockSize = stat.getBlockSizeLong();
+        } else {
+            blockCount = stat.getBlockCount();
+            blockSize = stat.getBlockSize();
+        }
+        return blockCount * blockSize;
+    }
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -644,6 +644,7 @@
     <string name="choose_data_directory">Choose Data Folder</string>
     <string name="choose_data_directory_message">Please choose the base of your data folder. AntennaPod will create the appropriate sub-directories.</string>
     <string name="choose_data_directory_permission_rationale">Access to external storage is required to change the data folder</string>
+    <string name="choose_data_directory_available_space">%1$s free</string>
     <string name="create_folder_msg">Create new folder with name "%1$s"?</string>
     <string name="create_folder_success">Created new folder</string>
     <string name="create_folder_error_no_write_access">Cannot write to this folder</string>


### PR DESCRIPTION
This displays a progress bar with the amount of used/free space in each
storage location to make it easier to identify storage devices. This is
particularly useful for devices that use non-standard names as mentioned in #3049.

**Yet to be implemented**: identify whether a location is internal/external.

Comments and feedback are welcome. =) 