### PR TITLE
show artistName in place of podcast url when it is availble

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     implementation "com.github.shts:TriangleLabelView:$triangleLabelViewVersion"
     implementation 'com.leinardi.android:speed-dial:3.0.0'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
-    implementation 'com.github.mfietz:fyydlin:v0.4.2'
+    implementation 'com.github.mfietz:fyydlin:v0.5.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
 
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"

--- a/app/src/main/java/de/danoeh/antennapod/adapter/gpodnet/PodcastListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/gpodnet/PodcastListAdapter.java
@@ -44,7 +44,7 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
             holder.image = convertView.findViewById(R.id.imgvCover);
             holder.title = convertView.findViewById(R.id.txtvTitle);
             holder.subscribers = convertView.findViewById(R.id.txtvSubscribers);
-            holder.url = convertView.findViewById(R.id.txtvUrl);
+            holder.description = convertView.findViewById(R.id.txtvDescription);
             convertView.setTag(holder);
         } else {
             holder = (Holder) convertView.getTag();
@@ -64,7 +64,7 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
 
         holder.title.setText(podcast.getTitle());
         holder.subscribers.setText(String.valueOf(podcast.getSubscribers()));
-        holder.url.setText(podcast.getUrl());
+        holder.description.setText(podcast.getDescription());
 
         return convertView;
     }
@@ -73,6 +73,6 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
         ImageView image;
         TextView title;
         TextView subscribers;
-        TextView url;
+        TextView description;
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/gpodnet/PodcastListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/gpodnet/PodcastListAdapter.java
@@ -64,8 +64,7 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
 
         holder.title.setText(podcast.getTitle());
         holder.subscribers.setText(String.valueOf(podcast.getSubscribers()));
-        // TODO: TT:
-        holder.author.setText(podcast.getDescription());
+        holder.author.setText(podcast.getAuthor());
 
         return convertView;
     }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/gpodnet/PodcastListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/gpodnet/PodcastListAdapter.java
@@ -44,7 +44,7 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
             holder.image = convertView.findViewById(R.id.imgvCover);
             holder.title = convertView.findViewById(R.id.txtvTitle);
             holder.subscribers = convertView.findViewById(R.id.txtvSubscribers);
-            holder.description = convertView.findViewById(R.id.txtvDescription);
+            holder.author = convertView.findViewById(R.id.txtvAuthor);
             convertView.setTag(holder);
         } else {
             holder = (Holder) convertView.getTag();
@@ -64,7 +64,8 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
 
         holder.title.setText(podcast.getTitle());
         holder.subscribers.setText(String.valueOf(podcast.getSubscribers()));
-        holder.description.setText(podcast.getDescription());
+        // TODO: TT:
+        holder.author.setText(podcast.getDescription());
 
         return convertView;
     }
@@ -73,6 +74,6 @@ public class PodcastListAdapter extends ArrayAdapter<GpodnetPodcast> {
         ImageView image;
         TextView title;
         TextView subscribers;
-        TextView description;
+        TextView author;
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
@@ -67,11 +67,14 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
 
         //Set the title
         viewHolder.titleView.setText(podcast.title);
-        if(podcast.feedUrl != null && !podcast.feedUrl.contains("itunes.apple.com")) {
-            viewHolder.urlView.setText(podcast.feedUrl);
-            viewHolder.urlView.setVisibility(View.VISIBLE);
+        if(podcast.summary != null && ! podcast.summary.trim().isEmpty()) {
+            viewHolder.descriptionView.setText(podcast.summary);
+            viewHolder.descriptionView.setVisibility(View.VISIBLE);
+        } else if(podcast.feedUrl != null && !podcast.feedUrl.contains("itunes.apple.com")) {
+            viewHolder.descriptionView.setText(podcast.feedUrl);
+            viewHolder.descriptionView.setVisibility(View.VISIBLE);
         } else {
-            viewHolder.urlView.setVisibility(View.GONE);
+            viewHolder.descriptionView.setVisibility(View.GONE);
         }
 
         //Update the empty imageView with the image from the feed
@@ -103,7 +106,7 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
          */
         final TextView titleView;
 
-        final TextView urlView;
+        final TextView descriptionView;
 
 
         /**
@@ -113,7 +116,7 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
         PodcastViewHolder(View view){
             coverView = view.findViewById(R.id.imgvCover);
             titleView = view.findViewById(R.id.txtvTitle);
-            urlView = view.findViewById(R.id.txtvUrl);
+            descriptionView = view.findViewById(R.id.txtvDescription);
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
@@ -67,14 +67,14 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
 
         //Set the title
         viewHolder.titleView.setText(podcast.title);
-        if(podcast.summary != null && ! podcast.summary.trim().isEmpty()) {
-            viewHolder.descriptionView.setText(podcast.summary);
-            viewHolder.descriptionView.setVisibility(View.VISIBLE);
+        if(podcast.author != null && ! podcast.author.trim().isEmpty()) {
+            viewHolder.authorView.setText(podcast.author);
+            viewHolder.authorView.setVisibility(View.VISIBLE);
         } else if(podcast.feedUrl != null && !podcast.feedUrl.contains("itunes.apple.com")) {
-            viewHolder.descriptionView.setText(podcast.feedUrl);
-            viewHolder.descriptionView.setVisibility(View.VISIBLE);
+            viewHolder.authorView.setText(podcast.feedUrl);
+            viewHolder.authorView.setVisibility(View.VISIBLE);
         } else {
-            viewHolder.descriptionView.setVisibility(View.GONE);
+            viewHolder.authorView.setVisibility(View.GONE);
         }
 
         //Update the empty imageView with the image from the feed
@@ -106,7 +106,7 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
          */
         final TextView titleView;
 
-        final TextView descriptionView;
+        final TextView authorView;
 
 
         /**
@@ -116,7 +116,7 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
         PodcastViewHolder(View view){
             coverView = view.findViewById(R.id.imgvCover);
             titleView = view.findViewById(R.id.txtvTitle);
-            descriptionView = view.findViewById(R.id.txtvDescription);
+            authorView = view.findViewById(R.id.txtvAuthor);
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
@@ -65,12 +65,12 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
             viewHolder = (PodcastViewHolder) view.getTag();
         }
 
-        //Set the title
+        // Set the title
         viewHolder.titleView.setText(podcast.title);
-        if(podcast.author != null && ! podcast.author.trim().isEmpty()) {
+        if (podcast.author != null && ! podcast.author.trim().isEmpty()) {
             viewHolder.authorView.setText(podcast.author);
             viewHolder.authorView.setVisibility(View.VISIBLE);
-        } else if(podcast.feedUrl != null && !podcast.feedUrl.contains("itunes.apple.com")) {
+        } else if (podcast.feedUrl != null && !podcast.feedUrl.contains("itunes.apple.com")) {
             viewHolder.authorView.setText(podcast.feedUrl);
             viewHolder.authorView.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
@@ -25,15 +25,25 @@ public class PodcastSearchResult {
     @Nullable
     public final String feedUrl;
 
+    /**
+     * artistName of the podcast feed
+     */
+    @Nullable
+    public final String summary;
 
-    private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl) {
+
+    private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl, @Nullable String summary) {
         this.title = title;
         this.imageUrl = imageUrl;
         this.feedUrl = feedUrl;
+        this.summary = summary;
+    }
+    private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl) {
+        this(title, imageUrl, feedUrl, "");
     }
 
     public static PodcastSearchResult dummy() {
-        return new PodcastSearchResult("", "", "");
+        return new PodcastSearchResult("", "", "", "");
     }
 
     /**
@@ -46,7 +56,8 @@ public class PodcastSearchResult {
         String title = json.optString("collectionName", "");
         String imageUrl = json.optString("artworkUrl100", null);
         String feedUrl = json.optString("feedUrl", null);
-        return new PodcastSearchResult(title, imageUrl, feedUrl);
+        String summary = json.optString("artistName", null);
+        return new PodcastSearchResult(title, imageUrl, feedUrl, summary);
     }
 
     /**
@@ -68,14 +79,27 @@ public class PodcastSearchResult {
         }
         String feedUrl = "https://itunes.apple.com/lookup?id=" +
                 json.getJSONObject("id").getJSONObject("attributes").getString("im:id");
-        return new PodcastSearchResult(title, imageUrl, feedUrl);
+
+        String summary = null;
+        try {
+            summary = json.getJSONObject("summary").getString("label");
+        } catch (Exception e) {
+            // Some feeds have empty summary
+        }
+        return new PodcastSearchResult(title, imageUrl, feedUrl, summary);
     }
 
     public static PodcastSearchResult fromFyyd(SearchHit searchHit) {
-        return new PodcastSearchResult(searchHit.getTitle(), searchHit.getThumbImageURL(), searchHit.getXmlUrl());
+        return new PodcastSearchResult(searchHit.getTitle(),
+                                       searchHit.getThumbImageURL(),
+                                       searchHit.getXmlUrl(),
+                                       searchHit.getDescription());
     }
 
     public static PodcastSearchResult fromGpodder(GpodnetPodcast searchHit) {
-        return new PodcastSearchResult(searchHit.getTitle(), searchHit.getLogoUrl(), searchHit.getUrl());
+        return new PodcastSearchResult(searchHit.getTitle(),
+                                       searchHit.getLogoUrl(),
+                                       searchHit.getUrl(),
+                                       searchHit.getDescription());
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
@@ -29,14 +29,14 @@ public class PodcastSearchResult {
      * artistName of the podcast feed
      */
     @Nullable
-    public final String summary;
+    public final String author;
 
 
-    private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl, @Nullable String summary) {
+    private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl, @Nullable String author) {
         this.title = title;
         this.imageUrl = imageUrl;
         this.feedUrl = feedUrl;
-        this.summary = summary;
+        this.author = author;
     }
     private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl) {
         this(title, imageUrl, feedUrl, "");
@@ -56,8 +56,8 @@ public class PodcastSearchResult {
         String title = json.optString("collectionName", "");
         String imageUrl = json.optString("artworkUrl100", null);
         String feedUrl = json.optString("feedUrl", null);
-        String summary = json.optString("artistName", null);
-        return new PodcastSearchResult(title, imageUrl, feedUrl, summary);
+        String author = json.optString("artistName", null);
+        return new PodcastSearchResult(title, imageUrl, feedUrl, author);
     }
 
     /**
@@ -80,20 +80,20 @@ public class PodcastSearchResult {
         String feedUrl = "https://itunes.apple.com/lookup?id=" +
                 json.getJSONObject("id").getJSONObject("attributes").getString("im:id");
 
-        String summary = null;
+        String author = null;
         try {
-            summary = json.getJSONObject("summary").getString("label");
+            author = json.getJSONObject("im:artist").getString("label");
         } catch (Exception e) {
-            // Some feeds have empty summary
+            // Some feeds have empty artist
         }
-        return new PodcastSearchResult(title, imageUrl, feedUrl, summary);
+        return new PodcastSearchResult(title, imageUrl, feedUrl, author);
     }
 
     public static PodcastSearchResult fromFyyd(SearchHit searchHit) {
         return new PodcastSearchResult(searchHit.getTitle(),
                                        searchHit.getThumbImageURL(),
                                        searchHit.getXmlUrl(),
-                                       searchHit.getDescription());
+                                       searchHit.getSubtitle());
     }
 
     public static PodcastSearchResult fromGpodder(GpodnetPodcast searchHit) {

--- a/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
@@ -38,6 +38,7 @@ public class PodcastSearchResult {
         this.feedUrl = feedUrl;
         this.author = author;
     }
+
     private PodcastSearchResult(String title, @Nullable String imageUrl, @Nullable String feedUrl) {
         this(title, imageUrl, feedUrl, "");
     }

--- a/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/PodcastSearchResult.java
@@ -94,13 +94,13 @@ public class PodcastSearchResult {
         return new PodcastSearchResult(searchHit.getTitle(),
                                        searchHit.getThumbImageURL(),
                                        searchHit.getXmlUrl(),
-                                       searchHit.getSubtitle());
+                                       searchHit.getAuthor());
     }
 
     public static PodcastSearchResult fromGpodder(GpodnetPodcast searchHit) {
         return new PodcastSearchResult(searchHit.getTitle(),
                                        searchHit.getLogoUrl(),
                                        searchHit.getUrl(),
-                                       searchHit.getDescription());
+                                       searchHit.getAuthor());
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
@@ -192,7 +192,7 @@ public class ItunesSearchFragment extends Fragment {
         progressBar.setVisibility(View.VISIBLE);
 
         ItunesTopListLoader loader = new ItunesTopListLoader(getContext());
-        disposable = loader.loadToplist(25)
+        disposable = loader.loadToplist(100)
                 .subscribe(podcasts -> {
                     progressBar.setVisibility(View.GONE);
                     topList = podcasts;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItunesSearchFragment.java
@@ -192,7 +192,7 @@ public class ItunesSearchFragment extends Fragment {
         progressBar.setVisibility(View.VISIBLE);
 
         ItunesTopListLoader loader = new ItunesTopListLoader(getContext());
-        disposable = loader.loadToplist(100)
+        disposable = loader.loadToplist(25)
                 .subscribe(podcasts -> {
                     progressBar.setVisibility(View.GONE);
                     topList = podcasts;

--- a/app/src/main/res/layout/gpodnet_podcast_listitem.xml
+++ b/app/src/main/res/layout/gpodnet_podcast_listitem.xml
@@ -70,7 +70,7 @@
         tools:background="@android:color/holo_green_dark" />
 
     <TextView
-        android:id="@+id/txtvUrl"
+        android:id="@+id/txtvDescription"
         style="android:style/TextAppearance.Small"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/gpodnet_podcast_listitem.xml
+++ b/app/src/main/res/layout/gpodnet_podcast_listitem.xml
@@ -70,7 +70,7 @@
         tools:background="@android:color/holo_green_dark" />
 
     <TextView
-        android:id="@+id/txtvDescription"
+        android:id="@+id/txtvAuthor"
         style="android:style/TextAppearance.Small"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -81,7 +81,7 @@
         android:textColor="?android:attr/textColorSecondary"
         android:ellipsize="middle"
         android:maxLines="2"
-        tools:text="http://www.example.com/feed"
+        tools:text="author"
         tools:background="@android:color/holo_green_dark"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/itunes_podcast_listitem.xml
+++ b/app/src/main/res/layout/itunes_podcast_listitem.xml
@@ -45,7 +45,7 @@
             tools:text="Podcast title" />
 
         <TextView
-            android:id="@+id/txtvUrl"
+            android:id="@+id/txtvDescription"
             style="android:style/TextAppearance.Small"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/itunes_podcast_listitem.xml
+++ b/app/src/main/res/layout/itunes_podcast_listitem.xml
@@ -45,7 +45,7 @@
             tools:text="Podcast title" />
 
         <TextView
-            android:id="@+id/txtvDescription"
+            android:id="@+id/txtvAuthor"
             style="android:style/TextAppearance.Small"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -53,7 +53,7 @@
             android:textColor="?android:attr/textColorSecondary"
             android:ellipsize="middle"
             android:maxLines="2"
-            tools:text="http://www.example.com/feed"
+            tools:text="author"
             tools:background="@android:color/holo_green_dark"/>
 
     </LinearLayout>

--- a/app/src/main/res/layout/searchlist_item.xml
+++ b/app/src/main/res/layout/searchlist_item.xml
@@ -47,7 +47,7 @@
             style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lines="1"
+            android:lines="2"
             tools:text="Search item subtitle"
             tools:background="@android:color/holo_blue_light"/>
     </LinearLayout>

--- a/app/src/main/res/layout/searchlist_item.xml
+++ b/app/src/main/res/layout/searchlist_item.xml
@@ -47,7 +47,7 @@
             style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lines="2"
+            android:lines="1"
             tools:text="Search item subtitle"
             tools:background="@android:color/holo_blue_light"/>
     </LinearLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
@@ -689,8 +689,20 @@ public class GpodnetService {
             website = (String) websiteObj;
         }
         String mygpoLink = object.getString("mygpo_link");
-        return new GpodnetPodcast(url, title, description, subscribers,
-                logoUrl, website, mygpoLink);
+
+        String author = null;
+        Object authorObj = object.opt("author");
+        if (authorObj != null && authorObj instanceof String) {
+            author = (String) authorObj;
+        }
+        return new GpodnetPodcast(url,
+                title,
+                description,
+                subscribers,
+                logoUrl,
+                website,
+                mygpoLink,
+                author);
     }
 
     private List<GpodnetDevice> readDeviceListFromJSONArray(@NonNull JSONArray array)

--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/model/GpodnetPodcast.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/model/GpodnetPodcast.java
@@ -10,6 +10,7 @@ public class GpodnetPodcast {
     private final String logoUrl;
     private final String website;
     private final String mygpoLink;
+    private final String author;
 
     public GpodnetPodcast(@NonNull String url,
                           @NonNull String title,
@@ -17,7 +18,9 @@ public class GpodnetPodcast {
                           int subscribers,
                           String logoUrl,
                           String website,
-                          String mygpoLink) {
+                          String mygpoLink,
+                          String author
+                          ) {
         this.url = url;
         this.title = title;
         this.description = description;
@@ -25,6 +28,7 @@ public class GpodnetPodcast {
         this.logoUrl = logoUrl;
         this.website = website;
         this.mygpoLink = mygpoLink;
+        this.author = author;
     }
 
     @Override
@@ -58,6 +62,8 @@ public class GpodnetPodcast {
     public String getWebsite() {
         return website;
     }
+
+    public String getAuthor() { return author; }
 
     public String getMygpoLink() {
         return mygpoLink;


### PR DESCRIPTION
fix #3754

1) In the iTunes search feed use artistName
2) In the RSS feed from iTunes, use summary
3) In GpodnetPodcast, and Fyyd - use description

Gpodder.net search
<img width="380" alt="Screen Shot 2020-01-16 at 4 57 43 PM" src="https://user-images.githubusercontent.com/149837/72575465-5a96f280-3881-11ea-9fab-7baf138e0c17.png">

Fyyd
<img width="314" alt="Screen Shot 2020-01-16 at 4 59 56 PM" src="https://user-images.githubusercontent.com/149837/72575564-b3ff2180-3881-11ea-8195-55f43260efb8.png">

Browsing on iTunes
<img width="367" alt="Screen Shot 2020-01-16 at 4 59 47 PM" src="https://user-images.githubusercontent.com/149837/72575577-beb9b680-3881-11ea-952f-5ebe4f4580a9.png">

Advance search on iTunes
<img width="314" alt="Screen Shot 2020-01-16 at 4 59 56 PM" src="https://user-images.githubusercontent.com/149837/72575779-60d99e80-3882-11ea-85b8-88f21611001f.png">
