### PR TITLE
Make sure to create notification channels

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -24,7 +24,6 @@ public class PreferenceUpgrader {
         int newVersion = BuildConfig.VERSION_CODE;
 
         if (oldVersion != newVersion) {
-            NotificationUtils.createChannels(context);
             AutoUpdateManager.restartUpdateAlarm();
 
             upgrade(oldVersion);

--- a/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -8,6 +8,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.exception.RxJavaErrorHandlerSetup;
+import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 
 /**
  * Stores callbacks for core classes like Services, DB classes etc. and other configuration variables.
@@ -44,6 +45,7 @@ public class ClientConfig {
         NetworkUtils.init(context);
         SleepTimerPreferences.init(context);
         RxJavaErrorHandlerSetup.setupRxJavaErrorHandler();
+        NotificationUtils.createChannels(context);
         initialized = true;
     }
 

--- a/core/src/play/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -10,6 +10,7 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.exception.RxJavaErrorHandlerSetup;
+import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 
 /**
  * Stores callbacks for core classes like Services, DB classes etc. and other configuration variables.
@@ -58,6 +59,7 @@ public class ClientConfig {
         }
         SleepTimerPreferences.init(context);
         RxJavaErrorHandlerSetup.setupRxJavaErrorHandler();
+        NotificationUtils.createChannels(context);
         initialized = true;
     }
 


### PR DESCRIPTION
This fixes a crash when starting services without starting the main activity. Also it fixes crashes when users upgrade their phone to Android 8+. Might also be related to #2817

```
11:48:06 V/InstrumentationResultParser: INSTRUMENTATION_STATUS: numtests=219
11:48:06 V/InstrumentationResultParser: INSTRUMENTATION_STATUS: stack=android.app.RemoteServiceException: Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification: Notification(channel=downloading pri=0 contentView=null vibrate=null sound=null defaults=0x0 flags=0x42 color=0x00000000 vis=PUBLIC)
11:48:06 V/InstrumentationResultParser: at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1737)
11:48:06 V/InstrumentationResultParser: at android.os.Handler.dispatchMessage(Handler.java:106)
11:48:06 V/InstrumentationResultParser: at android.os.Looper.loop(Looper.java:193)
11:48:06 V/InstrumentationResultParser: at android.app.ActivityThread.main(ActivityThread.java:6669)
11:48:06 V/InstrumentationResultParser: at java.lang.reflect.Method.invoke(Native Method)
11:48:06 V/InstrumentationResultParser: at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
11:48:06 V/InstrumentationResultParser: at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
11:48:06 V/InstrumentationResultParser: 
11:48:06 V/InstrumentationResultParser: INSTRUMENTATION_STATUS: stream=
11:48:06 V/InstrumentationResultParser: Process crashed while executing testEventsGeneratedCaseMediaDownloadSuccess_withEnqueue(de.test.antennapod.service.download.DownloadServiceTest):
11:48:06 V/InstrumentationResultParser: android.app.RemoteServiceException: Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification: Notification(channel=downloading pri=0 contentView=null vibrate=null sound=null defaults=0x0 flags=0x42 color=0x00000000 vis=PUBLIC)
11:48:06 V/InstrumentationResultParser: at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1737)
11:48:06 V/InstrumentationResultParser: at android.os.Handler.dispatchMessage(Handler.java:106)
11:48:06 V/InstrumentationResultParser: at android.os.Looper.loop(Looper.java:193)
11:48:06 V/InstrumentationResultParser: at android.app.ActivityThread.main(ActivityThread.java:6669)
11:48:06 V/InstrumentationResultParser: at java.lang.reflect.Method.invoke(Native Method)
11:48:06 V/InstrumentationResultParser: at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
11:48:06 V/InstrumentationResultParser: at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
11:48:06 V/InstrumentationResultParser: 
```