### PR TITLE
Fixed jumping icon on splash screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/SplashActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/SplashActivity.java
@@ -45,6 +45,7 @@ public class SplashActivity extends AppCompatActivity {
             .subscribe(() -> {
                 Intent intent = new Intent(SplashActivity.this, MainActivity.class);
                 startActivity(intent);
+                overridePendingTransition(0, 0);
                 finish();
             });
     }

--- a/app/src/main/res/layout/splash.xml
+++ b/app/src/main/res/layout/splash.xml
@@ -9,6 +9,6 @@
             android:layout_height="24dp"
             android:layout_alignParentBottom="true"
             android:layout_centerHorizontal="true"
-            android:layout_margin="36dp"
+            android:layout_marginBottom="96dp"
             android:id="@+id/progressBar"/>
 </RelativeLayout>

--- a/core/src/main/res/values-v26/styles.xml
+++ b/core/src/main/res/values-v26/styles.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="Theme.AntennaPod.Splash" parent="Theme.Base.AntennaPod.Splash">
-        <item name="android:windowSplashscreenContent">@drawable/bg_splash</item>
-    </style>
-</resources>


### PR DESCRIPTION
The progress bar is only shown if there are long database migrations

![jump](https://user-images.githubusercontent.com/5811634/77163541-91220100-6aae-11ea-9225-6fb893d3af5a.gif)
