### PR TITLE
Make the incorrect :app:lintVitalRelease error go away.

### DIFF
--- a/app/src/main/res/values-w300dp/dimens-fabspeeddial.xml
+++ b/app/src/main/res/values-w300dp/dimens-fabspeeddial.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- increase FAB speed dial label's max width if the screen is wide enough
          (300dp ~ 1.875 inch, devices with 3.5-inch screens have a width of ~ 1.9in
           so the setup is applicable for most phones)
          -->
-    <dimen name="sd_label_max_width">240dp</dimen>
+    <dimen name="sd_label_max_width" tools:ignore="MissingDefaultResource">240dp</dimen>
 </resources>


### PR DESCRIPTION
make the incorrect :app:lintVitalRelease error go away.

(The base named dimen comes from fab speeddial library, thus it is not actually missing)