### PR TITLE
Prevent actionbar items from moving when searching for episodes

### DIFF
--- a/app/src/main/res/menu/episodes.xml
+++ b/app/src/main/res/menu/episodes.xml
@@ -6,7 +6,7 @@
     <item
         android:id="@+id/action_search"
         android:icon="?attr/action_search"
-        custom:showAsAction="always"
+        custom:showAsAction="collapseActionView|ifRoom"
         custom:actionViewClass="android.support.v7.widget.SearchView"
         android:title="@string/search_label"/>
 
@@ -14,7 +14,7 @@
         android:id="@+id/refresh_item"
         android:title="@string/refresh_label"
         android:menuCategory="container"
-        custom:showAsAction="always"
+        custom:showAsAction="ifRoom"
         android:icon="?attr/navigation_refresh"/>
 
     <item


### PR DESCRIPTION
Previously, when the user clicked the search button, the context menu
would be hidden and the refresh button would move way too close to the
edge of the screen.

This makes sure that when a user clicks the search button on the
episodes screen, the remaining actionbar items (refresh and context
menu) stay where they are.