### PR TITLE
Reduced probability for closing player accidentally

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemDescriptionFragment.java
@@ -47,6 +47,17 @@ public class ItemDescriptionFragment extends Fragment {
             // Restoring the scroll position might not always work
             webvDescription.postDelayed(ItemDescriptionFragment.this::restoreFromPreference, 50);
         });
+
+        root.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View v, int left, int top, int right,
+                    int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                if (root.getMeasuredHeight() != webvDescription.getMinimumHeight()) {
+                    webvDescription.setMinimumHeight(root.getMeasuredHeight());
+                }
+                root.removeOnLayoutChangeListener(this);
+            }
+        });
         registerForContextMenu(webvDescription);
         return root;
     }

--- a/app/src/main/java/de/danoeh/antennapod/view/ShownotesWebView.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/ShownotesWebView.java
@@ -165,4 +165,11 @@ public class ShownotesWebView extends WebView implements View.OnLongClickListene
     public void setPageFinishedListener(Runnable pageFinishedListener) {
         this.pageFinishedListener = pageFinishedListener;
     }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        setMeasuredDimension(Math.max(getMeasuredWidth(), getMinimumWidth()),
+                Math.max(getMeasuredHeight(), getMinimumHeight()));
+    }
 }


### PR DESCRIPTION
If the description is really short, the WebView shrinks. When touching
below the WebView, one needs to slide pretty precisely to swipe horizontally.
If there is a little bit of slope, the player closes (completely, without following
the finger). This change resizes the WebView, so that one can not touch below it.

![](https://user-images.githubusercontent.com/5811634/81018554-0b42f500-8e65-11ea-9beb-884aa36ef76c.gif)
