### PR TITLE
Fix symmetry issues of feed item list

### DIFF
--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -9,8 +9,10 @@
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:baselineAligned="false"
+        android:paddingStart="12dp"
         android:paddingLeft="12dp"
-        android:paddingStart="12dp">
+        android:paddingEnd="0dp"
+        android:paddingRight="0dp">
 
     <LinearLayout
             android:layout_width="wrap_content"
@@ -23,6 +25,8 @@
                 android:contentDescription="@string/drag_handle_content_description"
                 android:scaleType="fitCenter"
                 android:src="?attr/dragview_background"
+                android:paddingStart="0dp"
+                android:paddingLeft="0dp"
                 android:paddingEnd="4dp"
                 android:paddingRight="4dp"
                 tools:src="@drawable/ic_drag_darktheme"


### PR DESCRIPTION
Android Studio was also giving hint about this

![image](https://user-images.githubusercontent.com/833473/79079728-fc659880-7d25-11ea-81a3-4e3ac6dcaf6b.png)

Went for other layouts to find similar issues but didn't find this hint on them.

I was seeing this particular issue as an user initially…

This change keeps LTR UI intact:

![image](https://user-images.githubusercontent.com/833473/79079701-c45e5580-7d25-11ea-8569-389eff8d02fa.png)

But turns:

![image](https://user-images.githubusercontent.com/833473/79079742-1606e000-7d26-11ea-9c79-039997e56f4c.png)

To:

![image](https://user-images.githubusercontent.com/833473/79079714-dcce7000-7d25-11ea-91ca-979bf91881dd.png)

which now matches with LTR UI.

