### PR TITLE
Fixed default sort method not showing up as selected

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/IntraFeedSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/IntraFeedSortDialog.java
@@ -29,9 +29,9 @@ public abstract class IntraFeedSortDialog {
             values[i] = SortOrder.valueOf(valueStrs[i]);
         }
 
-        int idxCurrentSort = -1;
+        int idxCurrentSort = 0;
         for  (int i = 0; i < values.length; i++) {
-            if (currentSortOrder == values[i] || currentSortOrder == null) {
+            if (currentSortOrder == values[i]) {
                 idxCurrentSort = i;
                 break;
             }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/IntraFeedSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/IntraFeedSortDialog.java
@@ -31,7 +31,7 @@ public abstract class IntraFeedSortDialog {
 
         int idxCurrentSort = -1;
         for  (int i = 0; i < values.length; i++) {
-            if (currentSortOrder == values[i]) {
+            if (currentSortOrder == values[i] || currentSortOrder == null) {
                 idxCurrentSort = i;
                 break;
             }


### PR DESCRIPTION
When a new feed is added their sort values are set to `null`. Added a check to default sort method to select "Date (New -> Old)" and show it is selected.

closes: #3918 