### PR TITLE
Recycle ViewHolders throughout the whole app

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -23,6 +23,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.snackbar.Snackbar;
@@ -74,6 +75,7 @@ public class MainActivity extends CastEnabledActivity {
     private ActionBarDrawerToggle drawerToggle;
     private LockableBottomSheetBehavior sheetBehavior;
     private long lastBackButtonPressTime = 0;
+    private RecyclerView.RecycledViewPool recycledViewPool = new RecyclerView.RecycledViewPool();
 
     @NonNull
     public static Intent getIntentToOpenFeed(@NonNull Context context, long feedId) {
@@ -89,6 +91,7 @@ public class MainActivity extends CastEnabledActivity {
         super.onCreate(savedInstanceState);
         StorageUtils.checkStorageAvailability(this);
         setContentView(R.layout.main);
+        recycledViewPool.setMaxRecycledViews(R.id.episode_item_view_holder, 25);
 
         drawerLayout = findViewById(R.id.drawer_layout);
         navDrawer = findViewById(R.id.navDrawerFragment);
@@ -189,6 +192,10 @@ public class MainActivity extends CastEnabledActivity {
         params.setMargins(0, 0, 0, visible ? (int) getResources().getDimension(R.dimen.external_player_height) : 0);
         mainView.setLayoutParams(params);
         findViewById(R.id.audioplayerFragment).setVisibility(visible ? View.VISIBLE : View.GONE);
+    }
+
+    public RecyclerView.RecycledViewPool getRecycledViewPool() {
+        return recycledViewPool;
     }
 
     public void loadFragment(String tag, Bundle args) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
@@ -42,14 +42,25 @@ public class EpisodeItemListAdapter extends RecyclerView.Adapter<EpisodeItemView
         notifyDataSetChanged();
     }
 
+    @Override
+    public final int getItemViewType(int position) {
+        return R.id.episode_item_view_holder;
+    }
+
     @NonNull
     @Override
-    public EpisodeItemViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    public final EpisodeItemViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         return new EpisodeItemViewHolder(mainActivityRef.get(), parent);
     }
 
     @Override
-    public void onBindViewHolder(EpisodeItemViewHolder holder, int pos) {
+    public final void onBindViewHolder(EpisodeItemViewHolder holder, int pos) {
+        // Reset state of recycled views
+        holder.coverHolder.setVisibility(View.VISIBLE);
+        holder.dragHandle.setVisibility(View.GONE);
+
+        beforeBindViewHolder(holder, pos);
+
         FeedItem item = episodes.get(pos);
         holder.bind(item);
         holder.itemView.setOnLongClickListener(v -> {
@@ -65,7 +76,14 @@ public class EpisodeItemListAdapter extends RecyclerView.Adapter<EpisodeItemView
             }
         });
         holder.itemView.setOnCreateContextMenuListener(this);
+        afterBindViewHolder(holder, pos);
         holder.hideSeparatorIfNecessary();
+    }
+
+    protected void beforeBindViewHolder(EpisodeItemViewHolder holder, int pos) {
+    }
+
+    protected void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
     }
 
     /**

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -35,8 +35,7 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
 
     @Override
     @SuppressLint("ClickableViewAccessibility")
-    public void onBindViewHolder(EpisodeItemViewHolder holder, int pos) {
-        super.onBindViewHolder(holder, pos);
+    protected void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
         View.OnTouchListener startDragTouchListener = (v1, event) -> {
             if (MotionEventCompat.getActionMasked(event) == MotionEvent.ACTION_DOWN) {
                 Log.d(TAG, "startDrag()");
@@ -56,7 +55,6 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
         }
 
         holder.isInQueue.setVisibility(View.GONE);
-        holder.hideSeparatorIfNecessary();
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -13,9 +13,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.EpisodeItemListAdapter;
@@ -31,6 +28,7 @@ import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.dialog.EpisodesApplyActionFragment;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
 import de.danoeh.antennapod.view.EmptyViewHandler;
+import de.danoeh.antennapod.view.EpisodeItemListRecyclerView;
 import de.danoeh.antennapod.view.viewholder.EpisodeItemViewHolder;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -55,7 +53,7 @@ public class CompletedDownloadsFragment extends Fragment {
 
     private List<FeedItem> items = new ArrayList<>();
     private CompletedDownloadsListAdapter adapter;
-    private RecyclerView recyclerView;
+    private EpisodeItemListRecyclerView recyclerView;
     private ProgressBar progressBar;
     private Disposable disposable;
     private EmptyViewHandler emptyView;
@@ -68,10 +66,7 @@ public class CompletedDownloadsFragment extends Fragment {
         toolbar.setVisibility(View.GONE);
 
         recyclerView = root.findViewById(R.id.recyclerView);
-        LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setHasFixedSize(true);
-        recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(getActivity()).build());
+        recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         recyclerView.setVisibility(View.GONE);
         adapter = new CompletedDownloadsListAdapter((MainActivity) getActivity());
         recyclerView.setAdapter(adapter);
@@ -215,8 +210,7 @@ public class CompletedDownloadsFragment extends Fragment {
         }
 
         @Override
-        public void onBindViewHolder(EpisodeItemViewHolder holder, int pos) {
-            super.onBindViewHolder(holder, pos);
+        public void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
             DeleteActionButton actionButton = new DeleteActionButton(getItem(pos));
             actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -8,12 +8,13 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
 import de.danoeh.antennapod.core.util.playback.Timeline;
 import de.danoeh.antennapod.view.ShownotesWebView;
+import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -74,7 +75,7 @@ public class ItemDescriptionFragment extends Fragment {
         if (webViewLoader != null) {
             webViewLoader.dispose();
         }
-        webViewLoader = Observable.fromCallable(this::loadData)
+        webViewLoader = Maybe.fromCallable(this::loadData)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(data -> {
@@ -84,10 +85,14 @@ public class ItemDescriptionFragment extends Fragment {
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 
-    @NonNull
+    @Nullable
     private String loadData() {
-        Timeline timeline = new Timeline(getActivity(), controller.getMedia());
-        return timeline.processShownotes();
+        if (controller.getMedia() != null) {
+            Timeline timeline = new Timeline(getActivity(), controller.getMedia());
+            return timeline.processShownotes();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -16,9 +16,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.EpisodeItemListAdapter;
@@ -34,6 +31,7 @@ import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
 import de.danoeh.antennapod.view.EmptyViewHandler;
+import de.danoeh.antennapod.view.EpisodeItemListRecyclerView;
 import de.danoeh.antennapod.view.viewholder.EpisodeItemViewHolder;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -51,7 +49,7 @@ public class PlaybackHistoryFragment extends Fragment {
     private List<FeedItem> playbackHistory;
     private PlaybackHistoryListAdapter adapter;
     private Disposable disposable;
-    private RecyclerView recyclerView;
+    private EpisodeItemListRecyclerView recyclerView;
     private EmptyViewHandler emptyView;
     private ProgressBar progressBar;
 
@@ -71,10 +69,7 @@ public class PlaybackHistoryFragment extends Fragment {
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 
         recyclerView = root.findViewById(R.id.recyclerView);
-        LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setHasFixedSize(true);
-        recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(getActivity()).build());
+        recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         recyclerView.setVisibility(View.GONE);
         adapter = new PlaybackHistoryListAdapter((MainActivity) getActivity());
         recyclerView.setAdapter(adapter);
@@ -246,8 +241,7 @@ public class PlaybackHistoryFragment extends Fragment {
         }
 
         @Override
-        public void onBindViewHolder(EpisodeItemViewHolder holder, int pos) {
-            super.onBindViewHolder(holder, pos);
+        protected void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
             // played items shouldn't be transparent for this fragment since, *all* items
             // in this fragment will, by definition, be played. So it serves no purpose and can make
             // it harder to read.

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.fragment;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import android.util.Pair;
@@ -18,7 +17,6 @@ import androidx.appcompat.widget.SearchView;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.EpisodeItemListAdapter;
@@ -35,6 +33,7 @@ import de.danoeh.antennapod.core.storage.FeedSearcher;
 import de.danoeh.antennapod.core.util.FeedItemUtil;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
 import de.danoeh.antennapod.view.EmptyViewHandler;
+import de.danoeh.antennapod.view.EpisodeItemListRecyclerView;
 import de.danoeh.antennapod.view.viewholder.EpisodeItemViewHolder;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -59,8 +58,7 @@ public class SearchFragment extends Fragment {
     private Disposable disposable;
     private ProgressBar progressBar;
     private EmptyViewHandler emptyViewHandler;
-    private RecyclerView recyclerView;
-    private RecyclerView recyclerViewFeeds;
+    private EpisodeItemListRecyclerView recyclerView;
     private List<FeedItem> results;
 
     /**
@@ -117,15 +115,12 @@ public class SearchFragment extends Fragment {
         progressBar = layout.findViewById(R.id.progressBar);
 
         recyclerView = layout.findViewById(R.id.recyclerView);
-        LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setHasFixedSize(true);
-        recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(getActivity()).build());
+        recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         recyclerView.setVisibility(View.GONE);
         adapter = new EpisodeItemListAdapter((MainActivity) getActivity());
         recyclerView.setAdapter(adapter);
 
-        recyclerViewFeeds = layout.findViewById(R.id.recyclerViewFeeds);
+        RecyclerView recyclerViewFeeds = layout.findViewById(R.id.recyclerViewFeeds);
         LinearLayoutManager layoutManagerFeeds = new LinearLayoutManager(getActivity());
         layoutManagerFeeds.setOrientation(RecyclerView.HORIZONTAL);
         recyclerViewFeeds.setLayoutManager(layoutManagerFeeds);

--- a/app/src/main/java/de/danoeh/antennapod/view/EpisodeItemListRecyclerView.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/EpisodeItemListRecyclerView.java
@@ -1,0 +1,73 @@
+package de.danoeh.antennapod.view;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.AttributeSet;
+import android.view.View;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
+import io.reactivex.annotations.Nullable;
+
+public class EpisodeItemListRecyclerView extends RecyclerView {
+    private static final String TAG = "EpisodeItemListRecyclerView";
+    private static final String PREF_PREFIX_SCROLL_POSITION = "scroll_position_";
+    private static final String PREF_PREFIX_SCROLL_OFFSET = "scroll_offset_";
+
+    private LinearLayoutManager layoutManager;
+
+    public EpisodeItemListRecyclerView(Context context) {
+        super(context);
+        setup();
+    }
+
+    public EpisodeItemListRecyclerView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        setup();
+    }
+
+    public EpisodeItemListRecyclerView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setup();
+    }
+
+    private void setup() {
+        layoutManager = new LinearLayoutManager(getContext());
+        layoutManager.setRecycleChildrenOnDetach(true);
+        setLayoutManager(layoutManager);
+        setHasFixedSize(true);
+        addItemDecoration(new HorizontalDividerItemDecoration.Builder(getContext()).build());
+    }
+
+    public void saveScrollPosition(String tag) {
+        int firstItem = layoutManager.findFirstVisibleItemPosition();
+        View firstItemView = layoutManager.findViewByPosition(firstItem);
+        float topOffset;
+        if (firstItemView == null) {
+            topOffset = 0;
+        } else {
+            topOffset = firstItemView.getTop();
+        }
+
+        getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE).edit()
+                .putInt(PREF_PREFIX_SCROLL_POSITION + tag, firstItem)
+                .putInt(PREF_PREFIX_SCROLL_OFFSET + tag, (int) topOffset)
+                .apply();
+    }
+
+    public void restoreScrollPosition(String tag) {
+        SharedPreferences prefs = getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE);
+        int position = prefs.getInt(PREF_PREFIX_SCROLL_POSITION + tag, 0);
+        int offset = prefs.getInt(PREF_PREFIX_SCROLL_OFFSET + tag, 0);
+        if (position > 0 || offset > 0) {
+            layoutManager.scrollToPositionWithOffset(position, offset);
+        }
+    }
+
+    public boolean isScrolledToBottom() {
+        int visibleEpisodeCount = getChildCount();
+        int totalEpisodeCount = layoutManager.getItemCount();
+        int firstVisibleEpisode = layoutManager.findFirstVisibleItemPosition();
+        return (totalEpisodeCount - visibleEpisodeCount) <= (firstVisibleEpisode + 3);
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -15,7 +15,6 @@ import com.joanzapata.iconify.Iconify;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.CoverLoader;
-import de.danoeh.antennapod.adapter.QueueRecyclerAdapter;
 import de.danoeh.antennapod.adapter.actionbutton.ItemActionButton;
 import de.danoeh.antennapod.core.event.PlaybackPositionEvent;
 import de.danoeh.antennapod.core.feed.FeedItem;

--- a/app/src/main/res/layout/all_episodes_fragment.xml
+++ b/app/src/main/res/layout/all_episodes_fragment.xml
@@ -17,7 +17,7 @@
         android:visibility="gone"
         tools:text="(i) Information" />
 
-    <androidx.recyclerview.widget.RecyclerView
+    <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -28,11 +28,6 @@
         android:paddingTop="@dimen/list_vertical_padding"
         android:paddingBottom="@dimen/list_vertical_padding"
         android:layout_above="@id/loadingMore"
-        app:fastScrollEnabled="true"
-        app:fastScrollHorizontalThumbDrawable="@drawable/scrollbar_thumb_drawable"
-        app:fastScrollHorizontalTrackDrawable="@drawable/scrollbar_line_drawable"
-        app:fastScrollVerticalThumbDrawable="@drawable/scrollbar_thumb_drawable"
-        app:fastScrollVerticalTrackDrawable="@drawable/scrollbar_line_drawable"
         tools:itemCount="13"
         tools:listitem="@layout/feeditemlist_item" />
 

--- a/app/src/main/res/layout/feed_item_list_fragment.xml
+++ b/app/src/main/res/layout/feed_item_list_fragment.xml
@@ -46,7 +46,7 @@
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
+    <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/queue_fragment.xml
+++ b/app/src/main/res/layout/queue_fragment.xml
@@ -32,12 +32,11 @@
         android:layout_below="@id/info_bar"
         android:background="?android:attr/listDivider"/>
 
-    <androidx.recyclerview.widget.RecyclerView
+    <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/divider"
-        android:scrollbars="vertical"/>
+        android:layout_below="@id/divider" />
 
     <ProgressBar
         android:id="@+id/progLoading"

--- a/app/src/main/res/layout/search_fragment.xml
+++ b/app/src/main/res/layout/search_fragment.xml
@@ -31,9 +31,9 @@
             android:paddingRight="12dp"
             android:clipToPadding="false"/>
 
-    <androidx.recyclerview.widget.RecyclerView
-            android:layout_below="@id/recyclerViewFeeds"
+    <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
             android:id="@+id/recyclerView"
+            android:layout_below="@id/recyclerViewFeeds"
             android:layout_marginTop="-4dp"
             android:paddingTop="12dp"
             android:clipToPadding="false"

--- a/app/src/main/res/layout/simple_list_fragment.xml
+++ b/app/src/main/res/layout/simple_list_fragment.xml
@@ -11,7 +11,7 @@
             android:layout_alignParentTop="true"
             android:id="@+id/toolbar"/>
 
-    <androidx.recyclerview.widget.RecyclerView
+    <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@id/toolbar"

--- a/core/src/main/res/values/ids.xml
+++ b/core/src/main/res/values/ids.xml
@@ -24,4 +24,5 @@
     <item name="notification_gpodnet_sync_autherror" type="id"/>
     <item name="undobar_button" type="id"/>
     <item name="undobar_message" type="id"/>
+    <item name="episode_item_view_holder" type="id"/>
 </resources>


### PR DESCRIPTION
`EpisodeItemViewHolder/LayoutInflater.inflate` takes a lot of time and is even executed on the UI Thread. Around 30% of layouting is spent inflating `EpisodeItemViewHolder`. Configured RecyclerView to re-use our ViewHolders throughout the whole app instead of per fragment instance. All lists use the same items, so this gives a noticeable performance impact. Especially noticeable on the "Episodes" page when swiping between the 3 tabs. Logging output shows that `EpisodeItemViewHolder.<init>` is called significantly less frequently (after some initial calls, you can navigate the app without any additional call).