### PR TITLE
Allow Proguard to optimize androidx packages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,6 +87,7 @@ android {
         release {
             resValue "string", "provider_authority", "de.danoeh.antennapod.provider"
             minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), "proguard.cfg"
             signingConfig signingConfigs.releaseConfig
         }

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -5,21 +5,24 @@
 -optimizationpasses 5
 
 -dontpreverify
--repackageclasses ''
 -allowaccessmodification
--keepattributes *Annotation*
+-dontskipnonpubliclibraryclassmembers
 
--keep public class * extends android.app.Activity
--keep public class * extends android.app.Application
--keep public class * extends android.app.Service
--keep public class * extends android.content.BroadcastReceiver
--keep public class * extends android.content.ContentProvider
+# Keep our own classes and members. They are all used.
+# Without this, methods only used in tests are removed and break tests.
+-keep class de.danoeh.antennapod**
+-keepclassmembers class de.danoeh.antennapod** {*;}
+-keep class de.test.antennapod**
+-keepclassmembers class de.test.antennapod** {*;}
 
--keep public class * extends android.view.View {
-    public <init>(android.content.Context);
-    public <init>(android.content.Context, android.util.AttributeSet);
-    public <init>(android.content.Context, android.util.AttributeSet, int);
-    public void set*(...);
+# Keep methods used in tests.
+# This is only needed when running tests with proguard enabled.
+-keepclassmembers class org.apache.commons.lang3.StringUtils {*;}
+-keepclassmembers class androidx.appcompat.app.ActionBar {
+    public ** getTitle();
+}
+-keepclassmembers class org.apache.commons.io.IOUtils {
+    public static void write(...);
 }
 
 -keepclassmembers enum * {
@@ -27,25 +30,8 @@
     public static ** valueOf(java.lang.String);
 }
 
--keepclasseswithmembers class * {
-    public <init>(android.content.Context, android.util.AttributeSet);
-}
-
--keepclasseswithmembers class * {
-    public <init>(android.content.Context, android.util.AttributeSet, int);
-}
-
--keepclassmembers class * extends android.content.Context {
-   public void *(android.view.View);
-   public void *(android.view.MenuItem);
-}
-
 -keepclassmembers class * implements android.os.Parcelable {
     static android.os.Parcelable$Creator CREATOR;
-}
-
--keepclassmembers class **.R$* {
-    public static <fields>;
 }
 
 -keep public class org.jsoup.** {
@@ -64,19 +50,6 @@
 
 # for retrolambda
 -dontwarn java.lang.invoke.*
-
--dontwarn com.google.android.material.**
--keep class com.google.android.material.** { *; }
-
--dontwarn androidx.**
--keep class androidx.** { *; }
--keep interface androidx.** { *; }
-
--dontwarn com.google.android.wearable.**
-
--keep class org.apache.commons.** { *; }
-
--dontskipnonpubliclibraryclassmembers
 
 # greenrobot EventBus
 -keepattributes *Annotation*

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBReaderTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBReaderTest.java
@@ -404,6 +404,7 @@ public class DBReaderTest {
         List<Feed> feeds = saveFeedlist(1, 1, false, true, NUM_CHAPTERS);
         FeedItem item1 = feeds.get(0).getItems().get(0);
         FeedItem item2 = DBReader.getFeedItem(item1.getId());
+        DBReader.loadChaptersOfFeedItem(item2);
         assertTrue(item2.hasChapters());
         assertEquals(item1.getChapters(), item2.getChapters());
     }

--- a/app/src/androidTest/java/de/test/antennapod/ui/NavigationDrawerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/NavigationDrawerTest.java
@@ -183,7 +183,7 @@ public class NavigationDrawerTest {
         onView(first(withText(R.string.queue_label))).perform(longClick());
         for (int i = 0; i < titles.length; i++) {
             String title = titles[i];
-            onView(first(withText(title))).perform(click());
+            onView(allOf(withText(title), isDisplayed())).perform(click());
 
             if (i == 3) {
                 onView(withId(R.id.select_dialog_listview)).perform(swipeUp());

--- a/app/src/androidTest/java/de/test/antennapod/ui/SpeedChangeTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/SpeedChangeTest.java
@@ -83,6 +83,7 @@ public class SpeedChangeTest {
     @After
     public void tearDown() throws Exception {
         uiTestUtils.tearDown();
+        controller.release();
     }
 
     @Test

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -1,14 +1,20 @@
 package de.test.antennapod.ui;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.util.Log;
-
 import de.danoeh.antennapod.core.event.FeedListUpdateEvent;
-import de.danoeh.antennapod.core.util.playback.Playable;
+import de.danoeh.antennapod.core.event.QueueEvent;
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.test.antennapod.util.service.download.HTTPBin;
+import de.test.antennapod.util.syndication.feedgenerator.RSS2Generator;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.greenrobot.eventbus.EventBus;
+import org.junit.Assert;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -18,19 +24,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-
-import de.danoeh.antennapod.activity.MainActivity;
-import de.danoeh.antennapod.core.event.QueueEvent;
-import de.danoeh.antennapod.core.feed.Feed;
-import de.danoeh.antennapod.core.feed.FeedItem;
-import de.danoeh.antennapod.core.feed.FeedMedia;
-import de.danoeh.antennapod.core.storage.PodDBAdapter;
-import de.danoeh.antennapod.core.util.playback.PlaybackController;
-import de.danoeh.antennapod.fragment.ExternalPlayerFragment;
-import de.test.antennapod.util.service.download.HTTPBin;
-import de.test.antennapod.util.syndication.feedgenerator.RSS2Generator;
-import org.greenrobot.eventbus.EventBus;
-import org.junit.Assert;
 
 /**
  * Utility methods for UI tests.
@@ -198,17 +191,6 @@ public class UITestUtils {
         adapter.close();
         EventBus.getDefault().post(new FeedListUpdateEvent(hostedFeeds));
         EventBus.getDefault().post(QueueEvent.setQueue(queue));
-    }
-
-    public PlaybackController getPlaybackController(MainActivity mainActivity) {
-        ExternalPlayerFragment fragment = (ExternalPlayerFragment) mainActivity.getSupportFragmentManager()
-                .findFragmentByTag(ExternalPlayerFragment.TAG);
-        return fragment.getPlaybackControllerTestingOnly();
-    }
-
-    public FeedMedia getCurrentMedia() {
-        Playable playable = Playable.PlayableUtils.createInstanceFromPreferences(context);
-        return (FeedMedia) playable;
     }
 
     public void setMediaFileName(String filename) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
@@ -210,10 +210,6 @@ public class ExternalPlayerFragment extends Fragment {
         }
     }
 
-    public PlaybackController getPlaybackControllerTestingOnly() {
-        return controller;
-    }
-
     private void onPositionObserverUpdate() {
         if (controller == null) {
             return;


### PR DESCRIPTION
This reduces the method count from 64k to 44k and the apk size from 8MB to 7MB.

This means we do not need to enable MultiDex, yet.