### PR TITLE
Fixed empty list not receiving updates

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -431,7 +431,10 @@ public class AllEpisodesFragment extends Fragment {
 
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
-        if (episodes == null || listAdapter == null) {
+        if (episodes == null) {
+            return;
+        } else if (listAdapter == null) {
+            loadItems();
             return;
         }
         for (FeedItem item : event.items) {
@@ -459,7 +462,11 @@ public class AllEpisodesFragment extends Fragment {
         if (isMenuInvalidationAllowed && isUpdatingFeeds != update.feedIds.length > 0) {
                 getActivity().supportInvalidateOptionsMenu();
         }
-        if(listAdapter != null && update.mediaIds.length > 0) {
+        if (listAdapter == null) {
+            loadItems();
+            return;
+        }
+        if (update.mediaIds.length > 0) {
             for(long mediaId : update.mediaIds) {
                 int pos = FeedItemUtil.indexOfItemWithMediaId(episodes, mediaId);
                 if(pos >= 0) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -125,7 +125,10 @@ public class QueueFragment extends Fragment {
 
     public void onEventMainThread(QueueEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
-        if(queue == null || recyclerAdapter == null) {
+        if (queue == null) {
+            return;
+        } else if (recyclerAdapter == null) {
+            loadItems(true);
             return;
         }
         switch(event.action) {
@@ -160,7 +163,10 @@ public class QueueFragment extends Fragment {
 
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
-        if(queue == null || recyclerAdapter == null) {
+        if (queue == null) {
+            return;
+        } else if (recyclerAdapter == null) {
+            loadItems(true);
             return;
         }
         for(int i=0, size = event.items.size(); i < size; i++) {


### PR DESCRIPTION
Because #3093 set the adapter to null, the eventbus changes are no longer handled. This PR just reloads the whole list if the list is empty and an event occurs.

Closes #3144