### PR TITLE
Always join FeedMedia instead of doing two queries

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedItem.java
@@ -140,17 +140,17 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, ImageR
     }
 
     public static FeedItem fromCursor(Cursor cursor) {
-        int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
-        int indexTitle = cursor.getColumnIndex(PodDBAdapter.KEY_TITLE);
-        int indexLink = cursor.getColumnIndex(PodDBAdapter.KEY_LINK);
-        int indexPubDate = cursor.getColumnIndex(PodDBAdapter.KEY_PUBDATE);
-        int indexPaymentLink = cursor.getColumnIndex(PodDBAdapter.KEY_PAYMENT_LINK);
-        int indexFeedId = cursor.getColumnIndex(PodDBAdapter.KEY_FEED);
-        int indexHasChapters = cursor.getColumnIndex(PodDBAdapter.KEY_HAS_CHAPTERS);
-        int indexRead = cursor.getColumnIndex(PodDBAdapter.KEY_READ);
-        int indexItemIdentifier = cursor.getColumnIndex(PodDBAdapter.KEY_ITEM_IDENTIFIER);
-        int indexAutoDownload = cursor.getColumnIndex(PodDBAdapter.KEY_AUTO_DOWNLOAD);
-        int indexImageUrl = cursor.getColumnIndex(PodDBAdapter.KEY_IMAGE_URL);
+        int indexId = cursor.getColumnIndexOrThrow(PodDBAdapter.SELECT_KEY_ITEM_ID);
+        int indexTitle = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_TITLE);
+        int indexLink = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_LINK);
+        int indexPubDate = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PUBDATE);
+        int indexPaymentLink = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PAYMENT_LINK);
+        int indexFeedId = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FEED);
+        int indexHasChapters = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_HAS_CHAPTERS);
+        int indexRead = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_READ);
+        int indexItemIdentifier = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_ITEM_IDENTIFIER);
+        int indexAutoDownload = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_AUTO_DOWNLOAD);
+        int indexImageUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_IMAGE_URL);
 
         long id = cursor.getInt(indexId);
         String title = cursor.getString(indexTitle);
@@ -359,7 +359,7 @@ public class FeedItem extends FeedComponent implements ShownotesProvider, ImageR
     public Callable<String> loadShownotes() {
         return () -> {
             if (contentEncoded == null || description == null) {
-                DBReader.loadExtraInformationOfFeedItem(FeedItem.this);
+                DBReader.loadDescriptionOfFeedItem(FeedItem.this);
             }
             if (TextUtils.isEmpty(contentEncoded)) {
                 return description;

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -98,17 +98,17 @@ public class FeedMedia extends FeedFile implements Playable {
     }
 
     public static FeedMedia fromCursor(Cursor cursor) {
-        int indexId = cursor.getColumnIndex(PodDBAdapter.KEY_ID);
-        int indexPlaybackCompletionDate = cursor.getColumnIndex(PodDBAdapter.KEY_PLAYBACK_COMPLETION_DATE);
-        int indexDuration = cursor.getColumnIndex(PodDBAdapter.KEY_DURATION);
-        int indexPosition = cursor.getColumnIndex(PodDBAdapter.KEY_POSITION);
-        int indexSize = cursor.getColumnIndex(PodDBAdapter.KEY_SIZE);
-        int indexMimeType = cursor.getColumnIndex(PodDBAdapter.KEY_MIME_TYPE);
-        int indexFileUrl = cursor.getColumnIndex(PodDBAdapter.KEY_FILE_URL);
-        int indexDownloadUrl = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOAD_URL);
-        int indexDownloaded = cursor.getColumnIndex(PodDBAdapter.KEY_DOWNLOADED);
-        int indexPlayedDuration = cursor.getColumnIndex(PodDBAdapter.KEY_PLAYED_DURATION);
-        int indexLastPlayedTime = cursor.getColumnIndex(PodDBAdapter.KEY_LAST_PLAYED_TIME);
+        int indexId = cursor.getColumnIndexOrThrow(PodDBAdapter.SELECT_KEY_MEDIA_ID);
+        int indexPlaybackCompletionDate = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PLAYBACK_COMPLETION_DATE);
+        int indexDuration = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_DURATION);
+        int indexPosition = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_POSITION);
+        int indexSize = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_SIZE);
+        int indexMimeType = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_MIME_TYPE);
+        int indexFileUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FILE_URL);
+        int indexDownloadUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_DOWNLOAD_URL);
+        int indexDownloaded = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_DOWNLOADED);
+        int indexPlayedDuration = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PLAYED_DURATION);
+        int indexLastPlayedTime = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_LAST_PLAYED_TIME);
 
         long mediaId = cursor.getLong(indexId);
         Date playbackCompletionDate = null;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/FeedSearcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/FeedSearcher.java
@@ -27,6 +27,7 @@ public class FeedSearcher {
             itemSearchTask.run();
             return itemSearchTask.get();
         } catch (ExecutionException | InterruptedException e) {
+            e.printStackTrace();
             return Collections.emptyList();
         }
     }
@@ -38,6 +39,7 @@ public class FeedSearcher {
             feedSearchTask.run();
             return feedSearchTask.get();
         } catch (ExecutionException | InterruptedException e) {
+            e.printStackTrace();
             return Collections.emptyList();
         }
     }


### PR DESCRIPTION
Closes #3971

Before:
![image](https://user-images.githubusercontent.com/5811634/78167370-a738a580-744e-11ea-806b-eda4dfe1adb8.png)

After:
![image](https://user-images.githubusercontent.com/5811634/78167707-2c23bf00-744f-11ea-8b34-5e0cf56ad7b8.png)

You can see that before the change, `extractItemlistFromCursor` needs 65% of the total `getRecentlyPublishedEpisodes` method duration. Afterwards, it needs 55%. This does not have a noticeable impact on the app's perceived speed, unfortunately.

`EpisodeItemViewHolder/LayoutInflater.inflate` takes way more time and is even executed on the UI Thread. Around 30% of layouting is spent inflating `EpisodeItemViewHolder`. We should probably configure RecyclerView to re-use our ViewHolders throughout the whole app instead of per fragment instance (all lists use the same items, so this could get us quite a bit of performance impact).