### PR TITLE
Try to fix ArrayIndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/AllEpisodesRecycleAdapter.java
@@ -245,8 +245,9 @@ public class AllEpisodesRecycleAdapter extends RecyclerView.Adapter<AllEpisodesR
         public void onClick(View v) {
             MainActivity mainActivity = mainActivityRef.get();
             if (mainActivity != null) {
-                long[] ids = itemAccess.getItemsIds().toArray();
-                mainActivity.loadChildFragment(ItemPagerFragment.newInstance(ids, getAdapterPosition()));
+                LongList itemIds = itemAccess.getItemsIds();
+                long[] ids = itemIds.toArray();
+                mainActivity.loadChildFragment(ItemPagerFragment.newInstance(ids, itemIds.indexOf(item.getId())));
             }
         }
 


### PR DESCRIPTION
We sometimes get an ArrayIndexOutOfBoundsException when trying to create the ItemPagerFragment. After trying quite a few things already, Google Play still reports the crash. Previous experiments showed that the index is not larger than the array length. Because it is an AIOOB Exception and not a NPE, the array must be created correctly. Maybe it is a negative index. Might be caused by getAdapterPosition() returning NO_POSITION (-1).