### PR TITLE
Always add UserAgent to requests

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/discovery/ItunesPodcastSearcher.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/ItunesPodcastSearcher.java
@@ -43,8 +43,7 @@ public class ItunesPodcastSearcher implements PodcastSearcher {
 
             OkHttpClient client = AntennapodHttpClient.getHttpClient();
             Request.Builder httpReq = new Request.Builder()
-                    .url(formattedUrl)
-                    .header("User-Agent", ClientConfig.USER_AGENT);
+                    .url(formattedUrl);
             List<PodcastSearchResult> podcasts = new ArrayList<>();
             try {
                 Response response = client.newCall(httpReq.build()).execute();

--- a/app/src/main/java/de/danoeh/antennapod/discovery/ItunesTopListLoader.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/ItunesTopListLoader.java
@@ -57,8 +57,7 @@ public class ItunesTopListLoader {
         return Single.create((SingleOnSubscribe<String>) emitter -> {
             OkHttpClient client = AntennapodHttpClient.getHttpClient();
             Request.Builder httpReq = new Request.Builder()
-                    .url(podcast.feedUrl)
-                    .header("User-Agent", ClientConfig.USER_AGENT);
+                    .url(podcast.feedUrl);
             try {
                 Response response = client.newCall(httpReq.build()).execute();
                 if (response.isSuccessful()) {
@@ -84,7 +83,6 @@ public class ItunesTopListLoader {
         Log.d(TAG, "Feed URL " + String.format(url, country));
         Request.Builder httpReq = new Request.Builder()
                 .cacheControl(new CacheControl.Builder().minFresh(1, TimeUnit.DAYS).build())
-                .header("User-Agent", ClientConfig.USER_AGENT)
                 .url(String.format(url, country));
 
         try (Response response = client.newCall(httpReq.build()).execute()) {

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ChapterImageModelLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ChapterImageModelLoader.java
@@ -71,7 +71,6 @@ public final class ChapterImageModelLoader implements ModelLoader<EmbeddedChapte
                     callback.onDataReady(ByteBuffer.wrap(imageContent));
                 } else {
                     Request.Builder httpReq = new Request.Builder();
-                    httpReq.header("User-Agent", ClientConfig.USER_AGENT);
                     // Skipping would download the whole file
                     httpReq.header("Range", "bytes=" + image.getPosition()
                             + "-" + (image.getPosition() + image.getLength()));

--- a/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/gpoddernet/GpodnetService.java
@@ -554,9 +554,8 @@ public class GpodnetService {
         }.start();
     }
 
-    private String executeRequest(@NonNull Request.Builder requestB)
-            throws GpodnetServiceException {
-        Request request = requestB.header("User-Agent", ClientConfig.USER_AGENT).build();
+    private String executeRequest(@NonNull Request.Builder requestB) throws GpodnetServiceException {
+        Request request = requestB.build();
         String responseString = null;
         Response response = null;
         ResponseBody body = null;
@@ -584,7 +583,7 @@ public class GpodnetService {
                     "request and credentials must not be null");
         }
 
-        Request request = requestB.header("User-Agent", ClientConfig.USER_AGENT).build();
+        Request request = requestB.build();
         String result = null;
         ResponseBody body = null;
         try {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/UserAgentInterceptor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/UserAgentInterceptor.java
@@ -1,0 +1,20 @@
+package de.danoeh.antennapod.core.service;
+
+import de.danoeh.antennapod.core.ClientConfig;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+public class UserAgentInterceptor implements Interceptor {
+
+    public UserAgentInterceptor() {
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        return chain.proceed(chain.request().newBuilder()
+                .header("User-Agent", ClientConfig.USER_AGENT)
+                .build());
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
@@ -32,6 +32,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.service.UserAgentInterceptor;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import okhttp3.Cache;
 import okhttp3.CipherSuite;
@@ -116,6 +117,7 @@ public class AntennapodHttpClient {
             return response;
         });
         builder.interceptors().add(new BasicAuthorizationInterceptor());
+        builder.networkInterceptors().add(new UserAgentInterceptor());
 
         // set cookie handler
         CookieManager cm = new CookieManager();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -63,8 +63,7 @@ public class HttpDownloader extends Downloader {
 
         try {
             final URI uri = URIUtil.getURIFromRequestUrl(request.getSource());
-            Request.Builder httpReq = new Request.Builder().url(uri.toURL())
-                    .header("User-Agent", ClientConfig.USER_AGENT);
+            Request.Builder httpReq = new Request.Builder().url(uri.toURL());
             httpReq.tag(request);
             if (request.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                 // set header explicitly so that okhttp doesn't do transparent gzip


### PR DESCRIPTION
Apparently, AntennaPod talked to fyyd with the UserAgent "OkHttp/x.y.z" instead of "AntennaPod/x.y.z". This should now be fixed.