### PR TITLE
Remove non-existing class from ClientConfig

### DIFF
--- a/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -39,7 +39,6 @@ public class ClientConfig {
         }
         PodDBAdapter.init(context);
         UserPreferences.init(context);
-        UpdateManager.init(context);
         PlaybackPreferences.init(context);
         NetworkUtils.init(context);
         SleepTimerPreferences.init(context);


### PR DESCRIPTION
When #3284 (Make ExoPlayer the default player) was merged [1],
`UpdateManager` was removed but a reference to it was left behind in
`ClientConfig`, which causes the project not to build.

Since its contents were integrated into `app/PreferenceUpgrader`, we no
longer need this entry here.

[1]: https://github.com/AntennaPod/AntennaPod/pull/3284