### PR TITLE
Performance improvements

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -186,7 +186,7 @@ public class QueueFragment extends Fragment {
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(DownloadEvent event) {
-        Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        Log.d(TAG, "onEventMainThread() called with DownloadEvent");
         DownloaderUpdate update = event.update;
         if (event.hasChangedFeedUpdateStatus(isUpdatingFeeds)) {
             getActivity().invalidateOptionsMenu();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
@@ -5,7 +5,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.os.Build;
-import android.text.TextUtils;
 import android.util.Log;
 import androidx.core.app.NotificationCompat;
 import de.danoeh.antennapod.core.ClientConfig;
@@ -14,7 +13,6 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class DownloadServiceNotification {
@@ -64,33 +62,36 @@ public class DownloadServiceNotification {
     }
 
     private static String compileNotificationString(List<Downloader> downloads) {
-        List<String> lines = new ArrayList<>(downloads.size());
-        for (Downloader downloader : downloads) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < downloads.size(); i++) {
+            Downloader downloader = downloads.get(i);
             if (downloader.cancelled) {
                 continue;
             }
-            StringBuilder line = new StringBuilder("• ");
+            stringBuilder.append("• ");
             DownloadRequest request = downloader.getDownloadRequest();
             switch (request.getFeedfileType()) {
                 case Feed.FEEDFILETYPE_FEED:
                     if (request.getTitle() != null) {
-                        line.append(request.getTitle());
+                        stringBuilder.append(request.getTitle());
                     }
                     break;
                 case FeedMedia.FEEDFILETYPE_FEEDMEDIA:
                     if (request.getTitle() != null) {
-                        line.append(request.getTitle())
+                        stringBuilder.append(request.getTitle())
                                 .append(" (")
                                 .append(request.getProgressPercent())
                                 .append("%)");
                     }
                     break;
                 default:
-                    line.append("Unknown: ").append(request.getFeedfileType());
+                    stringBuilder.append("Unknown: ").append(request.getFeedfileType());
             }
-            lines.add(line.toString());
+            if (i != downloads.size()) {
+                stringBuilder.append("\n");
+            }
         }
-        return TextUtils.join("\n", lines);
+        return stringBuilder.toString();
     }
 
     private static String createAutoDownloadNotificationContent(List<DownloadStatus> statuses) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -63,6 +63,7 @@ public class DBWriter {
     static {
         dbExec = Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r);
+            t.setName("DatabaseExecutor");
             t.setPriority(Thread.MIN_PRIORITY);
             return t;
         });

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/util/SyndTypeUtils.java
@@ -1,55 +1,44 @@
 package de.danoeh.antennapod.core.syndication.util;
 
-import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
-
 import org.apache.commons.io.FilenameUtils;
 
-import java.util.Arrays;
-
-/** Utility class for handling MIME-Types of enclosures */
+/**
+ * Utility class for handling MIME-Types of enclosures.
+ * */
 public class SyndTypeUtils {
+    private SyndTypeUtils() {
 
-	private static final String VALID_MEDIA_MIMETYPE = TextUtils.join("|", Arrays.asList(
-			"audio/.*",
-			"video/.*",
-			"application/ogg",
-			"application/octet-stream"));
+    }
 
-	private static final String VALID_IMAGE_MIMETYPE = "image/.*";
+    public static boolean enclosureTypeValid(String type) {
+        if (type == null) {
+            return false;
+        } else {
+            return type.startsWith("audio/")
+                    || type.startsWith("video/")
+                    || type.equals("application/ogg")
+                    || type.equals("application/octet-stream");
+        }
+    }
 
-	private SyndTypeUtils() {
+    public static boolean imageTypeValid(String type) {
+        if (type == null) {
+            return false;
+        } else {
+            return type.startsWith("image/");
+        }
+    }
 
-	}
-
-	public static boolean enclosureTypeValid(String type) {
-		if (type == null) {
-			return false;
-		} else {
-			return type.matches(VALID_MEDIA_MIMETYPE);
-		}
-	}
-	public static boolean imageTypeValid(String type) {
-		if (type == null) {
-			return false;
-		} else {
-			return type.matches(VALID_IMAGE_MIMETYPE);
-		}
-	}
-
-	/**
-	 * Should be used if mime-type of enclosure tag is not supported. This
-	 * method will return the mime-type of the file extension.
-	 */
-	public static String getMimeTypeFromUrl(String url) {
-		if (url == null) {
-			return null;
-		}
-		String extension = FilenameUtils.getExtension(url);
-		if (extension == null) {
-			return null;
-		}
-
-		return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-	}
+    /**
+     * Should be used if mime-type of enclosure tag is not supported. This
+     * method will return the mime-type of the file extension.
+     */
+    public static String getMimeTypeFromUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+        String extension = FilenameUtils.getExtension(url);
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -20,9 +20,15 @@ public class DateUtils {
 
     private DateUtils(){}
 
-	private static final String TAG = "DateUtils";
+    private static final String TAG = "DateUtils";
 
     private static final TimeZone defaultTimezone = TimeZone.getTimeZone("GMT");
+    private static final SimpleDateFormat dateFormatParser = new SimpleDateFormat("", Locale.US);
+
+    static {
+        dateFormatParser.setLenient(false);
+        dateFormatParser.setTimeZone(defaultTimezone);
+    }
 
     public static Date parse(final String input) {
         if (input == null) {
@@ -92,16 +98,12 @@ public class DateUtils {
                 "EEE d MMM yyyy HH:mm:ss 'GMT'Z (z)"
         };
 
-        SimpleDateFormat parser = new SimpleDateFormat("", Locale.US);
-        parser.setLenient(false);
-        parser.setTimeZone(defaultTimezone);
-
         ParsePosition pos = new ParsePosition(0);
         for (String pattern : patterns) {
-            parser.applyPattern(pattern);
+            dateFormatParser.applyPattern(pattern);
             pos.setIndex(0);
             try {
-                Date result = parser.parse(date, pos);
+                Date result = dateFormatParser.parse(date, pos);
                 if (result != null && pos.getIndex() == date.length()) {
                     return result;
                 }
@@ -111,7 +113,7 @@ public class DateUtils {
         }
 
         // if date string starts with a weekday, try parsing date string without it
-        if(date.matches("^\\w+, .*$")) {
+        if (date.matches("^\\w+, .*$")) {
             return parse(date.substring(date.indexOf(',') + 1));
         }
 


### PR DESCRIPTION
According to my Profiling session, we spend around a third of our UI thread time during download building Strings:

![image](https://user-images.githubusercontent.com/5811634/78163269-72295480-7448-11ea-92c7-ce1c4901418c.png)

Even though parsing the feeds is done only in one thread, it still has enough time to sleep. So this is not a bottle-neck:

![image](https://user-images.githubusercontent.com/5811634/78163734-11e6e280-7449-11ea-847e-7b629753ffd1.png)

Of the actual feed parsing, handling the date parsing takes by far the most time. We might want to think about that to make the app more efficient. As a first step, do not create a `SimpleDateFormat` instance for every single `parse` method call.

Parsing the MIME types in `SyndTypeUtils` takes surprisingly long. Not anywhere near critical but considering this can be done with `startsWith` [much more efficiently](https://stackoverflow.com/questions/19807253/java-string-parsing-what-is-faster-regex-or-string-methods), do that instead.

![image](https://user-images.githubusercontent.com/5811634/78164186-aa7d6280-7449-11ea-8f1c-bc339489768b.png)
