### PR TITLE
put a date with the filename being exported

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -84,7 +84,7 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private String dateStampFilename(String fname) {
-       return String.format(fname,
+        return String.format(fname,
                 new SimpleDateFormat("yyyy-MM-dd")
                        .format(new Date()));
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -35,7 +35,6 @@ import io.reactivex.schedulers.Schedulers;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -47,16 +46,16 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
     private static final String PREF_HTML_EXPORT = "prefHtmlExport";
     private static final String PREF_DATABASE_IMPORT = "prefDatabaseImport";
     private static final String PREF_DATABASE_EXPORT = "prefDatabaseExport";
-    private static final String DEFAULT_OPML_OUTPUT_NAME = "antennapod-feeds.%s.opml";
+    private static final String DEFAULT_OPML_OUTPUT_NAME = "antennapod-feeds-%s.opml";
     private static final String CONTENT_TYPE_OPML = "text/x-opml";
-    private static final String DEFAULT_HTML_OUTPUT_NAME = "antennapod-feeds.%s.html";
+    private static final String DEFAULT_HTML_OUTPUT_NAME = "antennapod-feeds-%s.html";
     private static final String CONTENT_TYPE_HTML = "text/html";
     private static final int REQUEST_CODE_CHOOSE_OPML_EXPORT_PATH = 1;
     private static final int REQUEST_CODE_CHOOSE_OPML_IMPORT_PATH = 2;
     private static final int REQUEST_CODE_CHOOSE_HTML_EXPORT_PATH = 3;
     private static final int REQUEST_CODE_RESTORE_DATABASE = 4;
     private static final int REQUEST_CODE_BACKUP_DATABASE = 5;
-    private static final String DATABASE_EXPORT_FILENAME = "AntennaPodBackup.%s.db";
+    private static final String DATABASE_EXPORT_FILENAME = "AntennaPodBackup-%s.db";
     private Disposable disposable;
     private ProgressDialog progressDialog;
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -85,7 +85,7 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
 
     private String dateStampFilename(String fname) {
        return String.format(fname,
-               new SimpleDateFormat("yyyy-MM-dd")
+                new SimpleDateFormat("yyyy-MM-dd")
                        .format(new Date()));
     }
 


### PR DESCRIPTION
fix #3956

add YYYY-MM_DD to the filenames for database, opml and html exports

<img width="297" alt="Screen Shot 2020-03-30 at 9 05 23 PM" src="https://user-images.githubusercontent.com/149837/77985820-48e2ba00-72ca-11ea-90a5-46b5bd4a4d5d.png">
