### PR TITLE
Fix removing wrong favourite message

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -275,6 +275,9 @@ public class AllEpisodesFragment extends Fragment {
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         Log.d(TAG, "onContextItemSelected() called with: " + "item = [" + item + "]");
+        if (!getUserVisibleHint()) {
+            return false;
+        }
         if(!isVisible()) {
             return false;
         }


### PR DESCRIPTION
Fixes #3209

#### Description 

Fixes the issue when that happens when long-pressing a favourite episode, selects "Remove from favourites" and it removes the wrong episode on some occasions.