### PR TITLE
Fixed compilation errors

### DIFF
--- a/app/src/free/java/de/danoeh/antennapod/preferences/PreferenceControllerFlavorHelper.java
+++ b/app/src/free/java/de/danoeh/antennapod/preferences/PreferenceControllerFlavorHelper.java
@@ -1,11 +1,12 @@
 package de.danoeh.antennapod.preferences;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.fragment.preferences.PlaybackPreferencesFragment;
 
 /**
  * Implements functions from PreferenceController that are flavor dependent.
  */
-class PreferenceControllerFlavorHelper {
+public class PreferenceControllerFlavorHelper {
 
     public static void setupFlavoredUI(PlaybackPreferencesFragment ui) {
         ui.findPreference(UserPreferences.PREF_CAST_ENABLED).setEnabled(false);


### PR DESCRIPTION
The build was failing because of a missing import and a non-public helper class.