### PR TITLE
Fixed receiving audio events after service shutdown

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -350,13 +350,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 setPlayerStatus(PlayerStatus.PAUSED, media, getPosition());
 
                 if (abandonFocus) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        AudioFocusRequest.Builder builder = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
-                                .setOnAudioFocusChangeListener(audioFocusChangeListener);
-                        audioManager.abandonAudioFocusRequest(builder.build());
-                    } else {
-                        audioManager.abandonAudioFocus(audioFocusChangeListener);
-                    }
+                    abandonAudioFocus();
                     pausedBecauseOfTransientAudiofocusLoss = false;
                 }
                 if (stream && reinit) {
@@ -368,6 +362,16 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
             playerLock.unlock();
         });
+    }
+
+    private void abandonAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioFocusRequest.Builder builder = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                    .setOnAudioFocusChangeListener(audioFocusChangeListener);
+            audioManager.abandonAudioFocusRequest(builder.build());
+        } else {
+            audioManager.abandonAudioFocus(audioFocusChangeListener);
+        }
     }
 
     /**
@@ -701,6 +705,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
      */
     @Override
     public void shutdown() {
+        abandonAudioFocus();
         executor.shutdown();
         if (mediaPlayer != null) {
             try {
@@ -907,13 +912,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 mediaPlayer.reset();
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                AudioFocusRequest.Builder builder = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
-                        .setOnAudioFocusChangeListener(audioFocusChangeListener);
-                audioManager.abandonAudioFocusRequest(builder.build());
-            } else {
-                audioManager.abandonAudioFocus(audioFocusChangeListener);
-            }
+            abandonAudioFocus();
 
             final Playable currentMedia = media;
             Playable nextMedia = null;


### PR DESCRIPTION
Android stops the PlaybackService but we still have the audio focus callbacks in place. When the service is stopped, we stop the executors in `PlaybackService.onDestroy`. If the callback is then executed, the app crashes because the executors are stopped.

After this PR, `PlaybackService.onDestroy` removes the audio listeners. Therefore, after an interruption that is long enough so that Android kills the service, the listeners are not called to a destroyed service. A side effect is that the user has to press *play* manually after leaving playback for too long but I think this behavior is okay.

Closes #3186

```
// Playing
2019-09-09 18:27:53.006 16336-16336/de.danoeh.antennapod.debug D/PlaybackService: Saving current position to 16770
2019-09-09 18:27:58.008 16336-16336/de.danoeh.antennapod.debug D/PlaybackService: Saving current position to 21772
2019-09-09 18:28:03.010 16336-16336/de.danoeh.antennapod.debug D/PlaybackService: Saving current position to 26780
// Received call
2019-09-09 18:28:05.054 16336-16336/de.danoeh.antennapod.debug D/PlaybackServiceTaskMgr: Cancelled PositionSaver
2019-09-09 18:28:05.054 16336-16336/de.danoeh.antennapod.debug D/PlaybackService: Saving current position to 28823
2019-09-09 18:28:05.054 16336-16336/de.danoeh.antennapod.debug D/PlaybackServiceTaskMgr: Cancelled WidgetUpdater
2019-09-09 18:28:05.056 16336-16336/de.danoeh.antennapod.debug D/PlaybackService: Writing player status playback preferences
2019-09-09 18:28:05.056 16336-17451/de.danoeh.antennapod.debug D/PlaybackService: Starting background work
2019-09-09 18:28:05.081 16336-17451/de.danoeh.antennapod.debug D/PlaybackService: Notification set up
2019-09-09 18:29:07.598 2293-2329/system_process W/ActivityManager: Stopping service due to app idle: u0a98 -1m53s984ms de.danoeh.antennapod.debug/de.danoeh.antennapod.core.service.playback.PlaybackService
2019-09-09 18:29:07.599 16336-16336/de.danoeh.antennapod.debug D/PlaybackService: Service is about to be destroyed
2019-09-09 18:29:07.604 16336-16336/de.danoeh.antennapod.debug D/ccl_BaseCastManager: [v2.9.1] Successfully removed the existing BaseCastConsumer listener de.danoeh.antennapod.core.service.playback.PlaybackServiceFlavorHelper$1@5661a6c
// Ended call
2019-09-09 18:29:21.951 16336-16336/de.danoeh.antennapod.debug D/PlaybackServiceTaskMgr: Call to startWidgetUpdater was ignored.
2019-09-09 18:29:21.952 16336-16336/de.danoeh.antennapod.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: de.danoeh.antennapod.debug, PID: 16336
    java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@a83fff rejected from java.util.concurrent.ScheduledThreadPoolExecutor@95d21cc[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 38]
        at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2086)
        at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:848)
        at java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:334)
        at java.util.concurrent.ScheduledThreadPoolExecutor.scheduleWithFixedDelay(ScheduledThreadPoolExecutor.java:629)
        at de.danoeh.antennapod.core.service.playback.PlaybackServiceTaskManager.startPositionSaver(PlaybackServiceTaskManager.java:138)
        at de.danoeh.antennapod.core.service.playback.PlaybackService$2.onPlaybackStart(PlaybackService.java:838)
        at de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer.setPlayerStatus(PlaybackServiceMediaPlayer.java:324)
        at de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer.setPlayerStatus(PlaybackServiceMediaPlayer.java:335)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP.resumeSync(LocalPSMP.java:321)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP.lambda$resume$3$LocalPSMP(LocalPSMP.java:275)
        at de.danoeh.antennapod.core.service.playback.-$$Lambda$LocalPSMP$qJO6fE9RrQzc5jd_fVqGKQZ-MqQ.run(Unknown Source:2)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP$PlayerExecutor.submit(LocalPSMP.java:77)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP.resume(LocalPSMP.java:273)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP$1.lambda$onAudioFocusChange$0$LocalPSMP$1(LocalPSMP.java:853)
        at de.danoeh.antennapod.core.service.playback.-$$Lambda$LocalPSMP$1$bWQm-SvHzg-23xcSmeXJeDjoCno.run(Unknown Source:4)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP$PlayerExecutor.submit(LocalPSMP.java:77)
        at de.danoeh.antennapod.core.service.playback.LocalPSMP$1.onAudioFocusChange(LocalPSMP.java:837)
        at android.media.AudioManager$ServiceEventHandlerDelegate$1.handleMessage(AudioManager.java:2488)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7319)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:934)
```