### PR TITLE
Show episode publish date in the audio player

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.request.RequestOptions;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.glide.ApGlideSettings;
 import de.danoeh.antennapod.core.feed.util.ImageResourceUtils;
+import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
 import io.reactivex.Maybe;
@@ -33,6 +34,7 @@ public class CoverFragment extends Fragment {
     private View root;
     private TextView txtvPodcastTitle;
     private TextView txtvEpisodeTitle;
+    private TextView txtvPubDate;
     private ImageView imgvCover;
     private PlaybackController controller;
     private Disposable disposable;
@@ -44,6 +46,7 @@ public class CoverFragment extends Fragment {
         root = inflater.inflate(R.layout.cover_fragment, container, false);
         txtvPodcastTitle = root.findViewById(R.id.txtvPodcastTitle);
         txtvEpisodeTitle = root.findViewById(R.id.txtvEpisodeTitle);
+        txtvPubDate = root.findViewById(R.id.txtvPubDate);
         imgvCover = root.findViewById(R.id.imgvCover);
         imgvCover.setOnClickListener(v -> onPlayPause());
         return root;
@@ -70,6 +73,14 @@ public class CoverFragment extends Fragment {
     private void displayMediaInfo(@NonNull Playable media) {
         txtvPodcastTitle.setText(media.getFeedTitle());
         txtvEpisodeTitle.setText(media.getEpisodeTitle());
+        if (media.getEpisodePubDate() != null) {
+            String pubDateStr = DateUtils.formatAbbrev(getActivity(), media.getEpisodePubDate());
+            txtvPubDate.setVisibility(View.VISIBLE);
+            txtvPubDate.setText(pubDateStr);
+        } else {
+            txtvPubDate.setVisibility(View.INVISIBLE);
+        }
+
         Glide.with(this)
                 .load(ImageResourceUtils.getImageLocation(media))
                 .apply(new RequestOptions()

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -41,4 +41,18 @@
         android:textIsSelectable="true"
         tools:text="Episode" />
 
+    <TextView
+        android:id="@+id/txtvPubDate"
+        style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_weight="0"
+        android:contentDescription="Published Date"
+        android:maxLines="1"
+        tools:background="@android:color/holo_green_dark"
+        tools:text="Jan 1" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -25,7 +25,7 @@
         android:layout_weight="0.125"
         android:ellipsize="end"
         android:gravity="center"
-        android:maxLines="1"
+        android:maxLines="2"
         android:textColor="?android:attr/textColorSecondary"
         android:textIsSelectable="true"
         tools:text="Podcast" />

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -6,17 +6,6 @@
     android:orientation="vertical"
     android:padding="8dp">
 
-    <TextView
-        android:id="@+id/txtvPodcastTitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.25"
-        android:ellipsize="end"
-        android:gravity="center"
-        android:maxLines="2"
-        android:textColor="?android:attr/textColorSecondary"
-        android:textIsSelectable="true"
-        tools:text="Podcast" />
 
     <ImageView
         android:id="@+id/imgvCover"
@@ -30,10 +19,22 @@
         android:foreground="?attr/selectableItemBackground" />
 
     <TextView
+        android:id="@+id/txtvPodcastTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.125"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textIsSelectable="true"
+        tools:text="Podcast" />
+
+    <TextView
         android:id="@+id/txtvEpisodeTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="0.25"
+        android:layout_weight="0.125"
         android:ellipsize="end"
         android:gravity="center"
         android:maxLines="2"
@@ -46,13 +47,10 @@
         style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
+        android:gravity="left"
         android:layout_weight="0"
         android:contentDescription="Published Date"
         android:maxLines="1"
-        tools:background="@android:color/holo_green_dark"
         tools:text="Jan 1" />
 
 </LinearLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -419,6 +419,18 @@ public class FeedMedia extends FeedFile implements Playable {
     }
 
     @Override
+    public Date getEpisodePubDate() {
+        if (item == null) {
+            return null;
+        }
+        if (item.getPubDate() != null) {
+            return item.getPubDate();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
     public List<Chapter> getChapters() {
         if (item == null) {
             return null;

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
@@ -9,6 +9,8 @@ import android.os.Parcelable;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.util.ChapterUtils;
+
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.apache.commons.io.FilenameUtils;
@@ -110,6 +112,11 @@ public class ExternalMedia implements Playable {
     @Override
     public String getEpisodeTitle() {
         return episodeTitle;
+    }
+
+    @Override
+    public Date getEpisodePubDate() {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.util.List;
+import java.util.Date;
 
 import de.danoeh.antennapod.core.asynctask.ImageResource;
 import de.danoeh.antennapod.core.feed.Chapter;
@@ -67,6 +68,11 @@ public interface Playable extends Parcelable,
      * Returns the title of the feed this Playable belongs to.
      */
     String getFeedTitle();
+
+    /**
+     * Returns the pubDate of the episode.
+     */
+    Date getEpisodePubDate();
 
     /**
      * Returns a unique identifier, for example a file url or an ID from a

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
@@ -283,8 +283,8 @@ public class RemoteMedia implements Playable {
     }
 
     @Override
-    public Date getPubDate() { return pubDate; }
-    
+    public Date getEpisodePubDate() { return pubDate; }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(downloadUrl);

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/RemoteMedia.java
@@ -283,6 +283,9 @@ public class RemoteMedia implements Playable {
     }
 
     @Override
+    public Date getPubDate() { return pubDate; }
+    
+    @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(downloadUrl);
         dest.writeString(itemIdentifier);


### PR DESCRIPTION
Fix #1672

@ByteHamster  I think center looks better than left justified.  Take a look at this PR and screenshot.

When an episode has a publish date, show it in abbreviation form (Jan 10) in the audio player.  This is helpful especially when listening to daily episodes to know what date we are listening to.

![Screenshot_20200112-130407](https://user-images.githubusercontent.com/149837/72225802-7bd4a780-353e-11ea-9542-f3ba0da3be97.png)

