### PR TITLE
Removed WiFi filter on Android 10

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -374,13 +374,6 @@ public class PreferencesTest {
         clickPreference(R.string.pref_automatic_download_on_battery_title);
         Awaitility.await().atMost(1000, MILLISECONDS)
                 .until(() -> enableAutodownloadOnBattery == UserPreferences.isEnableAutodownloadOnBattery());
-        final boolean enableWifiFilter = UserPreferences.isEnableAutodownloadWifiFilter();
-        clickPreference(R.string.pref_autodl_wifi_filter_title);
-        Awaitility.await().atMost(1000, MILLISECONDS)
-                .until(() -> enableWifiFilter != UserPreferences.isEnableAutodownloadWifiFilter());
-        clickPreference(R.string.pref_autodl_wifi_filter_title);
-        Awaitility.await().atMost(1000, MILLISECONDS)
-                .until(() -> enableWifiFilter == UserPreferences.isEnableAutodownloadWifiFilter());
     }
 
     @Test

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/AutoDownloadPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/AutoDownloadPreferencesFragment.java
@@ -1,41 +1,31 @@
 package de.danoeh.antennapod.fragment.preferences;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
+import android.util.Log;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
-import android.util.Log;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.activity.PreferenceActivity;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.PreferenceActivity;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
-
 public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
     private static final String TAG = "AutoDnldPrefFragment";
 
-    private static final int LOCATION_PERMISSION_REQUEST_CODE = 1;
-    private static final String PREF_KEY_LOCATION_PERMISSION_REQUEST_PROMPT = "prefAutoDownloadWifiFilterAndroid10PermissionPrompt";
-
     private CheckBoxPreference[] selectedNetworks;
-
-    private Preference prefPermissionRequestPromptOnAndroid10 = null;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -67,6 +57,9 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
                     }
                     return true;
                 });
+        if (Build.VERSION.SDK_INT >= 29) {
+            findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setVisible(false);
+        }
         findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER)
                 .setOnPreferenceChangeListener(
                         (preference, newValue) -> {
@@ -93,6 +86,10 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private void buildAutodownloadSelectedNetworksPreference() {
+        if (Build.VERSION.SDK_INT >= 29) {
+            return;
+        }
+
         final Activity activity = getActivity();
 
         if (selectedNetworks != null) {
@@ -192,65 +189,10 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private void setSelectedNetworksEnabled(boolean b) {
-        if (showPermissionRequestPromptOnAndroid10IfNeeded(b)) {
-            return;
-        }
-
         if (selectedNetworks != null) {
             for (Preference p : selectedNetworks) {
                 p.setEnabled(b);
             }
         }
     }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (requestCode != LOCATION_PERMISSION_REQUEST_CODE) {
-            return;
-        }
-        if (permissions.length > 0 && permissions[0].equals(Manifest.permission.ACCESS_FINE_LOCATION) &&
-                grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            buildAutodownloadSelectedNetworksPreference();
-        }
-    }
-
-    private boolean showPermissionRequestPromptOnAndroid10IfNeeded(boolean wifiFilterEnabled) {
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-            return false;
-        }
-
-        // Cases Android 10(Q) or later
-        if (prefPermissionRequestPromptOnAndroid10 != null) {
-            getPreferenceScreen().removePreference(prefPermissionRequestPromptOnAndroid10);
-            prefPermissionRequestPromptOnAndroid10 = null;
-        }
-
-        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED) {
-            return false;
-        }
-
-        // Case location permission not yet granted, permission-specific UI is needed
-        if (!wifiFilterEnabled) {
-            // Don't show the UI when WiFi filter disabled.
-            // it still return true, so that the caller knows
-            // it does not have required permission, and will not invoke codes that require so.
-            return true;
-        }
-
-        Preference pref = new Preference(requireActivity());
-        pref.setKey(PREF_KEY_LOCATION_PERMISSION_REQUEST_PROMPT);
-        pref.setTitle(R.string.autodl_wifi_filter_permission_title);
-        pref.setSummary(R.string.autodl_wifi_filter_permission_message);
-        pref.setIcon(R.drawable.ic_warning_red);
-        pref.setOnPreferenceClickListener(preference -> {
-            requestPermissions(new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_PERMISSION_REQUEST_CODE);
-            return true;
-        });
-        pref.setPersistent(false);
-        getPreferenceScreen().addPreference(pref);
-        prefPermissionRequestPromptOnAndroid10 = pref;
-        return true;
-    }
-
 }

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -9,11 +9,6 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <!-- ACCESS_FINE_LOCATION is needed only on Android 10+,
-        for Automatic Download Wifi filter's UI, which uses
-        WifiManager.WifiManager.getConfiguredNetworks()
-      -->
-    <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.preferences;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
@@ -559,7 +560,7 @@ public class UserPreferences {
     }
 
     public static boolean isEnableAutodownloadWifiFilter() {
-        return prefs.getBoolean(PREF_ENABLE_AUTODL_WIFI_FILTER, false);
+        return Build.VERSION.SDK_INT < 29 && prefs.getBoolean(PREF_ENABLE_AUTODL_WIFI_FILTER, false);
     }
 
     public static int getImageCacheSize() {

--- a/core/src/main/res/drawable/ic_warning_red.xml
+++ b/core/src/main/res/drawable/ic_warning_red.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#FF0000"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
-</vector>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -416,8 +416,6 @@
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes.</string>
     <string name="pref_autodl_wifi_filter_title">Enable Wi-Fi filter</string>
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
-    <string name="autodl_wifi_filter_permission_title">Permission required</string>
-    <string name="autodl_wifi_filter_permission_message">Location permission is required for Wi-Fi filter. Tap to grant the permission.</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>
     <string name="pref_automatic_download_on_battery_sum">Allow automatic download when the battery is not charging</string>
     <string name="pref_parallel_downloads_title">Parallel Downloads</string>


### PR DESCRIPTION
We implemented a workaround requiring location permissions. Quite a few users complained about the permission in Google Play comments. As soon as we target Android 10 (and we need to do that, rather sooner than later, to keep uploading updates), even the workaround stops to work. The system then always returns an empty list of known WiFi networks.

This change in Android is actually a privacy feature. The list of known networks allows to track your location. Unfortunately, this breaks legitimate uses like ours.

Closes #3387