### PR TITLE
Reorganize fragment lifecycle

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -309,21 +309,19 @@ public class AllEpisodesFragment extends Fragment {
         emptyView.attachToRecyclerView(recyclerView);
         emptyView.setTitle(R.string.no_all_episodes_head_label);
         emptyView.setMessage(R.string.no_all_episodes_label);
-        emptyView.hide();
 
-        createRecycleAdapter();
+        createRecycleAdapter(recyclerView, emptyView);
+        emptyView.hide();
 
         return root;
     }
 
-    private void onFragmentLoaded() {
-        if (episodes.size() > 0) {
-            recyclerView.setVisibility(View.VISIBLE);
-            listAdapter.notifyDataSetChanged();
-        } else {
-            createRecycleAdapter();
-            recyclerView.setVisibility(View.GONE);
-            emptyView.updateAdapter(listAdapter);
+    private void onFragmentLoaded(List<FeedItem> episodes) {
+        this.episodes = episodes;
+        listAdapter.notifyDataSetChanged();
+
+        if (episodes.size() == 0) {
+            createRecycleAdapter(recyclerView, emptyView);
         }
 
         restoreScrollPosition();
@@ -334,12 +332,12 @@ public class AllEpisodesFragment extends Fragment {
      * Currently, we need to recreate the list adapter in order to be able to undo last item via the
      * snackbar. See #3084 for details.
      */
-    private void createRecycleAdapter() {
+    private void createRecycleAdapter(RecyclerView recyclerView, EmptyViewHandler emptyViewHandler) {
         MainActivity mainActivity = (MainActivity) getActivity();
         listAdapter = new AllEpisodesRecycleAdapter(mainActivity, itemAccess, showOnlyNewEpisodes());
         listAdapter.setHasStableIds(true);
         recyclerView.setAdapter(listAdapter);
-        emptyView.updateAdapter(listAdapter);
+        emptyViewHandler.updateAdapter(listAdapter);
     }
 
     private final AllEpisodesRecycleAdapter.ItemAccess itemAccess = new AllEpisodesRecycleAdapter.ItemAccess() {
@@ -455,10 +453,8 @@ public class AllEpisodesFragment extends Fragment {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(data -> {
-                    recyclerView.setVisibility(View.VISIBLE);
                     progLoading.setVisibility(View.GONE);
-                    episodes = data;
-                    onFragmentLoaded();
+                    onFragmentLoaded(data);
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -21,10 +21,13 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.List;
 
@@ -50,15 +53,11 @@ import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
 import de.danoeh.antennapod.menuhandler.MenuItemUtils;
-
 import de.danoeh.antennapod.view.EmptyViewHandler;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
-import org.greenrobot.eventbus.ThreadMode;
 
 /**
  * Shows unread or recently published episodes
@@ -93,8 +92,13 @@ public class AllEpisodesFragment extends Fragment {
     Disposable disposable;
     private LinearLayoutManager layoutManager;
 
-    boolean showOnlyNewEpisodes() { return false; }
-    String getPrefName() { return DEFAULT_PREF_NAME; }
+    boolean showOnlyNewEpisodes() {
+        return false;
+    }
+
+    String getPrefName() {
+        return DEFAULT_PREF_NAME;
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -146,7 +150,7 @@ public class AllEpisodesFragment extends Fragment {
         int firstItem = layoutManager.findFirstVisibleItemPosition();
         View firstItemView = layoutManager.findViewByPosition(firstItem);
         float topOffset;
-        if(firstItemView == null) {
+        if (firstItemView == null) {
             topOffset = 0;
         } else {
             topOffset = firstItemView.getTop();
@@ -184,7 +188,7 @@ public class AllEpisodesFragment extends Fragment {
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if(!isAdded()) {
+        if (!isAdded()) {
             return;
         }
         super.onCreateOptionsMenu(menu, inflater);
@@ -220,7 +224,7 @@ public class AllEpisodesFragment extends Fragment {
             markAllRead.setVisible(!showOnlyNewEpisodes() && episodes != null && !episodes.isEmpty());
         }
         MenuItem markAllSeen = menu.findItem(R.id.mark_all_seen_item);
-        if(markAllSeen != null) {
+        if (markAllSeen != null) {
             markAllSeen.setVisible(showOnlyNewEpisodes() && episodes != null && !episodes.isEmpty());
         }
     }
@@ -275,10 +279,10 @@ public class AllEpisodesFragment extends Fragment {
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         Log.d(TAG, "onContextItemSelected() called with: " + "item = [" + item + "]");
-        if(!isVisible()) {
+        if (!isVisible()) {
             return false;
         }
-        if(item.getItemId() == R.id.share_item) {
+        if (item.getItemId() == R.id.share_item) {
             return true; // avoids that the position is reset when we need it in the submenu
         }
 
@@ -387,11 +391,11 @@ public class AllEpisodesFragment extends Fragment {
 
         @Override
         public LongList getItemsIds() {
-            if(episodes == null) {
+            if (episodes == null) {
                 return new LongList(0);
             }
             LongList ids = new LongList(episodes.size());
-            for(FeedItem episode : episodes) {
+            for (FeedItem episode : episodes) {
                 ids.add(episode.getId());
             }
             return ids;
@@ -418,11 +422,11 @@ public class AllEpisodesFragment extends Fragment {
         @Override
         public LongList getQueueIds() {
             LongList queueIds = new LongList();
-            if(episodes == null) {
+            if (episodes == null) {
                 return queueIds;
             }
-            for(FeedItem item : episodes) {
-                if(item.isTagged(FeedItem.TAG_QUEUE)) {
+            for (FeedItem item : episodes) {
+                if (item.isTagged(FeedItem.TAG_QUEUE)) {
                     queueIds.add(item.getId());
                 }
             }
@@ -464,16 +468,16 @@ public class AllEpisodesFragment extends Fragment {
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
         if (isMenuInvalidationAllowed && isUpdatingFeeds != update.feedIds.length > 0) {
-                getActivity().supportInvalidateOptionsMenu();
+            getActivity().supportInvalidateOptionsMenu();
         }
         if (listAdapter == null) {
             loadItems();
             return;
         }
         if (update.mediaIds.length > 0) {
-            for(long mediaId : update.mediaIds) {
+            for (long mediaId : update.mediaIds) {
                 int pos = FeedItemUtil.indexOfItemWithMediaId(episodes, mediaId);
-                if(pos >= 0) {
+                if (pos >= 0) {
                     listAdapter.notifyItemChanged(pos);
                 }
             }
@@ -537,7 +541,7 @@ public class AllEpisodesFragment extends Fragment {
         DBWriter.markItemPlayed(FeedItem.UNPLAYED, item.getId());
 
         final Handler h = new Handler(getActivity().getMainLooper());
-        final Runnable r  = () -> {
+        final Runnable r = () -> {
             FeedMedia media = item.getMedia();
             if (media != null && media.hasAlmostEnded() && UserPreferences.isAutoDelete()) {
                 DBWriter.deleteFeedMediaOfItem(getActivity(), media.getId());
@@ -552,7 +556,6 @@ public class AllEpisodesFragment extends Fragment {
             h.removeCallbacks(r);
         });
         snackbar.show();
-        h.postDelayed(r, (int)Math.ceil(snackbar.getDuration() * 1.05f));
+        h.postDelayed(r, (int) Math.ceil(snackbar.getDuration() * 1.05f));
     }
-
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -134,11 +134,11 @@ public class CompletedDownloadsFragment extends ListFragment {
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if(!isAdded()) {
+        if (!isAdded()) {
             return;
         }
         super.onCreateOptionsMenu(menu, inflater);
-        if(items != null) {
+        if (items != null) {
             inflater.inflate(R.menu.downloads_completed, menu);
             menu.findItem(R.id.episode_actions).setVisible(items.size() > 0);
         }
@@ -202,7 +202,7 @@ public class CompletedDownloadsFragment extends ListFragment {
                     if (viewCreated && getActivity() != null) {
                         onFragmentLoaded();
                     }
-                }, error ->  Log.e(TAG, Log.getStackTraceString(error)));
+                }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -100,22 +100,27 @@ public class CompletedDownloadsFragment extends ListFragment {
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-        // add padding
-        final ListView lv = getListView();
-        lv.setClipToPadding(false);
-        final int vertPadding = getResources().getDimensionPixelSize(R.dimen.list_vertical_padding);
-        lv.setPadding(0, vertPadding, 0, vertPadding);
+        addVerticalPadding();
+        addEmptyView();
 
         viewCreated = true;
         if (items != null && getActivity() != null) {
             onFragmentLoaded();
         }
+    }
 
+    private void addEmptyView() {
         EmptyViewHandler emptyView = new EmptyViewHandler(getActivity());
         emptyView.setTitle(R.string.no_comp_downloads_head_label);
         emptyView.setMessage(R.string.no_comp_downloads_label);
         emptyView.attachToListView(getListView());
+    }
+
+    private void addVerticalPadding() {
+        final ListView lv = getListView();
+        lv.setClipToPadding(false);
+        final int vertPadding = getResources().getDimensionPixelSize(R.dimen.list_vertical_padding);
+        lv.setPadding(0, vertPadding, 0, vertPadding);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.fragment;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ListFragment;
 import android.util.Log;
 import android.view.Menu;
@@ -26,6 +27,9 @@ import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
+
+import static de.danoeh.antennapod.dialog.EpisodesApplyActionFragment.ACTION_ADD_TO_QUEUE;
+import static de.danoeh.antennapod.dialog.EpisodesApplyActionFragment.ACTION_DELETE;
 
 /**
  * Displays all running downloads and provides a button to delete them
@@ -94,7 +98,7 @@ public class CompletedDownloadsFragment extends ListFragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         // add padding
@@ -119,7 +123,7 @@ public class CompletedDownloadsFragment extends ListFragment {
         super.onListItemClick(l, v, position, id);
         position -= l.getHeaderViewsCount();
         long[] ids = FeedItemUtil.getIds(items);
-        ((MainActivity) getActivity()).loadChildFragment(ItemFragment.newInstance(ids, position));
+        ((MainActivity) requireActivity()).loadChildFragment(ItemFragment.newInstance(ids, position));
     }
 
     private void onFragmentLoaded() {
@@ -129,7 +133,7 @@ public class CompletedDownloadsFragment extends ListFragment {
         }
         setListShown(true);
         listAdapter.notifyDataSetChanged();
-        getActivity().supportInvalidateOptionsMenu();
+        requireActivity().invalidateOptionsMenu();
     }
 
     @Override
@@ -146,15 +150,12 @@ public class CompletedDownloadsFragment extends ListFragment {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.episode_actions:
-                EpisodesApplyActionFragment fragment = EpisodesApplyActionFragment
-                        .newInstance(items, EpisodesApplyActionFragment.ACTION_DELETE | EpisodesApplyActionFragment.ACTION_ADD_TO_QUEUE);
-                ((MainActivity) getActivity()).loadChildFragment(fragment);
-                return true;
-            default:
-                return false;
+        if (item.getItemId() == R.id.episode_actions) {
+            ((MainActivity) requireActivity())
+                    .loadChildFragment(EpisodesApplyActionFragment.newInstance(items, ACTION_DELETE | ACTION_ADD_TO_QUEUE));
+            return true;
         }
+        return false;
     }
 
     private final DownloadedEpisodesListAdapter.ItemAccess itemAccess = new DownloadedEpisodesListAdapter.ItemAccess() {
@@ -174,7 +175,7 @@ public class CompletedDownloadsFragment extends ListFragment {
 
         @Override
         public void onFeedItemSecondaryAction(FeedItem item) {
-            DBWriter.deleteFeedMediaOfItem(getActivity(), item.getMedia().getId());
+            DBWriter.deleteFeedMediaOfItem(requireActivity(), item.getMedia().getId());
         }
     };
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
@@ -8,7 +8,8 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
+
+import org.greenrobot.eventbus.Subscribe;
 
 import java.util.List;
 
@@ -18,15 +19,11 @@ import de.danoeh.antennapod.core.event.FavoritesEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
-import org.greenrobot.eventbus.Subscribe;
-import org.greenrobot.eventbus.ThreadMode;
-
 
 /**
  * Like 'EpisodesFragment' except that it only shows favorite episodes and
  * supports swiping to remove from favorites.
  */
-
 public class FavoriteEpisodesFragment extends AllEpisodesFragment {
 
     private static final String TAG = "FavoriteEpisodesFrag";
@@ -34,10 +31,14 @@ public class FavoriteEpisodesFragment extends AllEpisodesFragment {
     private static final String PREF_NAME = "PrefFavoriteEpisodesFragment";
 
     @Override
-    protected boolean showOnlyNewEpisodes() { return true; }
+    protected boolean showOnlyNewEpisodes() {
+        return true;
+    }
 
     @Override
-    protected String getPrefName() { return PREF_NAME; }
+    protected String getPrefName() {
+        return PREF_NAME;
+    }
 
     @Subscribe
     public void onEvent(FavoritesEvent event) {
@@ -65,7 +66,7 @@ public class FavoriteEpisodesFragment extends AllEpisodesFragment {
 
             @Override
             public void onSwiped(RecyclerView.ViewHolder viewHolder, int swipeDir) {
-                AllEpisodesRecycleAdapter.Holder holder = (AllEpisodesRecycleAdapter.Holder)viewHolder;
+                AllEpisodesRecycleAdapter.Holder holder = (AllEpisodesRecycleAdapter.Holder) viewHolder;
                 Log.d(TAG, "remove(" + holder.getItemId() + ")");
 
                 if (disposable != null) {
@@ -75,8 +76,7 @@ public class FavoriteEpisodesFragment extends AllEpisodesFragment {
                 if (item != null) {
                     DBWriter.removeFavoriteItem(item);
 
-                    Snackbar snackbar = Snackbar.make(root, getString(R.string.removed_item),
-                            Snackbar.LENGTH_LONG);
+                    Snackbar snackbar = Snackbar.make(root, getString(R.string.removed_item), Snackbar.LENGTH_LONG);
                     snackbar.setAction(getString(R.string.undo), v -> DBWriter.addFavoriteItem(item));
                     snackbar.show();
                 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.fragment;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
@@ -27,7 +28,6 @@ import de.danoeh.antennapod.core.storage.DBWriter;
 public class FavoriteEpisodesFragment extends AllEpisodesFragment {
 
     private static final String TAG = "FavoriteEpisodesFrag";
-
     private static final String PREF_NAME = "PrefFavoriteEpisodesFragment";
 
     @Override
@@ -42,19 +42,14 @@ public class FavoriteEpisodesFragment extends AllEpisodesFragment {
 
     @Subscribe
     public void onEvent(FavoritesEvent event) {
-        Log.d(TAG, "onEvent() called with: " + "event = [" + event + "]");
+        Log.d(TAG, String.format("onEvent() called with: event = [%s]", event));
         loadItems();
     }
 
+    @NonNull
     @Override
-    protected void resetViewState() {
-        super.resetViewState();
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View root = super.onCreateViewHelper(inflater, container, savedInstanceState,
-                R.layout.all_episodes_fragment);
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View root = super.onCreateView(inflater, container, savedInstanceState);
         emptyView.setTitle(R.string.no_fav_episodes_head_label);
         emptyView.setMessage(R.string.no_fav_episodes_label);
 
@@ -67,7 +62,7 @@ public class FavoriteEpisodesFragment extends AllEpisodesFragment {
             @Override
             public void onSwiped(RecyclerView.ViewHolder viewHolder, int swipeDir) {
                 AllEpisodesRecycleAdapter.Holder holder = (AllEpisodesRecycleAdapter.Holder) viewHolder;
-                Log.d(TAG, "remove(" + holder.getItemId() + ")");
+                Log.d(TAG, String.format("remove(%s)", holder.getItemId()));
 
                 if (disposable != null) {
                     disposable.dispose();
@@ -88,6 +83,7 @@ public class FavoriteEpisodesFragment extends AllEpisodesFragment {
         return root;
     }
 
+    @NonNull
     @Override
     protected List<FeedItem> loadData() {
         return DBReader.getFavoriteItemsList();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -36,6 +36,9 @@ import com.joanzapata.iconify.Iconify;
 import com.joanzapata.iconify.widget.IconButton;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.List;
 
@@ -71,9 +74,6 @@ import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
-import org.greenrobot.eventbus.ThreadMode;
 
 /**
  * Displays information about a FeedItem and actions.
@@ -266,7 +266,6 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        load();
     }
 
     @Override
@@ -274,6 +273,7 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
         super.onStart();
         EventDistributor.getInstance().register(contentUpdate);
         EventBus.getDefault().register(this);
+        load();
     }
 
     @Override
@@ -306,19 +306,20 @@ public class ItemFragment extends Fragment implements OnSwipeGesture {
 
     @Override
     public boolean onSwipeLeftToRight() {
-        Log.d(TAG, "onSwipeLeftToRight()");
-        feedItemPos = feedItemPos - 1;
-        if(feedItemPos < 0) {
-            feedItemPos = feedItems.length - 1;
-        }
-        load();
-        return true;
+        return swipeFeedItem(-1);
     }
 
     @Override
     public boolean onSwipeRightToLeft() {
-        Log.d(TAG, "onSwipeRightToLeft()");
-        feedItemPos = (feedItemPos + 1) % feedItems.length;
+        return swipeFeedItem(+1);
+    }
+
+    private boolean swipeFeedItem(int position) {
+        Log.d(TAG, String.format("onSwipe() shift: %s", position));
+        feedItemPos = (feedItemPos + position) % feedItems.length;
+        if (feedItemPos < 0) {
+            feedItemPos = feedItems.length - 1;
+        }
         load();
         return true;
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -3,34 +3,35 @@ package de.danoeh.antennapod.fragment;
 import android.os.Bundle;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
+
 import java.util.List;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.AllEpisodesRecycleAdapter;
-import de.danoeh.antennapod.core.event.FeedItemEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.storage.DBReader;
-import de.danoeh.antennapod.core.util.FeedItemUtil;
-
 
 /**
  * Like 'EpisodesFragment' except that it only shows new episodes and
  * supports swiping to mark as read.
  */
-
 public class NewEpisodesFragment extends AllEpisodesFragment {
 
     public static final String TAG = "NewEpisodesFragment";
     private static final String PREF_NAME = "PrefNewEpisodesFragment";
-    @Override
-    protected boolean showOnlyNewEpisodes() { return true; }
 
     @Override
-    protected String getPrefName() { return PREF_NAME; }
+    protected boolean showOnlyNewEpisodes() {
+        return true;
+    }
+
+    @Override
+    protected String getPrefName() {
+        return PREF_NAME;
+    }
 
     @Override
     protected void resetViewState() {
@@ -57,7 +58,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
 
             @Override
             public void onSwiped(RecyclerView.ViewHolder viewHolder, int swipeDir) {
-                AllEpisodesRecycleAdapter.Holder holder = (AllEpisodesRecycleAdapter.Holder)viewHolder;
+                AllEpisodesRecycleAdapter.Holder holder = (AllEpisodesRecycleAdapter.Holder) viewHolder;
                 markItemAsSeenWithUndo(holder.getFeedItem());
             }
 
@@ -75,6 +76,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
 
                 super.onSelectedChanged(viewHolder, actionState);
             }
+
             @Override
             public void clearView(RecyclerView recyclerView,
                                   RecyclerView.ViewHolder viewHolder) {
@@ -98,5 +100,4 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
     protected List<FeedItem> loadData() {
         return DBReader.getNewItemsList();
     }
-
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NewEpisodesFragment.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.fragment;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.LayoutInflater;
@@ -34,19 +35,14 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
     }
 
     @Override
-    protected void resetViewState() {
-        super.resetViewState();
-    }
-
-    @Override
     protected boolean shouldUpdatedItemRemainInList(FeedItem item) {
         return item.isNew();
     }
 
+    @NonNull
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View root = super.onCreateViewHelper(inflater, container, savedInstanceState,
-                R.layout.all_episodes_fragment);
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View root = super.onCreateView(inflater, container, savedInstanceState);
         emptyView.setTitle(R.string.no_new_episodes_head_label);
         emptyView.setMessage(R.string.no_new_episodes_label);
 
@@ -96,6 +92,7 @@ public class NewEpisodesFragment extends AllEpisodesFragment {
         return root;
     }
 
+    @NonNull
     @Override
     protected List<FeedItem> loadData() {
         return DBReader.getNewItemsList();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/RunningDownloadsFragment.java
@@ -7,6 +7,10 @@ import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.ArrayList;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
@@ -21,8 +25,6 @@ import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.view.EmptyViewHandler;
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
 
 /**
  * Displays all running downloads and provides actions to cancel them
@@ -32,7 +34,7 @@ public class RunningDownloadsFragment extends ListFragment {
     private static final String TAG = "RunningDownloadsFrag";
 
     private DownloadlistAdapter adapter;
-    private List<Downloader> downloaderList;
+    private List<Downloader> downloaderList = new ArrayList<>();
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
@@ -70,7 +72,6 @@ public class RunningDownloadsFragment extends ListFragment {
     public void onDestroy() {
         super.onDestroy();
         setListAdapter(null);
-        adapter = null;
     }
 
     @Subscribe(sticky = true)
@@ -78,21 +79,18 @@ public class RunningDownloadsFragment extends ListFragment {
         Log.d(TAG, "onEvent() called with: " + "event = [" + event + "]");
         DownloaderUpdate update = event.update;
         downloaderList = update.downloaders;
-        if (adapter != null) {
-            adapter.notifyDataSetChanged();
-        }
+        adapter.notifyDataSetChanged();
     }
-
 
     private final DownloadlistAdapter.ItemAccess itemAccess = new DownloadlistAdapter.ItemAccess() {
         @Override
         public int getCount() {
-            return (downloaderList != null) ? downloaderList.size() : 0;
+            return downloaderList.size();
         }
 
         @Override
         public Downloader getItem(int position) {
-            if (downloaderList != null && 0 <= position && position < downloaderList.size()) {
+            if (0 <= position && position < downloaderList.size()) {
                 return downloaderList.get(position);
             } else {
                 return null;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -14,6 +14,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
@@ -40,11 +41,7 @@ public class SearchFragment extends ListFragment {
     private static final String ARG_FEED = "feed";
 
     private SearchlistAdapter searchAdapter;
-    private List<SearchResult> searchResults;
-
-    private boolean viewCreated = false;
-    private boolean itemsLoaded = false;
-
+    private List<SearchResult> searchResults = new ArrayList<>();
     private Disposable disposable;
 
     /**
@@ -74,13 +71,13 @@ public class SearchFragment extends ListFragment {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
         setHasOptionsMenu(true);
-        search();
     }
 
     @Override
     public void onStart() {
         super.onStart();
         EventDistributor.getInstance().register(contentUpdate);
+        search();
     }
 
     @Override
@@ -90,21 +87,6 @@ public class SearchFragment extends ListFragment {
             disposable.dispose();
         }
         EventDistributor.getInstance().unregister(contentUpdate);
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        if(disposable != null) {
-            disposable.dispose();
-        }
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        searchAdapter = null;
-        viewCreated = false;
     }
 
     @Override
@@ -118,10 +100,9 @@ public class SearchFragment extends ListFragment {
         lv.setPadding(0, vertPadding, 0, vertPadding);
 
         ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(R.string.search_label);
-        viewCreated = true;
-        if (itemsLoaded) {
-            onFragmentLoaded();
-        }
+
+        searchAdapter = new SearchlistAdapter(getActivity(), itemAccess);
+        setListAdapter(searchAdapter);
     }
 
     @Override
@@ -142,28 +123,26 @@ public class SearchFragment extends ListFragment {
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        if (itemsLoaded) {
-            MenuItem item = menu.add(Menu.NONE, R.id.search_item, Menu.NONE, R.string.search_label);
-            MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
-            final SearchView sv = new SearchView(getActivity());
-            sv.setQueryHint(getString(R.string.search_hint));
-            sv.setQuery(getArguments().getString(ARG_QUERY), false);
-            sv.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-                @Override
-                public boolean onQueryTextSubmit(String s) {
-                    getArguments().putString(ARG_QUERY, s);
-                    itemsLoaded = false;
-                    search();
-                    return true;
-                }
+        MenuItem item = menu.add(Menu.NONE, R.id.search_item, Menu.NONE, R.string.search_label);
+        MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
+        final SearchView sv = new SearchView(getActivity());
+        sv.setQueryHint(getString(R.string.search_hint));
+        sv.setQuery(getArguments().getString(ARG_QUERY), false);
+        sv.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String s) {
+                sv.clearFocus();
+                getArguments().putString(ARG_QUERY, s);
+                search();
+                return true;
+            }
 
-                @Override
-                public boolean onQueryTextChange(String s) {
-                    return false;
-                }
-            });
-            MenuItemCompat.setActionView(item, sv);
-        }
+            @Override
+            public boolean onQueryTextChange(String s) {
+                return false;
+            }
+        });
+        MenuItemCompat.setActionView(item, sv);
     }
 
     private final EventDistributor.EventListener contentUpdate = new EventDistributor.EventListener() {
@@ -176,14 +155,9 @@ public class SearchFragment extends ListFragment {
         }
     };
 
-    private void onFragmentLoaded() {
-        if (searchAdapter == null) {
-            searchAdapter = new SearchlistAdapter(getActivity(), itemAccess);
-            setListAdapter(searchAdapter);
-        }
+    private void onSearchResults(List<SearchResult> results) {
+        searchResults = results;
         searchAdapter.notifyDataSetChanged();
-        setListShown(true);
-
         String query = getArguments().getString(ARG_QUERY);
         setEmptyText(getString(R.string.no_results_for_query, query));
     }
@@ -191,12 +165,12 @@ public class SearchFragment extends ListFragment {
     private final SearchlistAdapter.ItemAccess itemAccess = new SearchlistAdapter.ItemAccess() {
         @Override
         public int getCount() {
-            return (searchResults != null) ? searchResults.size() : 0;
+            return searchResults.size();
         }
 
         @Override
         public SearchResult getItem(int position) {
-            if (searchResults != null && 0 <= position && position < searchResults.size()) {
+            if (0 <= position && position < searchResults.size()) {
                 return searchResults.get(position);
             } else {
                 return null;
@@ -204,24 +178,14 @@ public class SearchFragment extends ListFragment {
         }
     };
 
-
     private void search() {
         if(disposable != null) {
             disposable.dispose();
         }
-        if (viewCreated && !itemsLoaded) {
-            setListShown(false);
-        }
         disposable = Observable.fromCallable(this::performSearch)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(result -> {
-                    itemsLoaded = true;
-                    searchResults = result;
-                    if (viewCreated) {
-                        onFragmentLoaded();
-                    }
-                }, error -> Log.e(TAG, Log.getStackTraceString(error)));
+                .subscribe(this::onSearchResults, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 
     @NonNull
@@ -232,5 +196,4 @@ public class SearchFragment extends ListFragment {
         Context context = getActivity();
         return FeedSearcher.performSearch(context, query, feed);
     }
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/event/DownloaderUpdate.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/event/DownloaderUpdate.java
@@ -1,5 +1,7 @@
 package de.danoeh.antennapod.core.event;
 
+import android.support.annotation.NonNull;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -11,6 +13,7 @@ import de.danoeh.antennapod.core.util.LongList;
 public class DownloaderUpdate {
 
     /* Downloaders that are currently running */
+    @NonNull
     public final List<Downloader> downloaders;
 
     /**
@@ -25,7 +28,7 @@ public class DownloaderUpdate {
      */
     public final long[] mediaIds;
 
-    public DownloaderUpdate(List<Downloader> downloaders) {
+    DownloaderUpdate(@NonNull List<Downloader> downloaders) {
         this.downloaders = downloaders;
         LongList feedIds1 = new LongList(), mediaIds1 = new LongList();
         for(Downloader d1 : downloaders) {


### PR DESCRIPTION
Unregistering from the EventDistributor on stop will prevent the screen
from updating when coming back from the off screen (#2747 and #3203),
so this registers/unregisters on start/stop while also making sure that
the screen is reloaded on start.

Therefore, we need to also call `loadItems()` (or the equivalent method
 of the fragment) to make sure that when we come back from an off screen
it is updated appropriately.

It also makes sure we take advantage of the native fragment lifecycle [[1]]
instead of storing state about whether views have been created and attributes
have been assigned.

[1]: https://developer.android.com/guide/components/fragments

Closes: #2747
Closes: #3203