### PR TITLE
Bundle a modern Security Provider (Conscrypt) in the Free builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           build-steps:
             - run:
                 name: Build debug
-                command: ./gradlew assembleDebug -PdisablePreDex
+                command: ./gradlew assemblePlayDebug -PdisablePreDex
             - run:
                 name: Execute debug unit tests
                 command: ./gradlew :core:testPlayDebugUnitTest -PdisablePreDex
@@ -47,7 +47,7 @@ workflows:
           build-steps:
             - run:
                 name: Build release
-                command: ./gradlew assembleRelease -PdisablePreDex
+                command: ./gradlew assemblePlayRelease -PdisablePreDex
             - run:
                 name: Execute release unit tests
                 command: ./gradlew :core:testPlayReleaseUnitTest -PdisablePreDex

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           build-steps:
             - run:
                 name: Build debug
-                command: ./gradlew assemblePlayDebug -PdisablePreDex
+                command: ./gradlew assembleDebug -PdisablePreDex
             - run:
                 name: Execute debug unit tests
                 command: ./gradlew :core:testPlayDebugUnitTest -PdisablePreDex
@@ -47,7 +47,7 @@ workflows:
           build-steps:
             - run:
                 name: Build release
-                command: ./gradlew assemblePlayRelease -PdisablePreDex
+                command: ./gradlew assembleRelease -PdisablePreDex
             - run:
                 name: Execute release unit tests
                 command: ./gradlew :core:testPlayReleaseUnitTest -PdisablePreDex

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,12 @@ project.ext {
     iconifyVersion = "2.2.2"
     audioPlayerVersion = "v2.0.0"
 
+    // Only used for free builds. This version should be updated regularly.
+    conscryptVersion = "2.4.0"
+    // Alternatively one can just use:
+    //  conscryptVersion = "latest.release"
+    // but it will mess up reproducible builds.
+
     // Google Play build
     wearableSupportVersion = "2.6.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,6 @@ project.ext {
 
     // Only used for free builds. This version should be updated regularly.
     conscryptVersion = "2.4.0"
-    // Alternatively one can just use:
-    //  conscryptVersion = "latest.release"
-    // but it will mess up reproducible builds.
 
     // Google Play build
     wearableSupportVersion = "2.6.0"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,7 +88,8 @@ dependencies {
         api "com.google.android.support:wearable:$wearableSupportVersion"
         compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
     } else {
-        System.out.println("core: free build hack, skipping some dependencies")
+        System.out.println("core: free build hack, skipping some dependencies and bundling conscrypt ("+"$conscryptVersion"+")")
+        implementation "org.conscrypt:conscrypt-android:$conscryptVersion"
     }
 
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,7 +88,7 @@ dependencies {
         api "com.google.android.support:wearable:$wearableSupportVersion"
         compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
     } else {
-        System.out.println("core: free build hack, skipping some dependencies and bundling conscrypt ("+"$conscryptVersion"+")")
+        System.out.println("core: free build hack, skipping some dependencies and bundling conscrypt ($conscryptVersion)")
         implementation "org.conscrypt:conscrypt-android:$conscryptVersion"
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,9 +88,11 @@ dependencies {
         api "com.google.android.support:wearable:$wearableSupportVersion"
         compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
     } else {
-        System.out.println("core: free build hack, skipping some dependencies and bundling conscrypt ($conscryptVersion)")
-        implementation "org.conscrypt:conscrypt-android:$conscryptVersion"
+        System.out.println("core: free build hack, skipping some dependencies")
     }
+
+    // bundle conscrypt with free builds
+    freeImplementation "org.conscrypt:conscrypt-android:$conscryptVersion"
 
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
     testImplementation 'junit:junit:4.13'

--- a/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -5,7 +5,10 @@ import java.security.Security;
 
 /*
  * If you get an error here ("package org.conscrypt does not exist"), you are probably doing a free
- * build and didn't pass -PfreeBuild to gradle (e.g. ./gradlew assembleFreeRelease -PfreeBuild).
+ * build and didn't pass "-PfreeBuild" to gradle (e.g. "./gradlew assembleFreeRelease -PfreeBuild").
+ *
+ * If you are doing a non-free build using "assembleRelease" or "assembleDebug" and get this error,
+ * use "assemblePlayRelease" or "assemblePlayDebug" instead (e.g. "./gradlew assemblePlayRelease").
  */
 import org.conscrypt.Conscrypt;
 

--- a/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -2,14 +2,6 @@ package de.danoeh.antennapod.core;
 
 import android.content.Context;
 import java.security.Security;
-
-/*
- * If you get an error here ("package org.conscrypt does not exist"), you are probably doing a free
- * build and didn't pass "-PfreeBuild" to gradle (e.g. "./gradlew assembleFreeRelease -PfreeBuild").
- *
- * If you are doing a non-free build using "assembleRelease" or "assembleDebug" and get this error,
- * use "assemblePlayRelease" or "assemblePlayDebug" instead (e.g. "./gradlew assemblePlayRelease").
- */
 import org.conscrypt.Conscrypt;
 
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;

--- a/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
+++ b/core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java
@@ -1,6 +1,13 @@
 package de.danoeh.antennapod.core;
 
 import android.content.Context;
+import java.security.Security;
+
+/*
+ * If you get an error here ("package org.conscrypt does not exist"), you are probably doing a free
+ * build and didn't pass -PfreeBuild to gradle (e.g. ./gradlew assembleFreeRelease -PfreeBuild).
+ */
+import org.conscrypt.Conscrypt;
 
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
@@ -55,6 +62,7 @@ public class ClientConfig {
     }
 
     private static void installSslProvider(Context context) {
-        // ProviderInstaller is a closed-source Google library
+        // Insert bundled conscrypt as highest security provider (overrides OS version).
+        Security.insertProviderAt(Conscrypt.newProvider(), 1);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
@@ -151,16 +151,15 @@ public class AntennapodHttpClient {
             }
         }
 
-        // The Free flavor bundles a modern conscrypt (security provider), so CustomSslSocketFactory
-        // is only used to make sure that modern protocols (TLSv1.3 and TLSv1.2) are enabled and
-        // that old, deprecated, protocols (like SSLv3, TLSv1.0 and TLSv1.1) are disabled.
         if (Flavors.FLAVOR == Flavors.FREE) {
+            // The Free flavor bundles a modern conscrypt (security provider), so CustomSslSocketFactory
+            // is only used to make sure that modern protocols (TLSv1.3 and TLSv1.2) are enabled and
+            // that old, deprecated, protocols (like SSLv3, TLSv1.0 and TLSv1.1) are disabled.
             builder.sslSocketFactory(new CustomSslSocketFactory(), trustManager());
-        }
-        // The Play flavor can not be assumed to have a modern security provider, so for Android
-        // older than 5.0 CustomSslSocketFactory is used to enable all possible protocols (modern
-        // and deprecated). And we explicitly enable deprecated cipher suites disabled by default.
-        else if (Build.VERSION.SDK_INT < 21) {
+        } else if (Build.VERSION.SDK_INT < 21) {
+            // The Play flavor can not be assumed to have a modern security provider, so for Android
+            // older than 5.0 CustomSslSocketFactory is used to enable all possible protocols (modern
+            // and deprecated). And we explicitly enable deprecated cipher suites disabled by default.
             builder.sslSocketFactory(new CustomSslSocketFactory(), trustManager());
 
             // workaround for Android 4.x for certain web sites.
@@ -225,12 +224,11 @@ public class AntennapodHttpClient {
             try {
                 SSLContext sslContext;
 
-                // Free flavor (bundles modern conscrypt): support for TLSv1.3 is guaranteed.
                 if (Flavors.FLAVOR == Flavors.FREE) {
+                    // Free flavor (bundles modern conscrypt): support for TLSv1.3 is guaranteed.
                     sslContext = SSLContext.getInstance("TLSv1.3");
-                }
-                // Play flavor (security provider can vary): only TLSv1.2 is guaranteed.
-                else {
+                } else {
+                    // Play flavor (security provider can vary): only TLSv1.2 is guaranteed.
                     sslContext = SSLContext.getInstance("TLSv1.2");
                 }
 
@@ -288,15 +286,14 @@ public class AntennapodHttpClient {
         }
 
         private void configureSocket(SSLSocket s) {
-            // Free flavor (bundles modern conscrypt): TLSv1.3 and modern cipher suites are
-            // guaranteed. Protocols older than TLSv1.2 are now deprecated and can be disabled.
             if (Flavors.FLAVOR == Flavors.FREE) {
-                s.setEnabledProtocols(new String[] { "TLSv1.3", "TLSv1.2" } );
-            }
-            // Play flavor (security provider can vary): only TLSv1.2 is guaranteed, supported
-            // cipher suites may vary. Old protocols might be necessary to keep things working.
-            else {
-                s.setEnabledProtocols(new String[] { "TLSv1.2", "TLSv1.1", "TLSv1" } );
+                // Free flavor (bundles modern conscrypt): TLSv1.3 and modern cipher suites are
+                // guaranteed. Protocols older than TLSv1.2 are now deprecated and can be disabled.
+                s.setEnabledProtocols(new String[] { "TLSv1.3", "TLSv1.2" });
+            } else {
+                // Play flavor (security provider can vary): only TLSv1.2 is guaranteed, supported
+                // cipher suites may vary. Old protocols might be necessary to keep things working.
+                s.setEnabledProtocols(new String[] { "TLSv1.2", "TLSv1.1", "TLSv1" });
             }
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
@@ -34,6 +34,7 @@ import javax.net.ssl.X509TrustManager;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.UserAgentInterceptor;
 import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.Flavors;
 import okhttp3.Cache;
 import okhttp3.CipherSuite;
 import okhttp3.ConnectionSpec;
@@ -149,7 +150,17 @@ public class AntennapodHttpClient {
                 });
             }
         }
-        if (Build.VERSION.SDK_INT < 21) {
+
+        // The Free flavor bundles a modern conscrypt (security provider), so CustomSslSocketFactory
+        // is only used to make sure that modern protocols (TLSv1.3 and TLSv1.2) are enabled and
+        // that old, deprecated, protocols (like SSLv3, TLSv1.0 and TLSv1.1) are disabled.
+        if (Flavors.FLAVOR == Flavors.FREE) {
+            builder.sslSocketFactory(new CustomSslSocketFactory(), trustManager());
+        }
+        // The Play flavor can not be assumed to have a modern security provider, so for Android
+        // older than 5.0 CustomSslSocketFactory is used to enable all possible protocols (modern
+        // and deprecated). And we explicitly enable deprecated cipher suites disabled by default.
+        else if (Build.VERSION.SDK_INT < 21) {
             builder.sslSocketFactory(new CustomSslSocketFactory(), trustManager());
 
             // workaround for Android 4.x for certain web sites.
@@ -178,6 +189,9 @@ public class AntennapodHttpClient {
         }
     }
 
+    /**
+     * Reimplements default trust manager (required for calling sslSocketFactory).
+     */
     private static X509TrustManager trustManager() {
         try {
             TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
@@ -199,13 +213,27 @@ public class AntennapodHttpClient {
         AntennapodHttpClient.cacheDirectory = cacheDirectory;
     }
 
+    /**
+     * Used to disable deprecated protocols and explicitly enable TLSv1.3 and TLSv1.2, or to enable
+     * all protocols (including deprecated) up to TLSv1.2, depending on build flavor (Free or Play).
+     */
     private static class CustomSslSocketFactory extends SSLSocketFactory {
 
         private SSLSocketFactory factory;
 
         public CustomSslSocketFactory() {
             try {
-                SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+                SSLContext sslContext;
+
+                // Free flavor (bundles modern conscrypt): support for TLSv1.3 is guaranteed.
+                if (Flavors.FLAVOR == Flavors.FREE) {
+                    sslContext = SSLContext.getInstance("TLSv1.3");
+                }
+                // Play flavor (security provider can vary): only TLSv1.2 is guaranteed.
+                else {
+                    sslContext = SSLContext.getInstance("TLSv1.2");
+                }
+
                 sslContext.init(null, null, null);
                 factory= sslContext.getSocketFactory();
             } catch(GeneralSecurityException e) {
@@ -260,7 +288,16 @@ public class AntennapodHttpClient {
         }
 
         private void configureSocket(SSLSocket s) {
-            s.setEnabledProtocols(new String[] { "TLSv1.2", "TLSv1.1", "TLSv1" } );
+            // Free flavor (bundles modern conscrypt): TLSv1.3 and modern cipher suites are
+            // guaranteed. Protocols older than TLSv1.2 are now deprecated and can be disabled.
+            if (Flavors.FLAVOR == Flavors.FREE) {
+                s.setEnabledProtocols(new String[] { "TLSv1.3", "TLSv1.2" } );
+            }
+            // Play flavor (security provider can vary): only TLSv1.2 is guaranteed, supported
+            // cipher suites may vary. Old protocols might be necessary to keep things working.
+            else {
+                s.setEnabledProtocols(new String[] { "TLSv1.2", "TLSv1.1", "TLSv1" } );
+            }
         }
 
     }


### PR DESCRIPTION
For instance, this solves #2814 for people not using Google services. It also solved other protocol errors I was starting to get on an old device (running android 4.4.4, without Google services installed). I have tested these changes on both 1.8.1 and the current develop branch without any problems (in fact, some episodes seem to download faster but that's probably just placebo). I hope this is acceptable to be included officially in AntennaPod.

This does not change the Play builds (it's primarily meant for the F-Droid releases). On Play builds Conscrypt does not get bundled and they get no changes to what protocols and cipher suites are enabled. But I'm almost tempted to suggest dropping the dependency on the Google GMS Provider Installer... By knowing that a modern security provider is always available it's safe to enable TLSv1.3 even on older versions of Android and no need to enable obsolete protocols (like SSLv3) and cipher suites (like TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA).

I already hardened the security for the Free builds by explicitly enable (and only enable) TLSv1.3 and TLSv1.2 (using the CustomSslSocketFactory, on all versions of Android), and by not enable the two obsolete cipher suites that gets enabled for API<21.

A few things to keep in mind:

- Free builds will increase in size (currently by around 3-4MB)
- The Conscrypt version specified by conscryptVersion in build.gradle should be updated when new versions are released. But I doubt there will be any serious security issues, especially compared to the often very old providers it will replace on most phones.
- Or just set conscryptVersion to "latest.release"? It's an easy solution but messes up reproducible builds and might result in unexpected updates to Conscrypt without anyone noticing and testing before release.
- Building "assembleRelease" or "assembleDebug" will result in errors (since it compiles both "free" and "play" files). So "assemblePlayRelease" or "assemblePlayDebug" should be used instead. The makeRelease.sh script already follows this convention. Updating the [wiki](https://github.com/AntennaPod/AntennaPod/wiki/Building-AntennaPod) might be a good idea.
- It's also now absolutely necessary to pass -PfreeBuild when doing assembleFreeRelease and assembleFreeDebug (again, the wiki will probably need some updating, although Free builds are currently not even mentioned there).
- The above two points are mentioned in a comment in the top of core/src/free/java/de/danoeh/antennapod/core/ClientConfig.java, because that's where errors will appear if the two points are not followed. Maybe you want to remove it. Or maybe not.