### PR TITLE
Fixed downloads taking long before being shown as started

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -474,7 +474,6 @@ public class DownloadService extends Service {
                                   @NonNull List<? extends FeedItem> itemsEnqueued) {
         writeFileUrl(request);
 
-        ClientConfig.installSslProvider(this);
         Downloader downloader = downloaderFactory.create(request);
         if (downloader != null) {
             numberOfDownloads.incrementAndGet();
@@ -485,9 +484,12 @@ public class DownloadService extends Service {
             }
             handler.post(() -> {
                 downloads.add(downloader);
-                downloadExecutor.submit(downloader);
                 postDownloaders();
             });
+            // Needs to be done after postDownloaders() because otherwise,
+            // it might take long before the progress bar circle starts spinning
+            ClientConfig.installSslProvider(this);
+            handler.post(() -> downloadExecutor.submit(downloader));
         }
         handler.post(this::queryDownloads);
     }


### PR DESCRIPTION
The first call to installSslProvider may take quite long.
Already report the started download.