### PR TITLE
Avoid error delivery to disposed Disposable

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.SearchView;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -106,7 +107,7 @@ public class ItunesSearchFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View root = inflater.inflate(R.layout.fragment_itunes_search, container, false);
@@ -146,7 +147,9 @@ public class ItunesSearchFragment extends Fragment {
                                     emitter.onError(new IOException(prefix + response));
                                 }
                             } catch (IOException | JSONException e) {
-                                emitter.onError(e);
+                                if (!disposable.isDisposed()) {
+                                    emitter.onError(e);
+                                }
                             }
                         })
                         .subscribeOn(Schedulers.io())
@@ -249,7 +252,9 @@ public class ItunesSearchFragment extends Fragment {
                         List<Podcast> podcasts = parseFeed(feedString);
                         emitter.onSuccess(podcasts);
                     } catch (IOException | JSONException e) {
-                        emitter.onError(e);
+                        if (!disposable.isDisposed()) {
+                            emitter.onError(e);
+                        }
                     }
                 })
                 .subscribeOn(Schedulers.io())


### PR DESCRIPTION
If the iTunes fragment is disposed (e.g. if the user navigated away) while the iTunes list is still loading, or while the metadata for a particular podcast is loading, an `InterruptedIOException` will be thrown and delivered to an error handling lambda. However, said lambda is part of a `Disposable` belonging to the fragment which, at the point of delivering this error, will have been cleaned up. This causes RxJava framework to throw an uncaught `UndeliverableException`, which terminates the app.

Thanks @ByteHamster for the stack trace :)

Fixes #3196.