### PR TITLE
Support for "Subscribe on Android" 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -297,6 +297,22 @@
                 <data android:scheme="antennapod-subscribe"/>
             </intent-filter>
 
+            <!--Support for subscribeonandroid.com URLS-->
+
+            <intent-filter android:label="android.intent.action.VIEW">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:pathPattern=".*\\..*/.*" />
+                <data android:host="subscribeonandroid.com" />
+                <data android:host="www.subscribeonandroid.com" />
+                <data android:host="*subscribeonandroid.com" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.SEND"/>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -299,7 +299,7 @@
 
             <!--Support for subscribeonandroid.com URLS-->
 
-            <intent-filter android:label="android.intent.action.VIEW">
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -311,6 +311,8 @@
                 <data android:host="*subscribeonandroid.com" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+
+
             </intent-filter>
 
             <intent-filter>
@@ -354,6 +356,8 @@
                 <action android:name="de.danoeh.antennapdsp.intent.SP_APPS_QUERY_FEEDS_RESPONSE"/>
             </intent-filter>
         </receiver>
+
+
 
         <provider
             android:authorities="@string/provider_authority"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -236,7 +236,6 @@
                 android:value="de.danoeh.antennapod.activity.MainActivity"/>
 
             <!-- URLs ending with '.xml' or '.rss' -->
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -252,7 +251,6 @@
             </intent-filter>
 
             <!-- Feedburner URLs -->
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -268,7 +266,6 @@
             </intent-filter>
 
             <!-- Files with mimeType rss/xml/atom -->
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -284,7 +281,6 @@
             </intent-filter>
 
             <!-- Podcast protocols -->
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 
@@ -297,8 +293,7 @@
                 <data android:scheme="antennapod-subscribe"/>
             </intent-filter>
 
-            <!--Support for subscribeonandroid.com URLS-->
-
+            <!-- Support for subscribeonandroid.com URLS -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -311,8 +306,6 @@
                 <data android:host="*subscribeonandroid.com" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />
-
-
             </intent-filter>
 
             <intent-filter>
@@ -356,8 +349,6 @@
                 <action android:name="de.danoeh.antennapdsp.intent.SP_APPS_QUERY_FEEDS_RESPONSE"/>
             </intent-filter>
         </receiver>
-
-
 
         <provider
             android:authorities="@string/provider_authority"

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -134,8 +134,9 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         } else {
             Log.d(TAG, "Activity was started with url " + feedUrl);
             setLoadingLayout();
+            //Remove subscribeonandroid.com from feed URL in order to subscribe to the actual feed URL
             if(feedUrl.contains("subscribeonandroid.com")){
-                feedUrl = feedUrl.replaceAll("((www.)?(subscribeonandroid.com/))","");
+                feedUrl = feedUrl.replaceFirst("((www.)?(subscribeonandroid.com/))","");
             }
             if (savedInstanceState == null) {
                 startFeedDownload(feedUrl, null, null);

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -134,9 +134,9 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         } else {
             Log.d(TAG, "Activity was started with url " + feedUrl);
             setLoadingLayout();
-            //Remove subscribeonandroid.com from feed URL in order to subscribe to the actual feed URL
-            if(feedUrl.contains("subscribeonandroid.com")){
-                feedUrl = feedUrl.replaceFirst("((www.)?(subscribeonandroid.com/))","");
+            // Remove subscribeonandroid.com from feed URL in order to subscribe to the actual feed URL
+            if (feedUrl.contains("subscribeonandroid.com")) {
+                feedUrl = feedUrl.replaceFirst("((www.)?(subscribeonandroid.com/))", "");
             }
             if (savedInstanceState == null) {
                 startFeedDownload(feedUrl, null, null);

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -134,6 +134,9 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         } else {
             Log.d(TAG, "Activity was started with url " + feedUrl);
             setLoadingLayout();
+            if(feedUrl.contains("subscribeonandroid.com")){
+                feedUrl = feedUrl.replaceAll("((www.)?(subscribeonandroid.com/))","");
+            }
             if (savedInstanceState == null) {
                 startFeedDownload(feedUrl, null, null);
             } else {


### PR DESCRIPTION
This PR introduces initial support for subscribeonandroid.com URLs.

Fixes #2297 

However, I'm not really happy with the way URLs are parsed now. In particular the RegEx I hacked together.

Other than that I'm not sure how to handle the http(s) part of the URL. If an user tries to subscribe to an subscribeonandroid.com URL served via https while the original only being available via plan http the subscription is probably going to fail.

Let me know your thoughts.