### PR TITLE
Support for chapter images

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBTestUtils.java
@@ -58,7 +58,8 @@ class DBTestUtils {
                     List<Chapter> chapters = new ArrayList<>();
                     item.setChapters(chapters);
                     for (int k = 0; k < numChapters; k++) {
-                        chapters.add(new SimpleChapter(k, "item " + j + " chapter " + k, item, "http://example.com"));
+                        chapters.add(new SimpleChapter(k, "item " + j + " chapter " + k,
+                                "http://example.com", "http://example.com/image.png"));
                     }
                 }
                 f.getItems().add(item);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 
+import de.danoeh.antennapod.core.util.ChapterUtils;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -104,18 +105,10 @@ public class ChaptersFragment extends ListFragment {
     }
 
     private int getCurrentChapter(Playable media) {
-        if (media == null || media.getChapters() == null || media.getChapters().size() == 0 || controller == null) {
+        if (controller == null) {
             return -1;
         }
-        int currentPosition = controller.getPosition();
-
-        List<Chapter> chapters = media.getChapters();
-        for (int i = 0; i < chapters.size(); i++) {
-            if (chapters.get(i).getStart() > currentPosition) {
-                return i - 1;
-            }
-        }
-        return chapters.size() - 1;
+        return ChapterUtils.getCurrentChapterIndex(media, controller.getPosition());
     }
 
     private void loadMediaInfo() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -81,6 +81,7 @@ public class CoverFragment extends Fragment {
     private void displayMediaInfo(@NonNull Playable media) {
         txtvPodcastTitle.setText(media.getFeedTitle());
         txtvEpisodeTitle.setText(media.getEpisodeTitle());
+        displayedChapterIndex = -1;
         Glide.with(this)
                 .load(ImageResourceUtils.getImageLocation(media))
                 .apply(new RequestOptions()

--- a/app/src/main/res/layout/simplechapter_item.xml
+++ b/app/src/main/res/layout/simplechapter_item.xml
@@ -10,6 +10,15 @@
         android:baselineAligned="false"
         android:descendantFocusability="blocksDescendants">
 
+    <ImageView
+        android:id="@+id/imgvCover"
+        android:layout_width="@dimen/thumbnail_length_queue_item"
+        android:layout_height="@dimen/thumbnail_length_queue_item"
+        android:contentDescription="@string/cover_label"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        tools:src="@tools:sample/avatars"/>
+
     <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
@@ -2,10 +2,7 @@ package de.danoeh.antennapod.core.feed;
 
 import android.database.Cursor;
 
-import android.text.TextUtils;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
-
-import java.util.Objects;
 
 public abstract class Chapter extends FeedComponent {
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Chapter.java
@@ -2,85 +2,99 @@ package de.danoeh.antennapod.core.feed;
 
 import android.database.Cursor;
 
+import android.text.TextUtils;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
+
+import java.util.Objects;
 
 public abstract class Chapter extends FeedComponent {
 
-	/** Defines starting point in milliseconds. */
+    /** Defines starting point in milliseconds. */
     long start;
-	String title;
-	String link;
+    String title;
+    String link;
+    String imageUrl;
 
-	Chapter() {
-	}
-	
-	Chapter(long start) {
-		super();
-		this.start = start;
-	}
+    Chapter() {
+    }
 
-	Chapter(long start, String title, FeedItem item, String link) {
-		super();
-		this.start = start;
-		this.title = title;
-		this.link = link;
-	}
+    Chapter(long start) {
+        super();
+        this.start = start;
+    }
 
-	public static Chapter fromCursor(Cursor cursor, FeedItem item) {
-		int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
-		int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
-		int indexStart = cursor.getColumnIndex(PodDBAdapter.KEY_START);
-		int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
-		int indexChapterType = cursor.getColumnIndex(PodDBAdapter.KEY_CHAPTER_TYPE);
+    Chapter(long start, String title, String link, String imageUrl) {
+        super();
+        this.start = start;
+        this.title = title;
+        this.link = link;
+        this.imageUrl = imageUrl;
+    }
 
-		long id = cursor.getLong(indexId);
-		String title = cursor.getString(indexTitle);
-		long start = cursor.getLong(indexStart);
-		String link = cursor.getString(indexLink);
-		int chapterType = cursor.getInt(indexChapterType);
+    public static Chapter fromCursor(Cursor cursor) {
+        int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
+        int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
+        int indexStart = cursor.getColumnIndex(PodDBAdapter.KEY_START);
+        int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
+        int indexImage = cursor.getColumnIndex(PodDBAdapter.KEY_IMAGE_URL);
+        int indexChapterType = cursor.getColumnIndex(PodDBAdapter.KEY_CHAPTER_TYPE);
 
-		Chapter chapter = null;
-		switch (chapterType) {
-			case SimpleChapter.CHAPTERTYPE_SIMPLECHAPTER:
-				chapter = new SimpleChapter(start, title, item, link);
-				break;
-			case ID3Chapter.CHAPTERTYPE_ID3CHAPTER:
-				chapter = new ID3Chapter(start, title, item, link);
-				break;
-			case VorbisCommentChapter.CHAPTERTYPE_VORBISCOMMENT_CHAPTER:
-				chapter = new VorbisCommentChapter(start, title, item, link);
-				break;
-		}
-		chapter.setId(id);
-		return chapter;
-	}
+        long id = cursor.getLong(indexId);
+        String title = cursor.getString(indexTitle);
+        long start = cursor.getLong(indexStart);
+        String link = cursor.getString(indexLink);
+        String imageUrl = cursor.getString(indexImage);
+        int chapterType = cursor.getInt(indexChapterType);
 
+        Chapter chapter = null;
+        switch (chapterType) {
+            case SimpleChapter.CHAPTERTYPE_SIMPLECHAPTER:
+                chapter = new SimpleChapter(start, title, link, imageUrl);
+                break;
+            case ID3Chapter.CHAPTERTYPE_ID3CHAPTER:
+                chapter = new ID3Chapter(start, title, link, imageUrl);
+                break;
+            case VorbisCommentChapter.CHAPTERTYPE_VORBISCOMMENT_CHAPTER:
+                chapter = new VorbisCommentChapter(start, title, link, imageUrl);
+                break;
+        }
+        chapter.setId(id);
+        return chapter;
+    }
 
-	public abstract int getChapterType();
+    public abstract int getChapterType();
 
-	public long getStart() {
-		return start;
-	}
+    public long getStart() {
+        return start;
+    }
 
-	public String getTitle() {
-		return title;
-	}
+    public String getTitle() {
+        return title;
+    }
 
-	public String getLink() {
-		return link;
-	}
+    public String getLink() {
+        return link;
+    }
 
-	public void setStart(long start) {
-		this.start = start;
-	}
+    public void setStart(long start) {
+        this.start = start;
+    }
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
+    public void setTitle(String title) {
+        this.title = title;
+    }
 
-	public void setLink(String link) {
-		this.link = link;
-	}
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 
     @Override
     public String getHumanReadableIdentifier() {

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/ID3Chapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/ID3Chapter.java
@@ -1,36 +1,36 @@
 package de.danoeh.antennapod.core.feed;
 
 public class ID3Chapter extends Chapter {
-	public static final int CHAPTERTYPE_ID3CHAPTER = 2;
+    public static final int CHAPTERTYPE_ID3CHAPTER = 2;
 
-	/**
-	 * Identifies the chapter in its ID3 tag. This attribute does not have to be
-	 * store in the DB and is only used for parsing.
-	 */
-	private String id3ID;
+    /**
+     * Identifies the chapter in its ID3 tag. This attribute does not have to be
+     * store in the DB and is only used for parsing.
+     */
+    private String id3ID;
 
-	public ID3Chapter(String id3ID, long start) {
-		super(start);
-		this.id3ID = id3ID;
-	}
+    public ID3Chapter(String id3ID, long start) {
+        super(start);
+        this.id3ID = id3ID;
+    }
 
-	public ID3Chapter(long start, String title, FeedItem item, String link) {
-		super(start, title, item, link);
-	}
+    public ID3Chapter(long start, String title, String link, String imageUrl) {
+        super(start, title, link, imageUrl);
+    }
 
-	@Override
-	public String toString() {
-		return "ID3Chapter [id3ID=" + id3ID + ", title=" + title + ", start="
-				+ start + ", url=" + link + "]";
-	}
+    @Override
+    public String toString() {
+        return "ID3Chapter [id3ID=" + id3ID + ", title=" + title + ", start="
+                + start + ", url=" + link + "]";
+    }
 
-	@Override
-	public int getChapterType() {
-		return CHAPTERTYPE_ID3CHAPTER;
-	}
+    @Override
+    public int getChapterType() {
+        return CHAPTERTYPE_ID3CHAPTER;
+    }
 
-	public String getId3ID() {
-		return id3ID;
-	}
+    public String getId3ID() {
+        return id3ID;
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/SimpleChapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/SimpleChapter.java
@@ -1,25 +1,14 @@
 package de.danoeh.antennapod.core.feed;
 
 public class SimpleChapter extends Chapter {
-	public static final int CHAPTERTYPE_SIMPLECHAPTER = 0;
-	
-	public SimpleChapter(long start, String title, FeedItem item, String link) {
-		super(start, title, item, link);
-	}
+    public static final int CHAPTERTYPE_SIMPLECHAPTER = 0;
 
-	@Override
-	public int getChapterType() {
-		return CHAPTERTYPE_SIMPLECHAPTER;
-	}
+    public SimpleChapter(long start, String title, String link, String imageUrl) {
+        super(start, title, link, imageUrl);
+    }
 
-	public void updateFromOther(SimpleChapter other) {
-		super.updateFromOther(other);
-		start = other.start;
-		if (other.title != null) {
-			title = other.title;
-		}
-		if (other.link != null) {
-			link = other.link;
-		}
-	}
+    @Override
+    public int getChapterType() {
+        return CHAPTERTYPE_SIMPLECHAPTER;
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/VorbisCommentChapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/VorbisCommentChapter.java
@@ -5,105 +5,84 @@ import java.util.concurrent.TimeUnit;
 import de.danoeh.antennapod.core.util.vorbiscommentreader.VorbisCommentReaderException;
 
 public class VorbisCommentChapter extends Chapter {
-	public static final int CHAPTERTYPE_VORBISCOMMENT_CHAPTER = 3;
+    public static final int CHAPTERTYPE_VORBISCOMMENT_CHAPTER = 3;
 
-	private static final int CHAPTERXXX_LENGTH = "chapterxxx".length();
+    private static final int CHAPTERXXX_LENGTH = "chapterxxx".length();
 
-	private int vorbisCommentId;
+    private int vorbisCommentId;
 
-	public VorbisCommentChapter(int vorbisCommentId) {
-		this.vorbisCommentId = vorbisCommentId;
-	}
+    public VorbisCommentChapter(int vorbisCommentId) {
+        this.vorbisCommentId = vorbisCommentId;
+    }
 
-	public VorbisCommentChapter(long start, String title, FeedItem item,
-			String link) {
-		super(start, title, item, link);
-	}
+    public VorbisCommentChapter(long start, String title, String link, String imageUrl) {
+        super(start, title, link, imageUrl);
+    }
 
-	@Override
-	public String toString() {
-		return "VorbisCommentChapter [id=" + id + ", title=" + title
-				+ ", link=" + link + ", start=" + start + "]";
-	}
+    @Override
+    public String toString() {
+        return "VorbisCommentChapter [id=" + id + ", title=" + title
+                + ", link=" + link + ", start=" + start + "]";
+    }
 
-	public static long getStartTimeFromValue(String value)
-			throws VorbisCommentReaderException {
-		String[] parts = value.split(":");
-		if (parts.length >= 3) {
-			try {
-				long hours = TimeUnit.MILLISECONDS.convert(
-						Long.parseLong(parts[0]), TimeUnit.HOURS);
-				long minutes = TimeUnit.MILLISECONDS.convert(
-						Long.parseLong(parts[1]), TimeUnit.MINUTES);
-				if (parts[2].contains("-->")) {
-					parts[2] = parts[2].substring(0, parts[2].indexOf("-->"));
-				}
-				long seconds = TimeUnit.MILLISECONDS.convert(
-						((long) Float.parseFloat(parts[2])), TimeUnit.SECONDS);
-				return hours + minutes + seconds;
-			} catch (NumberFormatException e) {
-				throw new VorbisCommentReaderException(e);
-			}
-		} else {
-			throw new VorbisCommentReaderException("Invalid time string");
-		}
-	}
+    public static long getStartTimeFromValue(String value)
+            throws VorbisCommentReaderException {
+        String[] parts = value.split(":");
+        if (parts.length >= 3) {
+            try {
+                long hours = TimeUnit.MILLISECONDS.convert(
+                        Long.parseLong(parts[0]), TimeUnit.HOURS);
+                long minutes = TimeUnit.MILLISECONDS.convert(
+                        Long.parseLong(parts[1]), TimeUnit.MINUTES);
+                if (parts[2].contains("-->")) {
+                    parts[2] = parts[2].substring(0, parts[2].indexOf("-->"));
+                }
+                long seconds = TimeUnit.MILLISECONDS.convert(
+                        ((long) Float.parseFloat(parts[2])), TimeUnit.SECONDS);
+                return hours + minutes + seconds;
+            } catch (NumberFormatException e) {
+                throw new VorbisCommentReaderException(e);
+            }
+        } else {
+            throw new VorbisCommentReaderException("Invalid time string");
+        }
+    }
 
-	/**
-	 * Return the id of a vorbiscomment chapter from a string like CHAPTERxxx*
-	 * 
-	 * @return the id of the chapter key or -1 if the id couldn't be read.
-	 * @throws VorbisCommentReaderException
-	 * */
-	public static int getIDFromKey(String key)
-			throws VorbisCommentReaderException {
-		if (key.length() >= CHAPTERXXX_LENGTH) { // >= CHAPTERxxx
-			try {
-				String strId = key.substring(8, 10);
-				return Integer.parseInt(strId);
-			} catch (NumberFormatException e) {
-				throw new VorbisCommentReaderException(e);
-			}
-		}
-		throw new VorbisCommentReaderException("key is too short (" + key + ")");
-	}
+    /**
+     * Return the id of a vorbiscomment chapter from a string like CHAPTERxxx*
+     *
+     * @return the id of the chapter key or -1 if the id couldn't be read.
+     * @throws VorbisCommentReaderException
+     * */
+    public static int getIDFromKey(String key) throws VorbisCommentReaderException {
+        if (key.length() >= CHAPTERXXX_LENGTH) { // >= CHAPTERxxx
+            try {
+                String strId = key.substring(8, 10);
+                return Integer.parseInt(strId);
+            } catch (NumberFormatException e) {
+                throw new VorbisCommentReaderException(e);
+            }
+        }
+        throw new VorbisCommentReaderException("key is too short (" + key + ")");
+    }
 
-	/**
-	 * Get the string that comes after 'CHAPTERxxx', for example 'name' or
-	 * 'url'.
-	 */
-	public static String getAttributeTypeFromKey(String key) {
-		if (key.length() > CHAPTERXXX_LENGTH) {
-			return key.substring(CHAPTERXXX_LENGTH, key.length());
-		}
-		return null;
-	}
+    /**
+     * Get the string that comes after 'CHAPTERxxx', for example 'name' or
+     * 'url'.
+     */
+    public static String getAttributeTypeFromKey(String key) {
+        if (key.length() > CHAPTERXXX_LENGTH) {
+            return key.substring(CHAPTERXXX_LENGTH);
+        }
+        return null;
+    }
 
-	@Override
-	public int getChapterType() {
-		return CHAPTERTYPE_VORBISCOMMENT_CHAPTER;
-	}
+    @Override
+    public int getChapterType() {
+        return CHAPTERTYPE_VORBISCOMMENT_CHAPTER;
+    }
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
-
-	public void setLink(String link) {
-		this.link = link;
-	}
-
-	public void setStart(long start) {
-		this.start = start;
-	}
-
-	public int getVorbisCommentId() {
-		return vorbisCommentId;
-	}
-
-	public void setVorbisCommentId(int vorbisCommentId) {
-		this.vorbisCommentId = vorbisCommentId;
-	}
-	
-	
-
+    public int getVorbisCommentId() {
+        return vorbisCommentId;
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
@@ -11,10 +11,12 @@ import com.bumptech.glide.load.DecodeFormat;
 import com.bumptech.glide.load.engine.cache.InternalCacheDiskCacheFactory;
 import com.bumptech.glide.module.AppGlideModule;
 
+import de.danoeh.antennapod.core.util.EmbeddedChapterImage;
 import java.io.InputStream;
 
 import com.bumptech.glide.request.RequestOptions;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import java.nio.ByteBuffer;
 
 /**
  * {@see com.bumptech.glide.integration.okhttp.OkHttpGlideModule}
@@ -32,5 +34,6 @@ public class ApGlideModule extends AppGlideModule {
     @Override
     public void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
         registry.replace(String.class, InputStream.class, new ApOkHttpUrlLoader.Factory());
+        registry.append(EmbeddedChapterImage.class, ByteBuffer.class, new ChapterImageModelLoader.Factory());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ChapterImageModelLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ChapterImageModelLoader.java
@@ -1,0 +1,98 @@
+package de.danoeh.antennapod.core.glide;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.bumptech.glide.Priority;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.data.DataFetcher;
+import com.bumptech.glide.load.model.ModelLoader;
+import com.bumptech.glide.load.model.ModelLoaderFactory;
+import com.bumptech.glide.load.model.MultiModelLoaderFactory;
+import com.bumptech.glide.signature.ObjectKey;
+import de.danoeh.antennapod.core.feed.Chapter;
+import de.danoeh.antennapod.core.util.EmbeddedChapterImage;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import org.apache.commons.io.IOUtils;
+
+public final class ChapterImageModelLoader implements ModelLoader<EmbeddedChapterImage, ByteBuffer> {
+
+    public static class Factory implements ModelLoaderFactory<EmbeddedChapterImage, ByteBuffer> {
+        @Override
+        public ModelLoader<EmbeddedChapterImage, ByteBuffer> build(MultiModelLoaderFactory unused) {
+            return new ChapterImageModelLoader();
+        }
+
+        @Override
+        public void teardown() {
+            // Do nothing.
+        }
+    }
+
+    @Nullable
+    @Override
+    public LoadData<ByteBuffer> buildLoadData(EmbeddedChapterImage model, int width, int height, Options options) {
+        return new LoadData<>(new ObjectKey(model), new EmbeddedImageFetcher(model));
+    }
+
+    @Override
+    public boolean handles(EmbeddedChapterImage model) {
+        return true;
+    }
+
+    class EmbeddedImageFetcher implements DataFetcher<ByteBuffer> {
+        private final EmbeddedChapterImage image;
+
+        public EmbeddedImageFetcher(EmbeddedChapterImage image) {
+            this.image = image;
+        }
+
+        @Override
+        public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super ByteBuffer> callback) {
+
+            BufferedInputStream stream = null;
+            try {
+                if (image.getMedia().localFileAvailable()) {
+                    File localFile = new File(image.getMedia().getLocalMediaUrl());
+                    stream = new BufferedInputStream(new FileInputStream(localFile));
+                } else {
+                    URL url = new URL(image.getMedia().getStreamUrl());
+                    stream = new BufferedInputStream(url.openStream());
+                }
+                byte[] imageContent = new byte[image.getLength()];
+                stream.skip(image.getPosition());
+                stream.read(imageContent, 0, image.getLength());
+                callback.onDataReady(ByteBuffer.wrap(imageContent));
+            } catch (IOException e) {
+                callback.onLoadFailed(new IOException("Loading embedded cover did not work"));
+                e.printStackTrace();
+            } finally {
+                IOUtils.closeQuietly(stream);
+            }
+        }
+
+        @Override public void cleanup() {
+            // nothing to clean up
+        }
+        @Override public void cancel() {
+            // cannot cancel
+        }
+
+        @NonNull
+        @Override
+        public Class<ByteBuffer> getDataClass() {
+            return ByteBuffer.class;
+        }
+
+        @NonNull
+        @Override
+        public DataSource getDataSource() {
+            return DataSource.LOCAL;
+        }
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -795,9 +795,7 @@ public final class DBReader {
     }
 
     private static void loadChaptersOfFeedItem(PodDBAdapter adapter, FeedItem item) {
-        Cursor cursor = null;
-        try {
-            cursor = adapter.getSimpleChaptersOfFeedItemCursor(item);
+        try (Cursor cursor = adapter.getSimpleChaptersOfFeedItemCursor(item)) {
             int chaptersCount = cursor.getCount();
             if (chaptersCount == 0) {
                 item.setChapters(null);
@@ -805,14 +803,7 @@ public final class DBReader {
             }
             item.setChapters(new ArrayList<>(chaptersCount));
             while (cursor.moveToNext()) {
-                Chapter chapter = Chapter.fromCursor(cursor, item);
-                if (chapter != null) {
-                    item.getChapters().add(chapter);
-                }
-            }
-        } finally {
-            if (cursor != null) {
-                cursor.close();
+                item.getChapters().add(Chapter.fromCursor(cursor));
             }
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBUpgrader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBUpgrader.java
@@ -95,7 +95,7 @@ class DBUpgrader {
                     + " ADD COLUMN " + PodDBAdapter.KEY_PASSWORD
                     + " TEXT");
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
-                    + " ADD COLUMN " + PodDBAdapter.KEY_IMAGE
+                    + " ADD COLUMN image"
                     + " INTEGER");
         }
         if (oldVersion <= 12) {
@@ -280,13 +280,13 @@ class DBUpgrader {
                     + " SELECT " + PodDBAdapter.KEY_DOWNLOAD_URL
                     + " FROM " + PodDBAdapter.TABLE_NAME_FEED_IMAGES
                     + " WHERE " + PodDBAdapter.TABLE_NAME_FEED_IMAGES + "." + PodDBAdapter.KEY_ID
-                    + " = " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_IMAGE + ")");
+                    + " = " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + ".image)");
 
             db.execSQL("UPDATE " + PodDBAdapter.TABLE_NAME_FEEDS + " SET " + PodDBAdapter.KEY_IMAGE_URL + " = ("
                     + " SELECT " + PodDBAdapter.KEY_DOWNLOAD_URL
                     + " FROM " + PodDBAdapter.TABLE_NAME_FEED_IMAGES
                     + " WHERE " + PodDBAdapter.TABLE_NAME_FEED_IMAGES + "." + PodDBAdapter.KEY_ID
-                    + " = " + PodDBAdapter.TABLE_NAME_FEEDS + "." + PodDBAdapter.KEY_IMAGE + ")");
+                    + " = " + PodDBAdapter.TABLE_NAME_FEEDS + ".image)");
 
             db.execSQL("DROP TABLE " + PodDBAdapter.TABLE_NAME_FEED_IMAGES);
         }
@@ -301,6 +301,8 @@ class DBUpgrader {
         if (oldVersion < 1090000) {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                     + " ADD COLUMN " + PodDBAdapter.KEY_FEED_VOLUME_ADAPTION + " INTEGER DEFAULT 0");
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_SIMPLECHAPTERS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_IMAGE_URL + " TEXT DEFAULT NULL");
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -69,7 +69,6 @@ public class PodDBAdapter {
     public static final String KEY_POSITION = "position";
     public static final String KEY_SIZE = "filesize";
     public static final String KEY_MIME_TYPE = "mime_type";
-    public static final String KEY_IMAGE = "image";
     public static final String KEY_IMAGE_URL = "image_url";
     public static final String KEY_FEED = "feed";
     public static final String KEY_MEDIA = "media";
@@ -183,7 +182,7 @@ public class PodDBAdapter {
     private static final String CREATE_TABLE_SIMPLECHAPTERS = "CREATE TABLE "
             + TABLE_NAME_SIMPLECHAPTERS + " (" + TABLE_PRIMARY_KEY + KEY_TITLE
             + " TEXT," + KEY_START + " INTEGER," + KEY_FEEDITEM + " INTEGER,"
-            + KEY_LINK + " TEXT," + KEY_CHAPTER_TYPE + " INTEGER)";
+            + KEY_LINK + " TEXT," + KEY_IMAGE_URL + " TEXT," + KEY_CHAPTER_TYPE + " INTEGER)";
 
     // SQL Statements for creating indexes
     static final String CREATE_INDEX_FEEDITEMS_FEED = "CREATE INDEX "
@@ -674,6 +673,7 @@ public class PodDBAdapter {
             values.put(KEY_START, chapter.getStart());
             values.put(KEY_FEEDITEM, item.getId());
             values.put(KEY_LINK, chapter.getLink());
+            values.put(KEY_IMAGE_URL, chapter.getImageUrl());
             values.put(KEY_CHAPTER_TYPE, chapter.getChapterType());
             if (chapter.getId() == 0) {
                 chapter.setId(db.insert(TABLE_NAME_SIMPLECHAPTERS, null, values));

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSSimpleChapters.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSSimpleChapters.java
@@ -22,12 +22,12 @@ public class NSSimpleChapters extends Namespace {
     private static final String START = "start";
     private static final String TITLE = "title";
     private static final String HREF = "href";
+    private static final String IMAGE = "image";
 
     @Override
-    public SyndElement handleElementStart(String localName, HandlerState state,
-                                          Attributes attributes) {
+    public SyndElement handleElementStart(String localName, HandlerState state, Attributes attributes) {
         FeedItem currentItem = state.getCurrentItem();
-        if(currentItem != null) {
+        if (currentItem != null) {
             if (localName.equals(CHAPTERS)) {
                 currentItem.setChapters(new ArrayList<>());
             } else if (localName.equals(CHAPTER)) {
@@ -35,7 +35,8 @@ public class NSSimpleChapters extends Namespace {
                     long start = DateUtils.parseTimeString(attributes.getValue(START));
                     String title = attributes.getValue(TITLE);
                     String link = attributes.getValue(HREF);
-                    SimpleChapter chapter = new SimpleChapter(start, title, currentItem, link);
+                    String imageUrl = attributes.getValue(IMAGE);
+                    SimpleChapter chapter = new SimpleChapter(start, title, link, imageUrl);
                     currentItem.getChapters().add(chapter);
                 } catch (NumberFormatException e) {
                     Log.e(TAG, "Unable to read chapter", e);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -36,24 +36,17 @@ public class ChapterUtils {
     private ChapterUtils() {
     }
 
-    @Nullable
-    public static Chapter getCurrentChapter(Playable media) {
-        if (media.getChapters() == null) {
-            return null;
+    public static int getCurrentChapterIndex(Playable media, int position) {
+        if (media == null || media.getChapters() == null || media.getChapters().size() == 0) {
+            return -1;
         }
         List<Chapter> chapters = media.getChapters();
-        if (chapters == null) {
-            return null;
-        }
-        Chapter current = chapters.get(0);
-        for (Chapter sc : chapters) {
-            if (sc.getStart() > media.getPosition()) {
-                break;
-            } else {
-                current = sc;
+        for (int i = 0; i < chapters.size(); i++) {
+            if (chapters.get(i).getStart() > position) {
+                return i - 1;
             }
         }
-        return current;
+        return chapters.size() - 1;
     }
 
     public static void loadChaptersFromStreamUrl(Playable media) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.Log;
 
+import java.util.zip.CheckedOutputStream;
 import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedInputStream;
@@ -23,6 +24,7 @@ import de.danoeh.antennapod.core.util.id3reader.ID3ReaderException;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.vorbiscommentreader.VorbisCommentChapterReader;
 import de.danoeh.antennapod.core.util.vorbiscommentreader.VorbisCommentReaderException;
+import org.apache.commons.io.input.CountingInputStream;
 
 /**
  * Utility class for getting chapter data from media files.
@@ -82,13 +84,12 @@ public class ChapterUtils {
             return;
         }
         Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
-        InputStream in = null;
+        CountingInputStream in = null;
         try {
             URL url = new URL(p.getStreamUrl());
-
-            in = url.openStream();
+            in = new CountingInputStream(url.openStream());
             List<Chapter> chapters = readChaptersFrom(in);
-            if(!chapters.isEmpty()) {
+            if (!chapters.isEmpty()) {
                 p.setChapters(chapters);
             }
             Log.i(TAG, "Chapters loaded");
@@ -114,9 +115,9 @@ public class ChapterUtils {
             return;
         }
 
-        InputStream in = null;
+        CountingInputStream in = null;
         try {
-            in = new BufferedInputStream(new FileInputStream(source));
+            in = new CountingInputStream(new BufferedInputStream(new FileInputStream(source)));
             List<Chapter> chapters = readChaptersFrom(in);
             if (!chapters.isEmpty()) {
                 p.setChapters(chapters);
@@ -130,7 +131,7 @@ public class ChapterUtils {
     }
 
     @NonNull
-    private static List<Chapter> readChaptersFrom(InputStream in) throws IOException, ID3ReaderException {
+    private static List<Chapter> readChaptersFrom(CountingInputStream in) throws IOException, ID3ReaderException {
         ChapterReader reader = new ChapterReader();
         reader.readInputStream(in);
         List<Chapter> chapters = reader.getChapters();

--- a/core/src/main/java/de/danoeh/antennapod/core/util/EmbeddedChapterImage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/EmbeddedChapterImage.java
@@ -2,37 +2,31 @@ package de.danoeh.antennapod.core.util;
 
 import android.text.TextUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class EmbeddedChapterImage {
-    private static final Pattern EMBEDDED_IMAGE_MATCHER = Pattern.compile("embedded-image://(.*)@(\\d+):(\\d+)");
-    final String mime;
-    final int position;
-    final int length;
+    private static final Pattern EMBEDDED_IMAGE_MATCHER = Pattern.compile("embedded-image://(\\d+)/(\\d+)");
+
+    private final int position;
+    private final int length;
     private final String imageUrl;
-    final Playable media;
+    private final Playable media;
 
     public EmbeddedChapterImage(Playable media, String imageUrl) {
         this.media = media;
         this.imageUrl = imageUrl;
         Matcher m = EMBEDDED_IMAGE_MATCHER.matcher(imageUrl);
         if (m.find()) {
-            this.mime = m.group(1);
-            this.position = Integer.parseInt(m.group(2));
-            this.length = Integer.parseInt(m.group(3));
+            this.position = Integer.parseInt(m.group(1));
+            this.length = Integer.parseInt(m.group(2));
         } else {
             throw new IllegalArgumentException("Not an embedded chapter");
         }
     }
 
-    public static String makeUrl(String mime, int position, int length) {
-        return "embedded-image://" + mime + "@" + position + ":" + length;
-    }
-
-    public String getMime() {
-        return mime;
+    public static String makeUrl(int position, int length) {
+        return "embedded-image://" + position + "/" + length;
     }
 
     public int getPosition() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/EmbeddedChapterImage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/EmbeddedChapterImage.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.core.util;
 
+import android.text.TextUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -9,10 +11,12 @@ public class EmbeddedChapterImage {
     final String mime;
     final int position;
     final int length;
+    private final String imageUrl;
     final Playable media;
 
     public EmbeddedChapterImage(Playable media, String imageUrl) {
         this.media = media;
+        this.imageUrl = imageUrl;
         Matcher m = EMBEDDED_IMAGE_MATCHER.matcher(imageUrl);
         if (m.find()) {
             this.mime = m.group(1);
@@ -41,6 +45,23 @@ public class EmbeddedChapterImage {
 
     public Playable getMedia() {
         return media;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmbeddedChapterImage that = (EmbeddedChapterImage) o;
+        return TextUtils.equals(imageUrl, that.imageUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return imageUrl.hashCode();
     }
 
     private static boolean isEmbeddedChapterImage(String imageUrl) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/EmbeddedChapterImage.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/EmbeddedChapterImage.java
@@ -1,0 +1,58 @@
+package de.danoeh.antennapod.core.util;
+
+import de.danoeh.antennapod.core.util.playback.Playable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EmbeddedChapterImage {
+    private static final Pattern EMBEDDED_IMAGE_MATCHER = Pattern.compile("embedded-image://(.*)@(\\d+):(\\d+)");
+    final String mime;
+    final int position;
+    final int length;
+    final Playable media;
+
+    public EmbeddedChapterImage(Playable media, String imageUrl) {
+        this.media = media;
+        Matcher m = EMBEDDED_IMAGE_MATCHER.matcher(imageUrl);
+        if (m.find()) {
+            this.mime = m.group(1);
+            this.position = Integer.parseInt(m.group(2));
+            this.length = Integer.parseInt(m.group(3));
+        } else {
+            throw new IllegalArgumentException("Not an embedded chapter");
+        }
+    }
+
+    public static String makeUrl(String mime, int position, int length) {
+        return "embedded-image://" + mime + "@" + position + ":" + length;
+    }
+
+    public String getMime() {
+        return mime;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public Playable getMedia() {
+        return media;
+    }
+
+    private static boolean isEmbeddedChapterImage(String imageUrl) {
+        return EMBEDDED_IMAGE_MATCHER.matcher(imageUrl).matches();
+    }
+
+    public static Object getModelFor(Playable media, int chapter) {
+        String imageUrl = media.getChapters().get(chapter).getImageUrl();
+        if (isEmbeddedChapterImage(imageUrl)) {
+            return new EmbeddedChapterImage(media, imageUrl);
+        } else {
+            return imageUrl;
+        }
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
@@ -105,8 +105,7 @@ public class ChapterReader extends ID3Reader {
                         // Data contains the picture
                         int length = header.getSize() - read;
                         if (TextUtils.isEmpty(currentChapter.getImageUrl()) || type == IMAGE_TYPE_COVER) {
-                            currentChapter.setImageUrl(
-                                    EmbeddedChapterImage.makeUrl(mime.toString(), input.getCount(), length));
+                            currentChapter.setImageUrl(EmbeddedChapterImage.makeUrl(input.getCount(), length));
                         }
                         skipBytes(input, length);
                     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
@@ -1,11 +1,17 @@
 package de.danoeh.antennapod.core.util.id3reader;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
 import android.util.Log;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.ID3Chapter;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.id3reader.model.FrameHeader;
 import de.danoeh.antennapod.core.util.id3reader.model.TagHeader;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -15,110 +21,158 @@ import java.util.List;
 public class ChapterReader extends ID3Reader {
     private static final String TAG = "ID3ChapterReader";
 
-	private static final String FRAME_ID_CHAPTER = "CHAP";
-	private static final String FRAME_ID_TITLE = "TIT2";
+    private static final String FRAME_ID_CHAPTER = "CHAP";
+    private static final String FRAME_ID_TITLE = "TIT2";
     private static final String FRAME_ID_LINK = "WXXX";
 
-	private List<Chapter> chapters;
-	private ID3Chapter currentChapter;
+    private List<Chapter> chapters;
+    private ID3Chapter currentChapter;
 
-	@Override
-	public int onStartTagHeader(TagHeader header) {
-		chapters = new ArrayList<>();
-		Log.d(TAG, "header: " + header);
-		return ID3Reader.ACTION_DONT_SKIP;
-	}
+    @Override
+    public int onStartTagHeader(TagHeader header) {
+        chapters = new ArrayList<>();
+        Log.d(TAG, "header: " + header);
+        return ID3Reader.ACTION_DONT_SKIP;
+    }
 
-	@Override
-	public int onStartFrameHeader(FrameHeader header, InputStream input)
-			throws IOException, ID3ReaderException {
-		Log.d(TAG, "header: " + header);
-		switch (header.getId()) {
-			case FRAME_ID_CHAPTER:
-				if (currentChapter != null) {
-					if (!hasId3Chapter(currentChapter)) {
-						chapters.add(currentChapter);
-						Log.d(TAG, "Found chapter: " + currentChapter);
-						currentChapter = null;
-					}
-				}
-				StringBuilder elementId = new StringBuilder();
-				readISOString(elementId, input, Integer.MAX_VALUE);
-				char[] startTimeSource = readBytes(input, 4);
-				long startTime = ((int) startTimeSource[0] << 24)
-						| ((int) startTimeSource[1] << 16)
-						| ((int) startTimeSource[2] << 8) | startTimeSource[3];
-				currentChapter = new ID3Chapter(elementId.toString(), startTime);
-				skipBytes(input, 12);
-				return ID3Reader.ACTION_DONT_SKIP;
-			case FRAME_ID_TITLE:
-				if (currentChapter != null && currentChapter.getTitle() == null) {
-					StringBuilder title = new StringBuilder();
-					readString(title, input, header.getSize());
-					currentChapter
-							.setTitle(title.toString());
-					Log.d(TAG, "Found title: " + currentChapter.getTitle());
+    @Override
+    public int onStartFrameHeader(FrameHeader header, InputStream input)
+            throws IOException, ID3ReaderException {
+        Log.d(TAG, "header: " + header);
+        switch (header.getId()) {
+            case FRAME_ID_CHAPTER:
+                if (currentChapter != null) {
+                    if (!hasId3Chapter(currentChapter)) {
+                        chapters.add(currentChapter);
+                        Log.d(TAG, "Found chapter: " + currentChapter);
+                        currentChapter = null;
+                    }
+                }
+                StringBuilder elementId = new StringBuilder();
+                readISOString(elementId, input, Integer.MAX_VALUE);
+                char[] startTimeSource = readChars(input, 4);
+                long startTime = ((int) startTimeSource[0] << 24)
+                        | ((int) startTimeSource[1] << 16)
+                        | ((int) startTimeSource[2] << 8) | startTimeSource[3];
+                currentChapter = new ID3Chapter(elementId.toString(), startTime);
+                skipBytes(input, 12);
+                return ID3Reader.ACTION_DONT_SKIP;
+            case FRAME_ID_TITLE:
+                if (currentChapter != null && currentChapter.getTitle() == null) {
+                    StringBuilder title = new StringBuilder();
+                    readString(title, input, header.getSize());
+                    currentChapter
+                            .setTitle(title.toString());
+                    Log.d(TAG, "Found title: " + currentChapter.getTitle());
 
-					return ID3Reader.ACTION_DONT_SKIP;
-				}
-				break;
-			case FRAME_ID_LINK:
-				if (currentChapter != null) {
-					// skip description
-					int descriptionLength = readString(null, input, header.getSize());
-					StringBuilder link = new StringBuilder();
-					readISOString(link, input, header.getSize() - descriptionLength);
-					try {
-						String decodedLink = URLDecoder.decode(link.toString(), "UTF-8");
-						currentChapter.setLink(decodedLink);
-						Log.d(TAG, "Found link: " + currentChapter.getLink());
-					} catch (IllegalArgumentException iae) {
-						Log.w(TAG, "Bad URL found in ID3 data");
-					}
+                    return ID3Reader.ACTION_DONT_SKIP;
+                }
+                break;
+            case FRAME_ID_LINK:
+                if (currentChapter != null) {
+                    // skip description
+                    int descriptionLength = readString(null, input, header.getSize());
+                    StringBuilder link = new StringBuilder();
+                    readISOString(link, input, header.getSize() - descriptionLength);
+                    try {
+                        String decodedLink = URLDecoder.decode(link.toString(), "UTF-8");
+                        currentChapter.setLink(decodedLink);
+                        Log.d(TAG, "Found link: " + currentChapter.getLink());
+                    } catch (IllegalArgumentException iae) {
+                        Log.w(TAG, "Bad URL found in ID3 data");
+                    }
 
-					return ID3Reader.ACTION_DONT_SKIP;
-				}
-				break;
-			case "APIC":
-				Log.d(TAG, header.toString());
-				break;
-		}
+                    return ID3Reader.ACTION_DONT_SKIP;
+                }
+                break;
+            case "APIC":
+                Log.d(TAG, header.toString());
+                StringBuilder mime = new StringBuilder();
+                int read = readString(mime, input, header.getSize());
+                byte type = (byte) input.read();
+                // $00  Other
+                // $01  32x32 pixels 'file icon' (PNG only)
+                // $02  Other file icon
+                // $03  Cover (front)
+                // $04  Cover (back)
+                // $05  Leaflet page
+                // $06  Media (e.g. label side of CD)
+                // $07  Lead artist/lead performer/soloist
+                // $08  Artist/performer
+                // $09  Conductor
+                // $0A  Band/Orchestra
+                // $0B  Composer
+                // $0C  Lyricist/text writer
+                // $0D  Recording Location
+                // $0E  During recording
+                // $0F  During performance
+                // $10  Movie/video screen capture
+                // $11  A bright coloured fish
+                // $12  Illustration
+                // $13  Band/artist logotype
+                // $14  Publisher/Studio logotype
+                read++;
+                StringBuilder description = new StringBuilder();
+                read += readISOString(description, input, header.getSize()); // Should use encoding from first string
 
-		return super.onStartFrameHeader(header, input);
-	}
 
-	private boolean hasId3Chapter(ID3Chapter chapter) {
-		for (Chapter c : chapters) {
-			if (((ID3Chapter) c).getId3ID().equals(chapter.getId3ID())) {
-				return true;
-			}
-		}
-		return false;
-	}
+                Log.d(TAG, "Found apic: " + mime + "," + description);
+                if (mime.toString().equals("-->")) {
+                    // Data contains a link to a picture
+                    StringBuilder link = new StringBuilder();
+                    readISOString(link, input, header.getSize());
+                    Log.d(TAG, "link: " + link);
+                } else {
+                    // Data contains the picture
+                    byte[] imageData = readBytes(input, header.getSize() - read);
 
-	@Override
-	public void onEndTag() {
-		if (currentChapter != null) {
-			if (!hasId3Chapter(currentChapter)) {
-				chapters.add(currentChapter);
-			}
-		}
-		Log.d(TAG, "Reached end of tag");
-		if (chapters != null) {
-			for (Chapter c : chapters) {
-				Log.d(TAG, "chapter: " + c);
-			}
-		}
-	}
+                    Bitmap bmp = BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
+                    try (FileOutputStream out = new FileOutputStream(new File(UserPreferences.getDataFolder(null),
+                            "chapter" + chapters.size() + ".jpg"))) {
+                        bmp.compress(Bitmap.CompressFormat.PNG, 100, out); // bmp is your Bitmap instance
+                        // PNG is a lossless format, the compression factor (100) is ignored
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+                return ID3Reader.ACTION_DONT_SKIP;
+        }
 
-	@Override
-	public void onNoTagHeaderFound() {
-		Log.d(TAG, "No tag header found");
-		super.onNoTagHeaderFound();
-	}
+        return super.onStartFrameHeader(header, input);
+    }
 
-	public List<Chapter> getChapters() {
-		return chapters;
-	}
+    private boolean hasId3Chapter(ID3Chapter chapter) {
+        for (Chapter c : chapters) {
+            if (((ID3Chapter) c).getId3ID().equals(chapter.getId3ID())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void onEndTag() {
+        if (currentChapter != null) {
+            if (!hasId3Chapter(currentChapter)) {
+                chapters.add(currentChapter);
+            }
+        }
+        Log.d(TAG, "Reached end of tag");
+        if (chapters != null) {
+            for (Chapter c : chapters) {
+                Log.d(TAG, "chapter: " + c);
+            }
+        }
+    }
+
+    @Override
+    public void onNoTagHeaderFound() {
+        Log.d(TAG, "No tag header found");
+        super.onNoTagHeaderFound();
+    }
+
+    public List<Chapter> getChapters() {
+        return chapters;
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ChapterReader.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.ID3Chapter;
+import de.danoeh.antennapod.core.util.EmbeddedChapterImage;
 import de.danoeh.antennapod.core.util.id3reader.model.FrameHeader;
 import de.danoeh.antennapod.core.util.id3reader.model.TagHeader;
 
@@ -104,8 +105,8 @@ public class ChapterReader extends ID3Reader {
                         // Data contains the picture
                         int length = header.getSize() - read;
                         if (TextUtils.isEmpty(currentChapter.getImageUrl()) || type == IMAGE_TYPE_COVER) {
-                            currentChapter.setImageUrl("embedded-image://" + mime.toString()
-                                    + "@" + input.getByteCount() + ":" + length);
+                            currentChapter.setImageUrl(
+                                    EmbeddedChapterImage.makeUrl(mime.toString(), input.getCount(), length));
                         }
                         skipBytes(input, length);
                     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ID3Reader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ID3Reader.java
@@ -9,6 +9,7 @@ import java.nio.charset.Charset;
 
 import de.danoeh.antennapod.core.util.id3reader.model.FrameHeader;
 import de.danoeh.antennapod.core.util.id3reader.model.TagHeader;
+import org.apache.commons.io.input.CountingInputStream;
 
 /**
  * Reads the ID3 Tag of a given file. In order to use this class, you should
@@ -33,8 +34,7 @@ public class ID3Reader {
     ID3Reader() {
     }
 
-    public final void readInputStream(InputStream input) throws IOException,
-            ID3ReaderException {
+    public final void readInputStream(CountingInputStream input) throws IOException, ID3ReaderException {
         int rc;
         readerPosition = 0;
         char[] tagHeaderSource = readChars(input, HEADER_LENGTH);
@@ -94,20 +94,6 @@ public class ID3Reader {
             readerPosition++;
             if (b != -1) {
                 header[i] = (char) b;
-            } else {
-                throw new ID3ReaderException("Unexpected end of stream");
-            }
-        }
-        return header;
-    }
-
-    byte[] readBytes(InputStream input, int number) throws IOException, ID3ReaderException {
-        byte[] header = new byte[number];
-        for (int i = 0; i < number; i++) {
-            int b = input.read();
-            readerPosition++;
-            if (b != -1) {
-                header[i] = (byte) b;
             } else {
                 throw new ID3ReaderException("Unexpected end of stream");
             }
@@ -243,8 +229,7 @@ public class ID3Reader {
         return ACTION_SKIP;
     }
 
-    int onStartFrameHeader(FrameHeader header, InputStream input)
-            throws IOException, ID3ReaderException {
+    int onStartFrameHeader(FrameHeader header, CountingInputStream input) throws IOException, ID3ReaderException {
         return ACTION_SKIP;
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ID3Reader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/id3reader/ID3Reader.java
@@ -37,7 +37,7 @@ public class ID3Reader {
             ID3ReaderException {
         int rc;
         readerPosition = 0;
-        char[] tagHeaderSource = readBytes(input, HEADER_LENGTH);
+        char[] tagHeaderSource = readChars(input, HEADER_LENGTH);
         tagHeader = createTagHeader(tagHeaderSource);
         if (tagHeader == null) {
             onNoTagHeaderFound();
@@ -47,7 +47,7 @@ public class ID3Reader {
                 onEndTag();
             } else {
                 while (readerPosition < tagHeader.getSize()) {
-                    FrameHeader frameHeader = createFrameHeader(readBytes(input, HEADER_LENGTH));
+                    FrameHeader frameHeader = createFrameHeader(readChars(input, HEADER_LENGTH));
                     if (checkForNullString(frameHeader.getId())) {
                         break;
                     }
@@ -84,17 +84,30 @@ public class ID3Reader {
     }
 
     /**
-     * Read a certain number of bytes from the given input stream. This method
+     * Read a certain number of chars from the given input stream. This method
      * changes the readerPosition-attribute.
      */
-    char[] readBytes(InputStream input, int number)
-            throws IOException, ID3ReaderException {
+    char[] readChars(InputStream input, int number) throws IOException, ID3ReaderException {
         char[] header = new char[number];
         for (int i = 0; i < number; i++) {
             int b = input.read();
             readerPosition++;
             if (b != -1) {
                 header[i] = (char) b;
+            } else {
+                throw new ID3ReaderException("Unexpected end of stream");
+            }
+        }
+        return header;
+    }
+
+    byte[] readBytes(InputStream input, int number) throws IOException, ID3ReaderException {
+        byte[] header = new byte[number];
+        for (int i = 0; i < number; i++) {
+            int b = input.read();
+            readerPosition++;
+            if (b != -1) {
+                header[i] = (byte) b;
             } else {
                 throw new ID3ReaderException("Unexpected end of stream");
             }
@@ -168,7 +181,7 @@ public class ID3Reader {
     protected int readString(StringBuilder buffer, InputStream input, int max) throws IOException,
             ID3ReaderException {
         if (max > 0) {
-            char[] encoding = readBytes(input, 1);
+            char[] encoding = readChars(input, 1);
             max--;
 
             if (encoding[0] == ENCODING_UTF16_WITH_BOM || encoding[0] == ENCODING_UTF16_WITHOUT_BOM) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/vorbiscommentreader/VorbisCommentChapterReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/vorbiscommentreader/VorbisCommentChapterReader.java
@@ -10,93 +10,91 @@ import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.VorbisCommentChapter;
 
 public class VorbisCommentChapterReader extends VorbisCommentReader {
-	private static final String TAG = "VorbisCommentChptrReadr";
+    private static final String TAG = "VorbisCommentChptrReadr";
 
-	private static final String CHAPTER_KEY = "chapter\\d\\d\\d.*";
-	private static final String CHAPTER_ATTRIBUTE_TITLE = "name";
-	private static final String CHAPTER_ATTRIBUTE_LINK = "url";
+    private static final String CHAPTER_KEY = "chapter\\d\\d\\d.*";
+    private static final String CHAPTER_ATTRIBUTE_TITLE = "name";
+    private static final String CHAPTER_ATTRIBUTE_LINK = "url";
 
-	private List<Chapter> chapters;
+    private List<Chapter> chapters;
 
-	public VorbisCommentChapterReader() {
-	}
+    public VorbisCommentChapterReader() {
+    }
 
-	@Override
-	public void onVorbisCommentFound() {
-		System.out.println("Vorbis comment found");
-	}
+    @Override
+    public void onVorbisCommentFound() {
+        System.out.println("Vorbis comment found");
+    }
 
-	@Override
-	public void onVorbisCommentHeaderFound(VorbisCommentHeader header) {
-		chapters = new ArrayList<>();
-		System.out.println(header.toString());
-	}
+    @Override
+    public void onVorbisCommentHeaderFound(VorbisCommentHeader header) {
+        chapters = new ArrayList<>();
+        System.out.println(header.toString());
+    }
 
-	@Override
-	public boolean onContentVectorKey(String content) {
-		return content.matches(CHAPTER_KEY);
-	}
+    @Override
+    public boolean onContentVectorKey(String content) {
+        return content.matches(CHAPTER_KEY);
+    }
 
-	@Override
-	public void onContentVectorValue(String key, String value)
-			throws VorbisCommentReaderException {
-		if (BuildConfig.DEBUG)
-			Log.d(TAG, "Key: " + key + ", value: " + value);
-		String attribute = VorbisCommentChapter.getAttributeTypeFromKey(key);
-		int id = VorbisCommentChapter.getIDFromKey(key);
-		Chapter chapter = getChapterById(id);
-		if (attribute == null) {
-			if (getChapterById(id) == null) {
-				// new chapter
-				long start = VorbisCommentChapter.getStartTimeFromValue(value);
-				chapter = new VorbisCommentChapter(id);
-				chapter.setStart(start);
-				chapters.add(chapter);
-			} else {
-				throw new VorbisCommentReaderException(
-						"Found chapter with duplicate ID (" + key + ", "
-								+ value + ")");
-			}
-		} else if (attribute.equals(CHAPTER_ATTRIBUTE_TITLE)) {
-			if (chapter != null) {
-				chapter.setTitle(value);
-			}
-		} else if (attribute.equals(CHAPTER_ATTRIBUTE_LINK)) {
-			if (chapter != null) {
-				chapter.setLink(value);
-			}
-		}
-	}
+    @Override
+    public void onContentVectorValue(String key, String value) throws VorbisCommentReaderException {
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Key: " + key + ", value: " + value);
+        }
+        String attribute = VorbisCommentChapter.getAttributeTypeFromKey(key);
+        int id = VorbisCommentChapter.getIDFromKey(key);
+        Chapter chapter = getChapterById(id);
+        if (attribute == null) {
+            if (getChapterById(id) == null) {
+                // new chapter
+                long start = VorbisCommentChapter.getStartTimeFromValue(value);
+                chapter = new VorbisCommentChapter(id);
+                chapter.setStart(start);
+                chapters.add(chapter);
+            } else {
+                throw new VorbisCommentReaderException("Found chapter with duplicate ID (" + key + ", " + value + ")");
+            }
+        } else if (attribute.equals(CHAPTER_ATTRIBUTE_TITLE)) {
+            if (chapter != null) {
+                chapter.setTitle(value);
+            }
+        } else if (attribute.equals(CHAPTER_ATTRIBUTE_LINK)) {
+            if (chapter != null) {
+                chapter.setLink(value);
+            }
+        }
+    }
 
-	@Override
-	public void onNoVorbisCommentFound() {
-		System.out.println("No vorbis comment found");
-	}
+    @Override
+    public void onNoVorbisCommentFound() {
+        System.out.println("No vorbis comment found");
+    }
 
-	@Override
-	public void onEndOfComment() {
-		System.out.println("End of comment");
-		for (Chapter c : chapters) {
-			System.out.println(c.toString());
-		}
-	}
+    @Override
+    public void onEndOfComment() {
+        System.out.println("End of comment");
+        for (Chapter c : chapters) {
+            System.out.println(c.toString());
+        }
+    }
 
-	@Override
-	public void onError(VorbisCommentReaderException exception) {
-		exception.printStackTrace();
-	}
+    @Override
+    public void onError(VorbisCommentReaderException exception) {
+        exception.printStackTrace();
+    }
 
-	private Chapter getChapterById(long id) {
-		for (Chapter c : chapters) {
-			if (((VorbisCommentChapter) c).getVorbisCommentId() == id) {
-				return c;
-			}
-		}
-		return null;
-	}
+    private Chapter getChapterById(long id) {
+        for (Chapter c : chapters) {
+            if (((VorbisCommentChapter) c).getVorbisCommentId() == id) {
+                return c;
+            }
+        }
+        return null;
+    }
 
-	public List<Chapter> getChapters() {
-		return chapters;
-	}
+    public List<Chapter> getChapters() {
+        return chapters;
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/vorbiscommentreader/VorbisCommentReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/vorbiscommentreader/VorbisCommentReader.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.util.vorbiscommentreader;
 
+import androidx.annotation.NonNull;
 import org.apache.commons.io.EndianUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -10,185 +11,165 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
-
 public abstract class VorbisCommentReader {
-	/** Length of first page in an ogg file in bytes. */
-	private static final int FIRST_PAGE_LENGTH = 58;
-	private static final int SECOND_PAGE_MAX_LENGTH = 64 * 1024 * 1024;
-	private static final int PACKET_TYPE_IDENTIFICATION = 1;
-	private static final int PACKET_TYPE_COMMENT = 3;
+    /** Length of first page in an ogg file in bytes. */
+    private static final int FIRST_PAGE_LENGTH = 58;
+    private static final int SECOND_PAGE_MAX_LENGTH = 64 * 1024 * 1024;
+    private static final int PACKET_TYPE_IDENTIFICATION = 1;
+    private static final int PACKET_TYPE_COMMENT = 3;
 
-	/** Called when Reader finds identification header. */
-	protected abstract void onVorbisCommentFound();
+    /** Called when Reader finds identification header. */
+    protected abstract void onVorbisCommentFound();
 
-	protected abstract void onVorbisCommentHeaderFound(VorbisCommentHeader header);
+    protected abstract void onVorbisCommentHeaderFound(VorbisCommentHeader header);
 
-	/**
-	 * Is called every time the Reader finds a content vector. The handler
-	 * should return true if it wants to handle the content vector.
-	 */
-	protected abstract boolean onContentVectorKey(String content);
+    /**
+     * Is called every time the Reader finds a content vector. The handler
+     * should return true if it wants to handle the content vector.
+     */
+    protected abstract boolean onContentVectorKey(String content);
 
-	/**
-	 * Is called if onContentVectorKey returned true for the key.
-	 * 
-	 * @throws VorbisCommentReaderException
-	 */
-	protected abstract void onContentVectorValue(String key, String value)
-			throws VorbisCommentReaderException;
+    /**
+     * Is called if onContentVectorKey returned true for the key.
+     */
+    protected abstract void onContentVectorValue(String key, String value) throws VorbisCommentReaderException;
 
-	protected abstract void onNoVorbisCommentFound();
+    protected abstract void onNoVorbisCommentFound();
 
-	protected abstract void onEndOfComment();
+    protected abstract void onEndOfComment();
 
-	protected abstract void onError(VorbisCommentReaderException exception);
+    protected abstract void onError(VorbisCommentReaderException exception);
 
-	public void readInputStream(InputStream input)
-			throws VorbisCommentReaderException {
-		try {
-			// look for identification header
-			if (findIdentificationHeader(input)) {
-				
-				onVorbisCommentFound();
-				input = new OggInputStream(input);
-				if (findCommentHeader(input)) {
-					VorbisCommentHeader commentHeader = readCommentHeader(input);
-					if (commentHeader != null) {
-						onVorbisCommentHeaderFound(commentHeader);
-						for (int i = 0; i < commentHeader
-								.getUserCommentLength(); i++) {
-							try {
-								long vectorLength = EndianUtils
-										.readSwappedUnsignedInteger(input);
-								String key = readContentVectorKey(input,
-										vectorLength).toLowerCase();
-								boolean readValue = onContentVectorKey(key);
-								if (readValue) {
-									String value = readUTF8String(
-											input,
-											(int) (vectorLength - key.length() - 1));
-									onContentVectorValue(key, value);
-								} else {
-									IOUtils.skipFully(input,
-											vectorLength - key.length() - 1);
-								}
-							} catch (IOException e) {
-								e.printStackTrace();
-							}
-						}
-						onEndOfComment();
-					}
+    public void readInputStream(InputStream input) throws VorbisCommentReaderException {
+        try {
+            // look for identification header
+            if (findIdentificationHeader(input)) {
+                onVorbisCommentFound();
+                input = new OggInputStream(input);
+                if (findCommentHeader(input)) {
+                    VorbisCommentHeader commentHeader = readCommentHeader(input);
+                    onVorbisCommentHeaderFound(commentHeader);
+                    for (int i = 0; i < commentHeader.getUserCommentLength(); i++) {
+                        readUserComment(input);
+                    }
+                    onEndOfComment();
+                } else {
+                    onError(new VorbisCommentReaderException("No comment header found"));
+                }
+            } else {
+                onNoVorbisCommentFound();
+            }
+        } catch (IOException e) {
+            onError(new VorbisCommentReaderException(e));
+        }
+    }
 
-				} else {
-					onError(new VorbisCommentReaderException(
-							"No comment header found"));
-				}
-			} else {
-				onNoVorbisCommentFound();
-			}
-		} catch (IOException e) {
-			onError(new VorbisCommentReaderException(e));
-		}
-	}
+    private void readUserComment(InputStream input) throws VorbisCommentReaderException {
+        try {
+            long vectorLength = EndianUtils.readSwappedUnsignedInteger(input);
+            String key = readContentVectorKey(input, vectorLength).toLowerCase();
+            boolean readValue = onContentVectorKey(key);
+            if (readValue) {
+                String value = readUtf8String(input, (int) (vectorLength - key.length() - 1));
+                onContentVectorValue(key, value);
+            } else {
+                IOUtils.skipFully(input, vectorLength - key.length() - 1);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
-	private String readUTF8String(InputStream input, long length)
-			throws IOException {
-		byte[] buffer = new byte[(int) length];
-		
-		IOUtils.readFully(input, buffer);
-		Charset charset = Charset.forName("UTF-8");
-		return charset.newDecoder().decode(ByteBuffer.wrap(buffer)).toString();
-	}
+    private String readUtf8String(InputStream input, long length) throws IOException {
+        byte[] buffer = new byte[(int) length];
+        IOUtils.readFully(input, buffer);
+        Charset charset = Charset.forName("UTF-8");
+        return charset.newDecoder().decode(ByteBuffer.wrap(buffer)).toString();
+    }
 
-	/**
-	 * Looks for an identification header in the first page of the file. If an
-	 * identification header is found, it will be skipped completely and the
-	 * method will return true, otherwise false.
-	 * 
-	 * @throws IOException
-	 */
-	private boolean findIdentificationHeader(InputStream input)
-			throws IOException {
-		byte[] buffer = new byte[FIRST_PAGE_LENGTH];
-		IOUtils.readFully(input, buffer);
-		int i;
-		for (i = 6; i < buffer.length; i++) {
-			if (buffer[i - 5] == 'v' && buffer[i - 4] == 'o'
-					&& buffer[i - 3] == 'r' && buffer[i - 2] == 'b'
-					&& buffer[i - 1] == 'i' && buffer[i] == 's'
-					&& buffer[i - 6] == PACKET_TYPE_IDENTIFICATION) {
-				return true;
-			}
-		}
-		return false;
-	}
+    /**
+     * Looks for an identification header in the first page of the file. If an
+     * identification header is found, it will be skipped completely and the
+     * method will return true, otherwise false.
+     */
+    private boolean findIdentificationHeader(InputStream input) throws IOException {
+        byte[] buffer = new byte[FIRST_PAGE_LENGTH];
+        IOUtils.readFully(input, buffer);
+        for (int i = 6; i < buffer.length; i++) {
+            if (buffer[i - 5] == 'v' && buffer[i - 4] == 'o'
+                    && buffer[i - 3] == 'r' && buffer[i - 2] == 'b'
+                    && buffer[i - 1] == 'i' && buffer[i] == 's'
+                    && buffer[i - 6] == PACKET_TYPE_IDENTIFICATION) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private boolean findCommentHeader(InputStream input) throws IOException {
-		char[] buffer = new char["vorbis".length() + 1];
-		for (int bytesRead = 0; bytesRead < SECOND_PAGE_MAX_LENGTH; bytesRead++) {
-			char c = (char) input.read();
-			int dest = -1;
-			switch (c) {
-			case PACKET_TYPE_COMMENT:
-				dest = 0;
-				break;
-			case 'v':
-				dest = 1;
-				break;
-			case 'o':
-				dest = 2;
-				break;
-			case 'r':
-				dest = 3;
-				break;
-			case 'b':
-				dest = 4;
-				break;
-			case 'i':
-				dest = 5;
-				break;
-			case 's':
-				dest = 6;
-				break;
-			}
-			if (dest >= 0) {
-				buffer[dest] = c;
-				if (buffer[1] == 'v' && buffer[2] == 'o' && buffer[3] == 'r'
-						&& buffer[4] == 'b' && buffer[5] == 'i'
-						&& buffer[6] == 's' && buffer[0] == PACKET_TYPE_COMMENT) {
-					return true;
-				}
-			} else {
-				Arrays.fill(buffer, (char) 0);
-			}
-		}
-		return false;
-	}
+    private boolean findCommentHeader(InputStream input) throws IOException {
+        char[] buffer = new char["vorbis".length() + 1];
+        for (int bytesRead = 0; bytesRead < SECOND_PAGE_MAX_LENGTH; bytesRead++) {
+            char c = (char) input.read();
+            int dest = -1;
+            switch (c) {
+                case PACKET_TYPE_COMMENT:
+                    dest = 0;
+                    break;
+                case 'v':
+                    dest = 1;
+                    break;
+                case 'o':
+                    dest = 2;
+                    break;
+                case 'r':
+                    dest = 3;
+                    break;
+                case 'b':
+                    dest = 4;
+                    break;
+                case 'i':
+                    dest = 5;
+                    break;
+                case 's':
+                    dest = 6;
+                    break;
+            }
+            if (dest >= 0) {
+                buffer[dest] = c;
+                if (buffer[1] == 'v' && buffer[2] == 'o' && buffer[3] == 'r'
+                        && buffer[4] == 'b' && buffer[5] == 'i'
+                        && buffer[6] == 's' && buffer[0] == PACKET_TYPE_COMMENT) {
+                    return true;
+                }
+            } else {
+                Arrays.fill(buffer, (char) 0);
+            }
+        }
+        return false;
+    }
 
-	private VorbisCommentHeader readCommentHeader(InputStream input)
-			throws IOException, VorbisCommentReaderException {
-		try {
-			long vendorLength = EndianUtils.readSwappedUnsignedInteger(input);
-			String vendorName = readUTF8String(input, vendorLength);
-			long userCommentLength = EndianUtils
-					.readSwappedUnsignedInteger(input);
-			return new VorbisCommentHeader(vendorName, userCommentLength);
-		} catch (UnsupportedEncodingException e) {
-			throw new VorbisCommentReaderException(e);
-		}
-	}
+    @NonNull
+    private VorbisCommentHeader readCommentHeader(InputStream input) throws IOException, VorbisCommentReaderException {
+        try {
+            long vendorLength = EndianUtils.readSwappedUnsignedInteger(input);
+            String vendorName = readUtf8String(input, vendorLength);
+            long userCommentLength = EndianUtils.readSwappedUnsignedInteger(input);
+            return new VorbisCommentHeader(vendorName, userCommentLength);
+        } catch (UnsupportedEncodingException e) {
+            throw new VorbisCommentReaderException(e);
+        }
+    }
 
-	private String readContentVectorKey(InputStream input, long vectorLength)
-			throws IOException {
-		StringBuilder builder = new StringBuilder();
-		for (int i = 0; i < vectorLength; i++) {
-			char c = (char) input.read();
-			if (c == '=') {
-				return builder.toString();
-			} else {
-				builder.append(c);
-			}
-		}
-		return null; // no key found
-	}
+    private String readContentVectorKey(InputStream input, long vectorLength) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < vectorLength; i++) {
+            char c = (char) input.read();
+            if (c == '=') {
+                return builder.toString();
+            } else {
+                builder.append(c);
+            }
+        }
+        return null; // no key found
+    }
 }


### PR DESCRIPTION
- Supports [Podlove Simple Chapters](https://podlove.org/simple-chapters/) and mp3. Vorbis [does not support chapter images](http://lists.xiph.org/pipermail/vorbis-dev/2012-April/020272.html).
- Chapter images are only supported for new episodes. Otherwise, we would need to fetch chapters for every item on feed refresh, what is really slow.
- While I was trying to understand the code, I added support for parsing opus files. The old Vorbis reader only supported ogg.

Closes #2102