### PR TITLE
Change default drawer counter to 'new episodes'

### DIFF
--- a/app/src/main/res/xml/preferences_user_interface.xml
+++ b/app/src/main/res/xml/preferences_user_interface.xml
@@ -28,7 +28,7 @@
                 android:title="@string/pref_nav_drawer_feed_counter_title"
                 android:key="prefDrawerFeedIndicator"
                 android:summary="@string/pref_nav_drawer_feed_counter_sum"
-                android:defaultValue="0"/>
+                android:defaultValue="1"/>
         <SwitchPreference
                 android:title="@string/pref_episode_cover_title"
                 android:key="prefEpisodeCover"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -236,12 +236,12 @@ public class UserPreferences {
     }
 
     public static int getFeedOrder() {
-        String value = prefs.getString(PREF_DRAWER_FEED_ORDER, "0");
+        String value = prefs.getString(PREF_DRAWER_FEED_ORDER, "" + FEED_ORDER_COUNTER);
         return Integer.parseInt(value);
     }
 
     public static int getFeedCounterSetting() {
-        String value = prefs.getString(PREF_DRAWER_FEED_COUNTER, "0");
+        String value = prefs.getString(PREF_DRAWER_FEED_COUNTER, "" + FEED_COUNTER_SHOW_NEW);
         return Integer.parseInt(value);
     }
 


### PR DESCRIPTION
instead of new+unplayed

In my studies, new users were regularly confused about what those numbers mean.