### PR TITLE
More skip values

### DIFF
--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -31,6 +31,8 @@
         <item>30</item>
         <item>45</item>
         <item>60</item>
+        <item>120</item>
+        <item>300</item>
     </integer-array>
 
     <string-array name="update_intervall_values">


### PR DESCRIPTION
	modified:   core/src/main/res/values/arrays.xml

Yop @ByteHamster 
(my first merge on github ^^, I did some merges to F-Droid (gitlab)).  

Here is a small update to add more values to the skip buttons (2 min and 5 min).   
It's useful because sometimes Antennapod restarts from 0 without reasons and we want to skip 30 min... :kissing_closed_eyes: 