### PR TITLE
Fixed pressing play from headset button

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceStateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceStateManager.java
@@ -22,6 +22,7 @@ class PlaybackServiceStateManager {
     void stopService() {
         stopForeground(true);
         playbackService.stopSelf();
+        hasReceivedValidStartCommand = false;
     }
 
     void stopForeground(boolean removeNotification) {
@@ -35,7 +36,6 @@ class PlaybackServiceStateManager {
             }
         }
         isInForeground = false;
-        hasReceivedValidStartCommand = false;
     }
 
     boolean isInForeground() {


### PR DESCRIPTION
When pausing, we stop the foreground service. This prevented re-entering
foreground state later, which lead to Android killing the service after a
few seconds.

Closes #3570 