### PR TITLE
Sort automatic download wifi names ignoring case

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/AutoDownloadPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/AutoDownloadPreferencesFragment.java
@@ -88,7 +88,7 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
             return;
         }
         Collections.sort(networks, (x, y) ->
-                blankIfNull(x.SSID).compareTo(blankIfNull(y.SSID)));
+                blankIfNull(x.SSID).compareToIgnoreCase(blankIfNull(y.SSID)));
         selectedNetworks = new CheckBoxPreference[networks.size()];
         List<String> prefValues = Arrays.asList(UserPreferences
                 .getAutodownloadSelectedNetworks());


### PR DESCRIPTION
When a user has many wifi networks it can be difficult to remember if
a given network has upper- or lower-case.