### PR TITLE
Reduced logcat output

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
+++ b/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
@@ -63,6 +63,8 @@ public class PodcastApp extends Application {
 		EventBus.builder()
 				.addIndex(new ApEventBusIndex())
 				.addIndex(new ApCoreEventBusIndex())
+				.logNoSubscriberMessages(false)
+				.sendNoSubscriberEvent(false)
 				.installDefaultEventBus();
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -92,11 +92,9 @@ class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
     @Nullable
     @Override
     public LoadData<InputStream> buildLoadData(@NonNull String model, int width, int height, @NonNull Options options) {
-        Log.d(TAG, "buildLoadData() called with: " + "model = [" + model + "], width = ["
-                + width + "], height = [" + height + "]");
-        if(TextUtils.isEmpty(model)) {
+        if (TextUtils.isEmpty(model)) {
             return null;
-        } else if(model.startsWith("/")) {
+        } else if (model.startsWith("/")) {
             return new LoadData<>(new ObjectKey(model), new AudioCoverFetcher(model));
         } else {
             GlideUrl url = new GlideUrl(model);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -584,7 +584,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
         }
 
         playerLock.unlock();
-        Log.d(TAG, "getPosition() -> " + retVal);
         return retVal;
     }
 


### PR DESCRIPTION
The amount of messages that AntennaPod produces is quite high. Especially the position update every second during playback produced a ton of messages. Removed those messages. Additionally, removed messages that contain the cover urls.