### PR TITLE
Show stream button rather than download (in queue, podcast views)

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/ItemActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/ItemActionButton.java
@@ -10,6 +10,7 @@ import android.widget.ImageButton;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 
 public abstract class ItemActionButton {
@@ -43,6 +44,8 @@ public abstract class ItemActionButton {
             return new PlayActionButton(item);
         } else if (isDownloadingMedia) {
             return new CancelDownloadActionButton(item);
+        } else if (UserPreferences.streamOverDownload()) {
+            return new StreamActionButton(item);
         } else if (MobileDownloadHelper.userAllowedMobileDownloads() || !MobileDownloadHelper.userChoseAddToQueue() || isInQueue) {
             return new DownloadActionButton(item, isInQueue);
         } else {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/StreamActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/StreamActionButton.java
@@ -1,0 +1,63 @@
+package de.danoeh.antennapod.adapter.actionbutton;
+
+import android.content.Context;
+
+import androidx.annotation.AttrRes;
+import androidx.annotation.StringRes;
+
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.util.IntentUtils;
+import de.danoeh.antennapod.core.util.NetworkUtils;
+import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
+
+import static de.danoeh.antennapod.core.service.playback.PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE;
+import static de.danoeh.antennapod.core.service.playback.PlaybackService.ACTION_RESUME_PLAY_CURRENT_EPISODE;
+
+public class StreamActionButton extends ItemActionButton{
+    StreamActionButton(FeedItem item) {
+        super(item);
+    }
+
+    @Override
+    @StringRes
+    public int getLabel() {
+        return R.string.stream_label;
+    }
+
+    @Override
+    @AttrRes
+    public int getDrawable() {
+        FeedMedia media = item.getMedia();
+        if (media != null && media.isCurrentlyPlaying()) {
+            return R.attr.av_pause;
+        }
+        return R.attr.action_stream;
+    }
+
+    @Override
+    public void onClick(Context context) {
+        final FeedMedia media = item.getMedia();
+        if (media == null) {
+            return;
+        }
+
+        if (media.isPlaying()) {
+            togglePlayPause(context, media);
+        } else {
+            DBTasks.playMedia(context, media, false, true, true);
+        }
+    }
+
+    private void togglePlayPause(Context context, FeedMedia media) {
+        new PlaybackServiceStarter(context, media)
+                .startWhenPrepared(true)
+                .shouldStream(true)
+                .start();
+
+        String pauseOrResume = media.isCurrentlyPlaying() ? ACTION_PAUSE_PLAY_CURRENT_EPISODE : ACTION_RESUME_PLAY_CURRENT_EPISODE;
+        IntentUtils.sendLocalBroadcast(context, pauseOrResume);
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/StreamActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/StreamActionButton.java
@@ -10,13 +10,13 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.util.IntentUtils;
-import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
 
 import static de.danoeh.antennapod.core.service.playback.PlaybackService.ACTION_PAUSE_PLAY_CURRENT_EPISODE;
 import static de.danoeh.antennapod.core.service.playback.PlaybackService.ACTION_RESUME_PLAY_CURRENT_EPISODE;
 
-public class StreamActionButton extends ItemActionButton{
+public class StreamActionButton extends ItemActionButton {
+
     StreamActionButton(FeedItem item) {
         super(item);
     }
@@ -57,7 +57,8 @@ public class StreamActionButton extends ItemActionButton{
                 .shouldStream(true)
                 .start();
 
-        String pauseOrResume = media.isCurrentlyPlaying() ? ACTION_PAUSE_PLAY_CURRENT_EPISODE : ACTION_RESUME_PLAY_CURRENT_EPISODE;
+        String pauseOrResume = media.isCurrentlyPlaying()
+                ? ACTION_PAUSE_PLAY_CURRENT_EPISODE : ACTION_RESUME_PLAY_CURRENT_EPISODE;
         IntentUtils.sendLocalBroadcast(context, pauseOrResume);
     }
 }

--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -76,6 +76,11 @@
                 android:key="prefPlaybackTimeRespectsSpeed"
                 android:summary="@string/pref_playback_time_respects_speed_sum"
                 android:title="@string/pref_playback_time_respects_speed_title"/>
+        <SwitchPreference
+                android:defaultValue="false"
+                android:key="prefStreamOverDownload"
+                android:summary="@string/pref_stream_over_download_sum"
+                android:title="@string/pref_stream_over_download_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/queue_label">

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -81,6 +81,7 @@ public class UserPreferences {
     private static final String PREF_RESUME_AFTER_CALL = "prefResumeAfterCall";
     public static final String PREF_VIDEO_BEHAVIOR = "prefVideoBehavior";
     private static final String PREF_TIME_RESPECTS_SPEED = "prefPlaybackTimeRespectsSpeed";
+    private static final String PREF_STREAM_OVER_DOWNLOAD = "prefStreamOverDownload";
 
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
@@ -929,6 +930,10 @@ public class UserPreferences {
 
     public static boolean timeRespectsSpeed() {
         return prefs.getBoolean(PREF_TIME_RESPECTS_SPEED, false);
+    }
+
+    public static boolean streamOverDownload() {
+        return prefs.getBoolean(PREF_STREAM_OVER_DOWNLOAD, false);
     }
 
     /**

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -376,6 +376,8 @@
     <string name="pref_pauseOnHeadsetDisconnect_title">Headphones Disconnect</string>
     <string name="pref_unpauseOnHeadsetReconnect_title">Headphones Reconnect</string>
     <string name="pref_unpauseOnBluetoothReconnect_title">Bluetooth Reconnect</string>
+    <string name="pref_stream_over_download_title">Prefer Streaming</string>
+    <string name="pref_stream_over_download_sum">Display stream button instead of download button in lists.</string>
     <string name="pref_mobileUpdate_title">Mobile Updates</string>
     <string name="pref_mobileUpdate_sum">Select what should be allowed over the mobile data connection</string>
     <string name="pref_mobileUpdate_refresh">Feed refresh</string>


### PR DESCRIPTION
Implementation of option to display `Stream` button in place of `Download` (closes #3019 )
* Added user preference to favor streams
* Added StreamAction to provide Stream button in feed/queue listitems