### PR TITLE
fix batch edit: deselect all label and FAB overlay remains when deselect all

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.dialog;
 import android.app.AlertDialog;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
@@ -13,7 +12,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.util.ArrayMap;
-import android.support.v4.view.ViewCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -218,7 +216,11 @@ public class EpisodesApplyActionFragment extends Fragment {
     }
 
     private void showSpeedDialIfAnyChecked() {
-        mSpeedDialView.setVisibility(checkedIds.size() > 0 ? View.VISIBLE : View.GONE);
+        if (checkedIds.size() > 0) {
+            mSpeedDialView.show();
+        } else {
+            mSpeedDialView.hide(); // hide() also handles UI, e.g., overlay properly.
+        }
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -244,10 +244,13 @@ public class EpisodesApplyActionFragment extends Fragment {
         // Prepare icon for select toggle button
 
         int[] icon = new int[1];
+        @StringRes int titleResId;
         if (checkedIds.size() == episodes.size()) {
             icon[0] = R.attr.ic_select_none;
+            titleResId = R.string.deselect_all_label;
         } else {
             icon[0] = R.attr.ic_select_all;
+            titleResId = R.string.select_all_label;
         }
 
         TypedArray a = getActivity().obtainStyledAttributes(icon);
@@ -255,6 +258,7 @@ public class EpisodesApplyActionFragment extends Fragment {
         a.recycle();
 
         mSelectToggle.setIcon(iconDrawable);
+        mSelectToggle.setTitle(titleResId);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -217,7 +217,9 @@ public class EpisodesApplyActionFragment extends Fragment {
 
     private void showSpeedDialIfAnyChecked() {
         if (checkedIds.size() > 0) {
-            mSpeedDialView.show();
+            if (!mSpeedDialView.isShown()) {
+                mSpeedDialView.show();
+            }
         } else {
             mSpeedDialView.hide(); // hide() also handles UI, e.g., overlay properly.
         }


### PR DESCRIPTION
Closes #3373, #3374 (bundle together as both are small enough fixes to lump in the same set of files).

For #3374, arguably, a better UX will be when fab is open, the user should not be able to change the items selected, i.e., hiding all the action menu items. In such UX, the UI will prevent users from deselect all when fab is open.