### PR TITLE
Use Android's own file size formatter

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DataFolderAdapter.java
@@ -2,15 +2,17 @@ package de.danoeh.antennapod.adapter;
 
 import android.app.Dialog;
 import android.content.Context;
-import android.widget.ProgressBar;
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
-import androidx.recyclerview.widget.RecyclerView;
+import android.text.format.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.RadioButton;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -18,7 +20,6 @@ import java.util.List;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
-import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.StorageUtils;
 import de.danoeh.antennapod.dialog.ChooseDataFolderDialog;
 
@@ -48,8 +49,9 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         StoragePath storagePath = entries.get(position);
-        String freeSpace = Converter.byteToString(storagePath.getAvailableSpace());
-        String totalSpace = Converter.byteToString(storagePath.getTotalSpace());
+        Context context = holder.root.getContext();
+        String freeSpace = Formatter.formatShortFileSize(context, storagePath.getAvailableSpace());
+        String totalSpace = Formatter.formatShortFileSize(context, storagePath.getTotalSpace());
 
         holder.path.setText(storagePath.getShortPath());
         holder.size.setText(String.format(freeSpaceString, freeSpace, totalSpace));

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadStatisticsListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadStatisticsListAdapter.java
@@ -1,13 +1,13 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.text.format.Formatter;
+
+import java.util.List;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.storage.StatisticsItem;
-import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.view.PieChartView;
-
-import java.util.List;
 
 /**
  * Adapter for the download statistics list.
@@ -25,7 +25,7 @@ public class DownloadStatisticsListAdapter extends StatisticsListAdapter {
 
     @Override
     String getHeaderValue() {
-        return Converter.byteToString((long) pieChartData.getSum());
+        return Formatter.formatShortFileSize(context, (long) pieChartData.getSum());
     }
 
     @Override
@@ -40,7 +40,7 @@ public class DownloadStatisticsListAdapter extends StatisticsListAdapter {
 
     @Override
     void onBindFeedViewHolder(StatisticsHolder holder, StatisticsItem item) {
-        holder.value.setText(Converter.byteToString(item.totalDownloadSize));
+        holder.value.setText(Formatter.formatShortFileSize(context, item.totalDownloadSize));
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadlistAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadlistAdapter.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.adapter;
 
 import android.content.Context;
+import android.text.format.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,7 +15,6 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.download.Downloader;
-import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.ThemeUtils;
 import de.danoeh.antennapod.view.CircularProgressBar;
 
@@ -79,9 +79,9 @@ public class DownloadlistAdapter extends BaseAdapter {
         if (request.getSoFar() <= 0) {
             status += context.getString(R.string.download_pending);
         } else {
-            status += Converter.byteToString(request.getSoFar());
+            status += Formatter.formatShortFileSize(context, request.getSoFar());
             if (request.getSize() != DownloadStatus.SIZE_UNKNOWN) {
-                status += " / " + Converter.byteToString(request.getSize());
+                status += " / " + Formatter.formatShortFileSize(context, request.getSize());
                 holder.secondaryActionProgress.setPercentage(
                         0.01f * Math.max(1, request.getProgressPercent()), request);
             }

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.view.viewholder;
 
 import android.os.Build;
 import android.text.Layout;
+import android.text.format.Formatter;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,9 +10,12 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
 import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
+
 import com.joanzapata.iconify.Iconify;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.adapter.CoverLoader;
@@ -153,14 +157,14 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
         }
 
         if (media.getSize() > 0) {
-            size.setText(Converter.byteToString(media.getSize()));
+            size.setText(Formatter.formatShortFileSize(activity, media.getSize()));
         } else if (NetworkUtils.isEpisodeHeadDownloadAllowed() && !media.checkedOnSizeButUnknown()) {
             size.setText("{fa-spinner}");
             Iconify.addIcons(size);
             NetworkUtils.getFeedMediaSizeObservable(media).subscribe(
                     sizeValue -> {
                         if (sizeValue > 0) {
-                            size.setText(Converter.byteToString(sizeValue));
+                            size.setText(Formatter.formatShortFileSize(activity, sizeValue));
                         } else {
                             size.setText("");
                         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod.core.util;
 
 import android.content.Context;
-import android.util.Log;
 
 import java.util.Locale;
 
@@ -15,53 +14,10 @@ public final class Converter {
 
     /** Logging tag. */
     private static final String TAG = "Converter";
-
-
-    /** Indicates that the value is in the Byte range.*/
-    private static final int B_RANGE = 0;
-    /** Indicates that the value is in the Kilobyte range.*/
-    private static final int KB_RANGE = 1;
-    /** Indicates that the value is in the Megabyte range.*/
-    private static final int MB_RANGE = 2;
-    /** Indicates that the value is in the Gigabyte range.*/
-    private static final int GB_RANGE = 3;
-    /** Determines the length of the number for best readability.*/
-    private static final int NUM_LENGTH = 1024;
     
     private static final int HOURS_MIL = 3600000;
 	private static final int MINUTES_MIL = 60000;
 	private static final int SECONDS_MIL = 1000;
-
-    /** Takes a byte-value and converts it into a more readable
-     *  String.
-     *  @param input The value to convert
-     *  @return The converted String with a unit
-     * */
-    public static String byteToString(final long input) {
-        int i = 0;
-        int result = 0;
-
-        for (i = 0; i < GB_RANGE + 1; i++) {
-            result = (int) (input / Math.pow(1024, i));
-            if (result < NUM_LENGTH) {
-                break;
-            }
-        }
-
-        switch (i) {
-            case B_RANGE:
-                return result + " B";
-            case KB_RANGE:
-                return result + " KB";
-            case MB_RANGE:
-                return result + " MB";
-            case GB_RANGE:
-                return result + " GB";
-            default:
-                Log.e(TAG, "Error happened in byteToString");
-                return "ERROR";
-        }
-    }
     
     /** Converts milliseconds to a string containing hours, minutes and seconds */
     public static String getDurationStringLong(int duration) {	


### PR DESCRIPTION
No change in English locale:

![image](https://user-images.githubusercontent.com/833473/79066094-4e78d080-7cca-11ea-9e35-abffecd1f200.png)

But turns:

![image](https://user-images.githubusercontent.com/833473/79066120-79fbbb00-7cca-11ea-89a8-3f2f8b07d9d9.png)

to:

![image](https://user-images.githubusercontent.com/833473/79066107-68b2ae80-7cca-11ea-84ff-f41c1cb5ba33.png)
