### PR TITLE
Fix weird behavior in CoverLoader

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/CoverLoader.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/CoverLoader.java
@@ -24,7 +24,6 @@ public class CoverLoader {
     private TextView txtvPlaceholder;
     private ImageView imgvCover;
     private MainActivity activity;
-    private int errorResource = -1;
 
     public CoverLoader(MainActivity activity) {
         this.activity = activity;
@@ -45,11 +44,6 @@ public class CoverLoader {
         return this;
     }
 
-    public CoverLoader withError(int errorResource) {
-        this.errorResource = errorResource;
-        return this;
-    }
-
     public CoverLoader withPlaceholderView(TextView placeholderView) {
         txtvPlaceholder = placeholderView;
         return this;
@@ -60,10 +54,6 @@ public class CoverLoader {
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                 .fitCenter()
                 .dontAnimate();
-
-        if (errorResource != -1) {
-            options = options.error(errorResource);
-        }
 
         RequestBuilder<Drawable> builder = Glide.with(activity)
                 .load(uri)
@@ -84,6 +74,9 @@ public class CoverLoader {
 
         public CoverTarget(TextView txtvPlaceholder, ImageView imgvCover) {
             super(imgvCover);
+            if (txtvPlaceholder != null) {
+                txtvPlaceholder.setVisibility(View.VISIBLE);
+            }
             placeholder = new WeakReference<>(txtvPlaceholder);
             cover = new WeakReference<>(imgvCover);
         }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
@@ -98,7 +98,6 @@ public class SubscriptionsAdapter extends BaseAdapter implements AdapterView.OnI
                 .withUri(feed.getImageLocation())
                 .withPlaceholderView(holder.feedTitle)
                 .withCoverView(holder.imageView)
-                .withError(R.color.light_gray)
                 .load();
 
         return convertView;


### PR DESCRIPTION
If you had an episode in the queue without a cover, it first showed the placeholder text.
After scrolling, the placeholder text was hidden and then there was just nothing at all.
This was inconsistent and confusing.

Now, always shows the placeholder (while loading and on error), making sure to update visibility.