### PR TITLE
Convert speed to float

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/SpeedChangeTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/SpeedChangeTest.java
@@ -66,8 +66,8 @@ public class SpeedChangeTest {
 
         List<FeedItem> queue = DBReader.getQueue();
         PlaybackPreferences.writeMediaPlaying(queue.get(0).getMedia(), PlayerStatus.PAUSED, false);
-        UserPreferences.setPlaybackSpeedArray(new String[] {"1.00", "2.00", "3.00"});
-        availableSpeeds = UserPreferences.getPlaybackSpeedArray();
+        availableSpeeds = new String[] {"1.00", "2.00", "3.00"};
+        UserPreferences.setPlaybackSpeedArray(availableSpeeds);
 
         EspressoTestUtils.tryKillPlaybackService();
         activityRule.launchActivity(new Intent());

--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -98,11 +98,11 @@ public class PlaybackControlsDialog extends DialogFragment {
         final TextView txtvPlaybackSpeed = (TextView) dialog.findViewById(R.id.txtvPlaybackSpeed);
         float currentSpeed = getCurrentSpeed();
 
-        String[] availableSpeeds = UserPreferences.getPlaybackSpeedArray();
+        float[] availableSpeeds = UserPreferences.getPlaybackSpeedArray();
         final float minPlaybackSpeed = availableSpeeds.length > 1 ?
-                Float.valueOf(availableSpeeds[0]) : DEFAULT_MIN_PLAYBACK_SPEED;
+                availableSpeeds[0] : DEFAULT_MIN_PLAYBACK_SPEED;
         float maxPlaybackSpeed = availableSpeeds.length > 1 ?
-                Float.valueOf(availableSpeeds[availableSpeeds.length - 1]) : DEFAULT_MAX_PLAYBACK_SPEED;
+                availableSpeeds[availableSpeeds.length - 1] : DEFAULT_MAX_PLAYBACK_SPEED;
         int progressMax = (int) ((maxPlaybackSpeed - minPlaybackSpeed) / PLAYBACK_SPEED_STEP);
         barPlaybackSpeed.setMax(progressMax);
 
@@ -113,13 +113,12 @@ public class PlaybackControlsDialog extends DialogFragment {
                 if (controller != null && controller.canSetPlaybackSpeed()) {
                     float playbackSpeed = progress * PLAYBACK_SPEED_STEP + minPlaybackSpeed;
                     controller.setPlaybackSpeed(playbackSpeed);
-                    String speedPref = String.format(Locale.US, "%.2f", playbackSpeed);
 
                     PlaybackPreferences.setCurrentlyPlayingTemporaryPlaybackSpeed(playbackSpeed);
                     if (isPlayingVideo) {
-                        UserPreferences.setVideoPlaybackSpeed(speedPref);
+                        UserPreferences.setVideoPlaybackSpeed(playbackSpeed);
                     } else {
-                        UserPreferences.setPlaybackSpeed(speedPref);
+                        UserPreferences.setPlaybackSpeed(playbackSpeed);
                     }
 
                     String speedStr = String.format("%.2fx", playbackSpeed);

--- a/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
@@ -6,8 +6,12 @@ import androidx.appcompat.app.AlertDialog;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class VariableSpeedDialog {
 
@@ -43,15 +47,22 @@ public class VariableSpeedDialog {
     }
 
     private static void showSpeedSelectorDialog(final Context context) {
+        DecimalFormatSymbols format = new DecimalFormatSymbols(Locale.US);
+        format.setDecimalSeparator('.');
+        DecimalFormat speedFormat = new DecimalFormat("0.00", format);
+
         final String[] speedValues = context.getResources().getStringArray(
                 R.array.playback_speed_values);
         // According to Java spec these get initialized to false on creation
         final boolean[] speedChecked = new boolean[speedValues.length];
 
-        // Build the "isChecked" array so that multiChoice dialog is
-        // populated correctly
-        List<String> selectedSpeedList = Arrays.asList(UserPreferences
-                .getPlaybackSpeedArray());
+        // Build the "isChecked" array so that multiChoice dialog is populated correctly
+        List<String> selectedSpeedList = new ArrayList<>();
+        float[] selectedSpeeds = UserPreferences.getPlaybackSpeedArray();
+        for (float speed : selectedSpeeds) {
+            selectedSpeedList.add(speedFormat.format(speed));
+        }
+
         for (int i = 0; i < speedValues.length; i++) {
             speedChecked[i] = selectedSpeedList.contains(speedValues[i]);
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -109,8 +109,7 @@ public class FeedSettingsFragment extends PreferenceFragmentCompat {
     private void setupPlaybackSpeedPreference() {
         ListPreference feedPlaybackSpeedPreference = findPreference(PREF_FEED_PLAYBACK_SPEED);
 
-        String[] speeds = UserPreferences.getPlaybackSpeedArray();
-
+        final String[] speeds = getResources().getStringArray(R.array.playback_speed_values);
         String[] values = new String[speeds.length + 1];
         values[0] = decimalFormat.format(SPEED_USE_GLOBAL);
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -389,7 +389,7 @@ public class UserPreferences {
             return Float.parseFloat(prefs.getString(PREF_PLAYBACK_SPEED, "1.00"));
         } catch (NumberFormatException e) {
             Log.e(TAG, Log.getStackTraceString(e));
-            UserPreferences.setPlaybackSpeed("1.00");
+            UserPreferences.setPlaybackSpeed(1.0f);
             return 1.0f;
         }
     }
@@ -399,7 +399,7 @@ public class UserPreferences {
             return Float.parseFloat(prefs.getString(PREF_VIDEO_PLAYBACK_SPEED, "1.00"));
         } catch (NumberFormatException e) {
             Log.e(TAG, Log.getStackTraceString(e));
-            UserPreferences.setVideoPlaybackSpeed("1.00");
+            UserPreferences.setVideoPlaybackSpeed(1.0f);
             return 1.0f;
         }
     }
@@ -408,7 +408,7 @@ public class UserPreferences {
         return prefs.getBoolean(PREF_PLAYBACK_SKIP_SILENCE, false);
     }
 
-    public static String[] getPlaybackSpeedArray() {
+    public static float[] getPlaybackSpeedArray() {
         return readPlaybackSpeedArray(prefs.getString(PREF_PLAYBACK_SPEED_ARRAY, null));
     }
 
@@ -638,15 +638,15 @@ public class UserPreferences {
              .apply();
     }
 
-    public static void setPlaybackSpeed(String speed) {
+    public static void setPlaybackSpeed(float speed) {
         prefs.edit()
-             .putString(PREF_PLAYBACK_SPEED, speed)
+             .putString(PREF_PLAYBACK_SPEED, String.valueOf(speed))
              .apply();
     }
 
-    public static void setVideoPlaybackSpeed(String speed) {
+    public static void setVideoPlaybackSpeed(float speed) {
         prefs.edit()
-                .putString(PREF_VIDEO_PLAYBACK_SPEED, speed)
+                .putString(PREF_VIDEO_PLAYBACK_SPEED, String.valueOf(speed))
                 .apply();
     }
 
@@ -769,24 +769,22 @@ public class UserPreferences {
         }
     }
 
-    private static String[] readPlaybackSpeedArray(String valueFromPrefs) {
-        String[] selectedSpeeds = null;
-        // If this preference hasn't been set yet, return the default options
-        if (valueFromPrefs == null) {
-            selectedSpeeds = new String[] { "0.75", "1.00", "1.25", "1.50", "1.75", "2.00" };
-        } else {
+    private static float[] readPlaybackSpeedArray(String valueFromPrefs) {
+        if (valueFromPrefs != null) {
             try {
                 JSONArray jsonArray = new JSONArray(valueFromPrefs);
-                selectedSpeeds = new String[jsonArray.length()];
+                float[] selectedSpeeds = new float[jsonArray.length()];
                 for (int i = 0; i < jsonArray.length(); i++) {
-                    selectedSpeeds[i] = jsonArray.getString(i);
+                    selectedSpeeds[i] = (float) jsonArray.getDouble(i);
                 }
+                return selectedSpeeds;
             } catch (JSONException e) {
                 Log.e(TAG, "Got JSON error when trying to get speeds from JSONArray");
                 e.printStackTrace();
             }
         }
-        return selectedSpeeds;
+        // If this preference hasn't been set yet, return the default options
+        return new float[] { 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f };
     }
 
     public static String getMediaPlayer() {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -639,6 +639,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
         float retVal = 1;
         if ((playerStatus == PlayerStatus.PLAYING
                 || playerStatus == PlayerStatus.PAUSED
+                || playerStatus == PlayerStatus.INITIALIZED
                 || playerStatus == PlayerStatus.PREPARED) && mediaPlayer.canSetSpeed()) {
             retVal = mediaPlayer.getCurrentSpeedMultiplier();
         }


### PR DESCRIPTION
### Better behavior
When setting the speed to a value that is not available for the button using the audio controls dialog, we no longer jump to the lowest value. Instead, we jump to the next bigger one.

### Fixes playback button
Steps to reproduce:
- Play
- Pause
- Close AudioPlayerActivity
- Open AudioPlayerActivity
- Tap speed button
- Always sets to the one after 1.0
