### PR TITLE
Fixed another phantom service is running notification

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -451,7 +451,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     notificationBuilder.loadIcon(getPlayable());
                 }
             }
-            startForeground(NOTIFICATION_ID, notificationBuilder.build());
+            stateManager.startForeground(NOTIFICATION_ID, notificationBuilder.build());
         }
 
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);


### PR DESCRIPTION
Steps to reproduce:
- Send STOP key two times
- Service starts foreground but does not stop again because stateManager does not know about foreground state