### PR TITLE
Extend play/pause functionality to Image Cover

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -44,6 +44,7 @@ public class CoverFragment extends Fragment {
         txtvPodcastTitle = root.findViewById(R.id.txtvPodcastTitle);
         txtvEpisodeTitle = root.findViewById(R.id.txtvEpisodeTitle);
         imgvCover = root.findViewById(R.id.imgvCover);
+        imgvCover.setOnClickListener(v -> onPlayPause());
         return root;
     }
 
@@ -113,5 +114,12 @@ public class CoverFragment extends Fragment {
         if (disposable != null) {
             disposable.dispose();
         }
+    }
+
+    void onPlayPause() {
+        if (controller == null) {
+            return;
+        }
+        controller.playPause();
     }
 }

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -26,7 +26,8 @@
         android:contentDescription="@string/cover_label"
         android:scaleType="fitCenter"
         android:transitionName="coverTransition"
-        tools:src="@android:drawable/sym_def_app_icon" />
+        tools:src="@android:drawable/sym_def_app_icon"
+        android:foreground="?attr/selectableItemBackground" />
 
     <TextView
         android:id="@+id/txtvEpisodeTitle"


### PR DESCRIPTION
Works on #3220

#### Description 
Extend the play/pause functionality to `image cover`. When the user taps the `image cover`  This performs the same actions as `play/pause` in the bottom control area.
