### PR TITLE
Fixed missing progress bar on position update

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistAdapter.java
@@ -209,6 +209,7 @@ public class FeedItemlistAdapter extends BaseAdapter {
                 return;
             }
             Holder holder = (Holder) view.getTag();
+            holder.episodeProgress.setVisibility(View.VISIBLE);
             holder.episodeProgress.setProgress((int) (100.0 * event.getPosition() / event.getDuration()));
             holder.lenSize.setText(Converter.getDurationStringLong(event.getDuration() - event.getPosition()));
         }


### PR DESCRIPTION
Steps to reproduce:

- Open feed screen, observe that item does not have a progress bar
- Play that exact item from the queue
- Switch back to feed screen
- Progress bar is updated but invisible