### PR TITLE
Fix incorrect progress string on widget

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/PlayerWidgetJobService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/PlayerWidgetJobService.java
@@ -219,7 +219,7 @@ public class PlayerWidgetJobService extends SafeJobIntentService {
     }
 
     private String getProgressString(int position, int duration, float speed) {
-        if (position > 0 && duration > 0) {
+        if (position >= 0 && duration > 0) {
             TimeSpeedConverter converter = new TimeSpeedConverter(speed);
             position = converter.convert(position);
             duration = converter.convert(duration);


### PR DESCRIPTION
If option "pref_followQueue_title" is disabled, when played episode #1 is ended and next episode #2 is loaded, progress string on widget show incorrect information about position and duration of episode, because it show (position / duration) of ended episode #1 instead of (position / duration) of loaded episode #2.