### PR TITLE
Add high priority feeds and expiring episodes after a configured number of days

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -37,6 +37,7 @@ import static de.danoeh.antennapod.core.feed.FeedPreferences.SPEED_USE_GLOBAL;
 public class FeedSettingsFragment extends PreferenceFragmentCompat {
     private static final CharSequence PREF_EPISODE_FILTER = "episodeFilter";
     private static final String PREF_FEED_PLAYBACK_SPEED = "feedPlaybackSpeed";
+    private static final String PREF_FEED_HIGH_PRIORITY = "isHighPriority";
     private static final DecimalFormat SPEED_FORMAT =
             new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.US));
     private static final String EXTRA_FEED_ID = "de.danoeh.antennapod.extra.feedId";
@@ -83,6 +84,7 @@ public class FeedSettingsFragment extends PreferenceFragmentCompat {
                     setupAuthentificationPreference();
                     setupEpisodeFilterPreference();
                     setupPlaybackSpeedPreference();
+                    setupHighPriorityPreference();
 
                     updateAutoDeleteSummary();
                     updateVolumeReductionValue();
@@ -259,6 +261,19 @@ public class FeedSettingsFragment extends PreferenceFragmentCompat {
         pref.setOnPreferenceChangeListener((preference, newValue) -> {
             boolean checked = newValue == Boolean.TRUE;
             feedPreferences.setKeepUpdated(checked);
+            feed.savePreferences();
+            pref.setChecked(checked);
+            return false;
+        });
+    }
+
+    private void setupHighPriorityPreference() {
+        SwitchPreference pref = (SwitchPreference) findPreference(PREF_FEED_HIGH_PRIORITY);
+
+        pref.setChecked(feedPreferences.getHighPriority());
+        pref.setOnPreferenceChangeListener((preference, newValue) -> {
+            boolean checked = newValue == Boolean.TRUE;
+            feedPreferences.setHighPriority(checked);
             feed.savePreferences();
             pref.setChecked(checked);
             return false;

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -53,6 +53,7 @@ public class EpisodeItemViewHolder extends FeedComponentViewHolder
     public final ImageView isInQueue;
     private final ImageView isVideo;
     public final ImageView isFavorite;
+    public final ImageView isHighPriority;
     private final ProgressBar progressBar;
     public final View secondaryActionButton;
     public final ImageView secondaryActionIcon;
@@ -82,6 +83,7 @@ public class EpisodeItemViewHolder extends FeedComponentViewHolder
         isVideo = itemView.findViewById(R.id.ivIsVideo);
         isNew = itemView.findViewById(R.id.statusUnread);
         isFavorite = itemView.findViewById(R.id.isFavorite);
+        isHighPriority = itemView.findViewById(R.id.isHighPriority);
         size = itemView.findViewById(R.id.size);
         separatorIcons = itemView.findViewById(R.id.separatorIcons);
         secondaryActionProgress = itemView.findViewById(R.id.secondaryActionProgress);
@@ -108,6 +110,7 @@ public class EpisodeItemViewHolder extends FeedComponentViewHolder
         pubDate.setText(DateUtils.formatAbbrev(activity, item.getPubDate()));
         isNew.setVisibility(item.isNew() ? View.VISIBLE : View.GONE);
         isFavorite.setVisibility(item.isTagged(FeedItem.TAG_FAVORITE) ? View.VISIBLE : View.GONE);
+        isHighPriority.setVisibility(item.getFeed().getPreferences().getHighPriority() ? View.VISIBLE : View.GONE);
         isInQueue.setVisibility(item.isTagged(FeedItem.TAG_QUEUE) ? View.VISIBLE : View.GONE);
         itemView.setAlpha(item.isPlayed() ? 0.5f : 1.0f);
 
@@ -209,6 +212,7 @@ public class EpisodeItemViewHolder extends FeedComponentViewHolder
         boolean hasIcons = isNew.getVisibility() == View.VISIBLE
                 || isInQueue.getVisibility() == View.VISIBLE
                 || isVideo.getVisibility() == View.VISIBLE
+                || isHighPriority.getVisibility() == View.VISIBLE
                 || isFavorite.getVisibility() == View.VISIBLE
                 || isNew.getVisibility() == View.VISIBLE;
         separatorIcons.setVisibility(hasIcons ? View.VISIBLE : View.GONE);

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -107,6 +107,12 @@
                     app:srcCompat="?attr/ic_unfav"
                     tools:srcCompat="@drawable/ic_star_grey600_24dp"
                     android:id="@+id/isFavorite"/>
+            <ImageView
+                    android:layout_width="14sp"
+                    android:layout_height="14sp"
+                    app:srcCompat="?attr/ic_high_priority"
+                    tools:srcCompat="?attr/ic_high_priority"
+                    android:id="@+id/isHighPriority"/>
 
             <ImageView
                     android:layout_width="14sp"

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -8,6 +8,12 @@
             android:title="@string/keep_updated"
             android:summary="@string/keep_updated_summary"/>
 
+    <SwitchPreference
+            android:key="isHighPriority"
+            android:icon="?attr/ic_high_priority"
+            android:title="@string/is_high_priority"
+            android:summary="@string/is_high_priority_summary"/>
+
     <Preference
             android:key="authentication"
             android:icon="?attr/ic_key"

--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -112,6 +112,13 @@
                 android:key="prefSkipKeepsEpisode"
                 android:summary="@string/pref_skip_keeps_episodes_sum"
                 android:title="@string/pref_skip_keeps_episodes_title"/>
+        <ListPreference
+                android:defaultValue="-1"
+                android:entries="@array/queue_max_age_entries"
+                android:entryValues="@array/queue_max_age_values"
+                android:key="prefPlaybackQueueMaxAge"
+                android:summary="@string/pref_queue_max_age_summary"
+                android:title="@string/pref_queue_max_age_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/media_player">

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -21,6 +21,7 @@ public class FeedPreferences {
     private long feedID;
     private boolean autoDownload;
     private boolean keepUpdated;
+    private boolean highPriority;
 
     public enum AutoDeleteAction {
         GLOBAL,
@@ -36,10 +37,10 @@ public class FeedPreferences {
     private float feedPlaybackSpeed;
 
     public FeedPreferences(long feedID, boolean autoDownload, AutoDeleteAction auto_delete_action, VolumeAdaptionSetting volumeAdaptionSetting, String username, String password) {
-        this(feedID, autoDownload, true, auto_delete_action, volumeAdaptionSetting, username, password, new FeedFilter(), SPEED_USE_GLOBAL);
+        this(feedID, autoDownload, true, auto_delete_action, volumeAdaptionSetting, username, password, new FeedFilter(), SPEED_USE_GLOBAL, false);
     }
 
-    private FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, AutoDeleteAction auto_delete_action, VolumeAdaptionSetting volumeAdaptionSetting, String username, String password, @NonNull FeedFilter filter, float feedPlaybackSpeed) {
+    private FeedPreferences(long feedID, boolean autoDownload, boolean keepUpdated, AutoDeleteAction auto_delete_action, VolumeAdaptionSetting volumeAdaptionSetting, String username, String password, @NonNull FeedFilter filter, float feedPlaybackSpeed, boolean highPriority) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
         this.keepUpdated = keepUpdated;
@@ -49,6 +50,7 @@ public class FeedPreferences {
         this.password = password;
         this.filter = filter;
         this.feedPlaybackSpeed = feedPlaybackSpeed;
+        this.highPriority = highPriority;
     }
 
     public static FeedPreferences fromCursor(Cursor cursor) {
@@ -62,10 +64,12 @@ public class FeedPreferences {
         int indexIncludeFilter = cursor.getColumnIndex(PodDBAdapter.KEY_INCLUDE_FILTER);
         int indexExcludeFilter = cursor.getColumnIndex(PodDBAdapter.KEY_EXCLUDE_FILTER);
         int indexFeedPlaybackSpeed = cursor.getColumnIndex(PodDBAdapter.KEY_FEED_PLAYBACK_SPEED);
+        int indexIsHighPriority = cursor.getColumnIndex(PodDBAdapter.KEY_FEED_IS_HIGH_PRIORITY);
 
         long feedId = cursor.getLong(indexId);
         boolean autoDownload = cursor.getInt(indexAutoDownload) > 0;
         boolean autoRefresh = cursor.getInt(indexAutoRefresh) > 0;
+        boolean isHighPriority = cursor.getInt(indexIsHighPriority) > 0;
         int autoDeleteActionIndex = cursor.getInt(indexAutoDeleteAction);
         AutoDeleteAction autoDeleteAction = AutoDeleteAction.values()[autoDeleteActionIndex];
         int volumeAdaptionValue = cursor.getInt(indexVolumeAdaption);
@@ -75,7 +79,7 @@ public class FeedPreferences {
         String includeFilter = cursor.getString(indexIncludeFilter);
         String excludeFilter = cursor.getString(indexExcludeFilter);
         float feedPlaybackSpeed = cursor.getFloat(indexFeedPlaybackSpeed);
-        return new FeedPreferences(feedId, autoDownload, autoRefresh, autoDeleteAction, volumeAdaptionSetting, username, password, new FeedFilter(includeFilter, excludeFilter), feedPlaybackSpeed);
+        return new FeedPreferences(feedId, autoDownload, autoRefresh, autoDeleteAction, volumeAdaptionSetting, username, password, new FeedFilter(includeFilter, excludeFilter), feedPlaybackSpeed, isHighPriority);
     }
 
     /**
@@ -100,6 +104,16 @@ public class FeedPreferences {
     public void setKeepUpdated(boolean keepUpdated) {
         this.keepUpdated = keepUpdated;
     }
+
+    /**
+     * @return true if this feed's episodes should always be placed on top of the queue and not
+     *         deleted automatically after the expire period.
+     */
+    public boolean getHighPriority() {
+      return highPriority;
+    }
+
+    public void setHighPriority(boolean highPriority) { this.highPriority = highPriority; }
 
     /**
      * Compare another FeedPreferences with this one. The feedID, autoDownload and AutoDeleteAction attribute are excluded from the

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -83,6 +83,7 @@ public class UserPreferences {
     public static final String PREF_VIDEO_BEHAVIOR = "prefVideoBehavior";
     private static final String PREF_TIME_RESPECTS_SPEED = "prefPlaybackTimeRespectsSpeed";
     public static final String PREF_STREAM_OVER_DOWNLOAD = "prefStreamOverDownload";
+    public static final String PREF_QUEUE_MAX_AGE = "prefPlaybackQueueMaxAge";
 
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
@@ -1036,6 +1037,22 @@ public class UserPreferences {
         }
         prefs.edit()
                 .putString(PREF_QUEUE_KEEP_SORTED_ORDER, sortOrder.name())
+                .apply();
+    }
+
+    /**
+     * Returns the sort order for the queue keep sorted mode.
+     * Note: This value is stored independently from the keep sorted state.
+     *
+     * @see #isQueueKeepSorted()
+     */
+    public static int getPlaybackQueueMaxAge() {
+        return Integer.valueOf(prefs.getString(PREF_QUEUE_MAX_AGE, "-1"));
+    }
+
+    public static void setPlaybackQueueMaxAge(int playbackQueueMaxAge) {
+        prefs.edit()
+                .putString(PREF_QUEUE_MAX_AGE, String.valueOf(playbackQueueMaxAge))
                 .apply();
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 /**
  * Implementation of the EpisodeCleanupAlgorithm interface used by AntennaPod.
@@ -91,20 +92,28 @@ public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
         Date mostRecentDateForDeletion = calcMostRecentDateForDeletion(new Date());
         for (FeedItem item : downloadedItems) {
-            if (item.hasMedia()
-                    && item.getMedia().isDownloaded()
-                    && !item.isTagged(FeedItem.TAG_QUEUE)
-                    && item.isPlayed()
-                    && !item.isTagged(FeedItem.TAG_FAVORITE)) {
-                FeedMedia media = item.getMedia();
-                // make sure this candidate was played at least the proper amount of days prior
-                // to now
-                if (media != null
-                        && media.getPlaybackCompletionDate() != null
-                        && media.getPlaybackCompletionDate().before(mostRecentDateForDeletion)) {
-                    candidates.add(item);
+            boolean addCandidate = false;
+            if (item.hasMedia()){
+                // Default behaviour
+                if (item.getMedia().isDownloaded()
+                        && !item.isTagged(FeedItem.TAG_QUEUE)
+                        && item.isPlayed()
+                        && !item.isTagged(FeedItem.TAG_FAVORITE)) {
+                    FeedMedia media = item.getMedia();
+                    // make sure this candidate was played at least the proper amount of days prior
+                    // to now
+                    if (media != null
+                            && media.getPlaybackCompletionDate() != null
+                            && media.getPlaybackCompletionDate().before(mostRecentDateForDeletion)) {
+                        addCandidate = true;
+                    }
                 }
             }
+            // Add expired items for deletion
+            if (item.isExpired()) {
+                addCandidate = true;
+            }
+            if (addCandidate) candidates.add(item);
         }
         return candidates;
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -480,6 +480,13 @@ public final class DBTasks {
                     final FeedItem item = newFeed.getItems().get(idx);
                     FeedItem oldItem = searchFeedItemByIdentifyingValue(savedFeed,
                             item.getIdentifyingValue());
+
+                    // if item is expired mark it as played
+                    if (item.isExpired()){
+                        item.setPlayed(true);
+                        item.setAutoDownload(false);
+                    }
+
                     if (oldItem == null) {
                         // item is new
                         item.setFeed(savedFeed);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBUpgrader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBUpgrader.java
@@ -304,6 +304,10 @@ class DBUpgrader {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_SIMPLECHAPTERS
                     + " ADD COLUMN " + PodDBAdapter.KEY_IMAGE_URL + " TEXT DEFAULT NULL");
         }
+        if (oldVersion < 1080195) {
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_FEED_IS_HIGH_PRIORITY + " INTEGER DEFAULT -1");
+        }
     }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -347,10 +347,17 @@ public class DBWriter {
             ItemEnqueuePositionCalculator positionCalculator =
                     new ItemEnqueuePositionCalculator(UserPreferences.getEnqueueLocation());
             Playable currentlyPlaying = Playable.PlayableUtils.createInstanceFromPreferences(context);
-            int insertPosition = positionCalculator.calcPosition(queue, currentlyPlaying);
             for (long itemId : itemIds) {
                 if (!itemListContains(queue, itemId)) {
                     final FeedItem item = DBReader.getFeedItem(itemId);
+                    // Find out if the item should be treated as a high priority one
+                    boolean isHighPriority = false;
+                    if (item.getFeed() != null
+                            && item.getFeed().getPreferences() != null) {
+                        isHighPriority = item.getFeed().getPreferences().getHighPriority();
+                    }
+                    int insertPosition = positionCalculator.calcPosition(queue, currentlyPlaying, isHighPriority);
+                    // Do the insert
                     if (item != null) {
                         queue.add(insertPosition, item);
                         events.add(QueueEvent.added(item, insertPosition));
@@ -361,7 +368,6 @@ public class DBWriter {
                         if (item.isNew()) {
                             markAsUnplayedIds.add(item.getId());
                         }
-                        insertPosition++;
                     }
                 }
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/ItemEnqueuePositionCalculator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/ItemEnqueuePositionCalculator.java
@@ -40,7 +40,7 @@ class ItemEnqueuePositionCalculator {
             case BACK:
                 // For high priority items, they will be inserted after the last high priority (if any)
                 if (isHighPriority) {
-                    return getPositionOfFirstNonHighPriorityItem(0 , curQueue);
+                    return getPositionOfFirstNonHighPriorityItem(0, curQueue);
                 } else {
                     return curQueue.size();
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -110,6 +110,7 @@ public class PodDBAdapter {
     public static final String KEY_INCLUDE_FILTER = "include_filter";
     public static final String KEY_EXCLUDE_FILTER = "exclude_filter";
     public static final String KEY_FEED_PLAYBACK_SPEED = "feed_playback_speed";
+    public static final String KEY_FEED_IS_HIGH_PRIORITY = "feed_is_high_priority";
 
     // Table names
     static final String TABLE_NAME_FEEDS = "Feeds";
@@ -145,7 +146,8 @@ public class PodDBAdapter {
             + KEY_LAST_UPDATE_FAILED + " INTEGER DEFAULT 0,"
             + KEY_AUTO_DELETE_ACTION + " INTEGER DEFAULT 0,"
             + KEY_FEED_PLAYBACK_SPEED + " REAL DEFAULT " + SPEED_USE_GLOBAL + ","
-            + KEY_FEED_VOLUME_ADAPTION + " INTEGER DEFAULT 0)";
+            + KEY_FEED_VOLUME_ADAPTION + " INTEGER DEFAULT 0" + ","
+            + KEY_FEED_IS_HIGH_PRIORITY + " INTEGER DEFAULT 0)";
 
     private static final String CREATE_TABLE_FEED_ITEMS = "CREATE TABLE "
             + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY + KEY_TITLE
@@ -245,7 +247,8 @@ public class PodDBAdapter {
             TABLE_NAME_FEEDS + "." + KEY_FEED_VOLUME_ADAPTION,
             TABLE_NAME_FEEDS + "." + KEY_INCLUDE_FILTER,
             TABLE_NAME_FEEDS + "." + KEY_EXCLUDE_FILTER,
-            TABLE_NAME_FEEDS + "." + KEY_FEED_PLAYBACK_SPEED
+            TABLE_NAME_FEEDS + "." + KEY_FEED_PLAYBACK_SPEED,
+            TABLE_NAME_FEEDS + "." + KEY_FEED_IS_HIGH_PRIORITY
     };
 
     /**
@@ -414,6 +417,7 @@ public class PodDBAdapter {
         values.put(KEY_INCLUDE_FILTER, prefs.getFilter().getIncludeFilter());
         values.put(KEY_EXCLUDE_FILTER, prefs.getFilter().getExcludeFilter());
         values.put(KEY_FEED_PLAYBACK_SPEED, prefs.getFeedPlaybackSpeed());
+        values.put(KEY_FEED_IS_HIGH_PRIORITY, prefs.getHighPriority());
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(prefs.getFeedID())});
     }
 

--- a/core/src/main/res/values-es-rES/strings.xml
+++ b/core/src/main/res/values-es-rES/strings.xml
@@ -221,6 +221,11 @@
   <!--Episodes apply actions-->
   <string name="all_label">Todos</string>
   <string name="none_label">Ningun</string>
+  <string name="pref_queue_max_age_title">Antigüedad límite de los episodios en días</string>
+  <string name="pref_queue_max_age_unlimited">Ilimitada</string>
+  <string name="pref_queue_max_age_summary">Una vez caducados, los episodios son desencolados, marcados como leídos y borrados. Los episodios de alta prioridad son ignorados.</string>
+  <string name="is_high_priority">Alta prioridad</string>
+  <string name="is_high_priority_summary">Los podcasts de alta prioridad se encolan sobre los demás y no expiran.</string>
   <!--Sort-->
   <!--Rating dialog-->
   <!--Audio controls-->

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -55,6 +55,24 @@
         <item>72</item>
     </string-array>
 
+    <string-array name="queue_max_age_entries">
+        <item>7</item>
+        <item>15</item>
+        <item>30</item>
+        <item>60</item>
+        <item>90</item>
+        <item>@string/pref_queue_max_age_unlimited</item>
+    </string-array>
+
+    <string-array name="queue_max_age_values">
+        <item>7</item>
+        <item>15</item>
+        <item>30</item>
+        <item>60</item>
+        <item>90</item>
+        <item>-1</item>
+    </string-array>
+
     <string-array name="episode_cache_size_entries">
         <item>5</item>
         <item>10</item>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -54,6 +54,7 @@
     <attr name="ic_questionmark" format="reference" />
     <attr name="ic_chat" format="reference"/>
     <attr name="ic_bug" format="reference" />
+    <attr name="ic_high_priority" format="reference" />
     <attr name="master_switch_background" format="color"/>
     <attr name="currently_playing_background" format="color"/>
     <attr name="ic_bookmark" format="reference"/>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -479,6 +479,9 @@
     <string name="pref_showDownloadReport_title">Show Download Report</string>
     <string name="pref_showDownloadReport_sum">If downloads fail, generate a report that shows the details of the failure.</string>
     <string name="pref_expand_notify_unsupport_toast">Android versions before 4.1 do not support expanded notifications.</string>
+    <string name="pref_queue_max_age_title">Episodes max age in days</string>
+    <string name="pref_queue_max_age_summary">Once expired, episodes will be de-queued, marked as read and deleted. Episodes of high priority feeds will be ignored.</string>
+    <string name="pref_queue_max_age_unlimited">Unlimited</string>
     <string name="pref_enqueue_location_title">Enqueue Location</string>
     <string name="pref_enqueue_location_sum">Add episodes to: %1$s</string>
     <string name="enqueue_location_back">Back</string>
@@ -681,6 +684,8 @@
     <string name="episode_filters_hint">Single words \n\"Multiple Words\"</string>
     <string name="keep_updated">Keep Updated</string>
     <string name="keep_updated_summary">Include this podcast when (auto-)refreshing all podcasts</string>
+    <string name="is_high_priority">Is high priority</string>
+    <string name="is_high_priority_summary">High priority podcasts are queued on top of the others and they don\'t expire.</string>
     <string name="auto_download_disabled_globally">Auto download is disabled in the main AntennaPod settings</string>
 
     <!-- Progress information -->

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -72,6 +72,7 @@
         <item name="currently_playing_background">@color/highlight_light</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="action_icon_color">#FF757575</item>
+        <item name="ic_high_priority">@drawable/navigation_up</item>
     </style>
 
     <style name="Theme.AntennaPod.Dark" parent="Theme.Base.AntennaPod.Dark">
@@ -147,6 +148,7 @@
         <item name="currently_playing_background">@color/highlight_dark</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="action_icon_color">@color/white</item>
+        <item name="ic_high_priority">@drawable/navigation_up_dark</item>
     </style>
 
     <style name="Theme.AntennaPod.TrueBlack" parent="Theme.Base.AntennaPod.TrueBlack">


### PR DESCRIPTION
This enables users to select feeds that are marked as high priority within the feed preferences:
![image](https://user-images.githubusercontent.com/2015196/76155763-ac713180-60e8-11ea-94cf-8dfcfadf660e.png)

These feeds will be queued on top of the others. 
Non priority feeds' items will be expired after a configured number of days:
![image](https://user-images.githubusercontent.com/2015196/76155783-0114ac80-60e9-11ea-97a0-008764387fd6.png)

This is simple approach (both from a user interaction and an implementation perspective) that prevents the user from being overwhelmed by subscribing to more feeds that he can consume. In those circumstances, seeing the queue continuously growing can be overwhelming.

With this approach, the user can select those high priority feeds that he doesn't want to miss and the rest of the feeds will be queued after those and will be removed after a configured number of days from publishing date (`unlimited` by default).

This change addresses some of the changes commented in the following issues but in a slightly different manner: #399 , #2400 
