### PR TITLE
#3387 short-term (v1.7.3) fix for Auto Downoad WiFi filter UI on Android 10+

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- ACCESS_FINE_LOCATION is needed only on Android 10+,
+        for Automatic Download Wifi filter's UI, which uses
+        WifiManager.WifiManager.getConfiguredNetworks()
+      -->
+    <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
minimal fix for #3387 to be included in v1.7.3 release (no UI changes)
