### PR TITLE
Serial podcasts - auto download oldest episodes first

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBReaderTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBReaderTest.java
@@ -328,7 +328,7 @@ public class DBReaderTest {
             feedPreferences.setAutoDownload(true);
         });
 
-        for(int i = 0; i < numSerial; i++) {
+        for (int i = 0; i < numSerial; i++) {
             updateFeedPreferences(feeds.get(i), feedPreferences -> {
                 feedPreferences.setSemanticType(FeedPreferences.SemanticType.SERIAL);
             });

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
@@ -9,6 +9,7 @@ import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.feed.SimpleChapter;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
@@ -46,6 +47,7 @@ class DBTestUtils {
         for (int i = 0; i < numFeeds; i++) {
             Feed f = new Feed(0, null, "feed " + i, null, "link" + i, "descr", null, null,
                     null, null, "id" + i, null, null, "url" + i, false, false, null, null, false);
+            f.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, null, null));
             f.setItems(new ArrayList<>());
             for (int j = 0; j < numItems; j++) {
                 FeedItem item = new FeedItem(0, "item " + j, "id" + j, "link" + j, new Date(),

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
@@ -1,5 +1,7 @@
 package de.test.antennapod.storage;
 
+import androidx.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -12,6 +14,7 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.feed.SimpleChapter;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.danoeh.antennapod.core.util.Consumer;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 
 import static org.junit.Assert.assertTrue;
@@ -34,6 +37,16 @@ class DBTestUtils {
      */
     public static List<Feed> saveFeedlist(int numFeeds, int numItems, boolean withMedia,
                                           boolean withChapters, int numChapters) {
+        return saveFeedlist(numFeeds, numItems, withMedia, withChapters, numChapters, null);
+
+    }
+
+    /**
+     * Use this method when test require specific Feed Preferences
+     */
+    public static List<Feed> saveFeedlist(int numFeeds, int numItems, boolean withMedia,
+                                          boolean withChapters, int numChapters,
+                                          @Nullable Consumer<FeedPreferences> feedPreferenceCustomizer) {
         if (numFeeds <= 0) {
             throw new IllegalArgumentException("numFeeds<=0");
         }
@@ -47,7 +60,11 @@ class DBTestUtils {
         for (int i = 0; i < numFeeds; i++) {
             Feed f = new Feed(0, null, "feed " + i, null, "link" + i, "descr", null, null,
                     null, null, "id" + i, null, null, "url" + i, false, false, null, null, false);
-            f.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, null, null));
+            FeedPreferences fPrefs = new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, null, null);
+            if (feedPreferenceCustomizer != null) {
+                feedPreferenceCustomizer.accept(fPrefs);
+            }
+            f.setPreferences(fPrefs);
             f.setItems(new ArrayList<>());
             for (int j = 0; j < numItems; j++) {
                 FeedItem item = new FeedItem(0, "item " + j, "id" + j, "link" + j, new Date(),

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
@@ -1,0 +1,167 @@
+package de.test.antennapod.storage;
+
+import android.util.Log;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedFilter;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.storage.APDownloadAlgorithm;
+import de.danoeh.antennapod.core.storage.DBReader;
+import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.storage.DownloadItemSelectorEpisodicImpl;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
+import static org.junit.Assert.assertEquals;
+
+public class DownloadItemSelectorEpisodicImplTest {
+
+    private static final String TAG = "DlItemSlctrEpisodicTest";
+
+    private static final boolean DEBUG = false;
+
+    @After
+    public void tearDown() throws Exception {
+        // Leave DB as-is so that if a test fails, the state of the DB can still be inspected.
+        // setUp() will delete the database anyway.
+        /// assertTrue(PodDBAdapter.deleteDatabase());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // create new database
+        PodDBAdapter.init(ApplicationProvider.getApplicationContext());
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.close();
+
+    }
+
+    @Test
+    public void testGetAutoDownloadableEpisodes() throws Exception {
+        // Setup test data and expectation
+        List<Long> expectedItemIds = new ArrayList<>();
+        {
+            List<Feed> feeds = DBTestUtils.saveFeedlist(4, 3, true);
+            {
+                Feed fAutoDl = feeds.get(0);
+
+                FeedItem fi0_in = fAutoDl.getItemAtIndex(0);
+                fi0_in.setNew();
+                DBWriter.setFeedItem(fi0_in).get();
+                expectedItemIds.add(fi0_in.getId());
+
+                FeedItem fi0_outUnplayed = fAutoDl.getItemAtIndex(1);
+                fi0_outUnplayed.setPlayed(false);
+                DBWriter.setFeedItem(fi0_outUnplayed).get();
+
+                FeedItem fi0_outPlayed = fAutoDl.getItemAtIndex(1);
+                fi0_outPlayed.setPlayed(true);
+                DBWriter.setFeedItem(fi0_outPlayed).get();
+
+                // set feed download preferences
+                // Do it after updating feedItems, before some feedItem operations
+                // could overwrite the settings,
+                fAutoDl.getPreferences().setAutoDownload(true);
+                DBWriter.setFeedPreferences(fAutoDl.getPreferences()).get();
+                DBWriter.setFeedsItemsAutoDownload(fAutoDl, true).get();
+            }
+
+            {
+                Feed fAutoDlSome = feeds.get(1);
+
+                // title "item 0" is not in the include filter below
+                FeedItem fi1_outByFilter = fAutoDlSome.getItemAtIndex(0);
+                fi1_outByFilter.setNew();
+                DBWriter.setFeedItem(fi1_outByFilter).get();
+                FeedItem fi1_in = fAutoDlSome.getItemAtIndex(1);
+                fi1_in.setNew();
+                DBWriter.setFeedItem(fi1_in).get();
+                expectedItemIds.add(fi1_in.getId());
+
+                // Find the item number to be set as the include filter
+                Matcher matcher = Pattern.compile("item (\\d+)").matcher(fi1_in.getTitle());
+                matcher.matches();
+                String inFilterStr = matcher.group(1);
+                debug("include filter for feed " + fAutoDlSome.getId() + " : " + inFilterStr);
+
+                fAutoDlSome.getPreferences().setAutoDownload(true);
+                DBWriter.setFeedsItemsAutoDownload(fAutoDlSome, true).get();
+                fAutoDlSome.getPreferences().setFilter(new FeedFilter(inFilterStr, ""));
+                DBWriter.setFeedPreferences(fAutoDlSome.getPreferences()).get();
+            }
+
+            {
+                Feed fNotAutoDl = feeds.get(2);
+
+                FeedItem fi2_out = fNotAutoDl.getItemAtIndex(0);
+                fi2_out.setNew();
+                DBWriter.setFeedItem(fi2_out).get();
+
+                fNotAutoDl.getPreferences().setAutoDownload(false);
+                DBWriter.setFeedPreferences(fNotAutoDl.getPreferences()).get();
+                DBWriter.setFeedsItemsAutoDownload(fNotAutoDl, false).get();
+            }
+
+            {
+                Feed fNotKeepUpdate = feeds.get(3);
+
+                FeedItem fi3_out = fNotKeepUpdate.getItemAtIndex(0);
+                fi3_out.setNew();
+                DBWriter.setFeedItem(fi3_out).get();
+
+                fNotKeepUpdate.getPreferences().setAutoDownload(true);
+                DBWriter.setFeedsItemsAutoDownload(fNotKeepUpdate, true).get();
+                fNotKeepUpdate.getPreferences().setKeepUpdated(false); // keep updated false make it gone
+                DBWriter.setFeedPreferences(fNotKeepUpdate.getPreferences()).get();
+            }
+
+            if (DEBUG) {
+                // verbose output of the feeds saved, in case the test fails
+                // it re-reads from DB to ensure they are up-to-date.
+                for (Feed f : DBReader.getFeedList()) {
+                    debug("feed " + f.getId() + " , " + f.getTitle() + " , autodownload=" + f.getPreferences().getAutoDownload());
+                    for (FeedItem fi : DBReader.getFeedItemList(f)) {
+                        debug("  fi " + fi.getId() + " , " + fi.getTitle() + ", pubDate=" + fi.getPubDate()
+                                + ", autodownload=" + fi.getAutoDownload() + ", new=" + fi.isNew());
+                    }
+                }
+            }
+
+            Collections.reverse(expectedItemIds); // the result is ordered by pubDate descending, thus reversing them
+        }
+
+        // Now create the selector under test
+        DownloadItemSelectorEpisodicImpl selector = new DownloadItemSelectorEpisodicImpl();
+
+        List<? extends FeedItem> fiAutoDlActual = selector.getAutoDownloadableEpisodes(new APDownloadAlgorithm.ItemProviderDefaultImpl());
+
+        assertEquals("Results should include only auto-downlodable new items. It actually returns: " + fiAutoDlActual,
+                expectedItemIds, toItemIds(fiAutoDlActual));
+    }
+
+    private List<Long> toItemIds(List<? extends FeedItem> feedItems) {
+        List<Long> result = new ArrayList<>(feedItems.size());
+        for (FeedItem fi : feedItems) {
+            result.add(fi.getId());
+        }
+        return result;
+    }
+
+    private void debug(String msg) {
+        if (DEBUG) Log.d(TAG, msg);
+    }
+
+}

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
@@ -95,10 +95,11 @@ public class DownloadItemSelectorEpisodicImplTest {
         debugAllFeeds();
 
         // Now create the selector under test and exercise it
-        DownloadItemSelectorEpisodicImpl selector = new DownloadItemSelectorEpisodicImpl();
+        DownloadItemSelectorEpisodicImpl selector =
+                new DownloadItemSelectorEpisodicImpl(new APDownloadAlgorithm.ItemProviderDefaultImpl());
 
         List<? extends FeedItem> fiAutoDlActual =
-                selector.getAutoDownloadableEpisodes(new APDownloadAlgorithm.ItemProviderDefaultImpl());
+                selector.getAutoDownloadableEpisodes();
 
         assertEquals("Results should include only auto-downloadable new items. It returns: " + fiAutoDlActual,
                 expectedNewItemIds, toItemIds(fiAutoDlActual));

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
@@ -18,7 +18,6 @@ import de.danoeh.antennapod.core.feed.FeedFilter;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
-import de.danoeh.antennapod.core.storage.APDownloadAlgorithm;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DownloadItemSelectorEpisodicImpl;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
@@ -96,7 +95,7 @@ public class DownloadItemSelectorEpisodicImplTest {
 
         // Now create the selector under test and exercise it
         DownloadItemSelectorEpisodicImpl selector =
-                new DownloadItemSelectorEpisodicImpl(new APDownloadAlgorithm.ItemProviderDefaultImpl());
+                new DownloadItemSelectorEpisodicImpl();
 
         List<? extends FeedItem> fiAutoDlActual =
                 selector.getAutoDownloadableEpisodes();

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
@@ -8,23 +8,28 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
+import java.util.Arrays;
 import java.util.List;
 
 import de.danoeh.antennapod.core.feed.Feed;
-import de.danoeh.antennapod.core.feed.FeedFilter;
 import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.feed.FeedMedia;
-import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DownloadItemSelectorEpisodicImpl;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.test.antennapod.storage.FeedTestUtil.FeedsAccessor;
 
 import static de.danoeh.antennapod.core.feed.FeedItem.NEW;
 import static de.danoeh.antennapod.core.feed.FeedItem.PLAYED;
 import static de.danoeh.antennapod.core.feed.FeedItem.UNPLAYED;
+import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.EPISODIC;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_FALSE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_TRUE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.KEEP_UPDATED_FALSE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.KEEP_UPDATED_TRUE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.cFI;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.createFeed;
+import static de.test.antennapod.storage.FeedTestUtil.saveFeeds;
+import static de.test.antennapod.storage.FeedTestUtil.toIds;
 import static org.junit.Assert.assertEquals;
 
 public class DownloadItemSelectorEpisodicImplTest {
@@ -32,11 +37,6 @@ public class DownloadItemSelectorEpisodicImplTest {
     private static final String TAG = "DlItemSlctrEpisodicTest";
 
     private static final boolean DEBUG = false;
-
-    private static final boolean AUTO_DL_TRUE = true;
-    private static final boolean AUTO_DL_FALSE = false;
-    private static final boolean KEEP_UPDATED_TRUE = true;
-    private static final boolean KEEP_UPDATED_FALSE = false;
 
     @After
     public void tearDown() throws Exception {
@@ -57,39 +57,32 @@ public class DownloadItemSelectorEpisodicImplTest {
     }
 
     @Test
-    public void testGetAutoDownloadableEpisodes() throws Exception {
+    public void basic() throws Exception {
         // Setup test data and expectation
-        List<Long> expectedNewItemIds = new ArrayList<>();
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        try {
-            adapter.open();
 
-            // typical auto-downloadable feed
-            Feed f0 = createFeed(0, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
-                    cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
+        // typical auto-downloadable feed
+        Feed f0 = createFeed(0, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
 
-            // have an include filter "1" that will accept "item 1" only
-            Feed f1 = createFeed(1, AUTO_DL_TRUE, "1", KEEP_UPDATED_TRUE,
-                    cFI(NEW), cFI(NEW), cFI(NEW));
+        // have an include filter "1" that will accept "item 1" only
+        Feed f1 = createFeed(1, EPISODIC, AUTO_DL_TRUE, "1", KEEP_UPDATED_TRUE,
+                cFI(NEW), cFI(NEW), cFI(NEW));
 
-            // non auto-downloadable feed
-            Feed f2 = createFeed(2, AUTO_DL_FALSE, "", KEEP_UPDATED_TRUE,
-                    cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
+        // non auto-downloadable feed
+        Feed f2 = createFeed(2, EPISODIC, AUTO_DL_FALSE, "", KEEP_UPDATED_TRUE,
+                cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
 
-            // feed not keep updated, which trumps auto-download settings
-            Feed f3 = createFeed(3, AUTO_DL_TRUE, "", KEEP_UPDATED_FALSE,
-                    cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
+        // feed not keep updated, which trumps auto-download settings
+        Feed f3 = createFeed(3, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_FALSE,
+                cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
 
-            adapter.setCompleteFeed(f0, f1, f2, f3);
+        FeedsAccessor a =  saveFeeds(f0, f1, f2, f3);
 
-            expectedNewItemIds.add((f0.getItemAtIndex(0).getId()));
-            expectedNewItemIds.add((f1.getItemAtIndex(1).getId()));
-
-            // the result is ordered by pubDate descending, thus reversing them
-            Collections.reverse(expectedNewItemIds);
-        } finally {
-            adapter.close();
-        }
+        // the result is ordered by pubDate descending,
+        List<Long> expectedNewItemIds = Arrays.asList(
+                a.fiId(1, 1), // fi(1, 0) is excluded by the feed includeFilter
+                a.fiId(0, 0)
+        );
 
         debugAllFeeds();
 
@@ -101,73 +94,8 @@ public class DownloadItemSelectorEpisodicImplTest {
                 selector.getAutoDownloadableEpisodes();
 
         assertEquals("Results should include only auto-downloadable new items. It returns: " + fiAutoDlActual,
-                expectedNewItemIds, toItemIds(fiAutoDlActual));
+                expectedNewItemIds, toIds(fiAutoDlActual));
     }
-
-    private List<Long> toItemIds(List<? extends FeedItem> feedItems) {
-        List<Long> result = new ArrayList<>(feedItems.size());
-        for (FeedItem fi : feedItems) {
-            result.add(fi.getId());
-        }
-        return result;
-    }
-
-    //
-    // Helpers to populate test data
-    //
-
-    private static long curPubDateMillis = System.currentTimeMillis() - 100000;
-
-    private static Feed createFeed(int titleId, boolean isAutoDownload, String includeFilter, boolean isKeepUpdated,
-                                   FeedItem... feedItems) {
-        Feed f = new Feed(0, null, "feed " + titleId, null, "link" + titleId, "descr", null, null,
-                null, null, "id" + titleId, null, null, "url" + titleId, false, false, null, null, false);
-
-        FeedPreferences fPrefs =
-                new FeedPreferences(0, isAutoDownload, FeedPreferences.AutoDeleteAction.GLOBAL, null, null);
-        fPrefs.setKeepUpdated(isKeepUpdated);
-        fPrefs.setFilter(new FeedFilter(includeFilter, ""));
-        f.setPreferences(fPrefs);
-
-        for (int j = 0; j < feedItems.length; j++) {
-            FeedItem fi = feedItems[j];
-            fi.setFeed(f);
-            curPubDateMillis += 1000; // ensure p
-            fi.setPubDate(new Date(curPubDateMillis));
-            fi.setAutoDownload(isAutoDownload);
-            fi.setTitle("item " + j);
-
-            f.getItems().add(fi);
-        }
-
-        return f;
-    }
-
-    /**
-     * @return a skeleton (incomplete) FeedItem of the specified state, createFeed() will fill in the details.
-     */
-    private static FeedItem cFI(int playState) {
-        FeedItem item = new FeedItem();
-        switch (playState) {
-            case NEW:
-                item.setNew();
-                break;
-            case UNPLAYED:
-                item.setPlayed(false);
-                break;
-            case PLAYED:
-                item.setPlayed(true);
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid playState: " + playState);
-        }
-
-        FeedMedia media = new FeedMedia(item, "url", 1, "audio/mp3");
-        item.setMedia(media);
-
-        return item;
-    }
-
 
     private void debugAllFeeds() {
         if (DEBUG) {

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorEpisodicImplTest.java
@@ -22,6 +22,7 @@ import static de.danoeh.antennapod.core.feed.FeedItem.NEW;
 import static de.danoeh.antennapod.core.feed.FeedItem.PLAYED;
 import static de.danoeh.antennapod.core.feed.FeedItem.UNPLAYED;
 import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.EPISODIC;
+import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.SERIAL;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_FALSE;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_TRUE;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.KEEP_UPDATED_FALSE;
@@ -94,6 +95,38 @@ public class DownloadItemSelectorEpisodicImplTest {
                 selector.getAutoDownloadableEpisodes();
 
         assertEquals("Results should include only auto-downloadable new items. It returns: " + fiAutoDlActual,
+                expectedNewItemIds, toIds(fiAutoDlActual));
+    }
+
+    @Test
+    public void excludeSerials() {
+        // Setup test data and expectation
+
+        // serial feeds - to be ignored
+        Feed f0 = createFeed(0, SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
+
+        // typical auto-downloadable feed
+        Feed f1 = createFeed(1, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(NEW), cFI(UNPLAYED), cFI(PLAYED));
+
+        // typical auto-downloadable feed
+        Feed f2 = createFeed(2, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(PLAYED), cFI(UNPLAYED), cFI(NEW));
+
+        FeedsAccessor a =  saveFeeds(f0, f1, f2);
+
+        // serial feed, f0, is ignored
+        List<Long> expectedNewItemIds = Arrays.asList(a.fiId(2, 2), a.fiId(1, 0));
+
+        // Now create the selector under test and exercise it
+        DownloadItemSelectorEpisodicImpl selector =
+                new DownloadItemSelectorEpisodicImpl();
+
+        List<? extends FeedItem> fiAutoDlActual =
+                selector.getAutoDownloadableEpisodes();
+
+        assertEquals("Results should include episodic feed items. It returns: " + fiAutoDlActual,
                 expectedNewItemIds, toIds(fiAutoDlActual));
     }
 

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
@@ -1,0 +1,41 @@
+package de.test.antennapod.storage;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
+public class DownloadItemSelectorSerialImplTest {
+
+    private static final String TAG = "DlItemSlctrSerialTest";
+
+    @After
+    public void tearDown() throws Exception {
+        // Leave DB as-is so that if a test fails, the state of the DB can still be inspected.
+        // setUp() will delete the database anyway.
+        /// assertTrue(PodDBAdapter.deleteDatabase());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // create new database
+        PodDBAdapter.init(ApplicationProvider.getApplicationContext());
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.close();
+
+    }
+
+    @Test
+    public void testGetAutoDownloadableEpisodes() throws Exception {
+        // TODO-1077: test DownloadItemSelectorSerialImpl
+        // - the picking of the feeditems are done in round-robin fashion
+        //
+        // - Also need to separately test the new DBAccess.getEpisodicToSerialRatio() method
+        //   - it excludes non-autodl (and not updated) ones in calculating the ratio
+    }
+}

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
@@ -23,7 +23,9 @@ import static de.danoeh.antennapod.core.feed.FeedItem.PLAYED;
 import static de.danoeh.antennapod.core.feed.FeedItem.UNPLAYED;
 import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.EPISODIC;
 import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.SERIAL;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_FALSE;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_TRUE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.KEEP_UPDATED_FALSE;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.KEEP_UPDATED_TRUE;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.cFI;
 import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.createFeed;
@@ -187,6 +189,28 @@ public class DownloadItemSelectorSerialImplTest {
         // Test overall
         List<? extends FeedItem> fiActual = selector.getAutoDownloadableEpisodes();
         assertEquals("Basic, ongoing case -  It returns: " + fiActual,
+                expected, toIds(fiActual));
+    }
+
+    @Test
+    public void boundary_ignoreNonAutoDownlodableFeeds() throws Exception {
+        // Setup test data
+        Feed f0 = createFeed(0, SERIAL, AUTO_DL_FALSE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED));
+        Feed f1 = createFeed(1, SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_FALSE,
+                cFI(UNPLAYED));
+        Feed f2 = createFeed(2, SERIAL, AUTO_DL_FALSE, "", KEEP_UPDATED_FALSE,
+                cFI(UNPLAYED));
+        Feed f3 = createFeed(3, SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED));
+        FeedsAccessor a = saveFeeds(f0, f1, f2, f3);
+
+        List<Long> expected = toIds(a.fi(3, 0));
+
+        // Now create the selector under test and exercise it
+        DownloadItemSelectorSerialImpl selector = new DownloadItemSelectorSerialImpl();
+        List<? extends FeedItem> fiActual = selector.getAutoDownloadableEpisodes();
+        assertEquals("Boundary, ignore non-autodownloadable feeds -  It returns: " + fiActual,
                 expected, toIds(fiActual));
     }
 

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
@@ -140,7 +140,10 @@ public class DownloadItemSelectorSerialImplTest {
                 cFI(NEW) // the one to be picked, new flag
         );
         Feed f4 = createFeed(4, SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
-                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+                cFI(UNPLAYED),
+                cFI(PLAYED), // marked as played, but not really played
+                cFI(UNPLAYED) // next to download should be this one, after the marked as played
+        );
         Feed f5 = createFeed(5, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
                 cFI(PLAYED), cFI(PLAYED)); // played time to be set later
         Feed f6 = createFeed(6, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
@@ -157,7 +160,7 @@ public class DownloadItemSelectorSerialImplTest {
             setLastPlaybackTimeDescending(a.fi(5,1), a.fi(6,0), a.fi(5,0), a.fi(3,2), a.fi(0,0));
         }
 
-        List<Long> expected = toIds(a.fi(4, 0), a.fi(2, 0), a.fi(3, 3), a.fi(1,1));
+        List<Long> expected = toIds(a.fi(4, 2), a.fi(2, 0), a.fi(3, 3), a.fi(1,1));
 
         // Run actual test
 
@@ -184,6 +187,11 @@ public class DownloadItemSelectorSerialImplTest {
             FeedItem nextToDownload = selector.getNextItemToDownloadForSerial(f1);
             assertEquals("getNextItemToDownloadForSerial() - skip downloaded",
                     a.fi(1,1), nextToDownload);
+        }
+        {
+            FeedItem nextToDownload = selector.getNextItemToDownloadForSerial(f4);
+            assertEquals("getNextItemToDownloadForSerial() - the one after the marked as played one",
+                    a.fi(4,2), nextToDownload);
         }
 
         // Test overall

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
@@ -6,7 +6,29 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.storage.DownloadItemSelectorSerialImpl;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.test.antennapod.storage.FeedTestUtil.FeedsAccessor;
+
+import static de.danoeh.antennapod.core.feed.FeedItem.NEW;
+import static de.danoeh.antennapod.core.feed.FeedItem.PLAYED;
+import static de.danoeh.antennapod.core.feed.FeedItem.UNPLAYED;
+import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.EPISODIC;
+import static de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType.SERIAL;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.AUTO_DL_TRUE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.KEEP_UPDATED_TRUE;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.cFI;
+import static de.test.antennapod.storage.DownloadItemSelectorTestUtil.createFeed;
+import static de.test.antennapod.storage.FeedTestUtil.saveFeeds;
+import static de.test.antennapod.storage.FeedTestUtil.toIds;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DownloadItemSelectorSerialImplTest {
 
@@ -30,12 +52,132 @@ public class DownloadItemSelectorSerialImplTest {
 
     }
 
+    /*
+    Test cases: TODO-1077a:
+    - no serial feeds
+    - no serial feeds with anything available
+     */
+    
     @Test
-    public void testGetAutoDownloadableEpisodes() throws Exception {
-        // TODO-1077: test DownloadItemSelectorSerialImpl
-        // - the picking of the feeditems are done in round-robin fashion
-        //
-        // - Also need to separately test the new DBAccess.getEpisodicToSerialRatio() method
-        //   - it excludes non-autodl (and not updated) ones in calculating the ratio
+    public void basic_Initial() throws Exception {
+        // - 3 serial ones, 3 items each, all unplayed
+        // - some non-serial one
+        // - no serial one has played before
+
+        // Setup test data
+        Feed f0 = createFeed(0, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED));
+        Feed f1 = createFeed("T Feed 1", SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+        Feed f2 = createFeed("A Feed 2", SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+        Feed f3 = createFeed("M Feed 3", SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+        Feed f4 = createFeed(4, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+        FeedsAccessor a = saveFeeds(f0, f1, f2, f3, f4);
+
+        List<Long> expected = toIds(a.fi(1, 0), a.fi(2, 0), a.fi(3, 0));
+        
+        // Run actual test
+
+        // Now create the selector under test and exercise it
+        DownloadItemSelectorSerialImpl selector = new DownloadItemSelectorSerialImpl();
+
+        // Test individual components of the implementation
+        {
+            // - The specific feed titles in test data ensure that the candidates are ordered by id
+            List<Feed> actual = selector.getSerialFeedsOrderedById();
+            assertEquals("getSerialFeedsOrderedById() - actual: " + actual,
+                    toIds(f1, f2, f3), toIds(actual));
+        }
+        {
+            FeedItem lastPlayed = selector.getLastPlayedSerialFeedItem();
+            assertNull("getLastPlayedSerialFeedItem() - should be null",
+                    lastPlayed);
+        }
+        { // none last played, so the order is the same as ids
+            List<Feed> actual = selector.getSerialFeedsOrderedByDownloadOrder();
+            assertEquals("getSerialFeedsOrderedById() - actual: " + actual,
+                    toIds(f1, f2, f3), toIds(actual));
+        }
+        {
+            FeedItem nextToDownload = selector.getNextItemToDownloadForSerial(f1);
+            assertEquals("getNextItemToDownloadForSerial()",
+                    a.fi(1,0), nextToDownload);
+        }
+
+        // Test Overall
+        List<? extends FeedItem> fiActual = selector.getAutoDownloadableEpisodes();
+        assertEquals("Basic, initial case -  It returns: " + fiActual,
+                expected, toIds(fiActual));
+    }
+
+    @Test
+    public void basic_Ongoing() throws Exception {
+        // - 3 serial ones, 3 items each
+        // - feed 0: all played
+        // - feed 1: all unplayed
+        // - feed 2: all unplayed
+        // - feed 3: 1 played, 1 ongoing
+        // - feed 4: all unplayed
+        // - the latest serial: feed3,  ongoing one
+        // - expectation: feed4, feed2, feed3, feed1
+        // Also test:
+        // - new flag does not matter (treated it the same as unplayed)
+
+        // Setup test data
+        Feed f0 = createFeed(0, SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(PLAYED), cFI(PLAYED), cFI(PLAYED));
+        Feed f1 = createFeed("T Feed 1", SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED),
+                cFI(UNPLAYED));
+        Feed f2 = createFeed("A Feed 2", SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+        Feed f3 = createFeed("M Feed 3", SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), // will not be picked
+                cFI(PLAYED),
+                cFI(UNPLAYED), // in-progress (to be set later)
+                cFI(NEW) // the one to be picked, new flag
+        );
+        Feed f4 = createFeed(4, SERIAL, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED), cFI(UNPLAYED), cFI(UNPLAYED));
+        Feed f5 = createFeed(5, EPISODIC, AUTO_DL_TRUE, "", KEEP_UPDATED_TRUE,
+                cFI(UNPLAYED));
+        FeedsAccessor a = saveFeeds(f0, f1, f2, f3, f4, f5);
+        { // ensure fi(3,2) is the ongoing one (with the most recent played timestamp)
+            FeedMedia fmOngoing = a.fi(3, 2).getMedia();
+            fmOngoing .setLastPlayedTime(System.currentTimeMillis() + 100);
+            DBWriter.setFeedMedia(fmOngoing).get();
+        }
+
+        List<Long> expected = toIds(a.fi(4, 0), a.fi(1,0), a.fi(2, 0), a.fi(3, 3));
+
+        // Run actual test
+
+        // Now create the selector under test and exercise it
+        DownloadItemSelectorSerialImpl selector = new DownloadItemSelectorSerialImpl();
+
+        // Test individual components of the implementation
+        {
+            FeedItem lastPlayed = selector.getLastPlayedSerialFeedItem();
+            assertEquals("getLastPlayedSerialFeedItem()",
+                    a.fi(3,2), lastPlayed);
+        }
+        {
+            List<Feed> actual = selector.getSerialFeedsOrderedByDownloadOrder();
+            assertEquals("getSerialFeedsOrderedById() - actual: " + actual,
+                    toIds(f4, f0, f1, f2, f3), toIds(actual));
+        }
+        {
+            FeedItem nextToDownload = selector.getNextItemToDownloadForSerial(f3);
+            assertEquals("getNextItemToDownloadForSerial() - the one after the ongoing",
+                    a.fi(3,3), nextToDownload);
+        }
+
+        // Test overall
+        List<? extends FeedItem> fiActual = selector.getAutoDownloadableEpisodes();
+        assertEquals("Basic, ongoing case -  It returns: " + fiActual,
+                expected, toIds(fiActual));
     }
 }

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorSerialImplTest.java
@@ -150,10 +150,7 @@ public class DownloadItemSelectorSerialImplTest {
                 cFI(UNPLAYED)); // in-progress, to be set later
         FeedsAccessor a = saveFeeds(f0, f1, f2, f3, f4, f5, f6);
         { // mark fi(1,0) as downloaded, so the feed will be pushed to the end
-            FeedMedia fmDownloaded =  a.fi(1, 0).getMedia();
-            fmDownloaded.setFile_url("file://downloaded.mp3"); // MUST set, or setDownloaded will be useless
-            fmDownloaded.setDownloaded(true);
-            DBWriter.setFeedMedia(fmDownloaded).get();
+            setDownloaded(a.fi(1,0));
         }
         { // ensure fi(3,2) is the ongoing one (with the most recent played timestamp)
             // also set the last playback time for some media to be more realistic
@@ -263,13 +260,22 @@ public class DownloadItemSelectorSerialImplTest {
     private void setLastPlaybackTimeDescending(FeedItem... feedItems) throws Exception {
         final long lastPlaybackTimeBase = System.currentTimeMillis() + 1000 * feedItems.length;
 
-        for (int i =0; i < feedItems.length; i++) {
+        for (int i = 0; i < feedItems.length; i++) {
             FeedItem item = feedItems[i];
             FeedMedia media = item.getMedia();
             media.setLastPlayedTime(lastPlaybackTimeBase - i * 1000);
             if (item.isPlayed()) {
                 media.setPlaybackCompletionDate(new Date(lastPlaybackTimeBase - i * 1000));
             }
+            DBWriter.setFeedMedia(media).get();
+        }
+    }
+
+    private void setDownloaded(FeedItem... feedItems) throws Exception {
+        for (FeedItem feedItem : feedItems) {
+            FeedMedia media = feedItem.getMedia();
+            media.setFile_url("file://downloaded.mp3"); // MUST set, or setDownloaded will be useless
+            media.setDownloaded(true);
             DBWriter.setFeedMedia(media).get();
         }
     }

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorTestUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorTestUtil.java
@@ -29,8 +29,16 @@ class DownloadItemSelectorTestUtil {
     static Feed createFeed(int titleId, @NonNull SemanticType semanticType,
                            boolean isAutoDownload, String includeFilter, boolean isKeepUpdated,
                            FeedItem... feedItems) {
+        return createFeed(FeedTestUtil.defaultFeedTitle(titleId), semanticType,
+                isAutoDownload, includeFilter, isKeepUpdated, feedItems);
+    }
 
-        return FeedTestUtil.createFeed(titleId, feedPreferences -> {
+    @NonNull
+    static Feed createFeed(String title, @NonNull SemanticType semanticType,
+                           boolean isAutoDownload, String includeFilter, boolean isKeepUpdated,
+                           FeedItem... feedItems) {
+
+        return FeedTestUtil.createFeed(title, feedPreferences -> {
             feedPreferences.setSemanticType(semanticType);
             feedPreferences.setKeepUpdated(isKeepUpdated);
             feedPreferences.setAutoDownload(isAutoDownload);

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorTestUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorTestUtil.java
@@ -10,6 +10,7 @@ import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
 import static de.danoeh.antennapod.core.feed.FeedItem.NEW;
 import static de.danoeh.antennapod.core.feed.FeedItem.PLAYED;
 import static de.danoeh.antennapod.core.feed.FeedItem.UNPLAYED;
+import static de.test.antennapod.storage.FeedTestUtil.HAS_MEIDA;
 
 class DownloadItemSelectorTestUtil {
     private DownloadItemSelectorTestUtil() { }
@@ -46,12 +47,17 @@ class DownloadItemSelectorTestUtil {
         }, feedItems);
     }
 
+    @NonNull
+    static FeedItem cFI(int playState) {
+        return cFI(playState, HAS_MEIDA);
+    }
+
     /**
      * @return a skeleton (incomplete) FeedItem of the specified state, createFeed() will fill in the details.
      */
     @NonNull
-    static FeedItem cFI(int playState) {
-        FeedItem item = FeedTestUtil.createFeedItemWithMedia();
+    static FeedItem cFI(int playState, boolean hasMedia) {
+        FeedItem item = FeedTestUtil.createFeedItem(hasMedia);
         switch (playState) {
             case NEW:
                 item.setNew();

--- a/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorTestUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DownloadItemSelectorTestUtil.java
@@ -1,0 +1,63 @@
+package de.test.antennapod.storage;
+
+import androidx.annotation.NonNull;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedFilter;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
+
+import static de.danoeh.antennapod.core.feed.FeedItem.NEW;
+import static de.danoeh.antennapod.core.feed.FeedItem.PLAYED;
+import static de.danoeh.antennapod.core.feed.FeedItem.UNPLAYED;
+
+class DownloadItemSelectorTestUtil {
+    private DownloadItemSelectorTestUtil() { }
+
+    // Useful constants for readability
+
+    static final boolean AUTO_DL_TRUE = true;
+    static final boolean AUTO_DL_FALSE = false;
+    static final boolean KEEP_UPDATED_TRUE = true;
+    static final boolean KEEP_UPDATED_FALSE = false;
+
+    //
+    // Helpers to create test feeds. Callers still need to persist them.
+    //
+
+    @NonNull
+    static Feed createFeed(int titleId, @NonNull SemanticType semanticType,
+                           boolean isAutoDownload, String includeFilter, boolean isKeepUpdated,
+                           FeedItem... feedItems) {
+
+        return FeedTestUtil.createFeed(titleId, feedPreferences -> {
+            feedPreferences.setSemanticType(semanticType);
+            feedPreferences.setKeepUpdated(isKeepUpdated);
+            feedPreferences.setAutoDownload(isAutoDownload);
+            feedPreferences.setFilter(new FeedFilter(includeFilter, ""));
+        }, feedItems);
+    }
+
+    /**
+     * @return a skeleton (incomplete) FeedItem of the specified state, createFeed() will fill in the details.
+     */
+    @NonNull
+    static FeedItem cFI(int playState) {
+        FeedItem item = FeedTestUtil.createFeedItemWithMedia();
+        switch (playState) {
+            case NEW:
+                item.setNew();
+                break;
+            case UNPLAYED:
+                item.setPlayed(false);
+                break;
+            case PLAYED:
+                item.setPlayed(true);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid playState: " + playState);
+        }
+        return item;
+    }
+
+}

--- a/app/src/androidTest/java/de/test/antennapod/storage/FeedTestUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/FeedTestUtil.java
@@ -7,8 +7,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedComponent;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
@@ -22,7 +25,25 @@ class FeedTestUtil {
     static Feed createFeed(int titleId,
                            @Nullable Consumer<FeedPreferences> feedPreferencesCustomizer,
                            FeedItem... feedItems) {
-        Feed f = new Feed(0, null, "feed " + titleId, null, "link" + titleId, "descr", null, null,
+        return createFeed(defaultFeedTitle(titleId), feedPreferencesCustomizer, feedItems);
+    }
+
+    private static final Pattern TITLE_ID_REGEX = Pattern.compile("\\d+$");
+
+    @NonNull
+    static Feed createFeed(@NonNull String feedTitle,
+                           @Nullable Consumer<FeedPreferences> feedPreferencesCustomizer,
+                           FeedItem... feedItems) {
+        String titleId;
+        { // extract the id (if any) in a suffix, e.g.,, 3 in "feed 3"
+            Matcher matcher = TITLE_ID_REGEX.matcher(feedTitle);
+            if (matcher.find()) {
+                titleId = matcher.group();
+            } else {
+                titleId = "";
+            }
+        }
+        Feed f = new Feed(0, null, feedTitle, null, "link" + titleId, "descr", null, null,
                 null, null, "id" + titleId, null, null, "url" + titleId, false, false, null, null, false);
 
         FeedPreferences fPrefs =
@@ -63,19 +84,24 @@ class FeedTestUtil {
     }
 
     @NonNull
-    static List<Long> toIds(List<? extends FeedItem> feedItems) {
-        List<Long> result = new ArrayList<>(feedItems.size());
-        for (FeedItem fi : feedItems) {
-            result.add(fi.getId());
+    static String defaultFeedTitle(int titleId) {
+        return "feed " + titleId;
+    }
+
+    @NonNull
+    static List<Long> toIds(List<? extends FeedComponent> feedComponents) {
+        List<Long> result = new ArrayList<>(feedComponents.size());
+        for (FeedComponent fc : feedComponents) {
+            result.add(fc.getId());
         }
         return result;
     }
 
     @NonNull
-    static List<Long> toIds(FeedItem... feedItems) {
-        List<Long> result = new ArrayList<>(feedItems.length);
-        for (FeedItem fi : feedItems) {
-            result.add(fi.getId());
+    static List<Long> toIds(FeedComponent... feedComponents) {
+        List<Long> result = new ArrayList<>(feedComponents.length);
+        for (FeedComponent fc : feedComponents) {
+            result.add(fc.getId());
         }
         return result;
     }

--- a/app/src/androidTest/java/de/test/antennapod/storage/FeedTestUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/FeedTestUtil.java
@@ -21,6 +21,9 @@ import de.danoeh.antennapod.core.util.Consumer;
 class FeedTestUtil {
     private FeedTestUtil() { }
 
+    static final boolean HAS_MEIDA = true;
+    static final boolean NO_MEDIA = false;
+
     @NonNull
     static Feed createFeed(int titleId,
                            @Nullable Consumer<FeedPreferences> feedPreferencesCustomizer,
@@ -74,12 +77,12 @@ class FeedTestUtil {
     }
 
     @NonNull
-    static FeedItem createFeedItemWithMedia() {
+    static FeedItem createFeedItem(boolean hasMedia) {
         FeedItem item = new FeedItem();
-
-        FeedMedia media = new FeedMedia(item, "url", 1, "audio/mp3");
-        item.setMedia(media);
-
+        if (hasMedia) {
+            FeedMedia media = new FeedMedia(item, "url", 1, "audio/mp3");
+            item.setMedia(media);
+        }
         return item;
     }
 

--- a/app/src/androidTest/java/de/test/antennapod/storage/FeedTestUtil.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/FeedTestUtil.java
@@ -1,0 +1,119 @@
+package de.test.antennapod.storage;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.danoeh.antennapod.core.util.Consumer;
+
+class FeedTestUtil {
+    private FeedTestUtil() { }
+
+    @NonNull
+    static Feed createFeed(int titleId,
+                           @Nullable Consumer<FeedPreferences> feedPreferencesCustomizer,
+                           FeedItem... feedItems) {
+        Feed f = new Feed(0, null, "feed " + titleId, null, "link" + titleId, "descr", null, null,
+                null, null, "id" + titleId, null, null, "url" + titleId, false, false, null, null, false);
+
+        FeedPreferences fPrefs =
+                new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, null, null);
+        fPrefs.setKeepUpdated(true);
+
+        if (feedPreferencesCustomizer != null) {
+            feedPreferencesCustomizer.accept(fPrefs);
+        }
+        f.setPreferences(fPrefs);
+
+        boolean isAutoDownload = fPrefs.getAutoDownload();
+
+        long curPubDateMillis = System.currentTimeMillis() - feedItems.length * 1000;
+
+        for (int j = 0; j < feedItems.length; j++) {
+            FeedItem fi = feedItems[j];
+            fi.setFeed(f);
+            curPubDateMillis += 1000; // pubDate is set to be in ascending order
+            fi.setPubDate(new Date(curPubDateMillis));
+            fi.setAutoDownload(isAutoDownload);
+            fi.setTitle("item " + j);
+
+            f.getItems().add(fi);
+        }
+
+        return f;
+    }
+
+    @NonNull
+    static FeedItem createFeedItemWithMedia() {
+        FeedItem item = new FeedItem();
+
+        FeedMedia media = new FeedMedia(item, "url", 1, "audio/mp3");
+        item.setMedia(media);
+
+        return item;
+    }
+
+    @NonNull
+    static List<Long> toIds(List<? extends FeedItem> feedItems) {
+        List<Long> result = new ArrayList<>(feedItems.size());
+        for (FeedItem fi : feedItems) {
+            result.add(fi.getId());
+        }
+        return result;
+    }
+
+    @NonNull
+    static List<Long> toIds(FeedItem... feedItems) {
+        List<Long> result = new ArrayList<>(feedItems.length);
+        for (FeedItem fi : feedItems) {
+            result.add(fi.getId());
+        }
+        return result;
+    }
+
+    @NonNull
+    static FeedsAccessor saveFeeds(Feed... feeds) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        try {
+            adapter.open();
+            adapter.setCompleteFeed(feeds);
+        } finally {
+            adapter.close();
+        }
+        return new FeedsAccessor(Arrays.asList(feeds));
+    }
+
+    /**
+     * Wrapper to provide convenience methods to access feeds / feed items of a collection
+     * (usually the test data)
+     */
+    static class FeedsAccessor {
+        @NonNull
+        private final List<Feed> feeds;
+
+        public FeedsAccessor(@NonNull List<Feed> feeds) {
+            this.feeds = feeds;
+        }
+
+        public @NonNull Feed f(int feedIndex) {
+            return feeds.get(feedIndex);
+        }
+
+        public @NonNull FeedItem fi(int feedIndex, int itemIndex) {
+            return feeds.get(feedIndex).getItemAtIndex(itemIndex);
+        }
+
+        public long fiId(int feedIndex, int itemIndex) {
+            return fi(feedIndex, itemIndex).getId();
+        }
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -3,16 +3,19 @@ package de.danoeh.antennapod.fragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.preference.SwitchPreference;
+import android.util.Log;
+
 import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
-import android.util.Log;
+import androidx.preference.SwitchPreference;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedFilter;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -67,6 +70,7 @@ public class FeedSettingsFragment extends PreferenceFragmentCompat {
                     setupAutoDeletePreference();
                     setupAuthentificationPreference();
                     setupEpisodeFilterPreference();
+                    setupSemanticTypePreference();
 
                     updateAutoDeleteSummary();
                     updateAutoDownloadEnabled();
@@ -172,6 +176,19 @@ public class FeedSettingsFragment extends PreferenceFragmentCompat {
         pref.setOnPreferenceChangeListener((preference, newValue) -> {
             boolean checked = newValue == Boolean.TRUE;
             feedPreferences.setKeepUpdated(checked);
+            feed.savePreferences();
+            pref.setChecked(checked);
+            return false;
+        });
+    }
+
+    private void setupSemanticTypePreference() {
+        SwitchPreference pref = (SwitchPreference) findPreference("semanticType");
+
+        pref.setChecked(SemanticType.SERIAL == feedPreferences.getSemanticType());
+        pref.setOnPreferenceChangeListener((preference, newValue) -> {
+            boolean checked = newValue == Boolean.TRUE;
+            feedPreferences.setSemanticType(checked ? SemanticType.SERIAL : SemanticType.EPISODIC);
             feed.savePreferences();
             pref.setChecked(checked);
             return false;

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -7,6 +7,11 @@
             android:title="@string/keep_updated"
             android:summary="@string/keep_updated_summary"/>
 
+    <SwitchPreference
+        android:key="semanticType"
+        android:title="@string/semantic_type_serial_label"
+        android:summary="@string/semantic_type_serial_summary"/>
+
     <Preference
             android:key="authentication"
             android:title="@string/authentication_label"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -2,8 +2,9 @@ package de.danoeh.antennapod.core.feed;
 
 import android.content.Context;
 import android.database.Cursor;
-import androidx.annotation.NonNull;
 import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -17,6 +18,28 @@ public class FeedPreferences {
     @NonNull
     private FeedFilter filter;
     private long feedID;
+
+    /**
+     * It mirrors <code><itunes:type></code> tag to specify the nature of the feed.
+     *
+     * @see https://blog.podbean.com/2017/07/02/get-your-podcast-ready-for-ios11/
+     */
+    public enum SemanticType {
+        EPISODIC(0),
+        SERIAL(1);
+
+        public final int code;
+
+        SemanticType(int code) {
+            this.code = code;
+        }
+    }
+
+    /**
+     * The nature of the feed. Unlike Feed.type, which is the format of the feed (rss , atom, etc.)
+     */
+    private SemanticType semanticType = SemanticType.EPISODIC;
+
     private boolean autoDownload;
     private boolean keepUpdated;
 
@@ -74,6 +97,14 @@ public class FeedPreferences {
 
     public void setFilter(@NonNull FeedFilter filter) {
         this.filter = filter;
+    }
+
+    public SemanticType getSemanticType() {
+        return semanticType;
+    }
+
+    public void setSemanticType(SemanticType semanticType) {
+        this.semanticType = semanticType;
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.storage.FeedSemanticTypeStorage;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 /**
@@ -33,12 +34,24 @@ public class FeedPreferences {
         SemanticType(int code) {
             this.code = code;
         }
+
+        public static SemanticType valueOf(int code) {
+            switch (code) {
+                case 0:
+                    return SemanticType.EPISODIC;
+                case 1:
+                    return SemanticType.SERIAL;
+                default:
+                    throw new IllegalArgumentException("SemanticType.valueOf(int) - Invalid code: " + code);
+            }
+        }
     }
 
     /**
      * The nature of the feed. Unlike Feed.type, which is the format of the feed (rss , atom, etc.)
      */
-    private SemanticType semanticType = SemanticType.EPISODIC;
+    @NonNull
+    private SemanticType semanticType;
 
     private boolean autoDownload;
     private boolean keepUpdated;
@@ -53,10 +66,11 @@ public class FeedPreferences {
     private String password;
 
     public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, String username, String password) {
-        this(feedID, autoDownload, true, auto_delete_action, username, password, new FeedFilter());
+        this(feedID, autoDownload, true, auto_delete_action, username, password, new FeedFilter(), SemanticType.EPISODIC);
     }
 
-    private FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter) {
+    private FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, AutoDeleteAction auto_delete_action, String username, String password, @NonNull FeedFilter filter,
+                            @NonNull SemanticType semanticType) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
         this.keepUpdated = keepUpdated;
@@ -64,6 +78,7 @@ public class FeedPreferences {
         this.username = username;
         this.password = password;
         this.filter = filter;
+        this.semanticType = semanticType;
     }
 
     public static FeedPreferences fromCursor(Cursor cursor) {
@@ -85,7 +100,9 @@ public class FeedPreferences {
         String password = cursor.getString(indexPassword);
         String includeFilter = cursor.getString(indexIncludeFilter);
         String excludeFilter = cursor.getString(indexExcludeFilter);
-        return new FeedPreferences(feedId, autoDownload, autoRefresh, autoDeleteAction, username, password, new FeedFilter(includeFilter, excludeFilter));
+        SemanticType semanticType = FeedSemanticTypeStorage.getSemanticType(feedId);
+        return new FeedPreferences(feedId, autoDownload, autoRefresh, autoDeleteAction, username, password, new FeedFilter(includeFilter, excludeFilter),
+                semanticType);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -103,7 +103,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                 List<? extends FeedItem> itemsToDownloadList = getItemsToDownload(context);
 
                 FeedItem[] itemsToDownload = itemsToDownloadList
-                        .toArray(new FeedItem[itemsToDownloadList.size()]);
+                        .toArray(new FeedItem[0]);
 
                 Log.d(TAG, "Enqueueing " + itemsToDownload.length + " items for download");
 
@@ -253,6 +253,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                     Math.min(this.serial, other.serial));
         }
 
+        @NonNull
         @Override
         public String toString() {
             return toString(episodic, serial);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -123,7 +123,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
         return candidates.subList(0, episodeSpaceLeft);
     }
 
-    private static class ItemProviderDefaultImpl implements ItemProvider {
+    @VisibleForTesting
+    public static class ItemProviderDefaultImpl implements ItemProvider {
         @Override
         public int getNumberOfDownloadedEpisodes() {
             return DBReader.getNumberOfDownloadedEpisodes();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -102,10 +102,10 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     @VisibleForTesting
     @NonNull
     List<? extends FeedItem> getItemsToDownload(@NonNull Context context) {
-        DownloadItemSelector selector = new DownloadItemSelectorEpisodicImpl();
+        DownloadItemSelector selector = new DownloadItemSelectorEpisodicImpl(itemProvider);
 
         List<? extends FeedItem> candidates =
-                selector.getAutoDownloadableEpisodes(itemProvider);
+                selector.getAutoDownloadableEpisodes();
 
         int autoDownloadableEpisodes = candidates.size();
         int downloadedEpisodes = itemProvider.getNumberOfDownloadedEpisodes();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.util.Pair;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -121,9 +122,10 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     List<? extends FeedItem> getItemsToDownload(@NonNull Context context) {
         List<? extends FeedItem> candidatesEpisodic =
                 selectorEpisodic.getAutoDownloadableEpisodes();
-
+        Log.v(TAG, "num. of episodic candidates: " + candidatesEpisodic.size());
         List<? extends FeedItem> candidatesSerial =
                 selectorSerial.getAutoDownloadableEpisodes();
+        Log.v(TAG, "num. of serial candidates: " + candidatesSerial.size());
 
         int autoDownloadableEpisodes = candidatesEpisodic.size() + candidatesSerial.size();
         int downloadedEpisodes = dbAccess.getNumberOfDownloadedEpisodes();
@@ -134,15 +136,16 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
         List<FeedItem> candidates;
         if (cacheIsUnlimited ||
                 episodeCacheSize >= downloadedEpisodes + autoDownloadableEpisodes) {
-            candidates = new java.util.ArrayList<>(autoDownloadableEpisodes);
+            candidates = new ArrayList<>(autoDownloadableEpisodes);
             candidates.addAll(candidatesEpisodic);
             candidates.addAll(candidatesSerial);
         } else {
             // determine the space allocated for episodic and serial feeds
             EpisodicSerialPair episodeSpaceLeft =
                     calcEpisodeSpaceLeftEpisodicAndSerial(candidatesEpisodic.size(), candidatesSerial.size());
+            Log.v(TAG, "num. items to download: " + episodeSpaceLeft);
 
-            candidates = new java.util.ArrayList<>(episodeSpaceLeft.episodic + episodeSpaceLeft.serial);
+            candidates = new ArrayList<>(episodeSpaceLeft.episodic + episodeSpaceLeft.serial);
             candidates.addAll(candidatesEpisodic.subList(0, episodeSpaceLeft.episodic));
             candidates.addAll(candidatesSerial.subList(0, episodeSpaceLeft.serial));
         }
@@ -162,6 +165,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     private EpisodicSerialPair calcEpisodeSpaceLeftEpisodicAndSerial(int numDownloadablesEpisodic, int numDownloadablesSerial) {
         EpisodicSerialPair episodicToSerialTarget = dbAccess.getEpisodicToSerialRatio()
                 .times(downloadPreferences.getEpisodeCacheSize());
+        Log.v(TAG, "Episodic to Serial Target: " + episodicToSerialTarget);
 
         EpisodicSerialPair episodicToSerialDownloaded;
         {
@@ -237,6 +241,13 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
         public EpisodicSerialPair min(EpisodicSerialPair other) {
             return new EpisodicSerialPair(Math.min(this.episodic, other.episodic),
                     Math.min(this.serial, other.serial));
+        }
+
+        @Override
+        public String toString() {
+            return "{episodic=" + episodic +
+                    ", serial=" + serial +
+                    '}';
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.util.Pair;
 
 import java.util.Collections;
 import java.util.List;
@@ -254,7 +255,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
         @NonNull
         @Override
         public EpisodicSerialPair getEpisodicToSerialRatio() {
-            return new EpisodicSerialPair(1, 0); // TODO-1077: a new method at DB layer
+            Pair<Integer, Integer> result = DBReader.getFeedEpisodicToSerialRatio();
+            return new EpisodicSerialPair(result.first, result.second);
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -6,12 +6,15 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import java.util.Collections;
 import java.util.List;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.PowerUtils;
+import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 
 /**
  * Implements the automatic download algorithm used by AntennaPod. This class assumes that
@@ -23,6 +26,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     // Subset of DBReader static methods, for ease of stubbing in tests
     interface DBAccess {
         int getNumberOfDownloadedEpisodes();
+        @NonNull EpisodicSerialPair getEpisodicToSerialRatio();
+        @NonNull List<? extends FeedItem> getDownloadedItems();
     }
 
     // Subset of UserPreferences static methods, for ease of stubbing in tests
@@ -38,6 +43,9 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     private final DownloadItemSelector selectorEpisodic;
 
     @NonNull
+    private final DownloadItemSelector selectorSerial;
+
+    @NonNull
     private final EpisodeCleanupAlgorithm cleanupAlgorithm;
     @NonNull
     private final DownloadPreferences downloadPreferences;
@@ -45,10 +53,12 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     @VisibleForTesting
     APDownloadAlgorithm(@NonNull DBAccess dbAccess,
                         @NonNull DownloadItemSelector selectorEpisodic,
+                        @NonNull DownloadItemSelector selectorSerial,
                         @NonNull EpisodeCleanupAlgorithm cleanupAlgorithm,
                         @NonNull DownloadPreferences downloadPreferences) {
         this.dbAccess = dbAccess;
         this.selectorEpisodic = selectorEpisodic;
+        this.selectorSerial = selectorSerial;
         this.cleanupAlgorithm = cleanupAlgorithm;
         this.downloadPreferences = downloadPreferences;
     }
@@ -56,6 +66,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     public APDownloadAlgorithm() {
         this(new DBAccessDefaultImpl()
                 , new DownloadItemSelectorEpisodicImpl()
+                , new DownloadItemSelectorSerialImpl()
                 , UserPreferences.getEpisodeCleanupAlgorithm()
                 , new DownloadPreferencesDefaultImpl());
     }
@@ -107,31 +118,143 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     @VisibleForTesting
     @NonNull
     List<? extends FeedItem> getItemsToDownload(@NonNull Context context) {
-
-        List<? extends FeedItem> candidates =
+        List<? extends FeedItem> candidatesEpisodic =
                 selectorEpisodic.getAutoDownloadableEpisodes();
 
-        int autoDownloadableEpisodes = candidates.size();
+        List<? extends FeedItem> candidatesSerial =
+                selectorSerial.getAutoDownloadableEpisodes();
+
+        int autoDownloadableEpisodes = candidatesEpisodic.size() + candidatesSerial.size();
         int downloadedEpisodes = dbAccess.getNumberOfDownloadedEpisodes();
         int deletedEpisodes = cleanupAlgorithm.makeRoomForEpisodes(context, autoDownloadableEpisodes);
         boolean cacheIsUnlimited = downloadPreferences.isCacheUnlimited();
         int episodeCacheSize = downloadPreferences.getEpisodeCacheSize();
 
-        int episodeSpaceLeft;
+        List<FeedItem> candidates;
         if (cacheIsUnlimited ||
                 episodeCacheSize >= downloadedEpisodes + autoDownloadableEpisodes) {
-            episodeSpaceLeft = autoDownloadableEpisodes;
+            candidates = new java.util.ArrayList<>(autoDownloadableEpisodes);
+            candidates.addAll(candidatesEpisodic);
+            candidates.addAll(candidatesSerial);
         } else {
-            episodeSpaceLeft = episodeCacheSize - (downloadedEpisodes - deletedEpisodes);
+            // determine the space allocated for episodic and serial feeds
+            EpisodicSerialPair episodeSpaceLeft =
+                    calcEpisodeSpaceLeftEpisodicAndSerial(candidatesEpisodic.size(), candidatesSerial.size());
+
+            candidates = new java.util.ArrayList<>(episodeSpaceLeft.episodic + episodeSpaceLeft.serial);
+            candidates.addAll(candidatesEpisodic.subList(0, episodeSpaceLeft.episodic));
+            candidates.addAll(candidatesSerial.subList(0, episodeSpaceLeft.serial));
         }
-        return candidates.subList(0, episodeSpaceLeft);
+
+        // sort them by pubDate descending, to avoid the serial ones being at the back of the download
+        // all the time (they are most likely still at the back though, as they tend to have older pubDates)
+        Collections.sort(candidates, new FeedItemPubdateComparator());
+
+        return candidates;
+    }
+
+    /**
+     * Divide the space available between episodic and serial, based on:
+     * - ratio between the number of episodic feeds and serial feeds
+     * - maintain the ratio among all the downloaded
+     */
+    private EpisodicSerialPair calcEpisodeSpaceLeftEpisodicAndSerial(int numDownloadablesEpisodic, int numDownloadablesSerial) {
+        EpisodicSerialPair episodicToSerialTarget = dbAccess.getEpisodicToSerialRatio()
+                .times(downloadPreferences.getEpisodeCacheSize());
+
+        EpisodicSerialPair episodicToSerialDownloaded;
+        {
+            List<? extends FeedItem> downloaded = dbAccess.getDownloadedItems();
+            int numEpisodic = 0;
+            for (FeedItem item : downloaded) {
+                if (SemanticType.EPISODIC == item.getFeed().getPreferences().getSemanticType()) {
+                    numEpisodic++;
+                }
+            }
+            episodicToSerialDownloaded = new EpisodicSerialPair(numEpisodic, downloaded.size() - numEpisodic);
+        }
+
+        EpisodicSerialPair episodeSpaceLeftInitial = episodicToSerialTarget.minus(episodicToSerialDownloaded);
+
+        // if there aren't enough downloadables, reduce the spaceLeft.
+        EpisodicSerialPair episodeSpaceLeft  = episodeSpaceLeftInitial.min(
+                new EpisodicSerialPair(numDownloadablesEpisodic, numDownloadablesSerial));
+
+        // after the above reduction (if any),
+        // allocate the freed space in, say, serial to episodic (and vice versa) to fill up the cache
+        if (episodeSpaceLeft.serial < episodeSpaceLeftInitial.serial) {
+            int freeSpace = episodeSpaceLeftInitial.serial - episodeSpaceLeft.serial;
+            int newSpaceLeftForEpisodic = Math.min(episodeSpaceLeft.episodic + freeSpace,
+                    numDownloadablesEpisodic);
+            episodeSpaceLeft = new EpisodicSerialPair(newSpaceLeftForEpisodic, episodeSpaceLeft.serial);
+        }
+        if (episodeSpaceLeft.episodic < episodeSpaceLeftInitial.episodic) {
+            int freeSpace = episodeSpaceLeftInitial.episodic - episodeSpaceLeft.episodic;
+            int newSpaceLeftForSerial = Math.min(episodeSpaceLeft.serial + freeSpace,
+                    numDownloadablesSerial);
+            episodeSpaceLeft = new EpisodicSerialPair(episodeSpaceLeft.episodic, newSpaceLeftForSerial);
+        }
+
+        return episodeSpaceLeft;
     }
 
     @VisibleForTesting
-    public static class DBAccessDefaultImpl implements DBAccess {
+    static class EpisodicSerialPair {
+        public final int episodic;
+        public final int serial;
+
+        public EpisodicSerialPair(int episodic, int serial) {
+            this.episodic = episodic;
+            this.serial = serial;
+        }
+
+        public EpisodicSerialPair minus(@NonNull EpisodicSerialPair other) {
+            return new EpisodicSerialPair(this.episodic - other.episodic, this.serial - other.serial);
+        }
+
+        /**
+         * Break the supplied number according to the episodic : serial ratio.
+         */
+        public EpisodicSerialPair times(int number) {
+            int total = episodic + serial;
+
+            int newEpisodic = Math.round((number * this.episodic + 0f) / total);
+
+            // boundary case handling
+            // - #serial rounded to 0: make it 1
+            if (newEpisodic == number && serial > 0) {
+                newEpisodic = number - 1;
+            }
+            // - #episodic rounded to 0: make it 1
+            if (newEpisodic == 0 && episodic > 0) {
+                newEpisodic = 1;
+            }
+
+            return new EpisodicSerialPair(newEpisodic, number - newEpisodic);
+        }
+
+        public EpisodicSerialPair min(EpisodicSerialPair other) {
+            return new EpisodicSerialPair(Math.min(this.episodic, other.episodic),
+                    Math.min(this.serial, other.serial));
+        }
+    }
+
+    private static class DBAccessDefaultImpl implements DBAccess {
         @Override
         public int getNumberOfDownloadedEpisodes() {
             return DBReader.getNumberOfDownloadedEpisodes();
+        }
+
+        @NonNull
+        @Override
+        public List<? extends FeedItem> getDownloadedItems() {
+            return DBReader.getDownloadedItems();
+        }
+
+        @NonNull
+        @Override
+        public EpisodicSerialPair getEpisodicToSerialRatio() {
+            return new EpisodicSerialPair(1, 0); // TODO-1077: a new method at DB layer
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -182,7 +182,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
         EpisodicSerialPair episodeSpaceLeftInitial = episodicToSerialTarget.minus(episodicToSerialDownloaded);
 
         // if there aren't enough downloadables, reduce the spaceLeft.
-        EpisodicSerialPair episodeSpaceLeft  = episodeSpaceLeftInitial.min(
+        EpisodicSerialPair episodeSpaceLeft = episodeSpaceLeftInitial.min(
                 new EpisodicSerialPair(numDownloadablesEpisodic, numDownloadablesSerial));
 
         // after the above reduction (if any),
@@ -209,18 +209,28 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
         public final int serial;
 
         public EpisodicSerialPair(int episodic, int serial) {
+            if (episodic < 0 || serial < 0) {
+                throw new IllegalArgumentException("EpisodicSerialPair() the numbers must be >= 0. Arguments: "
+                        + toString(episodic, serial));
+            }
             this.episodic = episodic;
             this.serial = serial;
         }
 
         public EpisodicSerialPair minus(@NonNull EpisodicSerialPair other) {
-            return new EpisodicSerialPair(this.episodic - other.episodic, this.serial - other.serial);
+            return new EpisodicSerialPair(
+                    Math.max(0, this.episodic - other.episodic),
+                    Math.max(0, this.serial - other.serial)
+            );
         }
 
         /**
          * Break the supplied number according to the episodic : serial ratio.
          */
         public EpisodicSerialPair times(int number) {
+            if (number < 0) {
+                throw new IllegalArgumentException("Argument number must be >= 0. Actual: " + number);
+            }
             int total = episodic + serial;
 
             int newEpisodic = Math.round((number * this.episodic + 0f) / total);
@@ -245,6 +255,11 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
 
         @Override
         public String toString() {
+            return toString(episodic, serial);
+        }
+
+        @NonNull
+        private static String toString(int episodic, int serial) {
             return "{episodic=" + episodic +
                     ", serial=" + serial +
                     '}';

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -23,8 +23,8 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
     // Subset of DBReader static methods, for ease of stubbing in tests
     interface ItemProvider {
         int getNumberOfDownloadedEpisodes();
-        List<? extends FeedItem> getQueue();
-        List<? extends FeedItem> getNewItemsList();
+        @NonNull List<? extends FeedItem> getQueue();
+        @NonNull List<? extends FeedItem> getNewItemsList();
     }
 
     // Subset of UserPreferences static methods, for ease of stubbing in tests
@@ -130,11 +130,13 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
             return DBReader.getNumberOfDownloadedEpisodes();
         }
 
+        @NonNull
         @Override
         public List<? extends FeedItem> getQueue() {
             return DBReader.getQueue();
         }
 
+        @NonNull
         @Override
         public List<? extends FeedItem> getNewItemsList() {
             return DBReader.getNewItemsList();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -1,11 +1,13 @@
 package de.danoeh.antennapod.core.storage;
 
 import android.database.Cursor;
+import android.text.TextUtils;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.ArrayMap;
-import android.text.TextUtils;
-import android.util.Log;
+import androidx.core.util.Pair;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -857,6 +859,26 @@ public final class DBReader {
         }
     }
 
+    /**
+     * Return the ratio of the number of episodic feeds to serial feeds
+     */
+    public static Pair<Integer, Integer> getFeedEpisodicToSerialRatio() {
+        int numEpisodic = 0;
+        int numSerial = 0;
+        for (Feed feed : getFeedList()) {
+            FeedPreferences fPrefs = feed.getPreferences();
+            if (!fPrefs.getAutoDownload() || !fPrefs.getKeepUpdated()) {
+                continue;
+            }
+            if (FeedPreferences.SemanticType.SERIAL == fPrefs.getSemanticType()) {
+                numSerial++;
+            } else {
+                numEpisodic++;
+            }
+        }
+        return new Pair<>(numEpisodic, numSerial);
+    }
+    
     /**
      * Searches the DB for statistics
      *

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -909,6 +909,7 @@ public final class DBReader {
     /**
      * Return the ratio of the number of episodic feeds to serial feeds
      */
+    @NonNull
     public static Pair<Integer, Integer> getFeedEpisodicToSerialRatio() {
         int numEpisodic = 0;
         int numSerial = 0;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -498,6 +498,8 @@ public final class DBReader {
         Set<Long> episodicFeedIdsSeen = new ArraySet<>();
         Cursor itemIdFeedIdCursor = null;
         try {
+            // TODO-1077: once serial settings is saved in db, consider to
+            // use it to filter directly with SQL to avoid getFeed() calls
             itemIdFeedIdCursor = adapter.getItemIdFeedIdCursorByLastPlayedDescending();
             while(itemIdFeedIdCursor.moveToNext()) {
                 long itemId = itemIdFeedIdCursor.getLong(0);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelector.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelector.java
@@ -1,13 +1,15 @@
 package de.danoeh.antennapod.core.storage;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.List;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
 
-interface DownloadItemSelector {
+@VisibleForTesting
+public interface DownloadItemSelector {
     @NonNull
     List<? extends FeedItem> getAutoDownloadableEpisodes(@NonNull ItemProvider itemProvider);
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelector.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelector.java
@@ -1,0 +1,14 @@
+package de.danoeh.antennapod.core.storage;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
+
+interface DownloadItemSelector {
+    @NonNull
+    List<? extends FeedItem> getAutoDownloadableEpisodes(@NonNull ItemProvider itemProvider);
+}
+

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelector.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelector.java
@@ -6,11 +6,10 @@ import androidx.annotation.VisibleForTesting;
 import java.util.List;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
 
 @VisibleForTesting
 public interface DownloadItemSelector {
     @NonNull
-    List<? extends FeedItem> getAutoDownloadableEpisodes(@NonNull ItemProvider itemProvider);
+    List<? extends FeedItem> getAutoDownloadableEpisodes();
 }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
@@ -10,25 +10,19 @@ import java.util.List;
 import de.danoeh.antennapod.core.feed.FeedFilter;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
-import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
 
-@VisibleForTesting
+@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 public class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
     private static final String TAG = "DlItemSelectorEpisodic";
 
-    @NonNull
-    private final ItemProvider itemProvider;
-
-    public DownloadItemSelectorEpisodicImpl(@NonNull ItemProvider itemProvider) {
-        this.itemProvider = itemProvider;
-    }
+    public DownloadItemSelectorEpisodicImpl() { }
 
     @Override
     @NonNull
     public List<? extends FeedItem> getAutoDownloadableEpisodes() {
         List<FeedItem> candidates;
-        final List<? extends FeedItem> queue = itemProvider.getQueue();
-        final List<? extends FeedItem> newItems = itemProvider.getNewItemsList();
+        final List<? extends FeedItem> queue = DBReader.getQueue();
+        final List<? extends FeedItem> newItems = DBReader.getNewItemsList();
         candidates = new ArrayList<>(queue.size() + newItems.size());
         candidates.addAll(queue);
         for(FeedItem newItem : newItems) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
@@ -16,9 +16,16 @@ import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
 public class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
     private static final String TAG = "DlItemSelectorEpisodic";
 
+    @NonNull
+    private final ItemProvider itemProvider;
+
+    public DownloadItemSelectorEpisodicImpl(@NonNull ItemProvider itemProvider) {
+        this.itemProvider = itemProvider;
+    }
+
     @Override
     @NonNull
-    public List<? extends FeedItem> getAutoDownloadableEpisodes(@NonNull ItemProvider itemProvider) {
+    public List<? extends FeedItem> getAutoDownloadableEpisodes() {
         List<FeedItem> candidates;
         final List<? extends FeedItem> queue = itemProvider.getQueue();
         final List<? extends FeedItem> newItems = itemProvider.getNewItemsList();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
@@ -1,0 +1,43 @@
+package de.danoeh.antennapod.core.storage;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.FeedFilter;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
+
+class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
+    private static final String TAG = "DlItemSelectorEpisodic";
+
+    @Override
+    @NonNull
+    public List<? extends FeedItem> getAutoDownloadableEpisodes(@NonNull ItemProvider itemProvider) {
+        List<FeedItem> candidates;
+        final List<? extends FeedItem> queue = itemProvider.getQueue();
+        final List<? extends FeedItem> newItems = itemProvider.getNewItemsList();
+        candidates = new ArrayList<>(queue.size() + newItems.size());
+        candidates.addAll(queue);
+        for(FeedItem newItem : newItems) {
+            FeedPreferences feedPrefs = newItem.getFeed().getPreferences();
+            FeedFilter feedFilter = feedPrefs.getFilter();
+            if(!candidates.contains(newItem) && feedFilter.shouldAutoDownload(newItem)) {
+                candidates.add(newItem);
+            }
+        }
+
+        // filter items that are not auto downloadable
+        Iterator<FeedItem> it = candidates.iterator();
+        while(it.hasNext()) {
+            FeedItem item = it.next();
+            if(!item.isAutoDownloadable()) {
+                it.remove();
+            }
+        }
+        return candidates;
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.core.storage;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -11,7 +12,8 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.storage.APDownloadAlgorithm.ItemProvider;
 
-class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
+@VisibleForTesting
+public class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
     private static final String TAG = "DlItemSelectorEpisodic";
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorEpisodicImpl.java
@@ -10,6 +10,7 @@ import java.util.List;
 import de.danoeh.antennapod.core.feed.FeedFilter;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
 
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 public class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
@@ -28,6 +29,9 @@ public class DownloadItemSelectorEpisodicImpl implements DownloadItemSelector {
         for(FeedItem newItem : newItems) {
             FeedPreferences feedPrefs = newItem.getFeed().getPreferences();
             FeedFilter feedFilter = feedPrefs.getFilter();
+            if (SemanticType.EPISODIC != feedPrefs.getSemanticType()) {
+                continue;
+            }
             if(!candidates.contains(newItem) && feedFilter.shouldAutoDownload(newItem)) {
                 candidates.add(newItem);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
@@ -153,21 +153,20 @@ public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
 
         if (idxLatestPlayedOrInProgress < 0) {
             // all unplayed, return the oldest, non-downloaded ones
-            return firstNonDownloadedItem(feedItems, 0);
+            return firstAutoDownloadableItem(feedItems, 0);
         } else if (idxLatestPlayedOrInProgress >= feedItems.size() - 1) {
             // the latest one is played or in progress, so nothing
             return null;
         } else {
-            return firstNonDownloadedItem(feedItems, idxLatestPlayedOrInProgress + 1);
+            return firstAutoDownloadableItem(feedItems, idxLatestPlayedOrInProgress + 1);
         }
     }
 
     @Nullable
-    private static FeedItem firstNonDownloadedItem(List<? extends FeedItem> feedItems, int startIdx) {
+    private static FeedItem firstAutoDownloadableItem(List<? extends FeedItem> feedItems, int startIdx) {
         for (int i = startIdx; i < feedItems.size(); i++) {
             FeedItem fi = feedItems.get(i);
-            FeedMedia media = fi.getMedia();
-            if (media != null && !media.isDownloaded()) {
+            if (fi.isAutoDownloadable()) { // it excludes downloaded, those with no media, etc.
                 return fi;
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
@@ -67,6 +67,11 @@ public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
         // - get list of all serial feeds grouped ordered by ID
         List<? extends Feed> serialFeedsById = getSerialFeedsOrderedById();
         int numFeeds = serialFeedsById.size();
+        Log.v(TAG, "num. of autodownlodable serial feeds: " + numFeeds);
+        if (numFeeds < 1) {
+            // optimization - skip the rest if there is no serial feeds
+            return Collections.emptyList();
+        }
         // - find out serial feed id with of which item is the last completely played or in-playback
         FeedItem lastPlayedSerialItem = getLastPlayedSerialFeedItem();
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
@@ -1,0 +1,22 @@
+package de.danoeh.antennapod.core.storage;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.FeedItem;
+
+@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
+    private static final String TAG = "DlItemSelectorSerial";
+
+    public DownloadItemSelectorSerialImpl() { }
+
+    @NonNull
+    @Override
+    public List<? extends FeedItem> getAutoDownloadableEpisodes() {
+        return new ArrayList<>(); // TODO-1077: 10/13/2019 - to be implemented
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
@@ -42,7 +42,7 @@ public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
                 excludeNonAutoDownloadables(getSerialFeedsOrderedByDownloadOrder());
 
         Set<Long> feedIdsWithDownloadedMedia = new ArraySet<>();
-        for(FeedItem item : DBReader.getDownloadedItems()) {
+        for (FeedItem item : DBReader.getDownloadedItems()) {
             feedIdsWithDownloadedMedia.add(item.getFeedId());
         }
 
@@ -141,7 +141,7 @@ public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
         }
 
         int idxLatestPlayedOrInProgress = -1;
-        for(int i = feedItems.size() - 1; i >= 0; i--) {
+        for (int i = feedItems.size() - 1; i >= 0; i--) {
             FeedItem item = feedItems.get(i);
             FeedMedia media = item.getMedia();
             if (item.isPlayed() ||
@@ -164,7 +164,7 @@ public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
 
     @Nullable
     private static FeedItem firstNonDownloadedItem(List<? extends FeedItem> feedItems, int startIdx) {
-        for(int i = startIdx; i < feedItems.size(); i++) {
+        for (int i = startIdx; i < feedItems.size(); i++) {
             FeedItem fi = feedItems.get(i);
             FeedMedia media = fi.getMedia();
             if (media != null && !media.isDownloaded()) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadItemSelectorSerialImpl.java
@@ -1,12 +1,20 @@
 package de.danoeh.antennapod.core.storage;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
+import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
@@ -17,6 +25,134 @@ public class DownloadItemSelectorSerialImpl implements DownloadItemSelector {
     @NonNull
     @Override
     public List<? extends FeedItem> getAutoDownloadableEpisodes() {
-        return new ArrayList<>(); // TODO-1077: 10/13/2019 - to be implemented
+        // - OPEN: accept an input hint for hint of how many are needed max (to return early)
+
+        // Outline:
+        // - starting with the feed of which the id is the next one
+        // - repeat until all feeds (not in queue) ar tried
+        //   (OPEN: repeat until the required number of items are in the result, if a hint is given)
+        //   - add the next unplayed episode to the result (i.e., the one after the last played / in-playback episode)
+        //   - then use the next feed
+        // - return the result
+
+        List<Feed> serialFeedsByDownloadOrder = getSerialFeedsOrderedByDownloadOrder();
+
+        List<? extends FeedItem> downloaded = DBReader.getDownloadedItems();
+
+        List<FeedItem> candidatesLater = new ArrayList<>();
+        List<FeedItem> candidates = new ArrayList<>(serialFeedsByDownloadOrder .size());
+
+        for (Feed feed : serialFeedsByDownloadOrder) {
+            FeedItem item = getNextItemToDownloadForSerial(feed);
+            if (item != null) {
+                candidates.add(item);
+            }
+        }
+        return candidates;
+    }
+
+    @VisibleForTesting
+    public List<Feed> getSerialFeedsOrderedByDownloadOrder() {
+        // - get list of all serial feeds grouped ordered by ID
+        List<? extends Feed> serialFeedsById = getSerialFeedsOrderedById();
+        int numFeeds = serialFeedsById.size();
+        // - find out serial feed id with of which item is the last completely played or in-playback
+        FeedItem lastPlayedSerialItem = getLastPlayedSerialFeedItem();
+
+        List<Feed> serialFeedsByDownloadOrder = new ArrayList<>(numFeeds);
+        if (lastPlayedSerialItem == null) {
+            serialFeedsByDownloadOrder.addAll(serialFeedsById);
+        } else {
+            int idxFeedLastPlayed = -1;
+            for (int i = 0; i < numFeeds; i++) {
+                Feed feed = serialFeedsById.get(i);
+                if (lastPlayedSerialItem.getFeedId() == feed.getId()) {
+                    idxFeedLastPlayed = i;
+                }
+            }
+            if (idxFeedLastPlayed < 0) {
+                Log.e(TAG, "getSerialFeedsOrderedByDownloadOrder: assertion error (idxFeedLastPlayed < 0)"
+                        + " , fallback to using order by feed id");
+                serialFeedsByDownloadOrder.addAll(serialFeedsById);
+            } else {
+                int idxStart = (idxFeedLastPlayed + 1) % numFeeds;
+                serialFeedsByDownloadOrder.addAll(serialFeedsById.subList(idxStart, numFeeds));
+                // round-robin: go back to the beginning
+                if (idxStart > 0) {
+                    serialFeedsByDownloadOrder.addAll(serialFeedsById.subList(0, idxStart));
+                }
+            }
+        }
+        return serialFeedsByDownloadOrder;
+    }
+
+    @VisibleForTesting
+    public List<Feed> getSerialFeedsOrderedById() {
+        List<Feed> serialFeeds = new ArrayList<>();
+        for (Feed feed: DBReader.getFeedList()) {
+            if (SemanticType.SERIAL == feed.getPreferences().getSemanticType()) {
+                feed.setItems(DBReader.getFeedItemList(feed));
+                serialFeeds.add(feed);
+            }
+        }
+
+        Collections.sort(serialFeeds, (o1, o2) -> Long.compare(o1.getId(), o2.getId()));
+
+        return serialFeeds;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    public FeedItem getLastPlayedSerialFeedItem() {
+        return DBReader.getLatestSerialPlaybackItem();
+    }
+
+    @VisibleForTesting
+    @Nullable
+    public FeedItem getNextItemToDownloadForSerial(@NonNull Feed feed) {
+        if (SemanticType.SERIAL != feed.getPreferences().getSemanticType()) {
+            throw new IllegalArgumentException("getNextItemToDownloadForSerial() - supplied feed is not serial");
+        }
+
+        // feedItems sorted by pubDate ascending
+        List<FeedItem> feedItems = new ArrayList<>(feed.getItems());
+        Collections.sort(feedItems, FeedItemPubdateComparator.ascending);
+
+        if (feedItems.size() < 1) {
+            return null;
+        }
+
+        int idxLatestPlayedOrInProgress = -1;
+        for(int i = feedItems.size() - 1; i >= 0; i--) {
+            FeedItem item = feedItems.get(i);
+            FeedMedia media = item.getMedia();
+            if (item.isPlayed() ||
+                    (media != null && media.getLastPlayedTime() > 0)) {
+                idxLatestPlayedOrInProgress = i;
+                break;
+            }
+        }
+
+        if (idxLatestPlayedOrInProgress < 0) {
+            // all unplayed, return the oldest, non-downloaded ones
+            return firstNonDownloadedItem(feedItems, 0);
+        } else if (idxLatestPlayedOrInProgress >= feedItems.size() - 1) {
+            // the latest one is played or in progress, so nothing
+            return null;
+        } else {
+            return firstNonDownloadedItem(feedItems, idxLatestPlayedOrInProgress + 1);
+        }
+    }
+
+    @Nullable
+    private FeedItem firstNonDownloadedItem(List<? extends FeedItem> feedItems, int startIdx) {
+        for(int i = startIdx; i < feedItems.size(); i++) {
+            FeedItem fi = feedItems.get(i);
+            FeedMedia media = fi.getMedia();
+            if (media != null && !media.isDownloaded()) {
+                return fi;
+            }
+        }
+        return null;
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/FeedSemanticTypeStorage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/FeedSemanticTypeStorage.java
@@ -1,0 +1,55 @@
+package de.danoeh.antennapod.core.storage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import de.danoeh.antennapod.core.feed.FeedPreferences.SemanticType;
+
+/**
+ * Persistent storage for FeedPreferences.semanticType
+ *
+ * TODO-1077: to be replaced by db-based persistence.
+ *
+ */
+public class FeedSemanticTypeStorage {
+    private static final String STORAGE_PREFS_NAME = "FeedSemanticTypeStorage";
+
+    private static Context context;
+
+    private FeedSemanticTypeStorage() { }
+
+    static void init(Context context) {
+        FeedSemanticTypeStorage.context = context.getApplicationContext();
+    }
+
+    // Public scope as it's needed from FeedPreferences#fromCursor()
+    @NonNull
+    public static SemanticType getSemanticType(long feedId) {
+        int typeCode = getStorage().getInt(toKey(feedId), SemanticType.EPISODIC.code);
+        return SemanticType.valueOf(typeCode);
+    }
+
+    static void setSemanticType(long feedId, @NonNull SemanticType semanticType) {
+        getStorage().edit()
+                .putInt(toKey(feedId), semanticType.code)
+                .apply();
+    }
+
+    static void clearAll() {
+        getStorage().edit()
+                .clear()
+                .commit();
+    }
+
+    @NonNull
+    private static SharedPreferences getStorage() {
+        return context.getSharedPreferences(STORAGE_PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    @NonNull
+    private static String toKey(long feedId) {
+        return Long.toString(feedId, 10);
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1043,16 +1043,17 @@ public class PodDBAdapter {
     }
 
     /**
-     * Returns a cursor of feed media objects ordered by last played time descending
+     * Returns a cursor of (itemId, feedId) ordered by last played time descending
      */
     public final Cursor getItemIdFeedIdCursorByLastPlayedDescending() {
         return db.rawQuery(
-                "SELECT fi.id, fi.feed\n" +
-                "  FROM FeedItems fi INNER JOIN FeedMedia fm ON fi.id = fm.feedItem\n" +
-                " WHERE fm.last_played_time > 0\n" +
-                " ORDER BY fm.last_played_time DESC",
+                "SELECT fi." + KEY_ID + ", fi." + KEY_FEED +"\n" +
+                "  FROM " + TABLE_NAME_FEED_ITEMS + " fi INNER JOIN " + TABLE_NAME_FEED_MEDIA + " fm\n" +
+                "    ON fi." + KEY_ID + " = fm." + KEY_FEEDITEM + "\n" +
+                " WHERE fm." + KEY_LAST_PLAYED_TIME + " > 0\n" +
+                " ORDER BY fm." + KEY_LAST_PLAYED_TIME + " DESC",
                 null
-        ); // TODO-1077a: use constants
+        );
     }
 
     public final Cursor getSingleFeedMediaCursor(long id) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -13,8 +13,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -290,6 +288,7 @@ public class PodDBAdapter {
 
     public static void init(Context context) {
         PodDBAdapter.context = context.getApplicationContext();
+        FeedSemanticTypeStorage.init(context);
     }
 
     // Bill Pugh Singleton Implementation
@@ -338,6 +337,7 @@ public class PodDBAdapter {
             for (String tableName : ALL_TABLES) {
                 db.delete(tableName, "1", null);
             }
+            FeedSemanticTypeStorage.clearAll();
             return true;
         } finally {
             adapter.close();
@@ -399,6 +399,7 @@ public class PodDBAdapter {
         values.put(KEY_INCLUDE_FILTER, prefs.getFilter().getIncludeFilter());
         values.put(KEY_EXCLUDE_FILTER, prefs.getFilter().getExcludeFilter());
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(prefs.getFeedID())});
+        FeedSemanticTypeStorage.setSemanticType(prefs.getFeedID(), prefs.getSemanticType());
     }
 
     public void setFeedItemFilter(long feedId, Set<String> filterValues) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -1042,6 +1042,19 @@ public class PodDBAdapter {
                 null, String.format("%s DESC LIMIT %d", KEY_PLAYBACK_COMPLETION_DATE, limit));
     }
 
+    /**
+     * Returns a cursor of feed media objects ordered by last played time descending
+     */
+    public final Cursor getItemIdFeedIdCursorByLastPlayedDescending() {
+        return db.rawQuery(
+                "SELECT fi.id, fi.feed\n" +
+                "  FROM FeedItems fi INNER JOIN FeedMedia fm ON fi.id = fm.feedItem\n" +
+                " WHERE fm.last_played_time > 0\n" +
+                " ORDER BY fm.last_played_time DESC",
+                null
+        ); // TODO-1077a: use constants
+    }
+
     public final Cursor getSingleFeedMediaCursor(long id) {
         return db.query(TABLE_NAME_FEED_MEDIA, null, KEY_ID + "=?", new String[]{String.valueOf(id)}, null, null, null);
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/comparator/FeedItemPubdateComparator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/comparator/FeedItemPubdateComparator.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.util.comparator;
 
+import java.util.Collections;
 import java.util.Comparator;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
@@ -7,7 +8,10 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 /** Compares the pubDate of two FeedItems for sorting*/
 public class FeedItemPubdateComparator implements Comparator<FeedItem> {
 
-	/** Returns a new instance of this comparator in reverse order. 
+	public static final Comparator<FeedItem> descending = new FeedItemPubdateComparator();
+	public static final Comparator<FeedItem> ascending = Collections.reverseOrder(new FeedItemPubdateComparator());
+
+	/** Returns a new instance of this comparator in reverse order.
 	public static FeedItemPubdateComparator newInstance() {
 		FeedItemPubdateComparator
 	}*/

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -636,6 +636,8 @@
     <string name="keep_updated">Keep Updated</string>
     <string name="keep_updated_summary">Include this feed when (auto-)refreshing all feeds</string>
     <string name="auto_download_disabled_globally">Auto download is disabled in the main AntennaPod settings</string>
+    <string name="semantic_type_serial_label">Serial</string>
+    <string name="semantic_type_serial_summary">Episodes are presented and downloaded oldest-to-newest.</string>
 
     <!-- Progress information -->
     <string name="progress_upgrading_database">Upgrading the database</string>

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/FeedMother.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/FeedMother.java
@@ -1,6 +1,6 @@
 package de.danoeh.antennapod.core.feed;
 
-class FeedMother {
+public class FeedMother {
     public static final String IMAGE_URL = "http://example.com/image";
 
     public static Feed anyFeed() {

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -221,6 +221,38 @@ public class APDownloadAlgorithmTest {
                 fis());
     }
 
+    @Test
+    public void mixed_Boundary_FillSerialTargetWillExceedCacheSize() {
+        withStubs(CACHE_SIZE_5,
+                fis(fi(1,3)), // queue, average
+                fis(fi(1,1), fi(100,1), fi(1,2), fi(2,2)), // played and downloaded, average
+                fis(fi(3,1), fi(200,1)), // auto-Dl items (episodic and serial)
+                0 // don't cleanup any of the downloaded
+        );
+        // episodic to serial feed ratio = 3:2, episode cache target allocation is 3:2,
+        // with download items at 4:1, 1 serial item, fi(200,1), could have been downloaded
+        // to reach serial target
+        // but total space left is 0, so none will be downloaded.
+        doTest("Mixed Boundary case - filling serial target would exceed cache size",
+                fis());
+    }
+
+    @Test
+    public void mixed_Boundary_FillEpisodicTargetWillExceedCacheSize() {
+        withStubs(CACHE_SIZE_5,
+                fis(fi(1,3)), // queue, average
+                fis(fi(2,1), fi(100,1), fi(100,2), fi(100,3)), // played and downloaded, average
+                fis(fi(3,1), fi(200,1)), // auto-Dl items (episodic and serial)
+                0 // don't cleanup any of the downloaded
+        );
+        // episodic to serial feed ratio = 3:2, episode cache target allocation is 3:2,
+        // with download items at 2:3, 1 episodic item, fi(3,1), could have been downloaded
+        // to reach episodic target
+        // but total space left is 0, so none will be downloaded.
+        doTest("Mixed Boundary case - filling episodic target would exceed cache size",
+                fis());
+    }
+
     // Run actual test, and comparing the result with the named expected.
     private void doTest(String msg, List<? extends FeedItem> expected) {
         APDownloadAlgorithm algorithm = new APDownloadAlgorithm(

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -314,7 +314,7 @@ public class APDownloadAlgorithmTest {
                     int amountOfRoomNeeded = invocation.getArgumentAt(1, Integer.class);
                     int numItemsToDelete = Math.min(maxNumToCleanup,
                             Math.min(amountOfRoomNeeded, itemsDownloadedAndPlayed.size()));
-                    for(int i = 0; i < numItemsToDelete; i++) {
+                    for (int i = 0; i < numItemsToDelete; i++) {
                         // here we assume that in the downloaded list
                         // the items played are at the head of the list, that can be cleaned-up
                         downloaded.remove(0);
@@ -345,12 +345,12 @@ public class APDownloadAlgorithmTest {
         final int numFeedItemsPerFeed = 3;
 
         Map<Long, Feed> feeds = new HashMap<>();
-        for(int i = 1; i <= 11; i++) {
+        for (int i = 1; i <= 11; i++) {
             feeds.put((long)i, feedWithItems(i, SemanticType.EPISODIC, IN_AUTO_DL, numFeedItemsPerFeed));
         }
 
         // convention: feed ids of 100, 200, etc. are serial feeds
-        for(int i = 1; i <= 11; i++) {
+        for (int i = 1; i <= 11; i++) {
             int feedId = i * 100;
             feeds.put((long)feedId, feedWithItems(feedId, SemanticType.SERIAL, IN_AUTO_DL, numFeedItemsPerFeed));
         }
@@ -360,7 +360,7 @@ public class APDownloadAlgorithmTest {
 
     private static Feed feedWithItems(long id, SemanticType semanticType, boolean isAutoDownload, int numFeedItems) {
         Feed feed = feed(id, semanticType, isAutoDownload);
-        for(int i = 1; i <= numFeedItems; i++) {
+        for (int i = 1; i <= numFeedItems; i++) {
             feedItem(feed, 10 * id + i);
         }
         return feed;

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -31,7 +31,7 @@ public class APDownloadAlgorithmTest {
     private static final boolean IN_AUTO_DL = true;
     private static final boolean NOT_AUTO_DL = false;
     private static final int CACHE_SIZE_UNLIMITED = -1;
-    private static final int CACHE_SIZE_DEFAULT = 5;
+    private static final int CACHE_SIZE_5 = 5;
 
     private static final long NotAdl1 = 9; // the constant is not all cap to make test codes look more natural.
 
@@ -52,7 +52,7 @@ public class APDownloadAlgorithmTest {
 
     @Test
     public void episodic_Average_AllAutoDownloadable() {
-        withStubs(CACHE_SIZE_DEFAULT,
+        withStubs(CACHE_SIZE_5,
                 fis(fi(1,3), fi(2,1), fi(2,2)), // queue, average
                 fis(fi(1,1), fi(1,2)), // played and downloaded, average
                 fis(fi(3,1), fi(2,3), fi(3,2), fi(3,3)) // new list, average
@@ -63,7 +63,7 @@ public class APDownloadAlgorithmTest {
 
     @Test
     public void episodic_Average_SomeNotAutoDownloadable() {
-        withStubs(CACHE_SIZE_DEFAULT,
+        withStubs(CACHE_SIZE_5,
                 fis(fi(1,3), fi(2,1), fi(2,2)), // queue, average
                 fis(fi(1,1), fi(1,2)), // played and downloaded, average
                 fis(fi(3,1), fi(NotAdl1,1), fi(2,3), fi(3,2), fi(3,3)) // new list, with item not downloadable

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -1,0 +1,201 @@
+package de.danoeh.antennapod.core.storage;
+
+import android.content.Context;
+
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedFilter;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.FeedMother;
+import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.feed.FeedPreferences.AutoDeleteAction;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class APDownloadAlgorithmTest {
+
+    private static final boolean IN_AUTO_DL = true;
+    private static final boolean NOT_AUTO_DL = false;
+    private static final int CACHE_SIZE_UNLIMITED = -1;
+    private static final int CACHE_SIZE_DEFAULT = 5;
+
+    private APDownloadAlgorithm.ItemProvider stubItemProvider;
+    private EpisodeCleanupAlgorithm stubCleanupAlgorithm;
+    private APDownloadAlgorithm.DownloadPreferences stubDownloadPreferences;
+
+    // Setup test data
+    private Feed f1 = feed(1, IN_AUTO_DL);
+    private Feed f2 = feed(2, IN_AUTO_DL);
+    private Feed f3 = feed(3, IN_AUTO_DL);
+    private Feed fNotAdl = feed(1, NOT_AUTO_DL);
+
+    private FeedItem fi1_1 = feedItem(f1, 11);
+    private FeedItem fi1_2 = feedItem(f1, 12);
+    private FeedItem fi1_3 = feedItem(f1, 13);
+
+    private FeedItem fi2_1 = feedItem(f2, 21);
+    private FeedItem fi2_2 = feedItem(f2, 22);
+    private FeedItem fi2_3 = feedItem(f2, 23);
+
+    private FeedItem fi3_1 = feedItem(f3, 31);
+    private FeedItem fi3_2 = feedItem(f3, 32);
+    private FeedItem fi3_3 = feedItem(f3, 33);
+
+    private FeedItem fiNotADl_1 = feedItem(fNotAdl, 91);
+
+    @Test
+    public void episodic_Average_AllAutoDownloadable() {
+        stubs(CACHE_SIZE_DEFAULT,
+                fis(fi1_3, fi2_1, fi2_2), // queue
+                fis(fi1_1, fi1_2), // played and downloaded
+                fis(fi3_1, fi2_3, fi3_2, fi3_3) // new list
+        );
+        expecting(fis(fi3_1, fi2_3));
+    }
+
+    @Test
+    public void episodic_Average_SomeNotAutoDownloadable() {
+        stubs(CACHE_SIZE_DEFAULT,
+                fis(fi1_3, fi2_1, fi2_2), // queue
+                fis(fi1_1, fi1_2), // played and downloaded
+                fis(fi3_1, fiNotADl_1, fi2_3, fi3_2, fi3_3) // new list
+        );
+        expecting(fis(fi3_1, fi2_3));
+    }
+
+    @Test
+    public void episodic_CacheUnlimited() {
+        stubs(CACHE_SIZE_UNLIMITED,
+                fis(fi1_3, fi2_1, fi2_2), // queue
+                fis(fi1_1, fi1_2), // played and downloaded
+                fis(fi3_1, fi2_3, fi3_2, fi3_3) // new list
+        );
+        expecting(fis(fi3_1, fi2_3, fi3_2, fi3_3));
+    }
+
+    @Test
+    public void episodic_NotEnoughInNewList() {
+        stubs(CACHE_SIZE_UNLIMITED,
+                fis(fi1_3, fi2_1, fi2_2), // queue
+                fis(fi1_1, fi1_2), // played and downloaded
+                fis(fi3_1) // new list
+        );
+        expecting(fis(fi3_1));
+    }
+
+    // Run actual test, and comparing the result with the named expected.
+    private void expecting(List<? extends FeedItem> expected) {
+        APDownloadAlgorithm algorithm = new APDownloadAlgorithm(
+                stubItemProvider, stubCleanupAlgorithm, stubDownloadPreferences);
+        List<? extends FeedItem> actual = algorithm.getItemsToDownload(mock(Context.class));
+
+        assertEquals(expected, actual);
+    }
+
+
+    //
+    // test data generation helpers
+    //
+
+    private void stubs(int cacheSize,
+                       List<? extends FeedItem> itemsInQueue,
+                       List<? extends FeedItem> itemsDownloadedAndPlayed,
+                       List<? extends FeedItem> itemsInNewList
+    ) {
+        // In the test cases, we assume all items in the queue has been downloaded (the typical case)
+        for (FeedItem item : itemsInQueue) {
+            item.setPlayed(false);
+            item.getMedia().setDownloaded(true);
+            item.getMedia().setFile_url("file://path/media-" + item.getId());
+        }
+
+        for (FeedItem item : itemsDownloadedAndPlayed) {
+            item.setPlayed(true);
+            item.getMedia().setDownloaded(true);
+            item.getMedia().setFile_url("file://path/media-" + item.getId());
+        }
+
+        for (FeedItem item : itemsDownloadedAndPlayed) {
+            item.setNew();
+            item.getMedia().setDownloaded(false);
+        }
+
+        List<FeedItem> downloaded = new ArrayList<>();
+        downloaded.addAll(itemsDownloadedAndPlayed);
+        downloaded.addAll(itemsInQueue);
+
+        stubItemProvider = mock(APDownloadAlgorithm.ItemProvider.class);
+        when(stubItemProvider.getQueue()).then(answer(itemsInQueue));
+        when(stubItemProvider.getNumberOfDownloadedEpisodes()).thenReturn(downloaded.size());
+        when(stubItemProvider.getNewItemsList()).then(answer(itemsInNewList));
+
+        stubCleanupAlgorithm = mock(EpisodeCleanupAlgorithm.class);
+        when(stubCleanupAlgorithm.makeRoomForEpisodes(any(Context.class), anyInt()))
+                .then(invocation -> {
+                    int amountOfRoomNeeded = invocation.getArgumentAt(1, Integer.class);
+                    int numItemsToDelete = Math.min(amountOfRoomNeeded, itemsDownloadedAndPlayed.size());
+                    for(int i = 0; i < numItemsToDelete; i++) {
+                        // here we assume that in the downloaded list
+                        // the items played are at the head of the list, that can be cleaned-up
+                        downloaded.remove(0);
+                    }
+                    return numItemsToDelete;
+                });
+
+
+        stubDownloadPreferences = mock(APDownloadAlgorithm.DownloadPreferences.class);
+        when(stubDownloadPreferences.getEpisodeCacheSize()).thenReturn(cacheSize);
+        when(stubDownloadPreferences.isCacheUnlimited()).thenReturn(cacheSize < 0);
+    }
+
+
+    private static Feed feed(long id, boolean isAutoDownload) {
+        FeedFilter filter = new FeedFilter("", "");
+        FeedPreferences fPrefs = new FeedPreferences(id, isAutoDownload, AutoDeleteAction.GLOBAL, "", "");
+        fPrefs.setFilter(filter);
+
+        Feed feed = FeedMother.anyFeed();
+        feed.setId(id);
+        feed.setTitle("feed-title-" + id);
+        feed.setPreferences(fPrefs);
+
+        return feed;
+    }
+
+    private static FeedItem feedItem(Feed feed, long id) {
+        FeedItem item = new FeedItem(id, "Item-" + id, "Item", "url", new Date(), FeedItem.UNPLAYED, feed);
+        item.setAutoDownload(feed.getPreferences().getAutoDownload());
+        FeedMedia media = new FeedMedia(item, "http://example.com/episode", 42, "audio/mp3") {
+            // Stub out methods that rely on static UserPreferences
+            @Override
+            public boolean isPlaying() {
+                return false;
+            }
+        };
+        media.setItem(item);
+        item.setMedia(media);
+        return item;
+    }
+
+    private static Answer<List<? extends FeedItem>> answer(List<? extends FeedItem> result) {
+        return invocation -> result;
+    }
+
+    private static List<? extends FeedItem> fis(FeedItem... feedItems) {
+        return Arrays.asList(feedItems);
+    }
+
+}
+

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -91,6 +91,18 @@ public class APDownloadAlgorithmTest {
     }
 
     @Test
+    public void episodic_Boundary_DownloadedMoreThanTarget() {
+        withStubs(CACHE_SIZE_5,
+                fis(fi(1,3), fi(2,1), fi(2,2)), // queue, average
+                fis(fi(1,1), fi(1,2), fi(3,1)), // played and downloaded, average
+                fis(fi(2,3), fi(3,2)),  // new list, average
+                0 // don't cleanup any of the downloaded
+        );
+        doTest("Case num. of downloaded (6) is more than the target(5)",
+                fis());
+    }
+
+    @Test
     public void mixed_Average_1SerialFeed() {
         withStubs(CACHE_SIZE_5,
                 fis(fi(1,3), fi(2,1), fi(2,2)), // queue, average
@@ -192,6 +204,23 @@ public class APDownloadAlgorithmTest {
                 fis(fi(3,1), fi(200,1)));
     }
 
+    @Test
+    public void mixed_Boundary_DownloadedMoreThanTarget_Both() {
+        withStubs(CACHE_SIZE_5,
+                fis(fi(1,3)), // queue, average
+                fis(fi(1,1), fi(100,1), fi(100,2), fi(100,3), fi(1,2), fi(2,2)), // played and downloaded, average
+                fis(fi(3,1), fi(200,1)), // auto-Dl items (episodic and serial)
+                0 // don't cleanup any of the downloaded
+        );
+        // episodic to serial feed ratio = 3:2, episode cache target allocation is 3:2,
+        // space left is 0 however.
+        // ensure the calculation does not become negative
+        // - episodic (target is 3, but 4 have been downloaded)
+        // - serial (target is 2, but 3 have been downloaded)
+        doTest("Mixed Boundary case - more downloaded than target - both",
+                fis());
+    }
+
     // Run actual test, and comparing the result with the named expected.
     private void doTest(String msg, List<? extends FeedItem> expected) {
         APDownloadAlgorithm algorithm = new APDownloadAlgorithm(
@@ -206,6 +235,16 @@ public class APDownloadAlgorithmTest {
                            List<? extends FeedItem> itemsInQueue,
                            List<? extends FeedItem> itemsDownloadedAndPlayed,
                            List<? extends FeedItem> itemsAutoDownloadablePubDateDesc
+    ) {
+        withStubs(cacheSize, itemsInQueue, itemsDownloadedAndPlayed, itemsAutoDownloadablePubDateDesc,
+                Integer.MAX_VALUE);
+    }
+
+    private void withStubs(int cacheSize,
+                           List<? extends FeedItem> itemsInQueue,
+                           List<? extends FeedItem> itemsDownloadedAndPlayed,
+                           List<? extends FeedItem> itemsAutoDownloadablePubDateDesc,
+                           int maxNumToCleanup
     ) {
         Set<Feed> feedSet = new ArraySet<>();
 
@@ -273,7 +312,8 @@ public class APDownloadAlgorithmTest {
         when(stubCleanupAlgorithm.makeRoomForEpisodes(any(Context.class), anyInt()))
                 .then(invocation -> {
                     int amountOfRoomNeeded = invocation.getArgumentAt(1, Integer.class);
-                    int numItemsToDelete = Math.min(amountOfRoomNeeded, itemsDownloadedAndPlayed.size());
+                    int numItemsToDelete = Math.min(maxNumToCleanup,
+                            Math.min(amountOfRoomNeeded, itemsDownloadedAndPlayed.size()));
                     for(int i = 0; i < numItemsToDelete; i++) {
                         // here we assume that in the downloaded list
                         // the items played are at the head of the list, that can be cleaned-up

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -57,51 +57,55 @@ public class APDownloadAlgorithmTest {
 
     @Test
     public void episodic_Average_AllAutoDownloadable() {
-        stubs(CACHE_SIZE_DEFAULT,
-                fis(fi1_3, fi2_1, fi2_2), // queue
-                fis(fi1_1, fi1_2), // played and downloaded
-                fis(fi3_1, fi2_3, fi3_2, fi3_3) // new list
+        withStubs(CACHE_SIZE_DEFAULT,
+                fis(fi1_3, fi2_1, fi2_2), // queue, average
+                fis(fi1_1, fi1_2), // played and downloaded, average
+                fis(fi3_1, fi2_3, fi3_2, fi3_3) // new list, average
         );
-        expecting(fis(fi3_1, fi2_3));
+        doTest("Average case - download some from new list",
+                fis(fi3_1, fi2_3));
     }
 
     @Test
     public void episodic_Average_SomeNotAutoDownloadable() {
-        stubs(CACHE_SIZE_DEFAULT,
-                fis(fi1_3, fi2_1, fi2_2), // queue
-                fis(fi1_1, fi1_2), // played and downloaded
-                fis(fi3_1, fiNotADl_1, fi2_3, fi3_2, fi3_3) // new list
+        withStubs(CACHE_SIZE_DEFAULT,
+                fis(fi1_3, fi2_1, fi2_2), // queue, average
+                fis(fi1_1, fi1_2), // played and downloaded, average
+                fis(fi3_1, fiNotADl_1, fi2_3, fi3_2, fi3_3) // new list, with item not downloadable
         );
-        expecting(fis(fi3_1, fi2_3));
+        doTest("Average case - some in new list not auto downloadable",
+                fis(fi3_1, fi2_3));
     }
 
     @Test
     public void episodic_CacheUnlimited() {
-        stubs(CACHE_SIZE_UNLIMITED,
-                fis(fi1_3, fi2_1, fi2_2), // queue
-                fis(fi1_1, fi1_2), // played and downloaded
-                fis(fi3_1, fi2_3, fi3_2, fi3_3) // new list
+        withStubs(CACHE_SIZE_UNLIMITED,
+                fis(fi1_3, fi2_1, fi2_2), // queue, average
+                fis(fi1_1, fi1_2), // played and downloaded, average
+                fis(fi3_1, fi2_3, fi3_2, fi3_3) // new list, average
         );
-        expecting(fis(fi3_1, fi2_3, fi3_2, fi3_3));
+        doTest("Case unlimited cache - download all from new list",
+                fis(fi3_1, fi2_3, fi3_2, fi3_3));
     }
 
     @Test
     public void episodic_NotEnoughInNewList() {
-        stubs(CACHE_SIZE_UNLIMITED,
+        withStubs(CACHE_SIZE_UNLIMITED,
                 fis(fi1_3, fi2_1, fi2_2), // queue
                 fis(fi1_1, fi1_2), // played and downloaded
                 fis(fi3_1) // new list
         );
-        expecting(fis(fi3_1));
+        doTest("Case new list is not enough to fill the queue",
+                fis(fi3_1));
     }
 
     // Run actual test, and comparing the result with the named expected.
-    private void expecting(List<? extends FeedItem> expected) {
+    private void doTest(String msg, List<? extends FeedItem> expected) {
         APDownloadAlgorithm algorithm = new APDownloadAlgorithm(
                 stubItemProvider, stubCleanupAlgorithm, stubDownloadPreferences);
         List<? extends FeedItem> actual = algorithm.getItemsToDownload(mock(Context.class));
 
-        assertEquals(expected, actual);
+        assertEquals(msg, expected, actual);
     }
 
 
@@ -109,10 +113,10 @@ public class APDownloadAlgorithmTest {
     // test data generation helpers
     //
 
-    private void stubs(int cacheSize,
-                       List<? extends FeedItem> itemsInQueue,
-                       List<? extends FeedItem> itemsDownloadedAndPlayed,
-                       List<? extends FeedItem> itemsInNewList
+    private void withStubs(int cacheSize,
+                           List<? extends FeedItem> itemsInQueue,
+                           List<? extends FeedItem> itemsDownloadedAndPlayed,
+                           List<? extends FeedItem> itemsInNewList
     ) {
         // In the test cases, we assume all items in the queue has been downloaded (the typical case)
         for (FeedItem item : itemsInQueue) {

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithmTest.java
@@ -122,7 +122,7 @@ public class APDownloadAlgorithmTest {
             item.getMedia().setFile_url("file://path/media-" + item.getId());
         }
 
-        for (FeedItem item : itemsDownloadedAndPlayed) {
+        for (FeedItem item : itemsInNewList) {
             item.setNew();
             item.getMedia().setDownloaded(false);
         }


### PR DESCRIPTION
Closes #1077

Plan:
- [x] 1. Refactor existing download logic and create unit tests for them
- [x] 2. Extend download logic to support serial podcasts, without database change
- [ ] 3. Database change (and upgrade) to support serial podcast
- [ ] 4. UX enhancement to minimize users' manual settings : identify serial podcast and mark them by default.

Notes: 
- By step (2), a build can be made available for early adopters to try the feature out (that does not require database upgrade, compatible with the latest official release).
- Details of UX changes [4] remain TBD. Without any of changes, power users can still use it by going to podcasts individually and set them as serial.
