### PR TITLE
Fix locale of every String.format number formatter

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -685,7 +686,7 @@ public class DBWriterTest {
                 if (from == to) {
                     continue;
                 }
-                Log.d(TAG, String.format("testMoveQueueItem: From=%d, To=%d", from, to));
+                Log.d(TAG, String.format(Locale.US, "testMoveQueueItem: From=%d, To=%d", from, to));
                 final long fromID = feed.getItems().get(from).getId();
 
                 adapter = PodDBAdapter.getInstance();

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.core.event.QueueEvent;
@@ -89,13 +90,13 @@ public class UITestUtils {
         out.close();
         int id = server.serveFile(feedFile);
         Assert.assertTrue(id != -1);
-        return String.format("%s/files/%d", server.getBaseUrl(), id);
+        return String.format(Locale.US, "%s/files/%d", server.getBaseUrl(), id);
     }
 
     private String hostFile(File file) {
         int id = server.serveFile(file);
         Assert.assertTrue(id != -1);
-        return String.format("%s/files/%d", server.getBaseUrl(), id);
+        return String.format(Locale.US, "%s/files/%d", server.getBaseUrl(), id);
     }
 
     private File newMediaFile(String name) throws IOException {

--- a/app/src/androidTest/java/de/test/antennapod/util/service/download/HTTPBin.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/service/download/HTTPBin.java
@@ -19,6 +19,7 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.zip.GZIPOutputStream;
@@ -88,7 +89,8 @@ public class HTTPBin extends NanoHTTPD {
 
         String[] segments = session.getUri().split("/");
         if (segments.length < 3) {
-            Log.w(TAG, String.format("Invalid number of URI segments: %d %s", segments.length, Arrays.toString(segments)));
+            Log.w(TAG, String.format(Locale.US, "Invalid number of URI segments: %d %s",
+                    segments.length, Arrays.toString(segments)));
             get404Error();
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -20,6 +20,7 @@ import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
 
 import java.util.List;
+import java.util.Locale;
 
 public class PlaybackControlsDialog extends DialogFragment {
     private static final String ARGUMENT_IS_PLAYING_VIDEO = "isPlayingVideo";
@@ -99,7 +100,7 @@ public class PlaybackControlsDialog extends DialogFragment {
         final TextView txtvPlaybackSpeed = dialog.findViewById(R.id.txtvPlaybackSpeed);
         float currentSpeed = getCurrentSpeed();
 
-        txtvPlaybackSpeed.setText(String.format("%.2fx", currentSpeed));
+        txtvPlaybackSpeed.setText(String.format(Locale.getDefault(), "%.2fx", currentSpeed));
         barPlaybackSpeed.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
@@ -114,7 +115,7 @@ public class PlaybackControlsDialog extends DialogFragment {
                         UserPreferences.setPlaybackSpeed(playbackSpeed);
                     }
 
-                    String speedStr = String.format("%.2fx", playbackSpeed);
+                    String speedStr = String.format(Locale.getDefault(), "%.2fx", playbackSpeed);
                     txtvPlaybackSpeed.setText(speedStr);
                 } else if (fromUser) {
                     float speed = getCurrentSpeed();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -10,6 +10,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
@@ -72,7 +73,7 @@ public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
         int counter = delete.size();
 
 
-        Log.i(TAG, String.format(
+        Log.i(TAG, String.format(Locale.US,
                 "Auto-delete deleted %d episodes (%d requested)", counter,
                 numberOfEpisodesToDelete));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
 import de.danoeh.antennapod.core.feed.FeedItem;
@@ -64,7 +65,7 @@ public class APQueueCleanupAlgorithm extends EpisodeCleanupAlgorithm {
         int counter = delete.size();
 
 
-        Log.i(TAG, String.format(
+        Log.i(TAG, String.format(Locale.US,
                 "Auto-delete deleted %d episodes (%d requested)", counter,
                 numberOfEpisodesToDelete));
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -94,7 +95,7 @@ public class DBWriter {
 
     private static boolean deleteFeedMediaSynchronous(
             @NonNull Context context, @NonNull FeedMedia media) {
-        Log.i(TAG, String.format("Requested to delete FeedMedia [id=%d, title=%s, downloaded=%s",
+        Log.i(TAG, String.format(Locale.US, "Requested to delete FeedMedia [id=%d, title=%s, downloaded=%s",
                 media.getId(), media.getEpisodeTitle(), media.isDownloaded()));
         if (media.isDownloaded()) {
             // delete downloaded media file

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import de.danoeh.antennapod.core.feed.Chapter;
@@ -425,7 +426,7 @@ public class PodDBAdapter {
 
     public void setFeedItemFilter(long feedId, Set<String> filterValues) {
         String valuesList = TextUtils.join(",", filterValues);
-        Log.d(TAG, String.format(
+        Log.d(TAG, String.format(Locale.US,
                 "setFeedItemFilter() called with: feedId = [%d], filterValues = [%s]", feedId, valuesList));
         ContentValues values = new ContentValues();
         values.put(KEY_HIDE, valuesList);
@@ -782,7 +783,7 @@ public class PodDBAdapter {
     }
 
     private boolean isItemInFavorites(FeedItem item) {
-        String query = String.format("SELECT %s from %s WHERE %s=%d",
+        String query = String.format(Locale.US, "SELECT %s from %s WHERE %s=%d",
                 KEY_ID, TABLE_NAME_FAVORITES, KEY_FEEDITEM, item.getId());
         Cursor c = db.rawQuery(query, null);
         int count = c.getCount();
@@ -1031,7 +1032,7 @@ public class PodDBAdapter {
 
         return db.query(TABLE_NAME_FEED_MEDIA, null,
                 KEY_PLAYBACK_COMPLETION_DATE + " > 0", null, null,
-                null, String.format("%s DESC LIMIT %d", KEY_PLAYBACK_COMPLETION_DATE, limit));
+                null, String.format(Locale.US, "%s DESC LIMIT %d", KEY_PLAYBACK_COMPLETION_DATE, limit));
     }
 
     public final Cursor getSingleFeedMediaCursor(long id) {

--- a/core/src/main/java/de/danoeh/antennapod/core/sync/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/gpoddernet/GpodnetService.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Communicates with the gpodder.net service.
@@ -70,7 +71,7 @@ public class GpodnetService implements ISyncService {
     public List<GpodnetTag> getTopTags(int count) throws GpodnetServiceException {
         URL url;
         try {
-            url = new URI(BASE_SCHEME, baseHost, String.format("/api/2/tags/%d.json", count), null).toURL();
+            url = new URI(BASE_SCHEME, baseHost, String.format(Locale.US, "/api/2/tags/%d.json", count), null).toURL();
         } catch (MalformedURLException | URISyntaxException e) {
             e.printStackTrace();
             throw new GpodnetServiceException(e);
@@ -103,7 +104,7 @@ public class GpodnetService implements ISyncService {
     public List<GpodnetPodcast> getPodcastsForTag(@NonNull GpodnetTag tag, int count)
             throws GpodnetServiceException {
         try {
-            URL url = new URI(BASE_SCHEME, baseHost, String.format(
+            URL url = new URI(BASE_SCHEME, baseHost, String.format(Locale.US,
                     "/api/2/tag/%s/%d.json", tag.getTag(), count), null).toURL();
             Request.Builder request = new Request.Builder().url(url);
             String response = executeRequest(request);
@@ -129,7 +130,7 @@ public class GpodnetService implements ISyncService {
         }
 
         try {
-            URL url = new URI(BASE_SCHEME, baseHost, String.format("/toplist/%d.json", count), null).toURL();
+            URL url = new URI(BASE_SCHEME, baseHost, String.format(Locale.US, "/toplist/%d.json", count), null).toURL();
             Request.Builder request = new Request.Builder().url(url);
             String response = executeRequest(request);
 
@@ -160,7 +161,8 @@ public class GpodnetService implements ISyncService {
         }
 
         try {
-            URL url = new URI(BASE_SCHEME, baseHost, String.format("/suggestions/%d.json", count), null).toURL();
+            URL url = new URI(BASE_SCHEME, baseHost,
+                    String.format(Locale.US, "/suggestions/%d.json", count), null).toURL();
             Request.Builder request = new Request.Builder().url(url);
             String response = executeRequest(request);
 
@@ -182,7 +184,7 @@ public class GpodnetService implements ISyncService {
      */
     public List<GpodnetPodcast> searchPodcasts(String query, int scaledLogoSize) throws GpodnetServiceException {
         String parameters = (scaledLogoSize > 0 && scaledLogoSize <= 256) ? String
-                .format("q=%s&scale_logo=%d", query, scaledLogoSize) : String
+                .format(Locale.US, "q=%s&scale_logo=%d", query, scaledLogoSize) : String
                 .format("q=%s", query);
         try {
             URL url = new URI(BASE_SCHEME, null, baseHost, -1, "/search.json",
@@ -384,7 +386,7 @@ public class GpodnetService implements ISyncService {
     public SubscriptionChanges getSubscriptionChanges(@NonNull String deviceId, long timestamp)
             throws GpodnetServiceException {
         requireLoggedIn();
-        String params = String.format("since=%d", timestamp);
+        String params = String.format(Locale.US, "since=%d", timestamp);
         String path = String.format("/api/2/subscriptions/%s/%s.json", username, deviceId);
         try {
             URL url = new URI(BASE_SCHEME, null, baseHost, -1, path, params,
@@ -466,7 +468,7 @@ public class GpodnetService implements ISyncService {
     @Override
     public EpisodeActionChanges getEpisodeActionChanges(long timestamp) throws SyncServiceException {
         requireLoggedIn();
-        String params = String.format("since=%d", timestamp);
+        String params = String.format(Locale.US, "since=%d", timestamp);
         String path = String.format("/api/2/episodes/%s.json", username);
         try {
             URL url = new URI(BASE_SCHEME, null, baseHost, -1, path, params, null).toURL();

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Timeline.java
@@ -193,7 +193,7 @@ public class Timeline {
 
                 String replacementText = group;
                 if (time < playableDuration) {
-                    replacementText = String.format(Locale.getDefault(), TIMECODE_LINK, time, group);
+                    replacementText = String.format(Locale.US, TIMECODE_LINK, time, group);
                 }
 
                 matcherForElement.appendReplacement(buffer, replacementText);

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastManager.java
@@ -1520,7 +1520,7 @@ public class CastManager extends BaseCastManager implements OnFailedListener {
     private void onQueueUpdated(List<MediaQueueItem> queueItems, MediaQueueItem item,
                                 int repeatMode, boolean shuffle) {
         Log.d(TAG, "onQueueUpdated() reached");
-        Log.d(TAG, String.format("Queue Items size: %d, Item: %s, Repeat Mode: %d, Shuffle: %s",
+        Log.d(TAG, String.format(Locale.US, "Queue Items size: %d, Item: %s, Repeat Mode: %d, Shuffle: %s",
                 queueItems == null ? 0 : queueItems.size(), item, repeatMode, shuffle));
         if (queueItems != null) {
             mediaQueue = new MediaQueue(new CopyOnWriteArrayList<>(queueItems), item, shuffle,


### PR DESCRIPTION
Split from #4020, searched `%d`, `%.1f`, `%.2f` entire the project to see if locale `String.format` has correct locale, which includes fixes on some SQL query fixes on locales don't use 123 digits (۱۲۳), URL builders that should've used 123 in any locale, improvements on logs.

Rule of thumb, use Locale.getDefault() everywhere string goes directly to view and use Locale.US (or Locale.ENGLISH, the former was used by the project already) every other place like building a SQL query or URL (and maybe logs as they are in English anyway)