### PR TITLE
Prefer image that is specified in feed over embedded image

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -375,10 +375,10 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, ImageR
 
     @Override
     public String getImageLocation() {
-        if(media != null && media.hasEmbeddedPicture()) {
-            return media.getImageLocation();
-        } else if (imageUrl != null) {
-           return imageUrl;
+        if (imageUrl != null) {
+            return imageUrl;
+        } else if (media != null && media.hasEmbeddedPicture()) {
+            return media.getLocalMediaUrl();
         } else if (feed != null) {
             return feed.getImageLocation();
         } else {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -566,10 +566,10 @@ public class FeedMedia extends FeedFile implements Playable {
 
     @Override
     public String getImageLocation() {
-        if (hasEmbeddedPicture()) {
-            return getLocalMediaUrl();
-        } else if(item != null) {
+        if (item != null) {
             return item.getImageLocation();
+        } else if (hasEmbeddedPicture()) {
+            return getLocalMediaUrl();
         } else {
             return null;
         }


### PR DESCRIPTION
Closes #2945

If the feed explicitly specifies an episode image, use that instead of the embedded image in the media file. This fixes the problem that media files change their icons if there is a mismatch between embedded and feed-specified image. In most feeds I tried, this change even improved the resolution of the image (embedded often seem to have lower resolution). In opus files, this speeds up loading the image.

I don't think that there are publishers who add an episode-specific cover to the media file but not to the feed. One side effect could be that users start to notice more episode-specific covers. #3505 adds an option to not show episode-specific covers if someone is not happy with that.