### PR TITLE
Avoid Cast initialization unless it is enabled

### DIFF
--- a/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
+++ b/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
@@ -123,6 +123,7 @@ public abstract class CastEnabledActivity extends AppCompatActivity
         if (!CastManager.isInitialized()) {
             return;
         }
+        castButtonVisibilityManager.setResumed(false);
     }
 
 

--- a/app/src/play/java/de/danoeh/antennapod/preferences/PreferenceControllerFlavorHelper.java
+++ b/app/src/play/java/de/danoeh/antennapod/preferences/PreferenceControllerFlavorHelper.java
@@ -1,8 +1,13 @@
 package de.danoeh.antennapod.preferences;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
+import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.fragment.preferences.PlaybackPreferencesFragment;
 
@@ -18,6 +23,7 @@ public class PreferenceControllerFlavorHelper {
                 final int googlePlayServicesCheck = GoogleApiAvailability.getInstance()
                         .isGooglePlayServicesAvailable(ui.getActivity());
                 if (googlePlayServicesCheck == ConnectionResult.SUCCESS) {
+                    displayRestartRequiredDialog(ui.requireContext());
                     return true;
                 } else {
                     GoogleApiAvailability.getInstance()
@@ -26,7 +32,16 @@ public class PreferenceControllerFlavorHelper {
                     return false;
                 }
             }
+            displayRestartRequiredDialog(ui.requireContext());
             return true;
         });
+    }
+
+    private static void displayRestartRequiredDialog(@NonNull Context context) {
+        AlertDialog.Builder dialog = new AlertDialog.Builder(context);
+        dialog.setTitle(android.R.string.dialog_alert_title);
+        dialog.setMessage(R.string.pref_restart_required);
+        dialog.setPositiveButton(android.R.string.ok, null);
+        dialog.show();
     }
 }

--- a/app/src/play/java/de/danoeh/antennapod/preferences/PreferenceControllerFlavorHelper.java
+++ b/app/src/play/java/de/danoeh/antennapod/preferences/PreferenceControllerFlavorHelper.java
@@ -32,7 +32,6 @@ public class PreferenceControllerFlavorHelper {
                     return false;
                 }
             }
-            displayRestartRequiredDialog(ui.requireContext());
             return true;
         });
     }
@@ -42,6 +41,7 @@ public class PreferenceControllerFlavorHelper {
         dialog.setTitle(android.R.string.dialog_alert_title);
         dialog.setMessage(R.string.pref_restart_required);
         dialog.setPositiveButton(android.R.string.ok, null);
+        dialog.setCancelable(false);
         dialog.show();
     }
 }

--- a/core/src/play/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.core;
 
 import android.content.Context;
+import android.util.Log;
 
 import de.danoeh.antennapod.core.cast.CastManager;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
@@ -15,6 +16,8 @@ import de.danoeh.antennapod.core.util.exception.RxJavaErrorHandlerSetup;
  * Apps using the core module of AntennaPod should register implementations of all interfaces here.
  */
 public class ClientConfig {
+    private static final String TAG = "ClientConfig";
+
     private ClientConfig(){}
 
     /**
@@ -44,7 +47,15 @@ public class ClientConfig {
         UserPreferences.init(context);
         PlaybackPreferences.init(context);
         NetworkUtils.init(context);
-        CastManager.init(context);
+        // Don't initialize Cast-related logic unless it is enabled, to avoid the unnecessary
+        // Google Play Service usage.
+        // Down side: when the user decides to enable casting, AntennaPod needs to be restarted
+        // for it to take effect.
+        if (UserPreferences.isCastEnabled()) {
+            CastManager.init(context);
+        } else {
+            Log.v(TAG, "Cast is disabled. All Cast-related initialization will be skipped.");
+        }
         SleepTimerPreferences.init(context);
         RxJavaErrorHandlerSetup.setupRxJavaErrorHandler();
         initialized = true;

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
@@ -163,6 +163,10 @@ public class CastManager extends BaseCastManager implements OnFailedListener {
         return INSTANCE;
     }
 
+    public static boolean isInitialized() {
+        return INSTANCE != null;
+    }
+
     /**
      * Returns the active {@link RemoteMediaPlayer} instance. Since there are a number of media
      * control APIs that this library do not provide a wrapper for, client applications can call

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceFlavorHelper.java
@@ -56,11 +56,18 @@ public class PlaybackServiceFlavorHelper {
 
     PlaybackServiceFlavorHelper(Context context, PlaybackService.FlavorHelperCallback callback) {
         this.callback = callback;
+        if (!CastManager.isInitialized()) {
+            return;
+        }
         mediaRouter = MediaRouter.getInstance(context.getApplicationContext());
         setCastConsumer(context);
     }
 
     void initializeMediaPlayer(Context context) {
+        if (!CastManager.isInitialized()) {
+            callback.setMediaPlayer(new LocalPSMP(context, callback.getMediaPlayerCallback()));
+            return;
+        }
         castManager = CastManager.getInstance();
         castManager.addCastConsumer(castConsumer);
         boolean isCasting = castManager.isConnected();
@@ -77,10 +84,16 @@ public class PlaybackServiceFlavorHelper {
     }
 
     void removeCastConsumer() {
+        if (!CastManager.isInitialized()) {
+            return;
+        }
         castManager.removeCastConsumer(castConsumer);
     }
 
     boolean castDisconnect(boolean castDisconnect) {
+        if (!CastManager.isInitialized()) {
+            return false;
+        }
         if (castDisconnect) {
             castManager.disconnect();
         }
@@ -88,6 +101,9 @@ public class PlaybackServiceFlavorHelper {
     }
 
     boolean onMediaPlayerInfo(Context context, int code, @StringRes int resourceId) {
+        if (!CastManager.isInitialized()) {
+            return false;
+        }
         switch (code) {
             case RemotePSMP.CAST_ERROR:
                 callback.sendNotificationBroadcast(PlaybackService.NOTIFICATION_TYPE_SHOW_TOAST, resourceId);
@@ -218,6 +234,9 @@ public class PlaybackServiceFlavorHelper {
     }
 
     void registerWifiBroadcastReceiver() {
+        if (!CastManager.isInitialized()) {
+            return;
+        }
         if (wifiBroadcastReceiver != null) {
             return;
         }
@@ -243,6 +262,9 @@ public class PlaybackServiceFlavorHelper {
     }
 
     void unregisterWifiBroadcastReceiver() {
+        if (!CastManager.isInitialized()) {
+            return;
+        }
         if (wifiBroadcastReceiver != null) {
             callback.unregisterReceiver(wifiBroadcastReceiver);
             wifiBroadcastReceiver = null;
@@ -250,6 +272,9 @@ public class PlaybackServiceFlavorHelper {
     }
 
     boolean onSharedPreference(String key) {
+        if (!CastManager.isInitialized()) {
+            return false;
+        }
         if (UserPreferences.PREF_CAST_ENABLED.equals(key)) {
             if (!UserPreferences.isCastEnabled()) {
                 if (castManager.isConnecting() || castManager.isConnected()) {
@@ -263,6 +288,9 @@ public class PlaybackServiceFlavorHelper {
     }
 
     void sessionStateAddActionForWear(PlaybackStateCompat.Builder sessionState, String actionName, CharSequence name, int icon) {
+        if (!CastManager.isInitialized()) {
+            return;
+        }
         PlaybackStateCompat.CustomAction.Builder actionBuilder =
             new PlaybackStateCompat.CustomAction.Builder(actionName, name, icon);
         Bundle actionExtras = new Bundle();
@@ -273,6 +301,9 @@ public class PlaybackServiceFlavorHelper {
     }
 
     void mediaSessionSetExtraForWear(MediaSessionCompat mediaSession) {
+        if (!CastManager.isInitialized()) {
+            return;
+        }
         Bundle sessionExtras = new Bundle();
         sessionExtras.putBoolean(MediaControlConstants.EXTRA_RESERVE_SLOT_SKIP_TO_PREVIOUS, true);
         sessionExtras.putBoolean(MediaControlConstants.EXTRA_RESERVE_SLOT_SKIP_TO_NEXT, true);


### PR DESCRIPTION
Closes #3069 - It fixes an issue that for Google Play store version, AntennaPod will invoke Cast-related Google Play Service even when an user disables Chromecast support.

TODOs:
- [ ] Test with actual cast device to ensure the PR doesn't break cast scenario. (I don't have one so someone else has to do it.)
- [x] Tweak Chromecast Settings UI so that when cast is enabled, it initializes cast (and may need to restart the app, and if not, at least restart playbackservice and any Cast-enabled activity instances)


