### PR TITLE
Always print current version of AntennaPod

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/CrashReportWriter.java
+++ b/app/src/main/java/de/danoeh/antennapod/CrashReportWriter.java
@@ -35,7 +35,9 @@ public class CrashReportWriter implements Thread.UncaughtExceptionHandler {
         PrintWriter out = null;
         try {
             out = new PrintWriter(new FileWriter(path));
-            out.println(getSystemInfo());
+            out.println("[ Crash info ]");
+            out.println("Time: " + new SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.getDefault()).format(new Date()));
+            out.println("AntennaPod version: " + BuildConfig.VERSION_NAME);
             out.println();
             out.println("[ StackTrace ]");
             ex.printStackTrace(out);
@@ -54,7 +56,6 @@ public class CrashReportWriter implements Thread.UncaughtExceptionHandler {
                 "\nAntennaPod version: " + BuildConfig.VERSION_NAME +
                 "\nModel: " + Build.MODEL +
                 "\nDevice: " + Build.DEVICE +
-                "\nProduct: " + Build.PRODUCT +
-                "\nTime: " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(new Date()) + "\n";
+                "\nProduct: " + Build.PRODUCT;
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
@@ -30,16 +30,17 @@ public class BugReportActivity extends AppCompatActivity {
         getSupportActionBar().setDisplayShowHomeEnabled(true);
         setContentView(R.layout.bug_report);
 
-        TextView crashDetailsText = findViewById(R.id.crash_report_logs);
+        String crashDetailsText = CrashReportWriter.getSystemInfo() + "\n\n";
+        TextView crashDetailsTextView = findViewById(R.id.crash_report_logs);
 
         try {
             File crashFile = CrashReportWriter.getFile();
-            String crashReportContent = IOUtils.toString(new FileInputStream(crashFile), Charset.forName("UTF-8"));
-            crashDetailsText.setText(crashReportContent);
+            crashDetailsText += IOUtils.toString(new FileInputStream(crashFile), Charset.forName("UTF-8"));
         } catch (IOException e) {
             e.printStackTrace();
-            crashDetailsText.setText("No crash report recorded\n" + CrashReportWriter.getSystemInfo());
+            crashDetailsText += "No crash report recorded";
         }
+        crashDetailsTextView.setText(crashDetailsText);
 
         findViewById(R.id.btn_open_bug_tracker).setOnClickListener(v -> {
             IntentUtils.openInBrowser(BugReportActivity.this, "https://github.com/AntennaPod/AntennaPod/issues");
@@ -47,7 +48,7 @@ public class BugReportActivity extends AppCompatActivity {
 
         findViewById(R.id.btn_copy_log).setOnClickListener(v -> {
             ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
-            ClipData clip = ClipData.newPlainText(getString(R.string.bug_report_title), crashDetailsText.getText());
+            ClipData clip = ClipData.newPlainText(getString(R.string.bug_report_title), crashDetailsTextView.getText());
             clipboard.setPrimaryClip(clip);
             Snackbar.make(findViewById(android.R.id.content), R.string.copied_to_clipboard, Snackbar.LENGTH_SHORT).show();
         });


### PR DESCRIPTION
Otherwise, users report bugs with old stack traces and therefore
old system info. Display a big system info block of the current
version and a simple line of the crash version.