### PR TITLE
Make subscriptions view more consistent when showing non-square images

### DIFF
--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -42,7 +42,7 @@
             android:layout_marginRight="@dimen/listitem_threeline_textleftpadding"
             android:layout_marginEnd="@dimen/listitem_threeline_textleftpadding"
             android:id="@+id/coverHolder"
-            app:cardBackgroundColor="#33777777"
+            app:cardBackgroundColor="@color/non_square_icon_background"
             app:cardCornerRadius="4dp"
             app:cardElevation="0dp">
 

--- a/app/src/main/res/layout/subscription_item.xml
+++ b/app/src/main/res/layout/subscription_item.xml
@@ -5,13 +5,15 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:foreground="?attr/selectableItemBackground">
 
     <de.danoeh.antennapod.view.SquareImageView
         android:id="@+id/imgvCover"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:scaleType="fitCenter"
+        android:background="@color/non_square_icon_background"
         tools:src="@mipmap/ic_launcher_round"
         squareImageView:direction="width"/>
 

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="highlight_light">#DDDDDD</color>
     <color name="highlight_dark">#414141</color>
     <color name="highlight_trueblack">#414141</color>
+    <color name="non_square_icon_background">#22777777</color>
 
     <color name="accent_light">#0078C2</color>
     <color name="accent_dark">#5C9DFF</color>


### PR DESCRIPTION
If you have many non-square images, they look somehow unaligned. This change adds clear boundaries.

Before / After:

<img width="250" src="https://user-images.githubusercontent.com/5811634/81012871-94086380-8e5a-11ea-9ff3-6da25e1b6340.png" /> <img width="250" src="https://user-images.githubusercontent.com/5811634/81012866-923ea000-8e5a-11ea-972a-9a335d22723c.png" />
