### PR TITLE
Validate username for characters not accepted.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/gpoddernet/GpodnetAuthenticationActivity.java
@@ -25,6 +25,8 @@ import android.widget.ViewFlipper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
@@ -123,6 +125,11 @@ public class GpodnetAuthenticationActivity extends AppCompatActivity {
                 final String usernameStr = username.getText().toString();
                 final String passwordStr = password.getText().toString();
 
+                if (usernameHasUnwantedChars(usernameStr)) {
+                    txtvError.setText(R.string.gpodnetsync_username_characters_error);
+                    txtvError.setVisibility(View.VISIBLE);
+                    return;
+                }
                 if (BuildConfig.DEBUG) Log.d(TAG, "Checking login credentials");
                 AsyncTask<GpodnetService, Void, Void> authTask = new AsyncTask<GpodnetService, Void, Void>() {
 
@@ -394,5 +401,11 @@ public class GpodnetAuthenticationActivity extends AppCompatActivity {
         } else {
             finish();
         }
+    }
+
+    private boolean usernameHasUnwantedChars(String username) {
+        Pattern special = Pattern.compile("[!@#$%&*()+=|<>?{}\\[\\]~]");
+        Matcher containsUnwantedChars = special.matcher(username);
+        return containsUnwantedChars.find();
     }
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -642,6 +642,7 @@
     <string name="gpodnetsync_error_descr">An error occurred during syncing:\u0020</string>
     <string name="gpodnetsync_pref_report_successful">Successful</string>
     <string name="gpodnetsync_pref_report_failed">Failed</string>
+    <string name="gpodnetsync_username_characters_error">Usernames may only contain letters, digits, hyphens and underscores.</string>
 
     <!-- Directory chooser -->
     <string name="selected_folder_label">Selected folder:</string>


### PR DESCRIPTION
Fixes #3148 

#### Description 
Provides warning when one attempts to log in to GPodder but enters unaccepted characters in the username field e.g When user enters email in username field, a warning will be provided to show that the user has entered unaccepted characters.

