### PR TITLE
Database size: Only store content_encoded or description

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -33,7 +33,6 @@ import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.core.event.PlayerStatusEvent;
 import de.danoeh.antennapod.core.feed.Feed;
-import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
 import de.danoeh.antennapod.core.feed.VolumeAdaptionSetting;
 import de.danoeh.antennapod.core.glide.ApGlideSettings;
@@ -258,7 +257,8 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         url = URLChecker.prepareURL(url);
         feed = new Feed(url, null);
         if (username != null && password != null) {
-            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL, VolumeAdaptionSetting.OFF, username, password));
+            feed.setPreferences(new FeedPreferences(0, false, FeedPreferences.AutoDeleteAction.GLOBAL,
+                    VolumeAdaptionSetting.OFF, username, password));
         }
         String fileUrl = new File(getExternalCacheDir(),
                 FileNameGenerator.generateFileName(feed.getDownload_url())).toString();
@@ -328,7 +328,6 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
                 .subscribeWith(new DisposableMaybeObserver<FeedHandlerResult>() {
                     @Override
                     public void onSuccess(@NonNull FeedHandlerResult result) {
-                        beforeShowFeedInformation(result.feed);
                         showFeedInformation(result.feed, result.alternateFeedUrls);
                     }
 
@@ -378,23 +377,6 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
     }
 
     /**
-     * Called after the feed has been downloaded and parsed and before showFeedInformation is called.
-     * This method is executed on a background thread
-     */
-    private void beforeShowFeedInformation(Feed feed) {
-        Log.d(TAG, "Removing HTML from feed description");
-
-        feed.setDescription(HtmlToPlainText.getPlainText(feed.getDescription()));
-
-        Log.d(TAG, "Removing HTML from shownotes");
-        if (feed.getItems() != null) {
-            for (FeedItem item : feed.getItems()) {
-                item.setDescription(HtmlToPlainText.getPlainText(item.getDescription()));
-            }
-        }
-    }
-
-    /**
      * Called when feed parsed successfully.
      * This method is executed on the GUI thread.
      */
@@ -437,7 +419,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
 
         viewBinding.titleLabel.setText(feed.getTitle());
         viewBinding.authorLabel.setText(feed.getAuthor());
-        description.setText(feed.getDescription());
+        description.setText(HtmlToPlainText.getPlainText(feed.getDescription()));
 
         viewBinding.subscribeButton.setOnClickListener(v -> {
             if (feedInFeedlist(feed)) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistDescriptionAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistDescriptionAdapter.java
@@ -20,6 +20,7 @@ import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
+import de.danoeh.antennapod.core.util.syndication.HtmlToPlainText;
 import de.danoeh.antennapod.dialog.StreamingConfirmationDialog;
 
 import java.util.List;
@@ -59,7 +60,7 @@ public class FeedItemlistDescriptionAdapter extends ArrayAdapter<FeedItem> {
         holder.title.setText(item.getTitle());
         holder.pubDate.setText(DateUtils.formatAbbrev(getContext(), item.getPubDate()));
         if (item.getDescription() != null) {
-            String description = item.getDescription()
+            String description = HtmlToPlainText.getPlainText(item.getDescription())
                     .replaceAll("\n", " ")
                     .replaceAll("\\s+", " ")
                     .trim();

--- a/config/checkstyle/checkstyle-new-code.xml
+++ b/config/checkstyle/checkstyle-new-code.xml
@@ -204,10 +204,6 @@
         </module>
         <module name="NonEmptyAtclauseDescription"/>
         <module name="JavadocTagContinuationIndentation"/>
-        <module name="SummaryJavadoc">
-            <property name="forbiddenSummaryFragments"
-             value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
-        </module>
         <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -4,7 +4,6 @@ import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.text.TextUtils;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -42,10 +41,6 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
      * The description of a feeditem.
      */
     private String description;
-    /**
-     * The content of the content-encoded tag of a feeditem.
-     */
-    private String contentEncoded;
 
     private String link;
     private Date pubDate;
@@ -181,9 +176,6 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
         if (other.getDescription() != null) {
             description = other.getDescription();
         }
-        if (other.getContentEncoded() != null) {
-            contentEncoded = other.contentEncoded;
-        }
         if (other.link != null) {
             link = other.link;
         }
@@ -237,10 +229,6 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
 
     public String getDescription() {
         return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     public String getLink() {
@@ -306,7 +294,7 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
     }
 
     public void setPlayed(boolean played) {
-        if(played) {
+        if (played) {
             state = PLAYED;
         } else {
             state = UNPLAYED;
@@ -317,12 +305,19 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
         return (media != null && media.isInProgress());
     }
 
-    public String getContentEncoded() {
-        return contentEncoded;
-    }
-
-    public void setContentEncoded(String contentEncoded) {
-        this.contentEncoded = contentEncoded;
+    /**
+     * Updates this item's description property if the given argument is longer than the already stored description
+     * @param newDescription The new item description, content:encoded, itunes:description, etc.
+     */
+    public void setDescriptionIfLonger(String newDescription) {
+        if (newDescription == null) {
+            return;
+        }
+        if (this.description == null) {
+            this.description = newDescription;
+        } else if (this.description.length() < newDescription.length()) {
+            this.description = newDescription;
+        }
     }
 
     public String getPaymentLink() {
@@ -360,18 +355,10 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
     @Override
     public Callable<String> loadShownotes() {
         return () -> {
-            if (contentEncoded == null || description == null) {
+            if (description == null) {
                 DBReader.loadDescriptionOfFeedItem(FeedItem.this);
             }
-            if (TextUtils.isEmpty(contentEncoded)) {
-                return description;
-            } else if (TextUtils.isEmpty(description)) {
-                return contentEncoded;
-            } else if (description.length() > 1.25 * contentEncoded.length()) {
-                return description;
-            } else {
-                return contentEncoded;
-            }
+            return description;
         };
     }
 
@@ -470,17 +457,23 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, Serial
     /**
      * @return true if the item has this tag
      */
-    public boolean isTagged(String tag) { return tags.contains(tag); }
+    public boolean isTagged(String tag) {
+        return tags.contains(tag);
+    }
 
     /**
      * @param tag adds this tag to the item. NOTE: does NOT persist to the database
      */
-    public void addTag(String tag) { tags.add(tag); }
+    public void addTag(String tag) {
+        tags.add(tag);
+    }
 
     /**
      * @param tag the to remove
      */
-    public void removeTag(String tag) { tags.remove(tag); }
+    public void removeTag(String tag) {
+        tags.remove(tag);
+    }
 
     @NonNull
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -169,7 +169,7 @@ public class LocalFeedUpdater {
         try {
             loadMetadata(item, file, context);
         } catch (Exception e) {
-            item.setDescription(e.getMessage());
+            item.setDescriptionIfLonger(e.getMessage());
         }
 
         return item;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -651,10 +651,7 @@ public final class DBReader {
             if (cursor.moveToFirst()) {
                 int indexDescription = cursor.getColumnIndex(PodDBAdapter.KEY_DESCRIPTION);
                 String description = cursor.getString(indexDescription);
-                int indexContentEncoded = cursor.getColumnIndex(PodDBAdapter.KEY_CONTENT_ENCODED);
-                String contentEncoded = cursor.getString(indexContentEncoded);
-                item.setDescription(description);
-                item.setContentEncoded(contentEncoded);
+                item.setDescriptionIfLonger(description);
             }
         } finally {
             adapter.close();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBUpgrader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBUpgrader.java
@@ -305,14 +305,20 @@ class DBUpgrader {
                     + " ADD COLUMN " + PodDBAdapter.KEY_IMAGE_URL + " TEXT DEFAULT NULL");
         }
         if (oldVersion < 1090001) {
-            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS +
-                    " ADD COLUMN " + PodDBAdapter.KEY_FEED_SKIP_INTRO + " INTEGER DEFAULT 0;");
-            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS +
-                    " ADD COLUMN " + PodDBAdapter.KEY_FEED_SKIP_ENDING + " INTEGER DEFAULT 0;");
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_FEED_SKIP_INTRO + " INTEGER DEFAULT 0;");
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_FEED_SKIP_ENDING + " INTEGER DEFAULT 0;");
         }
         if (oldVersion < 2020000) {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                     + " ADD COLUMN " + PodDBAdapter.KEY_EPISODE_NOTIFICATION + " INTEGER DEFAULT 0;");
+        }
+        if (oldVersion < 2030000) {
+            db.execSQL("UPDATE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
+                    + " SET " + PodDBAdapter.KEY_DESCRIPTION + " = content_encoded, content_encoded = NULL "
+                    + "WHERE length(" + PodDBAdapter.KEY_DESCRIPTION + ") < length(content_encoded)");
+            db.execSQL("UPDATE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + " SET content_encoded = NULL");
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -52,7 +52,7 @@ public class PodDBAdapter {
 
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
-    public static final int VERSION = 2020000;
+    public static final int VERSION = 2030000;
 
     /**
      * Maximum number of arguments for IN-operator.
@@ -84,7 +84,6 @@ public class PodDBAdapter {
     public static final String KEY_FEEDFILETYPE = "feedfile_type";
     public static final String KEY_COMPLETION_DATE = "completion_date";
     public static final String KEY_FEEDITEM = "feeditem";
-    public static final String KEY_CONTENT_ENCODED = "content_encoded";
     public static final String KEY_PAYMENT_LINK = "payment_link";
     public static final String KEY_START = "start";
     public static final String KEY_LANGUAGE = "language";
@@ -158,9 +157,9 @@ public class PodDBAdapter {
             + KEY_EPISODE_NOTIFICATION + " INTEGER DEFAULT 0)";
 
     private static final String CREATE_TABLE_FEED_ITEMS = "CREATE TABLE "
-            + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY + KEY_TITLE
-            + " TEXT," + KEY_CONTENT_ENCODED + " TEXT," + KEY_PUBDATE
-            + " INTEGER," + KEY_READ + " INTEGER," + KEY_LINK + " TEXT,"
+            + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY
+            + KEY_TITLE + " TEXT," + KEY_PUBDATE + " INTEGER,"
+            + KEY_READ + " INTEGER," + KEY_LINK + " TEXT,"
             + KEY_DESCRIPTION + " TEXT," + KEY_PAYMENT_LINK + " TEXT,"
             + KEY_MEDIA + " INTEGER," + KEY_FEED + " INTEGER,"
             + KEY_HAS_CHAPTERS + " INTEGER," + KEY_ITEM_IDENTIFIER + " TEXT,"
@@ -311,8 +310,7 @@ public class PodDBAdapter {
 
     private static final String SELECT_FEED_ITEMS_AND_MEDIA_WITH_DESCRIPTION =
             "SELECT " + KEYS_FEED_ITEM_WITHOUT_DESCRIPTION + ", " + KEYS_FEED_MEDIA + ", "
-                    + TABLE_NAME_FEED_ITEMS + "." + KEY_DESCRIPTION + ", "
-                    + TABLE_NAME_FEED_ITEMS + "." + KEY_CONTENT_ENCODED
+                    + TABLE_NAME_FEED_ITEMS + "." + KEY_DESCRIPTION
             + " FROM " + TABLE_NAME_FEED_ITEMS
             + JOIN_FEED_ITEM_AND_MEDIA;
     private static final String SELECT_FEED_ITEMS_AND_MEDIA =
@@ -626,9 +624,6 @@ public class PodDBAdapter {
         values.put(KEY_LINK, item.getLink());
         if (item.getDescription() != null) {
             values.put(KEY_DESCRIPTION, item.getDescription());
-        }
-        if (item.getContentEncoded() != null) {
-            values.put(KEY_CONTENT_ENCODED, item.getContentEncoded());
         }
         values.put(KEY_PUBDATE, item.getPubDate().getTime());
         values.put(KEY_PAYMENT_LINK, item.getPaymentLink());
@@ -964,7 +959,7 @@ public class PodDBAdapter {
      * Return the description and content_encoded of item
      */
     public final Cursor getDescriptionOfItem(final FeedItem item) {
-        final String query = "SELECT " + KEY_DESCRIPTION + ", " + KEY_CONTENT_ENCODED
+        final String query = "SELECT " + KEY_DESCRIPTION
                 + " FROM " + TABLE_NAME_FEED_ITEMS
                 + " WHERE " + KEY_ID + "=" + item.getId();
         return db.rawQuery(query, null);
@@ -1316,8 +1311,6 @@ public class PodDBAdapter {
             sb
                     .append("(")
                     .append(KEY_DESCRIPTION + " LIKE '%").append(queryWords[i])
-                    .append("%' OR ")
-                    .append(KEY_CONTENT_ENCODED).append(" LIKE '%").append(queryWords[i])
                     .append("%' OR ")
                     .append(KEY_TITLE).append(" LIKE '%").append(queryWords[i])
                     .append("%') ");

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSContent.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSContent.java
@@ -5,23 +5,21 @@ import org.xml.sax.Attributes;
 import de.danoeh.antennapod.core.syndication.handler.HandlerState;
 
 public class NSContent extends Namespace {
-	public static final String NSTAG = "content";
-	public static final String NSURI = "http://purl.org/rss/1.0/modules/content/";
-	
-	private static final String ENCODED = "encoded";
-	
-	@Override
-	public SyndElement handleElementStart(String localName, HandlerState state,
-			Attributes attributes) {
-		return new SyndElement(localName, this);
-	}
+    public static final String NSTAG = "content";
+    public static final String NSURI = "http://purl.org/rss/1.0/modules/content/";
 
-	@Override
-	public void handleElementEnd(String localName, HandlerState state) {
-		if (ENCODED.equals(localName) && state.getCurrentItem() != null &&
-			state.getContentBuf() != null) {
-			state.getCurrentItem().setContentEncoded(state.getContentBuf().toString());
-		}
-	}
+    private static final String ENCODED = "encoded";
+
+    @Override
+    public SyndElement handleElementStart(String localName, HandlerState state, Attributes attributes) {
+        return new SyndElement(localName, this);
+    }
+
+    @Override
+    public void handleElementEnd(String localName, HandlerState state) {
+        if (ENCODED.equals(localName) && state.getCurrentItem() != null && state.getContentBuf() != null) {
+            state.getCurrentItem().setDescriptionIfLonger(state.getContentBuf().toString());
+        }
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSITunes.java
@@ -7,7 +7,6 @@ import androidx.core.text.HtmlCompat;
 
 import org.xml.sax.Attributes;
 
-import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.syndication.handler.HandlerState;
 import de.danoeh.antennapod.core.syndication.parsers.DurationParser;
 
@@ -90,7 +89,7 @@ public class NSITunes extends Namespace {
         }
         if (state.getCurrentItem() != null) {
             if (TextUtils.isEmpty(state.getCurrentItem().getDescription())) {
-                state.getCurrentItem().setDescription(subtitle);
+                state.getCurrentItem().setDescriptionIfLonger(subtitle);
             }
         } else {
             if (state.getFeed() != null && TextUtils.isEmpty(state.getFeed().getDescription())) {
@@ -105,16 +104,10 @@ public class NSITunes extends Namespace {
             return;
         }
 
-        FeedItem currentItem = state.getCurrentItem();
-        String description = getDescription(currentItem);
-        if (currentItem != null && description.length() * 1.25 < summary.length()) {
-            currentItem.setDescription(summary);
+        if (state.getCurrentItem() != null) {
+            state.getCurrentItem().setDescriptionIfLonger(summary);
         } else if (NSRSS20.CHANNEL.equals(secondElementName) && state.getFeed() != null) {
             state.getFeed().setDescription(summary);
         }
-    }
-
-    private String getDescription(FeedItem item) {
-        return (item != null && item.getDescription() != null) ? item.getDescription() : "";
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -121,9 +121,8 @@ public class NSMedia extends Namespace {
     public void handleElementEnd(String localName, HandlerState state) {
         if (DESCRIPTION.equals(localName)) {
             String content = state.getContentBuf().toString();
-            if (state.getCurrentItem() != null && content != null
-                    && state.getCurrentItem().getDescription() == null) {
-                state.getCurrentItem().setDescription(content);
+            if (state.getCurrentItem() != null) {
+                state.getCurrentItem().setDescriptionIfLonger(content);
             }
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -13,10 +13,7 @@ import de.danoeh.antennapod.core.syndication.util.SyndTypeUtils;
 import de.danoeh.antennapod.core.util.DateUtils;
 
 /**
- * SAX-Parser for reading RSS-Feeds
- *
- * @author daniel
- *
+ * SAX-Parser for reading RSS-Feeds.
  */
 public class NSRSS20 extends Namespace {
 
@@ -83,8 +80,7 @@ public class NSRSS20 extends Namespace {
             if (state.getCurrentItem() != null) {
                 FeedItem currentItem = state.getCurrentItem();
                 // the title tag is optional in RSS 2.0. The description is used
-                // as a
-                // title if the item has no title-tag.
+                // as a title if the item has no title-tag.
                 if (currentItem.getTitle() == null) {
                     currentItem.setTitle(currentItem.getDescription());
                 }
@@ -138,7 +134,7 @@ public class NSRSS20 extends Namespace {
                 if (CHANNEL.equals(second) && state.getFeed() != null) {
                     state.getFeed().setDescription(content);
                 } else if (ITEM.equals(second) && state.getCurrentItem() != null) {
-                    state.getCurrentItem().setDescription(content);
+                    state.getCurrentItem().setDescriptionIfLonger(content);
                 }
             } else if (LANGUAGE.equals(localName) && state.getFeed() != null) {
                 state.getFeed().setLanguage(content.toLowerCase());

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -198,10 +198,10 @@ public class NSAtom extends Namespace {
                 state.getFeed().setDescription(textElement.getProcessedContent());
             } else if (CONTENT.equals(top) && ENTRY.equals(second) && textElement != null &&
                 state.getCurrentItem() != null) {
-                state.getCurrentItem().setDescription(textElement.getProcessedContent());
-            } else if (SUMMARY.equals(top) && ENTRY.equals(second) && textElement != null &&
-                state.getCurrentItem() != null && state.getCurrentItem().getDescription() == null) {
-                state.getCurrentItem().setDescription(textElement.getProcessedContent());
+                state.getCurrentItem().setDescriptionIfLonger(textElement.getProcessedContent());
+            } else if (SUMMARY.equals(top) && ENTRY.equals(second) && textElement != null
+                    && state.getCurrentItem() != null) {
+                state.getCurrentItem().setDescriptionIfLonger(textElement.getProcessedContent());
             } else if (UPDATED.equals(top) && ENTRY.equals(second) && state.getCurrentItem() != null &&
                 state.getCurrentItem().getPubDate() == null) {
                 state.getCurrentItem().setPubDate(DateUtils.parse(content));

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/FeedItemTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/FeedItemTest.java
@@ -136,8 +136,8 @@ public class FeedItemTest {
     private void testShownotes(String description, String contentEncoded) throws Exception {
         try (MockedStatic<DBReader> ignore = Mockito.mockStatic(DBReader.class)) {
             FeedItem item = new FeedItem();
-            item.setDescription(description);
-            item.setContentEncoded(contentEncoded);
+            item.setDescriptionIfLonger(description);
+            item.setDescriptionIfLonger(contentEncoded);
             assertEquals(TEXT_LONG, item.loadShownotes().call());
         }
     }

--- a/core/src/test/java/de/danoeh/antennapod/core/syndication/handler/AtomParserTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/syndication/handler/AtomParserTest.java
@@ -38,7 +38,6 @@ public class AtomParserTest {
             assertEquals("http://example.com/item-" + i, item.getItemIdentifier());
             assertEquals("item-" + i, item.getTitle());
             assertNull(item.getDescription());
-            assertNull(item.getContentEncoded());
             assertEquals("http://example.com/items/" + i, item.getLink());
             assertEquals(new Date(i * 60000), item.getPubDate());
             assertNull(item.getPaymentLink());

--- a/core/src/test/java/de/danoeh/antennapod/core/syndication/handler/RssParserTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/syndication/handler/RssParserTest.java
@@ -39,7 +39,6 @@ public class RssParserTest {
             assertEquals("http://example.com/item-" + i, item.getItemIdentifier());
             assertEquals("item-" + i, item.getTitle());
             assertNull(item.getDescription());
-            assertNull(item.getContentEncoded());
             assertEquals("http://example.com/items/" + i, item.getLink());
             assertEquals(new Date(i * 60000), item.getPubDate());
             assertNull(item.getPaymentLink());

--- a/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
@@ -55,7 +55,7 @@ public class TimelineTest {
     private Playable newTestPlayable(List<Chapter> chapters, String shownotes, int duration) {
         FeedItem item = new FeedItem(0, "Item", "item-id", "http://example.com/item", new Date(), FeedItem.PLAYED, null);
         item.setChapters(chapters);
-        item.setContentEncoded(shownotes);
+        item.setDescriptionIfLonger(shownotes);
         FeedMedia media = new FeedMedia(item, "http://example.com/episode", 100, "audio/mp3");
         media.setDuration(duration);
         item.setMedia(media);


### PR DESCRIPTION
- For existing episodes, moves the longer text to `description` and sets `content_encoded` to `NULL`.
- For new episodes, only stores the longer text.
- The freed up space will not be available immediately. It will be used later when adding new data to the database. We can not simply execute `VACUUM` after upgrading because `onUpgrade` is called in a transaction.
- After executing `VACUUM` on my PC, the database from #3932 decreased its size from 71.2MB to 52.8MB. This does not match the old measurements because in the experiment, I just deleted one of the columns instead of the one with the shorter text. This is still a decrease of around 25%.
- Upgrade takes around 5-10 seconds. User stays on splash screen with spinning circle. We should probably add a text "Upgrading database".

**Needs testing.**

Closes #3932