### PR TITLE
add Open Podcast to player screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.activity;
 
 import android.annotation.TargetApi;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -10,6 +11,7 @@ import android.database.DataSetObserver;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
@@ -32,9 +34,11 @@ import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 
-import de.danoeh.antennapod.preferences.PreferenceUpgrader;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.List;
 
@@ -67,13 +71,11 @@ import de.danoeh.antennapod.fragment.PlaybackHistoryFragment;
 import de.danoeh.antennapod.fragment.QueueFragment;
 import de.danoeh.antennapod.fragment.SubscriptionFragment;
 import de.danoeh.antennapod.menuhandler.NavDrawerActivity;
+import de.danoeh.antennapod.preferences.PreferenceUpgrader;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
-import org.greenrobot.eventbus.ThreadMode;
 
 /**
  * The activity that is shown when the user launches the app.
@@ -93,7 +95,7 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     public static final String EXTRA_NAV_INDEX = "nav_index";
     public static final String EXTRA_FRAGMENT_TAG = "fragment_tag";
     public static final String EXTRA_FRAGMENT_ARGS = "fragment_args";
-    public static final String EXTRA_FEED_ID = "fragment_feed_id";
+    private static final String EXTRA_FEED_ID = "fragment_feed_id";
 
     private static final String SAVE_BACKSTACK_COUNT = "backstackCount";
     private static final String SAVE_TITLE = "title";
@@ -126,6 +128,14 @@ public class MainActivity extends CastEnabledActivity implements NavDrawerActivi
     private Disposable disposable;
 
     private long lastBackButtonPressTime = 0;
+
+    @NonNull
+    public static Intent getIntentToOpenFeed(@NonNull Context context, long feedId) {
+        Intent intent = new Intent(context.getApplicationContext(), MainActivity.class);
+        intent.putExtra(MainActivity.EXTRA_FEED_ID, feedId);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        return intent;
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -454,9 +454,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         if(media instanceof FeedMedia) {
                             FeedItem feedItem = ((FeedMedia)media).getItem();
                             if (feedItem != null) {
-                                Intent intent = new Intent(getApplicationContext(), MainActivity.class);
-                                intent.putExtra(MainActivity.EXTRA_FEED_ID, feedItem.getFeedId());
-                                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                                Intent intent = MainActivity.getIntentToOpenFeed(this, feedItem.getFeedId());
                                 startActivity(intent);
                             }
                         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -391,7 +391,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
             return true;
         } else {
             if (media != null) {
-                final FeedItem feedItem = getFeedItem(media); // some options option requires FeedItem
+                final @Nullable FeedItem feedItem = getFeedItem(media); // some options option requires FeedItem
                 switch (item.getItemId()) {
                     case R.id.add_to_favorites_item:
                         if (feedItem != null) {
@@ -456,22 +456,22 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         startActivity(new Intent(Intent.ACTION_VIEW, uri));
                         break;
                     case R.id.share_link_item:
-                        if (media instanceof FeedMedia) {
+                        if (feedItem != null) {
                             ShareUtils.shareFeedItemLink(this, feedItem);
                         }
                         break;
                     case R.id.share_download_url_item:
-                        if (media instanceof FeedMedia) {
+                        if (feedItem != null) {
                             ShareUtils.shareFeedItemDownloadLink(this, feedItem);
                         }
                         break;
                     case R.id.share_link_with_position_item:
-                        if (media instanceof FeedMedia) {
+                        if (feedItem != null) {
                             ShareUtils.shareFeedItemLink(this, feedItem, true);
                         }
                         break;
                     case R.id.share_download_url_with_position_item:
-                        if (media instanceof FeedMedia) {
+                        if (feedItem != null) {
                             ShareUtils.shareFeedItemDownloadLink(this, feedItem, true);
                         }
                         break;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -322,6 +322,8 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
         Playable media = controller.getMedia();
         boolean isFeedMedia = media != null && (media instanceof FeedMedia);
 
+        menu.findItem(R.id.open_feed_item).setVisible(isFeedMedia); // FeedMedia implies it belongs to a Feed
+
         boolean hasWebsiteLink = ( getWebsiteLinkWithFallback(media) != null );
         menu.findItem(R.id.visit_website_item).setVisible(hasWebsiteLink);
 
@@ -447,6 +449,17 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         boolean isPlayingVideo = controller.getMedia().getMediaType() == MediaType.VIDEO;
                         PlaybackControlsDialog dialog = PlaybackControlsDialog.newInstance(isPlayingVideo);
                         dialog.show(getSupportFragmentManager(), "playback_controls");
+                        break;
+                    case R.id.open_feed_item:
+                        if(media instanceof FeedMedia) {
+                            FeedItem feedItem = ((FeedMedia)media).getItem();
+                            if (feedItem != null) {
+                                Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+                                intent.putExtra(MainActivity.EXTRA_FEED_ID, feedItem.getFeedId());
+                                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                                startActivity(intent);
+                            }
+                        }
                         break;
                     case R.id.visit_website_item:
                         Uri uri = Uri.parse(getWebsiteLinkWithFallback(media));

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -391,29 +391,24 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
             return true;
         } else {
             if (media != null) {
+                final FeedItem feedItem = getFeedItem(media); // some options option requires FeedItem
                 switch (item.getItemId()) {
                     case R.id.add_to_favorites_item:
-                        if(media instanceof FeedMedia) {
-                            FeedItem feedItem = ((FeedMedia)media).getItem();
-                            if(feedItem != null) {
-                                DBWriter.addFavoriteItem(feedItem);
-                                isFavorite = true;
-                                invalidateOptionsMenu();
-                                Toast.makeText(this, R.string.added_to_favorites, Toast.LENGTH_SHORT)
-                                     .show();
-                            }
+                        if(feedItem != null) {
+                            DBWriter.addFavoriteItem(feedItem);
+                            isFavorite = true;
+                            invalidateOptionsMenu();
+                            Toast.makeText(this, R.string.added_to_favorites, Toast.LENGTH_SHORT)
+                                 .show();
                         }
                         break;
                     case R.id.remove_from_favorites_item:
-                        if(media instanceof FeedMedia) {
-                            FeedItem feedItem = ((FeedMedia)media).getItem();
-                            if(feedItem != null) {
-                                DBWriter.removeFavoriteItem(feedItem);
-                                isFavorite = false;
-                                invalidateOptionsMenu();
-                                Toast.makeText(this, R.string.removed_from_favorites, Toast.LENGTH_SHORT)
-                                     .show();
-                            }
+                        if(feedItem != null) {
+                            DBWriter.removeFavoriteItem(feedItem);
+                            isFavorite = false;
+                            invalidateOptionsMenu();
+                            Toast.makeText(this, R.string.removed_from_favorites, Toast.LENGTH_SHORT)
+                                    .show();
                         }
                         break;
                     case R.id.disable_sleeptimer_item:
@@ -451,12 +446,9 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         dialog.show(getSupportFragmentManager(), "playback_controls");
                         break;
                     case R.id.open_feed_item:
-                        if(media instanceof FeedMedia) {
-                            FeedItem feedItem = ((FeedMedia)media).getItem();
-                            if (feedItem != null) {
-                                Intent intent = MainActivity.getIntentToOpenFeed(this, feedItem.getFeedId());
-                                startActivity(intent);
-                            }
+                        if (feedItem != null) {
+                            Intent intent = MainActivity.getIntentToOpenFeed(this, feedItem.getFeedId());
+                            startActivity(intent);
                         }
                         break;
                     case R.id.visit_website_item:
@@ -465,22 +457,22 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         break;
                     case R.id.share_link_item:
                         if (media instanceof FeedMedia) {
-                            ShareUtils.shareFeedItemLink(this, ((FeedMedia) media).getItem());
+                            ShareUtils.shareFeedItemLink(this, feedItem);
                         }
                         break;
                     case R.id.share_download_url_item:
                         if (media instanceof FeedMedia) {
-                            ShareUtils.shareFeedItemDownloadLink(this, ((FeedMedia) media).getItem());
+                            ShareUtils.shareFeedItemDownloadLink(this, feedItem);
                         }
                         break;
                     case R.id.share_link_with_position_item:
                         if (media instanceof FeedMedia) {
-                            ShareUtils.shareFeedItemLink(this, ((FeedMedia) media).getItem(), true);
+                            ShareUtils.shareFeedItemLink(this, feedItem, true);
                         }
                         break;
                     case R.id.share_download_url_with_position_item:
                         if (media instanceof FeedMedia) {
-                            ShareUtils.shareFeedItemDownloadLink(this, ((FeedMedia) media).getItem(), true);
+                            ShareUtils.shareFeedItemDownloadLink(this, feedItem, true);
                         }
                         break;
                     case R.id.share_file:
@@ -824,11 +816,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
     }
 
     private void checkFavorite() {
-        Playable playable = controller.getMedia();
-        if (!(playable instanceof FeedMedia)) {
-            return;
-        }
-        FeedItem feedItem = ((FeedMedia) playable).getItem();
+        FeedItem feedItem = getFeedItem(controller.getMedia());
         if (feedItem == null) {
             return;
         }
@@ -881,6 +869,15 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
             if (grantResults.length <= 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
                 Toast.makeText(this, R.string.needs_storage_permission, Toast.LENGTH_LONG).show();
             }
+        }
+    }
+
+    @Nullable
+    private static FeedItem getFeedItem(@Nullable Playable playable) {
+        if (playable instanceof FeedMedia) {
+            return ((FeedMedia)playable).getItem();
+        } else {
+            return null;
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -394,7 +394,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                 final FeedItem feedItem = getFeedItem(media); // some options option requires FeedItem
                 switch (item.getItemId()) {
                     case R.id.add_to_favorites_item:
-                        if(feedItem != null) {
+                        if (feedItem != null) {
                             DBWriter.addFavoriteItem(feedItem);
                             isFavorite = true;
                             invalidateOptionsMenu();
@@ -403,7 +403,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
                         }
                         break;
                     case R.id.remove_from_favorites_item:
-                        if(feedItem != null) {
+                        if (feedItem != null) {
                             DBWriter.removeFavoriteItem(feedItem);
                             isFavorite = false;
                             invalidateOptionsMenu();
@@ -874,7 +874,7 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
 
     @Nullable
     private static FeedItem getFeedItem(@Nullable Playable playable) {
-        if (playable instanceof FeedMedia) {
+        if ((playable != null) && (playable instanceof FeedMedia)) {
             return ((FeedMedia)playable).getItem();
         } else {
             return null;

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -32,7 +32,6 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
-import de.danoeh.antennapod.core.glide.FastBlurTransformation;
 import org.apache.commons.lang3.StringUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -55,6 +54,7 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.glide.ApGlideSettings;
+import de.danoeh.antennapod.core.glide.FastBlurTransformation;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
@@ -442,11 +442,9 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
 
         subscribeButton.setOnClickListener(v -> {
             if(feedInFeedlist(feed)) {
-                Intent intent = new Intent(OnlineFeedViewActivity.this, MainActivity.class);
                 // feed.getId() is always 0, we have to retrieve the id from the feed list from
                 // the database
-                intent.putExtra(MainActivity.EXTRA_FEED_ID, getFeedId(feed));
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                Intent intent = MainActivity.getIntentToOpenFeed(this, getFeedId(feed));
                 startActivity(intent);
             } else {
                 Feed f = new Feed(selectedDownloadUrl, null, feed.getTitle());

--- a/app/src/main/res/menu/mediaplayer.xml
+++ b/app/src/main/res/menu/mediaplayer.xml
@@ -35,6 +35,14 @@
     </item>
 
     <item
+        android:id="@+id/open_feed_item"
+        android:icon="?attr/feed"
+        custom:showAsAction="collapseActionView"
+        android:title="@string/open_podcast"
+        android:visible="false">
+    </item>
+
+    <item
         android:id="@+id/visit_website_item"
         android:icon="?attr/location_web_site"
         custom:showAsAction="collapseActionView"


### PR DESCRIPTION
It addresses a point of #2929 .
(I personally would be happy to close the issue with this PR, but there are still requests about the opening podcast from Episode (feedItem) Screen.)

Added a new action menu item "Open Podcast" to go to the podcast from Player Screen directly.

![image](https://user-images.githubusercontent.com/250644/65379106-b953b300-dc77-11e9-8e2e-872015c5fe69.png)

