### PR TITLE
Fix thrown exceptions when adding/removing podcasts

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemlistFragment.java
@@ -6,7 +6,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.LightingColorFilter;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ListFragment;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.SearchView;
@@ -61,6 +61,7 @@ import de.danoeh.antennapod.core.storage.DownloadRequestException;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.LongList;
+import de.danoeh.antennapod.core.util.Optional;
 import de.danoeh.antennapod.core.util.gui.MoreContentListFooterUtil;
 import de.danoeh.antennapod.dialog.EpisodesApplyActionFragment;
 import de.danoeh.antennapod.dialog.RenameFeedDialog;
@@ -618,7 +619,7 @@ public class ItemlistFragment extends ListFragment {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
-                    feed = result;
+                    feed = result.orElse(null);
                     itemsLoaded = true;
                     if (viewsCreated) {
                         onFragmentLoaded();
@@ -626,18 +627,15 @@ public class ItemlistFragment extends ListFragment {
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 
-    @Nullable
-    private Feed loadData() {
+    @NonNull
+    private Optional<Feed> loadData() {
         Feed feed = DBReader.getFeed(feedID);
-        if (feed == null) {
-            return null;
-        }
-        DBReader.loadAdditionalFeedItemListData(feed.getItems());
-        if (feed.getItemFilter() != null) {
+        if (feed != null && feed.getItemFilter() != null) {
+            DBReader.loadAdditionalFeedItemListData(feed.getItems());
             FeedItemFilter filter = feed.getItemFilter();
             feed.setItems(filter.filter(feed.getItems()));
         }
-        return feed;
+        return Optional.ofNullable(feed);
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
@@ -238,42 +238,19 @@ public class ItunesSearchFragment extends Fragment {
         progressBar.setVisibility(View.VISIBLE);
         disposable = Single.create((SingleOnSubscribe<List<Podcast>>) emitter -> {
                     String lang = Locale.getDefault().getLanguage();
-                    String url = "https://itunes.apple.com/" + lang + "/rss/toppodcasts/limit=25/explicit=true/json";
                     OkHttpClient client = AntennapodHttpClient.getHttpClient();
-                    Request.Builder httpReq = new Request.Builder()
-                            .url(url)
-                            .header("User-Agent", ClientConfig.USER_AGENT);
-                    List<Podcast> results = new ArrayList<>();
+                    String feedString;
                     try {
-                        Response response = client.newCall(httpReq.build()).execute();
-                        if(!response.isSuccessful()) {
-                            // toplist for language does not exist, fall back to united states
-                            url = "https://itunes.apple.com/us/rss/toppodcasts/limit=25/explicit=true/json";
-                            httpReq = new Request.Builder()
-                                    .url(url)
-                                    .header("User-Agent", ClientConfig.USER_AGENT);
-                            response = client.newCall(httpReq.build()).execute();
+                        try {
+                            feedString = getTopListFeed(client, lang);
+                        } catch (IOException e) {
+                            feedString = getTopListFeed(client, "us");
                         }
-                        if(response.isSuccessful()) {
-                            String resultString = response.body().string();
-                            JSONObject result = new JSONObject(resultString);
-                            JSONObject feed = result.getJSONObject("feed");
-                            JSONArray entries = feed.getJSONArray("entry");
-
-                            for(int i=0; i < entries.length(); i++) {
-                                JSONObject json = entries.getJSONObject(i);
-                                Podcast podcast = Podcast.fromToplist(json);
-                                results.add(podcast);
-                            }
-                        }
-                        else {
-                            String prefix = getString(R.string.error_msg_prefix);
-                            emitter.onError(new IOException(prefix + response));
-                        }
+                        List<Podcast> podcasts = parseFeed(feedString);
+                        emitter.onSuccess(podcasts);
                     } catch (IOException | JSONException e) {
                         emitter.onError(e);
                     }
-                    emitter.onSuccess(results);
                 })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -289,6 +266,35 @@ public class ItunesSearchFragment extends Fragment {
                     butRetry.setOnClickListener(v -> loadToplist());
                     butRetry.setVisibility(View.VISIBLE);
                 });
+    }
+
+    private String getTopListFeed(OkHttpClient client, String language) throws IOException {
+        String url = "https://itunes.apple.com/%s/rss/toppodcasts/limit=25/explicit=true/json";
+        Request.Builder httpReq = new Request.Builder()
+                .header("User-Agent", ClientConfig.USER_AGENT)
+                .url(String.format(url, language));
+
+        try (Response response = client.newCall(httpReq.build()).execute()) {
+            if (response.isSuccessful()) {
+                return response.body().string();
+            }
+            String prefix = getString(R.string.error_msg_prefix);
+            throw new IOException(prefix + response);
+        }
+    }
+
+    private List<Podcast> parseFeed(String jsonString) throws JSONException {
+        JSONObject result = new JSONObject(jsonString);
+        JSONObject feed = result.getJSONObject("feed");
+        JSONArray entries = feed.getJSONArray("entry");
+
+        List<Podcast> results = new ArrayList<>();
+        for (int i=0; i < entries.length(); i++) {
+            JSONObject json = entries.getJSONObject(i);
+            results.add(Podcast.fromToplist(json));
+        }
+
+        return results;
     }
 
     private void search(String query) {


### PR DESCRIPTION
When adding certain podcasts, a `LeakedClosableViolation` is thrown
due to the fact that we can make multiple requests with the same `OkHttpClient`.

Also, when removing podcasts, another exception is thrown since RxJava no longer accepts `null` values.

This PR fixes both issues. More details can be found in the individual commit messages.