### PR TITLE
Switch theme without user obstruction

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -76,6 +76,7 @@ public class MainActivity extends CastEnabledActivity {
     private LockableBottomSheetBehavior sheetBehavior;
     private long lastBackButtonPressTime = 0;
     private RecyclerView.RecycledViewPool recycledViewPool = new RecyclerView.RecycledViewPool();
+    private int lastTheme = 0;
 
     @NonNull
     public static Intent getIntentToOpenFeed(@NonNull Context context, long feedId) {
@@ -87,7 +88,8 @@ public class MainActivity extends CastEnabledActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        setTheme(UserPreferences.getNoTitleTheme());
+        lastTheme = UserPreferences.getNoTitleTheme();
+        setTheme(lastTheme);
         super.onCreate(savedInstanceState);
         StorageUtils.checkStorageAvailability(this);
         setContentView(R.layout.main);
@@ -323,11 +325,12 @@ public class MainActivity extends CastEnabledActivity {
         super.onStart();
         EventBus.getDefault().register(this);
         RatingDialog.init(this);
-    }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
+        if (lastTheme != UserPreferences.getNoTitleTheme()) {
+            // Nav drawer is empty for half a second after recreating. Don't confuse users with that.
+            drawerLayout.closeDrawer(navDrawer);
+            recreate();
+        }
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -28,6 +28,8 @@ import de.danoeh.antennapod.fragment.preferences.UserInterfacePreferencesFragmen
  * PreferenceController.
  */
 public class PreferenceActivity extends AppCompatActivity implements SearchPreferenceResultListener {
+    private static final String FRAGMENT_TAG = "tag_preferences";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         setTheme(UserPreferences.getTheme());
@@ -44,8 +46,11 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
                 ViewGroup.LayoutParams.MATCH_PARENT));
         setContentView(root);
 
-        getSupportFragmentManager().beginTransaction().replace(R.id.content, new MainPreferencesFragment()).commit();
-
+        if (getSupportFragmentManager().findFragmentByTag(FRAGMENT_TAG) == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.content, new MainPreferencesFragment(), FRAGMENT_TAG)
+                    .commit();
+        }
     }
 
     private PreferenceFragmentCompat getPreferenceScreen(int screen) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/UserInterfacePreferencesFragment.java
@@ -35,11 +35,7 @@ public class UserInterfacePreferencesFragment extends PreferenceFragmentCompat {
         findPreference(UserPreferences.PREF_THEME)
                 .setOnPreferenceChangeListener(
                         (preference, newValue) -> {
-                            Intent i = new Intent(getActivity(), MainActivity.class);
-                            i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK
-                                    | Intent.FLAG_ACTIVITY_NEW_TASK);
-                            getActivity().finish();
-                            startActivity(i);
+                            getActivity().recreate();
                             return true;
                         }
                 );


### PR DESCRIPTION
Users might want to try all themes to see how they look. Having to re-open the settings screen every time is cumbersome.