### PR TITLE
Fixed seeking when streaming

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -547,7 +547,7 @@ public class PlaybackController {
      */
     public void onSeekBarStopTrackingTouch(SeekBar seekBar, float prog) {
         if (playbackService != null && media != null) {
-            playbackService.seekTo((int) (prog * media.getDuration()));
+            seekTo((int) (prog * getDuration()));
         }
     }
 


### PR DESCRIPTION
Sometimes, `media` does not know the duration. `getDuration()` loads directly from the `PlaybackService`.