### PR TITLE
30dp buttons for notification / lock screen (play, fwd, rewind) buttons

### DIFF
--- a/core/src/main/res/drawable/ic_notification_cast_off.xml
+++ b/core/src/main/res/drawable/ic_notification_cast_off.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="24dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="24dp">
+        android:height="36dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="36dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M1.6,1.27L0.25,2.75L1.41,3.8C1.16,4.13 1,4.55 1,5V8H3V5.23L18.2,19H14V21H20.41L22.31,22.72L23.65,21.24M6.5,3L8.7,5H21V16.14L23,17.95V5C23,3.89 22.1,3 21,3M1,10V12A9,9 0 0,1 10,21H12C12,14.92 7.08,10 1,10M1,14V16A5,5 0 0,1 6,21H8A7,7 0 0,0 1,14M1,18V21H4A3,3 0 0,0 1,18Z" />
 </vector>

--- a/core/src/main/res/drawable/ic_notification_cast_off.xml
+++ b/core/src/main/res/drawable/ic_notification_cast_off.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="36dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="36dp">
+        android:height="30dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="30dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M1.6,1.27L0.25,2.75L1.41,3.8C1.16,4.13 1,4.55 1,5V8H3V5.23L18.2,19H14V21H20.41L22.31,22.72L23.65,21.24M6.5,3L8.7,5H21V16.14L23,17.95V5C23,3.89 22.1,3 21,3M1,10V12A9,9 0 0,1 10,21H12C12,14.92 7.08,10 1,10M1,14V16A5,5 0 0,1 6,21H8A7,7 0 0,0 1,14M1,18V21H4A3,3 0 0,0 1,18Z" />
 </vector>

--- a/core/src/main/res/drawable/ic_notification_fast_forward.xml
+++ b/core/src/main/res/drawable/ic_notification_fast_forward.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="24dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="24dp">
+        android:height="36dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="36dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M4,18l8.5,-6L4,6v12zM13,6v12l8.5,-6L13,6z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_fast_forward.xml
+++ b/core/src/main/res/drawable/ic_notification_fast_forward.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="36dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="36dp">
+        android:height="30dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="30dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M4,18l8.5,-6L4,6v12zM13,6v12l8.5,-6L13,6z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_fast_rewind.xml
+++ b/core/src/main/res/drawable/ic_notification_fast_rewind.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="24dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="24dp">
+        android:height="36dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="36dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M11,18L11,6l-8.5,6 8.5,6zM11.5,12l8.5,6L20,6l-8.5,6z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_fast_rewind.xml
+++ b/core/src/main/res/drawable/ic_notification_fast_rewind.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="36dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="36dp">
+        android:height="30dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="30dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M11,18L11,6l-8.5,6 8.5,6zM11.5,12l8.5,6L20,6l-8.5,6z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_pause.xml
+++ b/core/src/main/res/drawable/ic_notification_pause.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="24dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="24dp">
+        android:height="36dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="36dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_pause.xml
+++ b/core/src/main/res/drawable/ic_notification_pause.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="36dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="36dp">
+        android:height="30dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="30dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_play.xml
+++ b/core/src/main/res/drawable/ic_notification_play.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="24dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="24dp">
+        android:height="36dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="36dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M8,5v14l11,-7z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_play.xml
+++ b/core/src/main/res/drawable/ic_notification_play.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="36dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="36dp">
+        android:height="30dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="30dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M8,5v14l11,-7z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_skip.xml
+++ b/core/src/main/res/drawable/ic_notification_skip.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="24dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="24dp">
+        android:height="36dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="36dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_notification_skip.xml
+++ b/core/src/main/res/drawable/ic_notification_skip.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:height="36dp" android:viewportHeight="24.0"
-        android:viewportWidth="24.0" android:width="36dp">
+        android:height="30dp" android:viewportHeight="24.0"
+        android:viewportWidth="24.0" android:width="30dp">
     <path android:fillColor="#FFFFFFFF" android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
 </vector>


### PR DESCRIPTION
A simple change to make the buttons 25% larger.  I've seen a few users complaining.

Screen shot to compare before (blue) and after (white)

Removing the 36dp one, way too big (from the reviewers)
![Screen Shot 2020-02-06 at 10 42 29 PM](https://user-images.githubusercontent.com/149837/74006978-0e941680-4932-11ea-8866-36cfd3e2e1fe.png)

New proposal is the 30dp

![Screen Shot 2020-02-08 at 3 10 10 PM](https://user-images.githubusercontent.com/149837/74093322-2d56f200-4a85-11ea-97af-d858b53d5974.png)
