### PR TITLE
Hotfix: Do not delete episodes

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -833,6 +833,9 @@ public class UserPreferences {
     }
 
     public static EpisodeCleanupAlgorithm getEpisodeCleanupAlgorithm() {
+        if (!isEnableAutodownload()) {
+            return new APNullCleanupAlgorithm();
+        }
         int cleanupValue = getEpisodeCleanupValue();
         if (cleanupValue == EPISODE_CLEANUP_QUEUE) {
             return new APQueueCleanupAlgorithm();
@@ -844,7 +847,7 @@ public class UserPreferences {
     }
 
     public static int getEpisodeCleanupValue() {
-        return Integer.parseInt(prefs.getString(PREF_EPISODE_CLEANUP, "-1"));
+        return Integer.parseInt(prefs.getString(PREF_EPISODE_CLEANUP, "" + EPISODE_CLEANUP_NULL));
     }
 
     public static void setEpisodeCleanupValue(int episodeCleanupValue) {


### PR DESCRIPTION
Hotfix for #3560. Auto cleanup needs to be re-organized in the future (see #3560) but for now, this fixes disappearing episodes that some users experience.