### PR TITLE
Explicitly set max gradle jvm memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
Explicitly set max gradle jvm memory - otherwise, release build fails on some machines after AndroidX migration.

On my box setting it to `-Xmx=1536m` would work. I chose to set it to a higher `-Xmx=4096m` so that for developers with better machine, the explicit settings wouldn't hamper them.