### PR TITLE
Change default rewind time to 10s

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -443,7 +443,7 @@ public class UserPreferences {
     }
 
     public static int getRewindSecs() {
-        return prefs.getInt(PREF_REWIND_SECS, 30);
+        return prefs.getInt(PREF_REWIND_SECS, 10);
     }
 
     public static String[] getAutodownloadSelectedNetworks() {


### PR DESCRIPTION
This allows the user to better search through an episode, by allowing
them to rewind less than what was just forwarded. It is also aligned
with how other apps out there behave.

Closes: #3262