### PR TITLE
Allow to select audio track

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -2,6 +2,8 @@ package de.danoeh.antennapod.dialog;
 
 import android.app.Dialog;
 import android.os.Bundle;
+import android.os.Handler;
+import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
@@ -16,6 +18,8 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
+
+import java.util.List;
 
 public class PlaybackControlsDialog extends DialogFragment {
     private static final String ARGUMENT_IS_PLAYING_VIDEO = "isPlayingVideo";
@@ -43,6 +47,7 @@ public class PlaybackControlsDialog extends DialogFragment {
             @Override
             public void setupGUI() {
                 setupUi();
+                setupAudioTracks();
             }
         };
         controller.init();
@@ -195,6 +200,23 @@ public class PlaybackControlsDialog extends DialogFragment {
             if (controller != null) {
                 controller.setDownmix(isChecked);
             }
+        });
+    }
+
+    private void setupAudioTracks() {
+        List<String> audioTracks = controller.getAudioTracks();
+        int selectedAudioTrack = controller.getSelectedAudioTrack();
+        final Button butAudioTracks = dialog.findViewById(R.id.audio_tracks);
+        if (audioTracks.size() < 2 || selectedAudioTrack < 0) {
+            butAudioTracks.setVisibility(View.GONE);
+            return;
+        }
+
+        butAudioTracks.setVisibility(View.VISIBLE);
+        butAudioTracks.setText(audioTracks.get(selectedAudioTrack));
+        butAudioTracks.setOnClickListener(v -> {
+            controller.setAudioTrack((selectedAudioTrack + 1) % audioTracks.size());
+            new Handler().postDelayed(this::setupAudioTracks, 500);
         });
     }
 

--- a/app/src/main/res/layout/audio_controls.xml
+++ b/app/src/main/res/layout/audio_controls.xml
@@ -11,6 +11,13 @@
         android:minWidth="300dp"
         android:orientation="vertical">
 
+        <Button
+            android:id="@+id/audio_tracks"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:layout_marginBottom="8dp"/>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -17,6 +17,7 @@ import org.antennapod.audio.MediaPlayer;
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
@@ -826,6 +827,18 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     @Override
     protected void setPlayable(Playable playable) {
         media = playable;
+    }
+
+    public List<String> getAudioTracks() {
+        return mediaPlayer.getAudioTracks();
+    }
+
+    public void setAudioTrack(int track) {
+        mediaPlayer.setAudioTrack(track);
+    }
+
+    public int getSelectedAudioTrack() {
+        return mediaPlayer.getSelectedAudioTrack();
     }
 
     private void createMediaPlayer() {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -42,6 +42,7 @@ import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.request.target.Target;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -1580,6 +1581,26 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             return INVALID_TIME;
         }
         return mediaPlayer.getPosition();
+    }
+
+    public List<String> getAudioTracks() {
+        if (mediaPlayer == null) {
+            return Collections.emptyList();
+        }
+        return mediaPlayer.getAudioTracks();
+    }
+
+    public int getSelectedAudioTrack() {
+        if (mediaPlayer == null) {
+            return -1;
+        }
+        return mediaPlayer.getSelectedAudioTrack();
+    }
+
+    public void setAudioTrack(int track) {
+        if (mediaPlayer != null) {
+            mediaPlayer.setAudioTrack(track);
+        }
     }
 
     public boolean isStreaming() {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceMediaPlayer.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.SurfaceHolder;
 
+import java.util.List;
 import java.util.concurrent.Future;
 
 import de.danoeh.antennapod.core.feed.MediaType;
@@ -229,6 +230,12 @@ public abstract class PlaybackServiceMediaPlayer {
     public abstract Playable getPlayable();
 
     protected abstract void setPlayable(Playable playable);
+
+    public abstract List<String> getAudioTracks();
+
+    public abstract void setAudioTrack(int track);
+
+    public abstract int getSelectedAudioTrack();
 
     public void skip() {
         endPlayback(false, true, true, true);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -10,45 +10,58 @@ import org.antennapod.audio.MediaPlayer;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 
+import java.util.Collections;
+import java.util.List;
+
 public class AudioPlayer extends MediaPlayer implements IPlayer {
-	private static final String TAG = "AudioPlayer";
+    private static final String TAG = "AudioPlayer";
 
-	public AudioPlayer(Context context) {
-		super(context);
-		PreferenceManager.getDefaultSharedPreferences(context)
-				.registerOnSharedPreferenceChangeListener(sonicListener);
-	}
+    public AudioPlayer(Context context) {
+        super(context);
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
+                    if (key.equals(UserPreferences.PREF_MEDIA_PLAYER)) {
+                        checkMpi();
+                    }
+                });
+    }
 
-	private final SharedPreferences.OnSharedPreferenceChangeListener sonicListener =
-			(sharedPreferences, key) -> {
-				if (key.equals(UserPreferences.PREF_MEDIA_PLAYER)) {
-					checkMpi();
-				}
-			};
+    @Override
+    public void setDisplay(SurfaceHolder sh) {
+        if (sh != null) {
+            Log.e(TAG, "Setting display not supported in Audio Player");
+            throw new UnsupportedOperationException("Setting display not supported in Audio Player");
+        }
+    }
 
-	@Override
-	public void setDisplay(SurfaceHolder sh) {
-		if (sh != null) {
-			Log.e(TAG, "Setting display not supported in Audio Player");
-			throw new UnsupportedOperationException("Setting display not supported in Audio Player");
-		}
-	}
+    @Override
+    public void setPlaybackParams(float speed, boolean skipSilence) {
+        if (canSetSpeed()) {
+            setPlaybackSpeed(speed);
+        }
+        //Default player does not support silence skipping
+    }
 
-	@Override
-	public void setPlaybackParams(float speed, boolean skipSilence) {
-		if(canSetSpeed()) {
-			setPlaybackSpeed(speed);
-		}
-		//Default player does not support silence skipping
-	}
+    @Override
+    protected boolean useSonic() {
+        return UserPreferences.useSonic();
+    }
 
-	@Override
-	protected boolean useSonic() {
-		return UserPreferences.useSonic();
-	}
+    @Override
+    protected boolean downmix() {
+        return UserPreferences.stereoToMono();
+    }
 
-	@Override
-	protected boolean downmix() {
-		return UserPreferences.stereoToMono();
-	}
+    public List<String> getAudioTracks() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void setAudioTrack(int track) {
+    }
+
+    @Override
+    public int getSelectedAudioTrack() {
+        return -1;
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/IPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/IPlayer.java
@@ -4,48 +4,54 @@ import android.content.Context;
 import android.view.SurfaceHolder;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface IPlayer {
 
-	boolean canSetSpeed();
+    boolean canSetSpeed();
 
-	boolean canDownmix();
+    boolean canDownmix();
 
+    int getCurrentPosition();
 
-	int getCurrentPosition();
+    float getCurrentSpeedMultiplier();
 
-	float getCurrentSpeedMultiplier();
+    int getDuration();
 
-	int getDuration();
+    boolean isPlaying();
 
-	boolean isPlaying();
+    void pause();
 
-	void pause();
+    void prepare() throws IllegalStateException, IOException;
 
-	void prepare() throws IllegalStateException, IOException;
+    void release();
 
-	void release();
+    void reset();
 
-	void reset();
+    void seekTo(int msec);
 
-	void seekTo(int msec);
+    void setAudioStreamType(int streamtype);
 
-	void setAudioStreamType(int streamtype);
-
-	void setDataSource(String path) throws IllegalStateException, IOException,
+    void setDataSource(String path) throws IllegalStateException, IOException,
             IllegalArgumentException, SecurityException;
 
-	void setDisplay(SurfaceHolder sh);
+    void setDisplay(SurfaceHolder sh);
 
-	void setPlaybackParams(float speed, boolean skipSilence);
+    void setPlaybackParams(float speed, boolean skipSilence);
 
-	void setDownmix(boolean enable);
+    void setDownmix(boolean enable);
 
-	void setVolume(float left, float right);
+    void setVolume(float left, float right);
 
-	void start();
+    void start();
 
-	void stop();
+    void stop();
 
     void setWakeMode(Context context, int mode);
+
+    List<String> getAudioTracks();
+
+    void setAudioTrack(int track);
+
+    int getSelectedAudioTrack();
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -44,6 +44,9 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Communicates with the playback service. GUI classes should use this class to
  * control playback instead of communicating with the PlaybackService directly.
@@ -624,6 +627,26 @@ public class PlaybackController {
     public void setDownmix(boolean enable) {
         if (playbackService != null) {
             playbackService.setDownmix(enable);
+        }
+    }
+
+    public List<String> getAudioTracks() {
+        if (playbackService == null) {
+            return Collections.emptyList();
+        }
+        return playbackService.getAudioTracks();
+    }
+
+    public int getSelectedAudioTrack() {
+        if (playbackService == null) {
+            return -1;
+        }
+        return playbackService.getSelectedAudioTrack();
+    }
+
+    public void setAudioTrack(int track) {
+        if (playbackService != null) {
+            playbackService.setAudioTrack(track);
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
@@ -3,37 +3,53 @@ package de.danoeh.antennapod.core.util.playback;
 import android.media.MediaPlayer;
 import android.util.Log;
 
+import java.util.Collections;
+import java.util.List;
+
 public class VideoPlayer extends MediaPlayer implements IPlayer {
-	private static final String TAG = "VideoPlayer";
+    private static final String TAG = "VideoPlayer";
 
-	@Override
-	public boolean canSetSpeed() {
-		return false;
-	}
+    @Override
+    public boolean canSetSpeed() {
+        return false;
+    }
 
-	@Override
-	public boolean canDownmix() {
-		return false;
-	}
+    @Override
+    public boolean canDownmix() {
+        return false;
+    }
 
-	@Override
-	public float getCurrentSpeedMultiplier() {
-		return 1;
-	}
+    @Override
+    public float getCurrentSpeedMultiplier() {
+        return 1;
+    }
 
-	@Override
-	public void setPlaybackParams(float speed, boolean skipSilence) {
-		//Ignore this for non ExoPlayer implementations
-	}
+    @Override
+    public void setPlaybackParams(float speed, boolean skipSilence) {
+        //Ignore this for non ExoPlayer implementations
+    }
 
-	@Override
-	public void setDownmix(boolean b) {
-		Log.e(TAG, "Setting downmix unsupported in video player");
-		throw new UnsupportedOperationException("Setting downmix unsupported in video player");
-	}
+    @Override
+    public void setDownmix(boolean b) {
+        Log.e(TAG, "Setting downmix unsupported in video player");
+        throw new UnsupportedOperationException("Setting downmix unsupported in video player");
+    }
 
     @Override
     public void setVideoScalingMode(int mode) {
         super.setVideoScalingMode(mode);
+    }
+
+    public List<String> getAudioTracks() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void setAudioTrack(int track) {
+    }
+
+    @Override
+    public int getSelectedAudioTrack() {
+        return -1;
     }
 }

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
@@ -16,6 +16,9 @@ import com.google.android.libraries.cast.companionlibrary.cast.exceptions.NoConn
 import com.google.android.libraries.cast.companionlibrary.cast.exceptions.TransientNetworkDisconnectionException;
 
 import de.danoeh.antennapod.core.cast.MediaInfoCreator;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -600,6 +603,19 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
             media = playable;
             remoteMedia = remoteVersion(playable);
         }
+    }
+
+    @Override
+    public List<String> getAudioTracks() {
+        return Collections.emptyList();
+    }
+
+    public void setAudioTrack(int track) {
+
+    }
+
+    public int getSelectedAudioTrack() {
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
This feature is probably only used by 1% of the users. Because the button is only shown when the items have more than one audio track, I do not consider this a problem. Most users will never see this.

You can try this with https://media.ccc.de/c/36c3/podcast/mp4-hq.xml. With this PR, you can select the live translation language in AntennaPod.