### PR TITLE
fix #3768 double check the item is still in the queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -472,15 +472,19 @@ public class QueueFragment extends Fragment {
             return super.onContextItemSelected(item);
         }
 
+        int position = FeedItemUtil.indexOfItemWithId(queue, selectedItem.getId());
+        if (position < 0) {
+            Log.i(TAG, "Selected item no longer exist, ignoring selection");
+            return super.onContextItemSelected(item);
+        }
+
         switch(item.getItemId()) {
             case R.id.move_to_top_item:
-                int position = FeedItemUtil.indexOfItemWithId(queue, selectedItem.getId());
                 queue.add(0, queue.remove(position));
                 recyclerAdapter.notifyItemMoved(position, 0);
                 DBWriter.moveQueueItemToTop(selectedItem.getId(), true);
                 return true;
             case R.id.move_to_bottom_item:
-                position = FeedItemUtil.indexOfItemWithId(queue, selectedItem.getId());
                 queue.add(queue.size()-1, queue.remove(position));
                 recyclerAdapter.notifyItemMoved(position, queue.size()-1);
                 DBWriter.moveQueueItemToBottom(selectedItem.getId(), true);


### PR DESCRIPTION
Fix #3768 

Fixes a crash, see #3768 for how to replicate.
Double check the item still exist in the queue. Remove one duplicate line of code as well.

Tested with this line
`I/QueueFragment: Selected item no longer exist, ignoring selection`

```
D/QueueFragment: onEventMainThread() called with: event = [FeedItemEvent[action=UPDATE,items=[FeedItem[autoDownload=0,chapters=<null>,contentEncoded=<null>,description=<null>,feed=de.danoeh.antennapod.core.feed.Feed@4e,feedId=78,hasChapters=false,imageUrl=https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/73fd80c2-48d6-433c-817f-aaa4017c3c16/1c35c947-56d2-49cc-be15-aaa4017c3c1e/image.jpg?t=1565391869&size=Large,itemIdentifier=adaa50ad-f303-4c8a-87fb-ab43016014f0,link=https://omny.fm/shows/by-the-book/epilogue-the-power-of-positive-thinking,media=de.danoeh.antennapod.core.feed.FeedMedia@5898,paymentLink=<null>,pubDate=Wed Jan 15 21:01:00 PST 2020,state=1,tags=[],title=Epilogue: The Power of Positive Thinking,id=22957]]]]
I/APCleanupAlgorithm: Auto-delete deleted 0 episodes (0 requested)
D/MainActivity: getLastNavFragment() -> QueueFragment
D/QueueFragment: onContextItemSelected() called with: item = [Move to top]
I/QueueFragment: Selected item no longer exist, ignoring selection
D/DBReader: getFeedItem() called with: itemId = [22958]
    Loading feeditem with id 22958
D/DBReader: getFavoriteIDList() called
D/DBReader: getQueueIDList() called
```
