### PR TITLE
Fix download order list

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -459,15 +459,12 @@ public class DownloadService extends Service {
         Downloader downloader = downloaderFactory.create(request);
         if (downloader != null) {
             numberOfDownloads.incrementAndGet();
-            // smaller rss feeds before bigger media files
-            if (request.getFeedfileType() == Feed.FEEDFILETYPE_FEED) {
-                downloads.add(0, downloader);
-            } else {
-                if (isEnqueued(request, itemsEnqueued)) {
-                    request.setMediaEnqueued(true);
-                }
-                downloads.add(downloader);
+
+            if (request.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA
+                    && isEnqueued(request, itemsEnqueued)) {
+                request.setMediaEnqueued(true);
             }
+            downloads.add(downloader);
             downloadExecutor.submit(downloader);
 
             postDownloaders();


### PR DESCRIPTION
We tried to prioritize feed downloads over media downloads but that never worked because the `downloadExecutor` executes requests in the order they were added in. This fix adds the downloads to our list in the same order.

Changing the priority in a `ThreadPoolExecutor` with custom queue is possible but we currently use a `ExecutorCompletionService` that wraps a `ThreadPoolExecutor`. The `ExecutorCompletionService` handles `Callable<Downloader>` while a normal `ThreadPoolExecutor` only handles `Runnable`.

If someone finds the time to implement the prioritization, I would be happy to merge a PR. For now, this PR fixes the bug of showing a wrong download list without changing the actual download order.

Closes #2894