### PR TITLE
Fix DownloadService deadlock

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -260,7 +260,6 @@ public class DownloadService extends Service {
                             removeDownload(downloader);
                             numberOfDownloads.decrementAndGet();
                             queryDownloadsAsync();
-
                         });
                     } else {
                         handleFailedDownload(downloader);
@@ -270,8 +269,10 @@ public class DownloadService extends Service {
                     }
                 } catch (InterruptedException e) {
                     Log.e(TAG, "DownloadCompletionThread was interrupted");
+                    return;
                 } catch (ExecutionException e) {
                     Log.e(TAG, "ExecutionException in DownloadCompletionThread: " + e.getMessage());
+                    return;
                 }
             }
             Log.d(TAG, "End of downloadCompletionThread");


### PR DESCRIPTION
downloadExecutor.take() clears the interrupted state of the thread when throwing an
InterruptedException. When getting this exception, we need to return instead of relying
on the loop to get cancelled.