### PR TITLE
Fix scheduling tasks on shutdown executor

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
@@ -229,6 +229,15 @@ public class PlaybackServiceTaskManagerTest {
     }
 
     @Test
+    public void testStartWidgetUpdaterAfterShutdown() {
+        // Should not throw.
+        final Context c = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
+        pstm.shutdown();
+        pstm.startWidgetUpdater();
+    }
+
+    @Test
     public void testIsWidgetUpdaterActive() {
         final Context c = InstrumentationRegistry.getInstrumentation().getTargetContext();
         PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -165,7 +165,7 @@ public class PlaybackServiceTaskManager {
      * Starts the widget updater task. If the widget updater is already active, nothing will happen.
      */
     public synchronized void startWidgetUpdater() {
-        if (!isWidgetUpdaterActive()) {
+        if (!isWidgetUpdaterActive() && !schedExecutor.isShutdown()) {
             Runnable widgetUpdater = callback::onWidgetUpdaterTick;
             widgetUpdater = useMainThreadIfNecessary(widgetUpdater);
             widgetUpdaterFuture = schedExecutor.scheduleWithFixedDelay(widgetUpdater, WIDGET_UPDATER_NOTIFICATION_INTERVAL,


### PR DESCRIPTION
According to the stack trace provided by @ByteHamster on #3197, the `ScheduleThreadPoolExecutor` is rejecting the task to start the widget updater. I'm guessing the executor was shut down based on the stack trace and [OpenJDK's source](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/ScheduledThreadPoolExecutor.java) for `ScheduledThreadPoolExecutor`.

What I'm guessing is happening is a race between the `PlaybackService` initiating shutdown after being destroyed by the system, and a media playback event that starts the widget updater back up. I've added a failing test as a first commit to confirm this, and the fix commit also makes the test pass.

Fixes #3197.