### PR TITLE
changed mentions of 'feed' to 'podcast'

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="app_name" translate="false">AntennaPod</string>
     <string name="provider_authority" translate="false">de.danoeh.antennapod.provider</string>
     <string name="feed_update_receiver_name">Update Subscriptions</string>
-    <string name="feeds_label">Feeds</string>
+    <string name="feeds_label">Podcasts</string>
     <string name="statistics_label">Statistics</string>
     <string name="add_feed_label">Add Podcast</string>
     <string name="episodes_label">Episodes</string>
@@ -116,7 +116,7 @@
     <string name="loading_more">Loading more…</string>
 
     <!-- 'Add Feed' Activity labels -->
-    <string name="feedurl_label">Feed URL</string>
+    <string name="feedurl_label">Podcast feed URL</string>
     <string name="etxtFeedurlHint">www.example.com/feed</string>
     <string name="txtvfeedurl_label">Add Podcast by URL</string>
     <string name="browse_gpoddernet_label">Browse gpodder.net</string>
@@ -142,7 +142,7 @@
     <string name="share_link_with_position_label">Share Episode URL with Position</string>
     <string name="share_file_label">Share File</string>
     <string name="share_website_url_label">Share Website URL</string>
-    <string name="share_feed_url_label">Share Feed URL</string>
+    <string name="share_feed_url_label">Share Podcast URL</string>
     <string name="share_item_url_label">Share Media File URL</string>
     <string name="share_item_url_with_position_label">Share Media File URL with Position</string>
     <string name="feed_delete_confirmation_msg">Please confirm that you want to delete the podcast \"%1$s\" and ALL its episodes (including downloaded episodes).</string>
@@ -380,7 +380,7 @@
     <string name="network_pref">Network</string>
     <string name="network_pref_sum">Update interval, Download controls, Mobile data</string>
     <string name="pref_autoUpdateIntervallOrTime_title">Update Interval or Time of Day</string>
-    <string name="pref_autoUpdateIntervallOrTime_sum">Specify an interval or a specific time of day to refresh the feeds automatically</string>
+    <string name="pref_autoUpdateIntervallOrTime_sum">Specify an interval or a specific time of day to refresh the podcasts automatically</string>
     <string name="pref_autoUpdateIntervallOrTime_message">You can set an <i>interval</i> like \"every 2 hours\", set a specific <i>time of day</i> like \"7:00 AM\" or <i>disable</i> automatic updates altogether.\n\n<small>Please note: Update times are inexact. You may encounter a short delay.</small></string>
     <string name="pref_autoUpdateIntervallOrTime_Disable">Disable</string>
     <string name="pref_autoUpdateIntervallOrTime_Interval">Set Interval</string>
@@ -395,7 +395,7 @@
     <string name="pref_stream_over_download_sum">Display stream button instead of download button in lists.</string>
     <string name="pref_mobileUpdate_title">Mobile Updates</string>
     <string name="pref_mobileUpdate_sum">Select what should be allowed over the mobile data connection</string>
-    <string name="pref_mobileUpdate_refresh">Feed refresh</string>
+    <string name="pref_mobileUpdate_refresh">Podcast refresh</string>
     <string name="pref_mobileUpdate_images">Cover images</string>
     <string name="pref_mobileUpdate_auto_download">Auto download</string>
     <string name="pref_mobileUpdate_episode_download">Episode download</string>
@@ -448,7 +448,7 @@
     <string name="pref_gpodnet_notifications_sum">This setting does not apply to authentication errors.</string>
     <string name="pref_playback_speed_title">Playback Speeds</string>
     <string name="pref_playback_speed_sum">Customize the speeds available for variable speed audio playback</string>
-    <string name="pref_feed_playback_speed_sum">The speed to use when starting audio playback for episodes in this feed</string>
+    <string name="pref_feed_playback_speed_sum">The speed to use when starting audio playback for episodes in this podcast</string>
     <string name="pref_playback_time_respects_speed_title">Adjust media info to playback speed</string>
     <string name="pref_playback_time_respects_speed_sum">Displayed position and duration are adapted to playback speed</string>
     <string name="pref_fast_forward">Fast Forward Skip Time</string>
@@ -671,7 +671,7 @@
     <string name="episode_filters_exclude">Exclude</string>
     <string name="episode_filters_hint">Single words \n\"Multiple Words\"</string>
     <string name="keep_updated">Keep Updated</string>
-    <string name="keep_updated_summary">Include this feed when (auto-)refreshing all feeds</string>
+    <string name="keep_updated_summary">Include this podcast when (auto-)refreshing all podcasts</string>
     <string name="auto_download_disabled_globally">Auto download is disabled in the main AntennaPod settings</string>
 
     <!-- Progress information -->


### PR DESCRIPTION
Adapted mentions of 'feed' to 'podcast' where plausible; fixes #3747.

Exceptions:

- Line 255 (always strings.xml): download_type_feed: It is the technical type of the download. Mentioning Podcast here might be confusing.

- Line 119: feedurl label: In this case some podcasts mention their feed url so it might help to say "Podcast feed URL" instead of "Podcast URL".

- Line 233: download_error_unsupported_type: The error should be technical. "Unsupported Podcast Type" might sound nice, but what would you think as a podcast provider if your user reports an "Unsupported Podcast Type"? (It think "Unsupported Feed Type" the better error message in this case.)