### PR TITLE
Targeting Android API 28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/android:api-26-alpha
+      - image: circleci/android:api-28
 
     working_directory: ~/AntennaPod
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <supports-screens
         android:anyDensity="true"

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ subprojects {
 }
 
 project.ext {
-    compileSdkVersion = 26
+    compileSdkVersion = 28
     minSdkVersion = 14
-    targetSdkVersion = 26
+    targetSdkVersion = 28
 
     supportVersion = "27.1.1"
     lifecycle_version = "1.1.1"


### PR DESCRIPTION
Starting in November, app updates must target API 28. I went through the list of [Behavior changes](https://developer.android.com/about/versions/pie/android-9.0-changes-all) to verify that nothing is broken. Extensive testing is still needed.