### PR TITLE
New ViewModel for loading feed preferences across lifecycle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,11 @@ dependencies {
     implementation "com.android.support:gridlayout-v7:$supportVersion"
     implementation "com.android.support:recyclerview-v7:$supportVersion"
     compileOnly 'com.google.android.wearable:wearable:2.2.0'
+
+    // ViewModel and LiveData
+    implementation "android.arch.lifecycle:extensions:$lifecycle_version"
+    annotationProcessor "android.arch.lifecycle:compiler:$lifecycle_version"
+
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
     implementation("org.shredzone.flattr4j:flattr4j-core:$flattr4jVersion") {
         exclude group: "org.json", module: "json"

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.fragment;
 
+import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -7,7 +8,6 @@ import android.support.v14.preference.SwitchPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.FeedSettingsActivity;
 import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedFilter;
@@ -16,6 +16,9 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.dialog.AuthenticationDialog;
 import de.danoeh.antennapod.dialog.EpisodeFilterDialog;
+import de.danoeh.antennapod.viewmodel.FeedSettingsViewModel;
+
+import static de.danoeh.antennapod.activity.FeedSettingsActivity.EXTRA_FEED_ID;
 
 public class FeedSettingsFragment extends PreferenceFragmentCompat {
     private static final CharSequence PREF_EPISODE_FILTER = "episodeFilter";
@@ -26,17 +29,21 @@ public class FeedSettingsFragment extends PreferenceFragmentCompat {
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.feed_settings);
 
-        feed = ((FeedSettingsActivity) getActivity()).getFeed();
-        feedPreferences = feed.getPreferences();
+        long feedId = getArguments().getLong(EXTRA_FEED_ID);
+        ViewModelProviders.of(getActivity()).get(FeedSettingsViewModel.class).getFeed(feedId)
+                .subscribe(result -> {
+                    feed = result;
+                    feedPreferences = feed.getPreferences();
 
-        setupAutoDownloadPreference();
-        setupKeepUpdatedPreference();
-        setupAutoDeletePreference();
-        setupAuthentificationPreference();
-        setupEpisodeFilterPreference();
+                    setupAutoDownloadPreference();
+                    setupKeepUpdatedPreference();
+                    setupAutoDeletePreference();
+                    setupAuthentificationPreference();
+                    setupEpisodeFilterPreference();
 
-        updateAutoDeleteSummary();
-        updateAutoDownloadEnabled();
+                    updateAutoDeleteSummary();
+                    updateAutoDownloadEnabled();
+                }).dispose();
     }
 
     private void setupEpisodeFilterPreference() {

--- a/app/src/main/java/de/danoeh/antennapod/viewmodel/FeedSettingsViewModel.java
+++ b/app/src/main/java/de/danoeh/antennapod/viewmodel/FeedSettingsViewModel.java
@@ -1,0 +1,30 @@
+package de.danoeh.antennapod.viewmodel;
+
+import android.arch.lifecycle.ViewModel;
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.storage.DBReader;
+import io.reactivex.Maybe;
+
+public class FeedSettingsViewModel extends ViewModel {
+    private Feed feed;
+
+    public Maybe<Feed> getFeed(long feedId) {
+        if (feed == null) {
+            return loadFeed(feedId);
+        } else {
+            return Maybe.just(feed);
+        }
+    }
+
+    private Maybe<Feed> loadFeed(long feedId) {
+        return Maybe.create(emitter -> {
+            Feed feed = DBReader.getFeed(feedId);
+            if (feed != null) {
+                this.feed = feed;
+                emitter.onSuccess(feed);
+            } else {
+                emitter.onComplete();
+            }
+        });
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ project.ext {
     targetSdkVersion = 26
 
     supportVersion = "27.1.1"
+    lifecycle_version = "1.1.1"
     workManagerVersion = "1.0.1"
     awaitilityVersion = "3.1.2"
     commonsioVersion = "2.5"


### PR DESCRIPTION
Currently, we're relying on the settings activity being created before the settings fragment. However, the latter will be recreated automatically on config changes, e.g. rotating the screen, at the `super.onCreate(savedInstanceState)` call.

This PR creates a new `ViewModel` for keeping Feed data around for the settings activity and fragment throughout their lifecycles, including config changes e.g. screen rotations. This effectively removes the assumption that the Activity will always control the creation of the Fragment.

Bonus: using the `ViewModel` means we don't re-read the Feed from the DB on every screen rotation. ;)

Fixes #3245.