### PR TITLE
hide chapters fragment when a podcast does not have chapter markers

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerInfoActivity.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.activity;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -259,7 +260,7 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
 
         pager = findViewById(R.id.pager);
         pager.setOffscreenPageLimit(3);
-        pagerAdapter = new MediaplayerInfoPagerAdapter(getSupportFragmentManager());
+        pagerAdapter = new MediaplayerInfoPagerAdapter(getSupportFragmentManager(), this);
         pager.setAdapter(pagerAdapter);
         CirclePageIndicator pageIndicator = findViewById(R.id.page_indicator);
         pageIndicator.setViewPager(pager);
@@ -512,9 +513,11 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
 
     private static class MediaplayerInfoPagerAdapter extends FragmentStatePagerAdapter {
         private static final String TAG = "MPInfoPagerAdapter";
+        private Activity activity;
 
-        public MediaplayerInfoPagerAdapter(FragmentManager fm) {
+        public MediaplayerInfoPagerAdapter(FragmentManager fm, Activity a) {
             super(fm);
+            activity = a;
         }
 
         @Override
@@ -534,7 +537,14 @@ public abstract class MediaplayerInfoActivity extends MediaplayerActivity implem
 
         @Override
         public int getCount() {
-            return NUM_CONTENT_FRAGMENTS;
+            PlaybackController controller = new PlaybackController(this.activity, false);
+            if (controller.getMedia() == null  ||
+                    controller.getMedia().getChapters() == null  ||
+                    controller.getMedia().getChapters().size() == 0) {
+                return NUM_CONTENT_FRAGMENTS - 1;
+            } else {
+                return NUM_CONTENT_FRAGMENTS;
+            }
         }
     }
 }


### PR DESCRIPTION
This has been nagging me for a while, I love chapters, but most podcasts do not have them.  But I keep on hoping and swipe to the 3rd fragment to find empty chapters.

Since most podcasts do not have chapter markers, this pull request will hide the 3rd fragment for chapters if an episode does not have chapters, but it will show the chapter markers if the playing episode has them.

This podcast `This Week In Startups` has chapter markers if you wanted to test.  Most other podcasts do not have chapter markers.

![Screen_Shot_2020-01-18_at_7_11_23_PM](https://user-images.githubusercontent.com/149837/72674018-a0d98680-3a26-11ea-814a-062660e781dc.png)

