### PR TITLE
Use toolbar's subtitle instead using our custom one

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -16,6 +16,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
@@ -70,7 +71,7 @@ import static de.danoeh.antennapod.dialog.EpisodesApplyActionFragment.ACTION_REM
 public class QueueFragment extends Fragment {
     public static final String TAG = "QueueFragment";
 
-    private TextView infoBar;
+    private Toolbar toolbar;
     private EpisodeItemListRecyclerView recyclerView;
     private QueueRecyclerAdapter recyclerAdapter;
     private EmptyViewHandler emptyView;
@@ -445,8 +446,8 @@ public class QueueFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
         View root = inflater.inflate(R.layout.queue_fragment, container, false);
-        ((AppCompatActivity) getActivity()).setSupportActionBar(root.findViewById(R.id.toolbar));
-        infoBar = root.findViewById(R.id.info_bar);
+        toolbar = root.findViewById(R.id.toolbar);
+        ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
         recyclerView = root.findViewById(R.id.recyclerView);
         RecyclerView.ItemAnimator animator = recyclerView.getItemAnimator();
         if (animator instanceof SimpleItemAnimator) {
@@ -597,7 +598,7 @@ public class QueueFragment extends Fragment {
             info += getString(R.string.time_left_label);
             info += Converter.getDurationStringLocalized(getActivity(), timeLeft);
         }
-        infoBar.setText(info);
+        toolbar.setSubtitle(info);
     }
 
     private void loadItems(final boolean restoreScrollPosition) {

--- a/app/src/main/res/layout/queue_fragment.xml
+++ b/app/src/main/res/layout/queue_fragment.xml
@@ -13,23 +13,11 @@
         app:title="@string/queue_label"
         android:id="@+id/toolbar"/>
 
-    <TextView
-        android:layout_below="@id/toolbar"
-        android:id="@+id/info_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="12sp"
-        android:layout_marginTop="-8dp"
-        android:layout_marginLeft="72dp"
-        android:layout_marginStart="72dp"
-        android:layout_marginBottom="4dp"
-        tools:text="12 Episodes - Time remaining: 12 hours"/>
-
     <View
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_below="@id/info_bar"
+        android:layout_below="@id/toolbar"
         android:background="?android:attr/listDivider"/>
 
     <de.danoeh.antennapod.view.EpisodeItemListRecyclerView


### PR DESCRIPTION
Maybe it has been done on propose but it feels much better to me as without it default toolbar size of the fragment looks a little weird to me. Not insisting on it, let's see if we can agree on it, guess can tweak its size also if needed.

Turns

![image](https://user-images.githubusercontent.com/833473/79066424-09a26900-7ccd-11ea-9e9e-cd81e580f239.png)

to

![Screenshot from 2020-04-12 14-50-04](https://user-images.githubusercontent.com/833473/79066413-fa232000-7ccc-11ea-98b2-737fc1cccbd2.png)
