### PR TITLE
Localize digits in queue episodes and parallel downloads numbers

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -58,6 +58,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.List;
+import java.util.Locale;
 
 import static de.danoeh.antennapod.dialog.EpisodesApplyActionFragment.ACTION_DELETE;
 import static de.danoeh.antennapod.dialog.EpisodesApplyActionFragment.ACTION_DOWNLOAD;
@@ -578,7 +579,8 @@ public class QueueFragment extends Fragment {
     }
 
     private void refreshInfoBar() {
-        String info = queue.size() + getString(R.string.episodes_suffix);
+        String info = String.format(Locale.getDefault(), "%d%s",
+                queue.size(), getString(R.string.episodes_suffix));
         if (queue.size() > 0) {
             long timeLeft = 0;
             for (FeedItem item : queue) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/NetworkPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/NetworkPreferencesFragment.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 public class NetworkPreferencesFragment extends PreferenceFragmentCompat {
@@ -96,7 +97,8 @@ public class NetworkPreferencesFragment extends PreferenceFragmentCompat {
     private void setParallelDownloadsText(int downloads) {
         final Resources res = getActivity().getResources();
 
-        String s = downloads + res.getString(R.string.parallel_downloads_suffix);
+        String s = String.format(Locale.getDefault(), "%d%s",
+                downloads, res.getString(R.string.parallel_downloads_suffix));
         findPreference(UserPreferences.PREF_PARALLEL_DOWNLOADS).setSummary(s);
     }
 


### PR DESCRIPTION
Ideally %d%s should be moved into the message itself this however is
a temporal fix before apply that to the messages themselves.