### PR TITLE
Executing notification actions in foreground

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.media.session.MediaSessionCompat;
@@ -178,7 +179,11 @@ public class PlaybackServiceNotificationBuilder extends NotificationCompat.Build
     private PendingIntent getPendingIntentForMediaAction(int keycodeValue, int requestCode) {
         Intent intent = new Intent(context, PlaybackService.class);
         intent.putExtra(MediaButtonReceiver.EXTRA_KEYCODE, keycodeValue);
-        return PendingIntent .getService(context, requestCode,
-                intent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        if (Build.VERSION.SDK_INT >= 26) {
+            return PendingIntent.getForegroundService(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        } else {
+            return PendingIntent.getService(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        }
     }
 }


### PR DESCRIPTION
Hopefully fixes some unreproducible cases where clicking the notification buttons just does nothing.