### PR TITLE
Fix cover fragment in small screens

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,7 +130,6 @@ dependencies {
     implementation "com.android.support:design:$supportVersion"
     implementation "com.android.support:preference-v14:$supportVersion"
     implementation "com.android.support:gridlayout-v7:$supportVersion"
-    implementation "com.android.support:percent:$supportVersion"
     implementation "com.android.support:recyclerview-v7:$supportVersion"
     compileOnly 'com.google.android.wearable:wearable:2.2.0'
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -1,70 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<android.support.percent.PercentRelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/txtvPodcastTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.25"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="2"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textIsSelectable="true"
+        tools:text="Podcast" />
 
     <ImageView
         android:id="@+id/imgvCover"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_centerInParent="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.5"
         android:contentDescription="@string/cover_label"
         android:scaleType="fitCenter"
-        app:layout_aspectRatio="100%"
-        app:layout_widthPercent="82%"
         android:transitionName="coverTransition"
         tools:src="@android:drawable/sym_def_app_icon" />
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/txtvEpisodeTitle"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.25"
+        android:ellipsize="end"
         android:gravity="center"
-        android:orientation="vertical"
-        android:layout_above="@id/imgvCover">
+        android:maxLines="2"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textIsSelectable="true"
+        tools:text="Episode" />
 
-        <TextView
-            android:id="@+id/txtvPodcastTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginRight="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="8dp"
-            android:gravity="center"
-            android:maxLines="2"
-            android:ellipsize="end"
-            android:text="Podcast"
-            android:textIsSelectable="true"
-            android:textColor="?android:attr/textColorSecondary" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:orientation="vertical"
-        android:layout_below="@id/imgvCover">
-
-        <TextView
-            android:id="@+id/txtvEpisodeTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginRight="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="8dp"
-            android:gravity="center"
-            android:maxLines="2"
-            android:ellipsize="end"
-            android:text="Episode"
-            android:textIsSelectable="true"
-            android:textColor="?android:attr/textColorPrimary" />
-
-    </LinearLayout>
-
-</android.support.percent.PercentRelativeLayout>
+</LinearLayout>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     implementation "com.android.support:support-v4:$supportVersion"
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:preference-v14:$supportVersion"
-    implementation "com.android.support:percent:$supportVersion"
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
     implementation "org.apache.commons:commons-text:$commonstextVersion"
     implementation ("org.shredzone.flattr4j:flattr4j-core:$flattr4jVersion") {


### PR DESCRIPTION
The cover fragment would hide both podcast and episode names in small
screen devices or multi-window mode.

This replaces the deprecated PercentRelativeLayout in favor of a regular
LinearLayout with weights to make sure that each section of the fragment
(podcast title, image, episode name) will have the necessary space in
the screen.

Since PercentRelativeLayout was only being used here, it also removes
the dependencies from the gradle files.

Closes: #3169