### PR TITLE
Use locale's digits in more places

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MediaplayerActivity.java
@@ -62,6 +62,8 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.text.NumberFormat;
+
 
 /**
  * Provides general features which are both needed for playing audio and video
@@ -555,13 +557,13 @@ public abstract class MediaplayerActivity extends CastEnabledActivity implements
         butRev = findViewById(R.id.butRev);
         txtvRev = findViewById(R.id.txtvRev);
         if (txtvRev != null) {
-            txtvRev.setText(String.valueOf(UserPreferences.getRewindSecs()));
+            txtvRev.setText(NumberFormat.getInstance().format(UserPreferences.getRewindSecs()));
         }
         butPlay = findViewById(R.id.butPlay);
         butFF = findViewById(R.id.butFF);
         txtvFF = findViewById(R.id.txtvFF);
         if (txtvFF != null) {
-            txtvFF.setText(String.valueOf(UserPreferences.getFastForwardSecs()));
+            txtvFF.setText(NumberFormat.getInstance().format(UserPreferences.getFastForwardSecs()));
         }
         butSkip = findViewById(R.id.butSkip);
 

--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -33,11 +33,11 @@ import de.danoeh.antennapod.fragment.SubscriptionFragment;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.lang.ref.WeakReference;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * BaseAdapter for the navigation drawer
@@ -247,19 +247,19 @@ public class NavListAdapter extends BaseAdapter
         if (tag.equals(QueueFragment.TAG)) {
             int queueSize = itemAccess.getQueueSize();
             if (queueSize > 0) {
-                holder.count.setText(String.format(Locale.getDefault(), "%d", queueSize));
+                holder.count.setText(NumberFormat.getInstance().format(queueSize));
                 holder.count.setVisibility(View.VISIBLE);
             }
         } else if (tag.equals(EpisodesFragment.TAG)) {
             int unreadItems = itemAccess.getNumberOfNewItems();
             if (unreadItems > 0) {
-                holder.count.setText(String.format(Locale.getDefault(), "%d", unreadItems));
+                holder.count.setText(NumberFormat.getInstance().format(unreadItems));
                 holder.count.setVisibility(View.VISIBLE);
             }
         } else if (tag.equals(SubscriptionFragment.TAG)) {
             int sum = itemAccess.getFeedCounterSum();
             if (sum > 0) {
-                holder.count.setText(String.format(Locale.getDefault(), "%d", sum));
+                holder.count.setText(NumberFormat.getInstance().format(sum));
                 holder.count.setVisibility(View.VISIBLE);
             }
         } else if(tag.equals(DownloadsFragment.TAG) && UserPreferences.isEnableAutodownload()) {
@@ -352,7 +352,7 @@ public class NavListAdapter extends BaseAdapter
         int counter = itemAccess.getFeedCounter(feed.getId());
         if(counter > 0) {
             holder.count.setVisibility(View.VISIBLE);
-            holder.count.setText(String.format(Locale.getDefault(), "%d", counter));
+            holder.count.setText(NumberFormat.getInstance().format(counter));
         } else {
             holder.count.setVisibility(View.GONE);
         }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsAdapter.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 
 import java.lang.ref.WeakReference;
+import java.text.NumberFormat;
 import java.util.Locale;
 
 import de.danoeh.antennapod.R;
@@ -99,8 +100,8 @@ public class SubscriptionsAdapter extends BaseAdapter implements AdapterView.OnI
 
         int count = itemAccess.getFeedCounter(feed.getId());
         if(count > 0) {
-            holder.count.setPrimaryText(String.format(Locale.getDefault(), "%d",
-                    itemAccess.getFeedCounter(feed.getId())));
+            holder.count.setPrimaryText(
+                    NumberFormat.getInstance().format(itemAccess.getFeedCounter(feed.getId())));
             holder.count.setVisibility(View.VISIBLE);
         } else {
             holder.count.setVisibility(View.GONE);

--- a/app/src/main/java/de/danoeh/antennapod/dialog/SkipPreferenceDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SkipPreferenceDialog.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 
+import java.text.NumberFormat;
 import java.util.Locale;
 
 import de.danoeh.antennapod.R;
@@ -29,7 +30,8 @@ public class SkipPreferenceDialog {
             if (skipSecs == values[i]) {
                 checked = i;
             }
-            choices[i] = values[i] + " " + context.getString(R.string.time_seconds);
+            choices[i] = String.format(Locale.getDefault(),
+                    "%d %s", values[i], context.getString(R.string.time_seconds));
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
@@ -48,7 +50,7 @@ public class SkipPreferenceDialog {
                     UserPreferences.setRewindSecs(seconds);
                 }
                 if (textView != null) {
-                    textView.setText(String.format(Locale.getDefault(), "%d", seconds));
+                    textView.setText(NumberFormat.getInstance().format(seconds));
                 }
             }
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -29,6 +29,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.CastEnabledActivity;
@@ -124,8 +125,8 @@ public class AudioPlayerFragment extends Fragment implements
         setupLengthTextView();
         setupControlButtons();
         setupPlaybackSpeedButton();
-        txtvRev.setText(String.valueOf(UserPreferences.getRewindSecs()));
-        txtvFF.setText(String.valueOf(UserPreferences.getFastForwardSecs()));
+        txtvRev.setText(NumberFormat.getInstance().format(UserPreferences.getRewindSecs()));
+        txtvFF.setText(NumberFormat.getInstance().format(UserPreferences.getFastForwardSecs()));
         sbPosition.setOnSeekBarChangeListener(this);
 
         pager = root.findViewById(R.id.pager);


### PR DESCRIPTION
Turns 
![image](https://user-images.githubusercontent.com/833473/80814044-6912db00-8be0-11ea-8867-e071dc615a09.png)

to 

![image](https://user-images.githubusercontent.com/833473/80813957-408ae100-8be0-11ea-86ce-dd07662db579.png)

How to reproduce? Use Persian فارسی as your phone's language.
 
Note the used digits. Am carefully fixing places should use locale's digits, and found out there is `NumberFormat.getInstance().format` which should be used for number that has sole visual purpose so normalized `String.format(Locale.getDefault(), "%d",` with this that should be a bit lighter also.