### PR TITLE
Disabled gpodnet in combined search

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/discovery/CombinedSearcher.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/CombinedSearcher.java
@@ -24,7 +24,7 @@ public class CombinedSearcher implements PodcastSearcher {
     public CombinedSearcher(Context context) {
         addProvider(new FyydPodcastSearcher(), 1.f);
         addProvider(new ItunesPodcastSearcher(context), 1.f);
-        addProvider(new GpodnetPodcastSearcher(), 0.6f);
+        //addProvider(new GpodnetPodcastSearcher(), 0.6f);
     }
 
     private void addProvider(PodcastSearcher provider, float priority) {


### PR DESCRIPTION
This needs more work but for now, we can just skip gpodnet results. Gpodder returns many outdated results which is worse for most users than not finding everything. Related to #3376.