### PR TITLE
Fixed blurring images on Android 4.4

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/glide/FastBlurTransformation.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/FastBlurTransformation.java
@@ -22,7 +22,9 @@ public class FastBlurTransformation extends BitmapTransformation {
 
     @Override
     protected Bitmap transform(BitmapPool pool, Bitmap source, int outWidth, int outHeight) {
-        Bitmap resized = ThumbnailUtils.extractThumbnail(source, outWidth / 3, outHeight / 3);
+        int targetWidth = outWidth / 3;
+        int targetHeight = (int) (1.0 * outHeight * targetWidth / outWidth);
+        Bitmap resized = ThumbnailUtils.extractThumbnail(source, targetWidth, targetHeight);
         Bitmap result = fastBlur(resized, STACK_BLUR_RADIUS);
         if (result == null) {
             Log.w(TAG, "result was null");


### PR DESCRIPTION
```
03-16 13:40:00.424 3096-3132/de.danoeh.antennapod.debug E/GlideExecutor: Request threw uncaught throwable
    java.lang.ArrayIndexOutOfBoundsException: length=9216; index=9427
        at de.danoeh.antennapod.core.glide.FastBlurTransformation.fastBlur(FastBlurTransformation.java:235)
        at de.danoeh.antennapod.core.glide.FastBlurTransformation.transform(FastBlurTransformation.java:26)
        at com.bumptech.glide.load.resource.bitmap.BitmapTransformation.transform(BitmapTransformation.java:81)
        at com.bumptech.glide.load.engine.DecodeJob.onResourceDecoded(DecodeJob.java:540)
        at com.bumptech.glide.load.engine.DecodeJob$DecodeCallback.onResourceDecoded(DecodeJob.java:604)
        at com.bumptech.glide.load.engine.DecodePath.decode(DecodePath.java:46)
        at com.bumptech.glide.load.engine.LoadPath.loadWithExceptionList(LoadPath.java:58)
        at com.bumptech.glide.load.engine.LoadPath.load(LoadPath.java:43)
        at com.bumptech.glide.load.engine.DecodeJob.runLoadPath(DecodeJob.java:507)
        at com.bumptech.glide.load.engine.DecodeJob.decodeFromFetcher(DecodeJob.java:472)
        at com.bumptech.glide.load.engine.DecodeJob.decodeFromData(DecodeJob.java:458)
        at com.bumptech.glide.load.engine.DecodeJob.decodeFromRetrievedData(DecodeJob.java:410)
        at com.bumptech.glide.load.engine.DecodeJob.onDataFetcherReady(DecodeJob.java:379)
        at com.bumptech.glide.load.engine.DataCacheGenerator.onDataReady(DataCacheGenerator.java:95)
        at com.bumptech.glide.load.model.ByteBufferFileLoader$ByteBufferFetcher.loadData(ByteBufferFileLoader.java:74)
        at com.bumptech.glide.load.engine.DataCacheGenerator.startNext(DataCacheGenerator.java:75)
        at com.bumptech.glide.load.engine.DecodeJob.runGenerators(DecodeJob.java:302)
        at com.bumptech.glide.load.engine.DecodeJob.runWrapped(DecodeJob.java:269)
        at com.bumptech.glide.load.engine.DecodeJob.run(DecodeJob.java:233)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
        at java.lang.Thread.run(Thread.java:841)
        at com.bumptech.glide.load.engine.executor.GlideExecutor$DefaultThreadFactory$1.run(GlideExecutor.java:446)
```