### PR TITLE
Offer to switch to ExoPlayer on media player error

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -24,6 +24,7 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
+import com.google.android.material.snackbar.Snackbar;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -302,13 +303,15 @@ public class AudioPlayerFragment extends Fragment implements
                 final AlertDialog.Builder errorDialog = new AlertDialog.Builder(getContext());
                 errorDialog.setTitle(R.string.error_label);
                 errorDialog.setMessage(MediaPlayerError.getErrorString(getContext(), code));
-                errorDialog.setNeutralButton(android.R.string.ok,
-                        (dialog, which) -> {
-                            dialog.dismiss();
-                            ((MainActivity) getActivity()).getBottomSheet()
-                                    .setState(BottomSheetBehavior.STATE_COLLAPSED);
-                        }
-                );
+                errorDialog.setPositiveButton(android.R.string.ok, (dialog, which) ->
+                        ((MainActivity) getActivity()).getBottomSheet().setState(BottomSheetBehavior.STATE_COLLAPSED));
+                if (!UserPreferences.useExoplayer()) {
+                    errorDialog.setNeutralButton(R.string.media_player_switch_to_exoplayer, (dialog, which) -> {
+                        UserPreferences.enableExoplayer();
+                        ((MainActivity) getActivity()).showSnackbarAbovePlayer(
+                                R.string.media_player_switched_to_exoplayer, Snackbar.LENGTH_LONG);
+                    });
+                }
                 errorDialog.create().show();
             }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -809,6 +809,10 @@ public class UserPreferences {
         prefs.edit().putString(PREF_MEDIA_PLAYER, "sonic").apply();
     }
 
+    public static void enableExoplayer() {
+        prefs.edit().putString(PREF_MEDIA_PLAYER, PREF_MEDIA_PLAYER_EXOPLAYER).apply();
+    }
+
     public static boolean stereoToMono() {
         return prefs.getBoolean(PREF_STEREO_TO_MONO, false);
     }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -504,6 +504,8 @@
     <string name="media_player_builtin">Built-in Android player</string>
     <string name="media_player_sonic" translatable="false">Sonic Media Player</string>
     <string name="media_player_exoplayer" translatable="false">ExoPlayer</string>
+    <string name="media_player_switch_to_exoplayer">Switch to ExoPlayer</string>
+    <string name="media_player_switched_to_exoplayer">Switched to ExoPlayer.</string>
     <string name="pref_skip_silence_title">Skip Silence in Audio</string>
     <string name="pref_videoBehavior_title">Upon exiting video</string>
     <string name="pref_videoBehavior_sum">Behavior when leaving video playback</string>


### PR DESCRIPTION
I just tried to play an opus file and received errors. Wondered what is wrong until I read in the stack trace that I had selected Sonic, which can not play opus files. Error dialog now shows a button that allows to switch to ExoPlayer.