### PR TITLE
Only modify and query downloads array in main thread

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -477,13 +477,13 @@ public class DownloadService extends Service {
                     && isEnqueued(request, itemsEnqueued)) {
                 request.setMediaEnqueued(true);
             }
-            downloads.add(downloader);
-            downloadExecutor.submit(downloader);
-
-            postDownloaders();
+            handler.post(() -> {
+                downloads.add(downloader);
+                downloadExecutor.submit(downloader);
+                postDownloaders();
+            });
         }
-
-        queryDownloads();
+        handler.post(this::queryDownloads);
     }
 
     private static boolean isEnqueued(@NonNull DownloadRequest request,


### PR DESCRIPTION
This fixes a ConcurrentModificationException if the thread that queues downloads (database IO)
adds the item to the downloads list and the notification updater queries the downloads list at
the same time.