### PR TITLE
More forgiving duplicate detection

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/util/URLCheckerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/URLCheckerTest.java
@@ -5,6 +5,8 @@ import de.danoeh.antennapod.core.util.URLChecker;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for URLChecker
@@ -118,5 +120,31 @@ public class URLCheckerTest {
         final String in = "example.com";
         final String out = URLChecker.prepareURL(in, null);
         assertEquals("http://example.com", out);
+    }
+
+    @Test
+    public void testUrlEqualsSame() {
+        assertTrue(URLChecker.urlEquals("https://www.example.com/test", "https://www.example.com/test"));
+        assertTrue(URLChecker.urlEquals("https://www.example.com/test", "https://www.example.com/test/"));
+        assertTrue(URLChecker.urlEquals("https://www.example.com/test", "https://www.example.com//test"));
+        assertTrue(URLChecker.urlEquals("https://www.example.com", "https://www.example.com/"));
+        assertTrue(URLChecker.urlEquals("https://www.example.com", "http://www.example.com"));
+        assertTrue(URLChecker.urlEquals("http://www.example.com/", "https://www.example.com/"));
+        assertTrue(URLChecker.urlEquals("https://www.example.com/?id=42", "https://www.example.com/?id=42"));
+        assertTrue(URLChecker.urlEquals("https://example.com/podcast%20test", "https://example.com/podcast test"));
+        assertTrue(URLChecker.urlEquals("https://example.com/?a=podcast%20test", "https://example.com/?a=podcast test"));
+        assertTrue(URLChecker.urlEquals("https://example.com/?", "https://example.com/"));
+        assertTrue(URLChecker.urlEquals("https://example.com/?", "https://example.com"));
+        assertTrue(URLChecker.urlEquals("https://Example.com", "https://example.com"));
+        assertTrue(URLChecker.urlEquals("https://example.com/test", "https://example.com/Test"));
+    }
+
+    @Test
+    public void testUrlEqualsDifferent() {
+        assertFalse(URLChecker.urlEquals("https://www.example.com/test", "https://www.example2.com/test"));
+        assertFalse(URLChecker.urlEquals("https://www.example.com/test", "https://www.example.de/test"));
+        assertFalse(URLChecker.urlEquals("https://example.com/", "https://otherpodcast.example.com/"));
+        assertFalse(URLChecker.urlEquals("https://www.example.com/?id=42&a=b", "https://www.example.com/?id=43&a=b"));
+        assertFalse(URLChecker.urlEquals("https://example.com/podcast%25test", "https://example.com/podcast test"));
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/GpodnetSyncService.java
@@ -38,6 +38,7 @@ import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.DownloadRequestException;
 import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.NetworkUtils;
+import de.danoeh.antennapod.core.util.URLChecker;
 import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 
 /**
@@ -185,15 +186,14 @@ public class GpodnetSyncService extends SafeJobIntentService {
         // local changes are always superior to remote changes!
         // add subscription if (1) not already subscribed and (2) not just unsubscribed
         for (String downloadUrl : changes.getAdded()) {
-            if (!localSubscriptions.contains(downloadUrl) &&
-                    !localRemoved.contains(downloadUrl)) {
+            if (!URLChecker.containsUrl(localSubscriptions, downloadUrl) && !localRemoved.contains(downloadUrl)) {
                 Feed feed = new Feed(downloadUrl, null);
                 DownloadRequester.getInstance().downloadFeed(this, feed);
             }
         }
         // remove subscription if not just subscribed (again)
         for (String downloadUrl : changes.getRemoved()) {
-            if(!localAdded.contains(downloadUrl)) {
+            if (!localAdded.contains(downloadUrl)) {
                 DBTasks.removeFeedWithDownloadUrl(GpodnetSyncService.this, downloadUrl);
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/URLChecker.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/URLChecker.java
@@ -1,10 +1,16 @@
 package de.danoeh.antennapod.core.util;
 
 import android.net.Uri;
+import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import android.util.Log;
 
 import de.danoeh.antennapod.core.BuildConfig;
+import okhttp3.HttpUrl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Provides methods for checking and editing a URL.
@@ -77,5 +83,46 @@ public final class URLChecker {
         } else {
             return prepareURL(url);
         }
+    }
+
+    public static boolean containsUrl(List<String> list, String url) {
+        for (String item : list) {
+            if (urlEquals(item, url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean urlEquals(String string1, String string2) {
+        HttpUrl url1 = HttpUrl.parse(string1);
+        HttpUrl url2 = HttpUrl.parse(string2);
+        if (!url1.host().equals(url2.host())) {
+            return false;
+        }
+        List<String> pathSegments1 = normalizePathSegments(url1.pathSegments());
+        List<String> pathSegments2 = normalizePathSegments(url2.pathSegments());
+        if (!pathSegments1.equals(pathSegments2)) {
+            return false;
+        }
+        if (TextUtils.isEmpty(url1.query())) {
+            return TextUtils.isEmpty(url2.query());
+        }
+        return url1.query().equals(url2.query());
+    }
+
+    /**
+     * Removes empty segments and converts all to lower case.
+     * @param input List of path segments
+     * @return Normalized list of path segments
+     */
+    private static List<String> normalizePathSegments(List<String> input) {
+        List<String> result = new ArrayList<>();
+        for (String string : input) {
+            if (!TextUtils.isEmpty(string)) {
+                result.add(string.toLowerCase());
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
I just looked at `GpodnetSyncService.processSubscriptionChanges`. There are several reasons for duplicate subscriptions after a gpodder full sync.

- The URLs do not match exactly (`https://www.example.com/feed` vs `https://example.com/feed/` vs `http://example.com/feed/`). Actually, those URLs are different. Servers could return a different reply. Because I think that this is unlikely, this PR changes the behavior.
- The feed moved to a new page. For example, `https://www.example.com/feed` could redirect to `https://www.example.com/newFeed`. AntennaPod updates the URL but if Gpodder still has the old url, AntennaPod does not know that it is the same feed. Actually, we can not really fix this, only suppress it. Gpodder will still have the old url on their server and it is a **full** sync.

Closes #2214