### PR TITLE
Added 0.75 to default playback speed list

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -706,7 +706,7 @@ public class UserPreferences {
         String[] selectedSpeeds = null;
         // If this preference hasn't been set yet, return the default options
         if (valueFromPrefs == null) {
-            selectedSpeeds = new String[] { "1.00", "1.25", "1.50", "1.75", "2.00" };
+            selectedSpeeds = new String[] { "0.75", "1.00", "1.25", "1.50", "1.75", "2.00" };
         } else {
             try {
                 JSONArray jsonArray = new JSONArray(valueFromPrefs);


### PR DESCRIPTION
Users on Google Play seem to be confused that they can not select a
playback speed lower than 1x anymore. The reason is that they just
use the preference dialog and that dialog only displays the range
that is selected for the button.