### PR TITLE
Updating notification play button in onDestroy

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -326,6 +326,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     public void onDestroy() {
         super.onDestroy();
         Log.d(TAG, "Service is about to be destroyed");
+
+        if (notificationBuilder.getPlayerStatus() == PlayerStatus.PLAYING) {
+            notificationBuilder.setPlayerStatus(PlayerStatus.STOPPED);
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
+            notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build());
+        }
         stateManager.stopForeground(!UserPreferences.isPersistNotify());
         isRunning = false;
         currentMediaType = MediaType.UNKNOWN;
@@ -1197,7 +1203,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
 
         PlayerStatus playerStatus = mediaPlayer.getPlayerStatus();
-        notificationBuilder.setMetadata(playable, mediaSession.getSessionToken(), playerStatus, isCasting);
+        notificationBuilder.setPlayable(playable);
+        notificationBuilder.setMediaSessionToken(mediaSession.getSessionToken());
+        notificationBuilder.setPlayerStatus(playerStatus);
+        notificationBuilder.setCasting(isCasting);
         notificationBuilder.updatePosition(getCurrentPosition(), getCurrentPlaybackSpeed());
 
         Log.d(TAG, "setupNotification: startForeground" + playerStatus);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
@@ -46,16 +46,11 @@ public class PlaybackServiceNotificationBuilder {
         this.context = context;
     }
 
-    public void setMetadata(Playable playable, MediaSessionCompat.Token mediaSessionToken,
-                            PlayerStatus playerStatus, boolean isCasting) {
-
+    public void setPlayable(Playable playable) {
         if (playable != this.playable) {
             clearCache();
         }
         this.playable = playable;
-        this.mediaSessionToken = mediaSessionToken;
-        this.playerStatus = playerStatus;
-        this.isCasting = isCasting;
     }
 
     private void clearCache() {
@@ -63,7 +58,7 @@ public class PlaybackServiceNotificationBuilder {
         this.position = null;
     }
 
-    public void updatePosition(int position,float speed) {
+    public void updatePosition(int position, float speed) {
         TimeSpeedConverter converter = new TimeSpeedConverter(speed);
         this.position = Converter.getDurationStringLong(converter.convert(position));
     }
@@ -238,5 +233,21 @@ public class PlaybackServiceNotificationBuilder {
         } else {
             return PendingIntent.getService(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         }
+    }
+
+    public void setMediaSessionToken(MediaSessionCompat.Token mediaSessionToken) {
+        this.mediaSessionToken = mediaSessionToken;
+    }
+
+    public void setPlayerStatus(PlayerStatus playerStatus) {
+        this.playerStatus = playerStatus;
+    }
+
+    public void setCasting(boolean casting) {
+        isCasting = casting;
+    }
+
+    public PlayerStatus getPlayerStatus() {
+        return playerStatus;
     }
 }


### PR DESCRIPTION
When destroying, make sure that the notification no longer displays playing state. Prevents inconsistent button state (as experienced in #3570) but not the root cause why the service is stopped in the first place.