### PR TITLE
Handle iTunes single-number duration format

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
@@ -5,10 +5,9 @@ import android.util.Log;
 
 import org.xml.sax.Attributes;
 
-import java.util.concurrent.TimeUnit;
-
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.syndication.handler.HandlerState;
+import de.danoeh.antennapod.core.syndication.parsers.DurationParser;
 
 public class NSITunes extends Namespace {
 
@@ -72,22 +71,12 @@ public class NSITunes extends Namespace {
         if (TextUtils.isEmpty(durationStr)) {
             return;
         }
-        String[] parts = durationStr.trim().split(":");
+
         try {
-            int durationMs = 0;
-            if (parts.length == 2) {
-                durationMs += TimeUnit.MINUTES.toMillis(Long.parseLong(parts[0])) +
-                        TimeUnit.SECONDS.toMillis((long) Float.parseFloat(parts[1]));
-            } else if (parts.length >= 3) {
-                durationMs += TimeUnit.HOURS.toMillis(Long.parseLong(parts[0])) +
-                        TimeUnit.MINUTES.toMillis(Long.parseLong(parts[1])) +
-                        TimeUnit.SECONDS.toMillis((long) Float.parseFloat(parts[2]));
-            } else {
-                return;
-            }
-            state.getTempObjects().put(DURATION, durationMs);
+            long durationMs = DurationParser.inMillis(durationStr);
+            state.getTempObjects().put(DURATION, (int) durationMs);
         } catch (NumberFormatException e) {
-            Log.e(NSTAG, "Duration \"" + durationStr + "\" could not be parsed");
+            Log.e(NSTAG, String.format("Duration '%s' could not be parsed", durationStr));
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
@@ -7,6 +7,7 @@ import org.xml.sax.Attributes;
 
 import java.util.concurrent.TimeUnit;
 
+import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.syndication.handler.HandlerState;
 
 public class NSITunes extends Namespace {
@@ -21,7 +22,6 @@ public class NSITunes extends Namespace {
     public static final String DURATION = "duration";
     private static final String SUBTITLE = "subtitle";
     private static final String SUMMARY = "summary";
-
 
     @Override
     public SyndElement handleElementStart(String localName, HandlerState state,
@@ -44,65 +44,85 @@ public class NSITunes extends Namespace {
 
     @Override
     public void handleElementEnd(String localName, HandlerState state) {
-        if(state.getContentBuf() == null) {
+        if (state.getContentBuf() == null) {
             return;
         }
-        SyndElement secondElement = state.getSecondTag();
-        String second = secondElement.getName();
 
         if (AUTHOR.equals(localName)) {
-            if (state.getFeed() != null) {
-                String author = state.getContentBuf().toString();
-                state.getFeed().setAuthor(author);
-            }
+            parseAuthor(state);
         } else if (DURATION.equals(localName)) {
-            String durationStr = state.getContentBuf().toString();
-            if(TextUtils.isEmpty(durationStr)) {
-                return;
-            }
-            String[] parts = durationStr.trim().split(":");
-            try {
-                int durationMs = 0;
-                if (parts.length == 2) {
-                    durationMs += TimeUnit.MINUTES.toMillis(Long.parseLong(parts[0])) +
-                            TimeUnit.SECONDS.toMillis((long)Float.parseFloat(parts[1]));
-                } else if (parts.length >= 3) {
-                    durationMs += TimeUnit.HOURS.toMillis(Long.parseLong(parts[0])) +
-                            TimeUnit.MINUTES.toMillis(Long.parseLong(parts[1])) +
-                            TimeUnit.SECONDS.toMillis((long)Float.parseFloat(parts[2]));
-                } else {
-                    return;
-                }
-                state.getTempObjects().put(DURATION, durationMs);
-            } catch (NumberFormatException e) {
-                Log.e(NSTAG, "Duration \"" + durationStr + "\" could not be parsed");
-            }
+            parseDuration(state);
         } else if (SUBTITLE.equals(localName)) {
-            String subtitle = state.getContentBuf().toString();
-            if (TextUtils.isEmpty(subtitle)) {
-                return;
-            }
-            if (state.getCurrentItem() != null) {
-                if (TextUtils.isEmpty(state.getCurrentItem().getDescription())) {
-                    state.getCurrentItem().setDescription(subtitle);
-                }
-            } else {
-                if (state.getFeed() != null && TextUtils.isEmpty(state.getFeed().getDescription())) {
-                    state.getFeed().setDescription(subtitle);
-                }
-            }
+            parseSubtitle(state);
         } else if (SUMMARY.equals(localName)) {
-            String summary = state.getContentBuf().toString();
-            if (TextUtils.isEmpty(summary)) {
+            SyndElement secondElement = state.getSecondTag();
+            parseSummary(state, secondElement.getName());
+        }
+    }
+
+    private void parseAuthor(HandlerState state) {
+        if (state.getFeed() != null) {
+            String author = state.getContentBuf().toString();
+            state.getFeed().setAuthor(author);
+        }
+    }
+
+    private void parseDuration(HandlerState state) {
+        String durationStr = state.getContentBuf().toString();
+        if (TextUtils.isEmpty(durationStr)) {
+            return;
+        }
+        String[] parts = durationStr.trim().split(":");
+        try {
+            int durationMs = 0;
+            if (parts.length == 2) {
+                durationMs += TimeUnit.MINUTES.toMillis(Long.parseLong(parts[0])) +
+                        TimeUnit.SECONDS.toMillis((long) Float.parseFloat(parts[1]));
+            } else if (parts.length >= 3) {
+                durationMs += TimeUnit.HOURS.toMillis(Long.parseLong(parts[0])) +
+                        TimeUnit.MINUTES.toMillis(Long.parseLong(parts[1])) +
+                        TimeUnit.SECONDS.toMillis((long) Float.parseFloat(parts[2]));
+            } else {
                 return;
             }
-            if (state.getCurrentItem() != null &&
-                    (TextUtils.isEmpty(state.getCurrentItem().getDescription()) ||
-                            state.getCurrentItem().getDescription().length() * 1.25 < summary.length())) {
-                state.getCurrentItem().setDescription(summary);
-            } else if (NSRSS20.CHANNEL.equals(second) && state.getFeed() != null) {
-                state.getFeed().setDescription(summary);
+            state.getTempObjects().put(DURATION, durationMs);
+        } catch (NumberFormatException e) {
+            Log.e(NSTAG, "Duration \"" + durationStr + "\" could not be parsed");
+        }
+    }
+
+    private void parseSubtitle(HandlerState state) {
+        String subtitle = state.getContentBuf().toString();
+        if (TextUtils.isEmpty(subtitle)) {
+            return;
+        }
+        if (state.getCurrentItem() != null) {
+            if (TextUtils.isEmpty(state.getCurrentItem().getDescription())) {
+                state.getCurrentItem().setDescription(subtitle);
+            }
+        } else {
+            if (state.getFeed() != null && TextUtils.isEmpty(state.getFeed().getDescription())) {
+                state.getFeed().setDescription(subtitle);
             }
         }
+    }
+
+    private void parseSummary(HandlerState state, String secondElementName) {
+        String summary = state.getContentBuf().toString();
+        if (TextUtils.isEmpty(summary)) {
+            return;
+        }
+
+        FeedItem currentItem = state.getCurrentItem();
+        String description = getDescription(currentItem);
+        if (currentItem != null && description.length() * 1.25 < summary.length()) {
+            currentItem.setDescription(summary);
+        } else if (NSRSS20.CHANNEL.equals(secondElementName) && state.getFeed() != null) {
+            state.getFeed().setDescription(summary);
+        }
+    }
+
+    private String getDescription(FeedItem item) {
+        return (item != null && item.getDescription() != null) ? item.getDescription() : "";
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/parsers/DurationParser.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/parsers/DurationParser.java
@@ -1,0 +1,35 @@
+package de.danoeh.antennapod.core.syndication.parsers;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class DurationParser {
+    public static long inMillis(String durationStr) throws NumberFormatException {
+        String[] parts = durationStr.trim().split(":");
+
+        if (parts.length == 2) {
+            return toMillis("0", parts[0], parts[1]);
+        } else if (parts.length == 3) {
+            return toMillis(parts[0], parts[1], parts[2]);
+        } else {
+            throw new NumberFormatException();
+        }
+    }
+
+    private static long toMillis(String hours, String minutes, String seconds) {
+        return HOURS.toMillis(Long.parseLong(hours))
+                + MINUTES.toMillis(Long.parseLong(minutes))
+                + toMillis(seconds);
+    }
+
+    private static long toMillis(String seconds) {
+        if (seconds.contains(".")) {
+            float value = Float.parseFloat(seconds);
+            float millis = value % 1;
+            return SECONDS.toMillis((long) value) + (long) (millis * 1000);
+        } else {
+            return SECONDS.toMillis(Long.parseLong(seconds));
+        }
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/parsers/DurationParser.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/parsers/DurationParser.java
@@ -8,7 +8,9 @@ public class DurationParser {
     public static long inMillis(String durationStr) throws NumberFormatException {
         String[] parts = durationStr.trim().split(":");
 
-        if (parts.length == 2) {
+        if (parts.length == 1) {
+            return toMillis(parts[0]);
+        } else if (parts.length == 2) {
             return toMillis("0", parts[0], parts[1]);
         } else if (parts.length == 3) {
             return toMillis(parts[0], parts[1], parts[2]);

--- a/core/src/test/java/de/danoeh/antennapod/core/syndication/parsers/DurationParserTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/syndication/parsers/DurationParserTest.java
@@ -17,6 +17,13 @@ public class DurationParserTest {
     }
 
     @Test
+    public void testSingleNumberDurationInMillis() {
+        int twoHoursInSeconds = 2 * 60 * 60;
+        long duration = DurationParser.inMillis(String.valueOf(twoHoursInSeconds));
+        assertEquals(2 * hours, duration);
+    }
+
+    @Test
     public void testMinuteSecondDurationInMillis() {
         long duration = DurationParser.inMillis("05:10");
         assertEquals(5 * minutes + 10 * seconds, duration);

--- a/core/src/test/java/de/danoeh/antennapod/core/syndication/parsers/DurationParserTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/syndication/parsers/DurationParserTest.java
@@ -1,0 +1,36 @@
+package de.danoeh.antennapod.core.syndication.parsers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DurationParserTest {
+    private int milliseconds = 1;
+    private int seconds = 1000 * milliseconds;
+    private int minutes = 60 * seconds;
+    private int hours = 60 * minutes;
+
+    @Test
+    public void testSecondDurationInMillis() {
+        long duration = DurationParser.inMillis("00:45");
+        assertEquals(45 * seconds, duration);
+    }
+
+    @Test
+    public void testMinuteSecondDurationInMillis() {
+        long duration = DurationParser.inMillis("05:10");
+        assertEquals(5 * minutes + 10 * seconds, duration);
+    }
+
+    @Test
+    public void testHourMinuteSecondDurationInMillis() {
+        long duration = DurationParser.inMillis("02:15:45");
+        assertEquals(2 * hours + 15 * minutes + 45 * seconds, duration);
+    }
+
+    @Test
+    public void testSecondsWithMillisecondsInMillis() {
+        long duration = DurationParser.inMillis("00:00:00.123");
+        assertEquals(123, duration);
+    }
+}


### PR DESCRIPTION
Apple says [this][1] about the `<itunes:duration>` tag:

    If you specify a single number as a value (without colons), Apple
    Podcasts displays the value as seconds.

This PR handles this single-number format.

Closes: #3024

[1]: https://help.apple.com/itc/podcasts_connect/#/itcb54353390