### PR TITLE
Ensure that ExoPlayer is set

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -42,10 +42,8 @@ public class PreferenceUpgrader {
             }
         }
         if (oldVersion < 1070300) {
-            if (UserPreferences.getMediaPlayer().equals("builtin")) {
-                prefs.edit().putString(UserPreferences.PREF_MEDIA_PLAYER,
-                        UserPreferences.PREF_MEDIA_PLAYER_EXOPLAYER).apply();
-            }
+            prefs.edit().putString(UserPreferences.PREF_MEDIA_PLAYER,
+                    UserPreferences.PREF_MEDIA_PLAYER_EXOPLAYER).apply();
 
             if (prefs.getBoolean("prefEnableAutoDownloadOnMobile", false)) {
                 UserPreferences.setAllowMobileAutoDownload(true);


### PR DESCRIPTION
Sonic also leads to crashes. Setting to ExoPlayer on upgrade for all users, regardless of their selected player. I don't think many users care about the media player and by switching the player, we can get rid of all kinds of playback issues.