### PR TITLE
Enqueue after currently playing: in-context UI prompt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
     implementation 'com.github.mfietz:fyydlin:v0.4.2'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
+    implementation 'com.tomergoldst.android:hoverview:1.0.2'
 
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
     androidTestImplementation 'com.nanohttpd:nanohttpd-webserver:2.1.1'

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -15,6 +15,7 @@ import android.widget.CheckBox;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.MenuItemCompat;
@@ -42,8 +43,8 @@ import de.danoeh.antennapod.core.event.DownloaderUpdate;
 import de.danoeh.antennapod.core.event.FeedItemEvent;
 import de.danoeh.antennapod.core.event.PlaybackPositionEvent;
 import de.danoeh.antennapod.core.event.PlayerStatusEvent;
-import de.danoeh.antennapod.core.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.core.event.QueueEvent;
+import de.danoeh.antennapod.core.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.util.PlaybackSpeedUtils;
@@ -164,10 +165,27 @@ public class QueueFragment extends Fragment {
                 recyclerAdapter.notifyDataSetChanged();
                 break;
             case MOVED:
+                promptUserToEnqueueAfterCurrentlyPlayingIfApplicable(event);
                 return;
         }
         saveScrollPosition();
         onFragmentLoaded(false);
+    }
+
+    private boolean promptUserToEnqueueAfterCurrentlyPlayingIfApplicable(@NonNull QueueEvent event) {
+        // applicable only if the item is moved to top
+        if (QueueEvent.Action.MOVED != event.action || event.position != 0) {
+            return false;
+        }
+        // TODO-2652: prompt if the item moved to the top is currently playing and enqueueLocation settings is FRONT
+        new AlertDialog.Builder(requireContext())
+                .setTitle("Enqueue Location Settings")
+                .setView(R.layout.suggest_enqueue_after_currently_playing_dialog)
+                .setPositiveButton("Yes", null)
+                .setNegativeButton("No", null)
+                .show();
+
+        return true;
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -26,6 +26,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.tomergoldst.hoverview.HoverView;
+import com.tomergoldst.hoverview.HoverViewManager;
 import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 
 import org.greenrobot.eventbus.EventBus;
@@ -177,13 +179,30 @@ public class QueueFragment extends Fragment {
         if (QueueEvent.Action.MOVED != event.action || event.position != 0) {
             return false;
         }
+
         // TODO-2652: prompt if the item moved to the top is currently playing and enqueueLocation settings is FRONT
-        new AlertDialog.Builder(requireContext())
-                .setTitle("Enqueue Location Settings")
-                .setView(R.layout.suggest_enqueue_after_currently_playing_dialog)
-                .setPositiveButton("Yes", null)
-                .setNegativeButton("No", null)
-                .show();
+
+        final HoverViewManager viewManager = new HoverViewManager();
+        final ViewGroup rootView = (ViewGroup) requireView();
+        final View anchorView = recyclerView.getChildAt(0);
+        // don't have tooltip arrow built-in. I need to draw it in the promptView, assuming
+        // the view will be put below the anchor
+        View promptView = LayoutInflater.from(requireContext())
+                .inflate(R.layout.suggest_enqueue_after_currently_playing_dialog, rootView, false);
+        promptView.findViewById(R.id.btnPositive).setOnClickListener(v -> {
+            // TODO-2652: actual logic
+            viewManager.findAndDismiss(anchorView);
+        });
+        promptView.findViewById(R.id.btnNegative).setOnClickListener(v -> {
+            viewManager.findAndDismiss(anchorView);
+        });
+
+        viewManager.show(new HoverView.Builder(requireContext(),
+                anchorView,
+                rootView,
+                promptView,
+                HoverView.POSITION_BELOW
+        ).build());
 
         return true;
     }

--- a/app/src/main/res/drawable/ic_tooltip_arrow_up_24dp.xml
+++ b/app/src/main/res/drawable/ic_tooltip_arrow_up_24dp.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:height="24dp" android:width="24dp"
+        android:viewportHeight="24.0" android:viewportWidth="24.0"
+        android:tint="?colorAccent">  <!-- TODO-2652: ensure theme's colorAccent works on android 4.x -->
+    <path android:fillColor="#FF000000" android:pathData="M12,8 0,24 24,24 z"/>
+</vector>

--- a/app/src/main/res/drawable/tooltip_background_no_arrow.xml
+++ b/app/src/main/res/drawable/tooltip_background_no_arrow.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?colorAccent" /> <!-- TODO-2652: ensure theme's colorAccent works on android 4.x -->
+    <corners android:radius="10dp"/>
+    <padding android:left="0dp" android:top="0dp" android:right="0dp" android:bottom="0dp" />
+</shape>

--- a/app/src/main/res/layout/suggest_enqueue_after_currently_playing_dialog.xml
+++ b/app/src/main/res/layout/suggest_enqueue_after_currently_playing_dialog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
+    <TextView android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="You have moved the currently playing episode to the top.\n\nDo you want to enqueue episodes after currently playing one in the future?"
+            />
+    <LinearLayout
+            android:layout_marginTop="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+        <CheckBox
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Remember the choice" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/suggest_enqueue_after_currently_playing_dialog.xml
+++ b/app/src/main/res/layout/suggest_enqueue_after_currently_playing_dialog.xml
@@ -1,24 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:padding="16dp">
-    <TextView android:layout_width="match_parent"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="48dp"
+        android:layout_marginRight="48dp"
+        android:drawableTop="@drawable/ic_tooltip_arrow_up_24dp"
+        >
+    <ImageView
+            android:id="@+id/ic_arrow"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="You have moved the currently playing episode to the top.\n\nDo you want to enqueue episodes after currently playing one in the future?"
+            app:srcCompat="@drawable/ic_tooltip_arrow_up_24dp"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true"
             />
-    <LinearLayout
-            android:layout_marginTop="8dp"
-            android:layout_width="match_parent"
+    <RelativeLayout
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-        <CheckBox
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+            android:background="@drawable/tooltip_background_no_arrow"
+            android:layout_below="@id/ic_arrow"
+            >
         <TextView
-                android:layout_width="match_parent"
+                android:id="@+id/txtvMessage"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Remember the choice" />
-    </LinearLayout>
-</LinearLayout>
+                android:textSize="14sp"
+                android:paddingTop="16dp"
+                android:paddingStart="16dp"
+                android:paddingLeft="16dp"
+                android:paddingEnd="16dp"
+                android:paddingRight="16dp"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentLeft="true"
+                android:text="You have moved the currently playing episode to the top.\nDo you want to enqueue episodes after currently playing one in the future?" />
+
+        <Space
+                android:id="@+id/spacer"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_below="@id/txtvMessage"
+                />
+
+        <Button
+                android:id="@+id/btnNegative"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/no"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_below="@id/spacer"
+                android:layout_toStartOf="@id/btnPositive"
+                android:layout_toLeftOf="@id/btnPositive"
+                />
+
+        <Button
+                android:id="@+id/btnPositive"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/yes"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_below="@id/spacer"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                />
+
+    </RelativeLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
(Currently at UI prototype stage. Soliciting feedback before I proceed any further.)

Follow-up on PR #2714, for the use case from #2652 (enqueue after currently playing).

This is a usability enhancement suggestion. The idea is to reduce user's need to go to settings to tweak it. The UI provides in-context suggestion.

In this case, the criteria is 
- enqueue location is set as Front
- users move the currently playing item to the top of the queue

The user's action indicates he/she really wants the newly queued episode to be placed after currently playing one.

With this PR, the app displays a dialog, asking if the user wants to set the enqueue location to after currently playing. The user thus does not need to dig through settings to find out it's possible.

From the UI prototype:

![AP_AfterCurrentlyPlaying_2448_ui_prompt_smaller](https://user-images.githubusercontent.com/250644/68345520-5c388300-00a6-11ea-9fd1-72044a7a2710.gif)

