### PR TITLE
Hide downloading notification earlier

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -558,6 +558,7 @@ public class DownloadService extends Service {
         if (numberOfDownloads.get() <= 0 && DownloadRequester.getInstance().hasNoDownloads()) {
             Log.d(TAG, "Number of downloads is " + numberOfDownloads.get() + ", attempting shutdown");
             stopSelf();
+            notificationUpdater.run();
         } else {
             setupNotificationUpdater();
             Notification notification = notificationManager.updateNotifications(
@@ -616,8 +617,8 @@ public class DownloadService extends Service {
      * Schedules the notification updater task if it hasn't been scheduled yet.
      */
     private void setupNotificationUpdater() {
-        Log.d(TAG, "Setting up notification updater");
         if (notificationUpdater == null) {
+            Log.d(TAG, "Setting up notification updater");
             notificationUpdater = new NotificationUpdater();
             notificationUpdaterFuture = schedExecutor.scheduleAtFixedRate(notificationUpdater, 1, 1, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
I do not know why showing the notification makes it disappear earlier but even if it does not
disappear earlier, the number will now be updated to show "0 downloads left" instead of
incorrectly sticking with 1 download until dismissed.