### PR TITLE
Enable caching for web responses

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/discovery/ItunesTopListLoader.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/ItunesTopListLoader.java
@@ -10,6 +10,7 @@ import io.reactivex.Single;
 import io.reactivex.SingleOnSubscribe;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
+import okhttp3.CacheControl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -21,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 public class ItunesTopListLoader {
     private static final String TAG = "ITunesTopListLoader";
@@ -81,6 +83,7 @@ public class ItunesTopListLoader {
         String url = "https://itunes.apple.com/%s/rss/toppodcasts/limit=" + limit + "/explicit=true/json";
         Log.d(TAG, "Feed URL " + String.format(url, country));
         Request.Builder httpReq = new Request.Builder()
+                .cacheControl(new CacheControl.Builder().minFresh(1, TimeUnit.DAYS).build())
                 .header("User-Agent", ClientConfig.USER_AGENT)
                 .url(String.format(url, country));
 

--- a/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.service.download.AntennapodHttpClient;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.exception.RxJavaErrorHandlerSetup;
@@ -43,6 +44,7 @@ public class ClientConfig {
         UserPreferences.init(context);
         PlaybackPreferences.init(context);
         NetworkUtils.init(context);
+        AntennapodHttpClient.setCacheDirectory(context.getCacheDir());
         SleepTimerPreferences.init(context);
         RxJavaErrorHandlerSetup.setupRxJavaErrorHandler();
         NotificationUtils.createChannels(context);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import de.danoeh.antennapod.core.service.BasicAuthorizationInterceptor;
+import okhttp3.CacheControl;
 import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedInputStream;
@@ -69,6 +70,7 @@ public class HttpDownloader extends Downloader {
                 // set header explicitly so that okhttp doesn't do transparent gzip
                 Log.d(TAG, "addHeader(\"Accept-Encoding\", \"identity\")");
                 httpReq.addHeader("Accept-Encoding", "identity");
+                httpReq.cacheControl(new CacheControl.Builder().noStore().build());
             }
 
             if (!TextUtils.isEmpty(request.getLastModified())) {

--- a/core/src/play/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -11,6 +11,7 @@ import de.danoeh.antennapod.core.cast.CastManager;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.service.download.AntennapodHttpClient;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.exception.RxJavaErrorHandlerSetup;
@@ -62,6 +63,7 @@ public class ClientConfig {
             Log.v(TAG, "Cast is disabled. All Cast-related initialization will be skipped.");
         }
         installSslProvider(context);
+        AntennapodHttpClient.setCacheDirectory(context.getCacheDir());
         SleepTimerPreferences.init(context);
         RxJavaErrorHandlerSetup.setupRxJavaErrorHandler();
         NotificationUtils.createChannels(context);


### PR DESCRIPTION
This makes feed updates faster and reduces the server load. Does not cache media files. Cached iTunes toplist at least one day.