### PR TITLE
Check if an episode has media before adding it to download batch

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -480,7 +480,7 @@ public class EpisodesApplyActionFragment extends Fragment {
         // download the check episodes in the same order as they are currently displayed
         List<FeedItem> toDownload = new ArrayList<>(checkedIds.size());
         for(FeedItem episode : episodes) {
-            if(checkedIds.contains(episode.getId())) {
+            if(checkedIds.contains(episode.getId()) && episode.hasMedia()) {
                 toDownload.add(episode);
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -490,7 +490,7 @@ public class EpisodesApplyActionFragment extends Fragment {
             e.printStackTrace();
             DownloadRequestErrorDialogCreator.newRequestErrorDialog(getActivity(), e.getMessage());
         }
-        close(R.plurals.downloading_batch_label, checkedIds.size());
+        close(R.plurals.downloading_batch_label, toDownload.size());
     }
 
     private void deleteChecked() {


### PR DESCRIPTION
This patch makes sure that an episode actually contains a media file before being added to the download batch. 

Right now AntennaPod crashes when an user attempts to batch download text-only feeds.

This commit will prevent AntennaPod from crashing, however the app will tell the user it is downloading the text-only entries when in fact it is just ignoring them. The user facing message should obviously be changed to make this behavior transparent to the user.

I would appreciate any suggestions.

Edit: My idea is to pass size of toDownload to close() instead of size of checkedIds. This way the number displayed should match the number of episodes actually being downloaded. In case only text-only entries have been selected no snackbar is being displayed. So the user tells the app to go download things and nothing happens. There is no visual feedback at all. This probably is as edge-case so I am not going to add any additional strings to the code to account for that.