### PR TITLE
Pad scrubber on large devices

### DIFF
--- a/app/src/main/res/layout/mediaplayerinfo_activity.xml
+++ b/app/src/main/res/layout/mediaplayerinfo_activity.xml
@@ -51,11 +51,13 @@
             android:orientation="vertical">
 
 
-                <RelativeLayout
+            <RelativeLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:paddingTop="@dimen/scrubber_vertical_padding"
+                    android:paddingBottom="@dimen/scrubber_vertical_padding">
 
-                    <TextView
+                <TextView
                         android:id="@+id/txtvPosition"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -67,9 +69,9 @@
                         android:text="@string/position_default_label"
                         android:textColor="?android:attr/textColorSecondary"
                         android:textSize="@dimen/text_size_micro"
-                        tools:background="@android:color/holo_green_dark" />
+                        tools:background="@android:color/holo_green_dark"/>
 
-                    <TextView
+                <TextView
                         android:id="@+id/txtvLength"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -81,9 +83,9 @@
                         android:text="@string/position_default_label"
                         android:textColor="?android:attr/textColorSecondary"
                         android:textSize="@dimen/text_size_micro"
-                        tools:background="@android:color/holo_green_dark" />
+                        tools:background="@android:color/holo_green_dark"/>
 
-                    <SeekBar
+                <SeekBar
                         android:id="@+id/sbPosition"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
@@ -97,9 +99,9 @@
                         android:layout_toRightOf="@id/txtvPosition"
                         android:layout_toEndOf="@id/txtvPosition"
                         android:max="500"
-                        tools:background="@android:color/holo_green_dark" />
+                        tools:background="@android:color/holo_green_dark"/>
 
-                </RelativeLayout>
+            </RelativeLayout>
 
             <RelativeLayout
                 android:id="@+id/player_control"

--- a/core/src/main/res/values-h768dp/dimens.xml
+++ b/core/src/main/res/values-h768dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="scrubber_vertical_padding">12dp</dimen>
+</resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -40,4 +40,6 @@
     <dimen name="media_router_controller_playback_control_start_padding">24dp</dimen>
     <dimen name="media_router_controller_bottom_margin">8dp</dimen>
 
+    <dimen name="scrubber_vertical_padding">0dp</dimen>
+
 </resources>


### PR DESCRIPTION
Extracts the scrub bar to a separate layout and adds vertical padding to the scrub bar on large devices.
**NOTE**: this PR is based on #3232 .

## "Normal" device
![Screenshot_1560528952](https://user-images.githubusercontent.com/569991/59523227-0681f500-8ed1-11e9-8cbd-293aa79455f4.png)

## Large device, _before_
![Screenshot_1560529265](https://user-images.githubusercontent.com/569991/59523338-4d6fea80-8ed1-11e9-86b2-15aa971ea17d.png)

## Large device, _after_
![Screenshot_1560528989](https://user-images.githubusercontent.com/569991/59523229-097ce580-8ed1-11e9-87f4-40f6ce24e750.png)



Fixes #3201.