### PR TITLE
Local feeds

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
@@ -422,6 +422,41 @@ public class DBWriterTest {
         adapter.close();
     }
 
+    @Test
+    public void testDeleteFeedItems() throws Exception {
+        Feed feed = new Feed("url", null, "title");
+        feed.setItems(new ArrayList<>());
+        feed.setImageUrl("url");
+
+        // create items
+        for (int i = 0; i < 10; i++) {
+            FeedItem item = new FeedItem(0, "Item " + i, "Item" + i, "url", new Date(), FeedItem.PLAYED, feed);
+            feed.getItems().add(item);
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.close();
+
+        List<FeedItem> itemsToDelete = feed.getItems().subList(0, 2);
+        DBWriter.deleteFeedItems(getInstrumentation().getTargetContext(), itemsToDelete).get(TIMEOUT, TimeUnit.SECONDS);
+
+        adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        for (int i = 0; i < feed.getItems().size(); i++) {
+            FeedItem feedItem = feed.getItems().get(i);
+            Cursor c = adapter.getFeedItemCursor(String.valueOf(feedItem.getId()));
+            if (i < 2) {
+                assertEquals(0, c.getCount());
+            } else {
+                assertEquals(1, c.getCount());
+            }
+            c.close();
+        }
+        adapter.close();
+    }
+
     private FeedMedia playbackHistorySetup(Date playbackCompletionDate) {
         Feed feed = new Feed("url", null, "title");
         feed.setItems(new ArrayList<>());

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DownloadActionButton.java
@@ -40,8 +40,7 @@ public class DownloadActionButton extends ItemActionButton {
 
     @Override
     public int getVisibility() {
-        return (item.getMedia() != null && DownloadRequester.getInstance().isDownloadingFile(item.getMedia()))
-                ? View.INVISIBLE : View.VISIBLE;
+        return item.getFeed().isLocalFeed() ? View.INVISIBLE : View.VISIBLE;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/ItemActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/ItemActionButton.java
@@ -42,6 +42,8 @@ public abstract class ItemActionButton {
         final boolean isDownloadingMedia = DownloadRequester.getInstance().isDownloadingFile(media);
         if (media.isCurrentlyPlaying()) {
             return new PauseActionButton(item);
+        } else if (item.getFeed().isLocalFeed()) {
+            return new PlayLocalActionButton(item);
         } else if (media.isDownloaded()) {
             return new PlayActionButton(item);
         } else if (isDownloadingMedia) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/PlayLocalActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/PlayLocalActionButton.java
@@ -1,0 +1,51 @@
+package de.danoeh.antennapod.adapter.actionbutton;
+
+import android.content.Context;
+import androidx.annotation.AttrRes;
+import androidx.annotation.StringRes;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.MediaType;
+import de.danoeh.antennapod.core.preferences.UsageStatistics;
+import de.danoeh.antennapod.core.service.playback.PlaybackService;
+import de.danoeh.antennapod.core.util.NetworkUtils;
+import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
+import de.danoeh.antennapod.dialog.StreamingConfirmationDialog;
+
+public class PlayLocalActionButton extends ItemActionButton {
+
+    public PlayLocalActionButton(FeedItem item) {
+        super(item);
+    }
+
+    @Override
+    @StringRes
+    public int getLabel() {
+        return R.string.play_label;
+    }
+
+    @Override
+    @AttrRes
+    public int getDrawable() {
+        return R.attr.av_play;
+    }
+
+    @Override
+    public void onClick(Context context) {
+        final FeedMedia media = item.getMedia();
+        if (media == null) {
+            return;
+        }
+
+        new PlaybackServiceStarter(context, media)
+                .callEvenIfRunning(true)
+                .startWhenPrepared(true)
+                .shouldStream(true)
+                .start();
+
+        if (media.getMediaType() == MediaType.VIDEO) {
+            context.startActivity(PlaybackService.getPlayerActivityIntent(context, media));
+        }
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -51,7 +51,7 @@ public class EpisodesApplyActionFragment extends Fragment {
     private static final int ACTION_MARK_UNPLAYED = 8;
     public static final int ACTION_DOWNLOAD = 16;
     public static final int ACTION_DELETE = 32;
-    private static final int ACTION_ALL = ACTION_ADD_TO_QUEUE | ACTION_REMOVE_FROM_QUEUE
+    public static final int ACTION_ALL = ACTION_ADD_TO_QUEUE | ACTION_REMOVE_FROM_QUEUE
             | ACTION_MARK_PLAYED | ACTION_MARK_UNPLAYED | ACTION_DOWNLOAD | ACTION_DELETE;
     private Toolbar toolbar;
 
@@ -101,10 +101,6 @@ public class EpisodesApplyActionFragment extends Fragment {
                 new ActionBinding(ACTION_DELETE,
                         R.id.delete_batch, this::deleteChecked)
                 );
-    }
-
-    public static EpisodesApplyActionFragment newInstance(List<FeedItem> items) {
-        return newInstance(items, ACTION_ALL);
     }
 
     public static EpisodesApplyActionFragment newInstance(List<FeedItem> items, int actions) {
@@ -449,7 +445,7 @@ public class EpisodesApplyActionFragment extends Fragment {
         // download the check episodes in the same order as they are currently displayed
         List<FeedItem> toDownload = new ArrayList<>(checkedIds.size());
         for (FeedItem episode : episodes) {
-            if (checkedIds.contains(episode.getId()) && episode.hasMedia()) {
+            if (checkedIds.contains(episode.getId()) && episode.hasMedia() && !episode.getFeed().isLocalFeed()) {
                 toDownload.add(episode);
             }
         }
@@ -473,10 +469,8 @@ public class EpisodesApplyActionFragment extends Fragment {
     }
 
     private void close(@PluralsRes int msgId, int numItems) {
-        if (numItems > 0) {
-            ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                    getResources().getQuantityString(msgId, numItems, numItems), Snackbar.LENGTH_LONG);
-        }
+        ((MainActivity) getActivity()).showSnackbarAbovePlayer(
+                getResources().getQuantityString(msgId, numItems, numItems), Snackbar.LENGTH_LONG);
         getActivity().getSupportFragmentManager().popBackStack();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
@@ -23,6 +23,7 @@ import de.danoeh.antennapod.activity.OnlineFeedViewActivity;
 import de.danoeh.antennapod.activity.OpmlImportActivity;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.util.SortOrder;
 import de.danoeh.antennapod.discovery.CombinedSearcher;
 import de.danoeh.antennapod.discovery.FyydPodcastSearcher;
 import de.danoeh.antennapod.discovery.ItunesPodcastSearcher;
@@ -153,6 +154,7 @@ public class AddFeedFragment extends Fragment {
                 Feed dirFeed = new Feed(Feed.PREFIX_LOCAL_FOLDER + uri.toString(), null, documentFile.getName());
                 dirFeed.setDescription(getString(R.string.local_feed_description));
                 dirFeed.setItems(Collections.emptyList());
+                dirFeed.setSortOrder(SortOrder.EPISODE_TITLE_A_Z);
                 DBTasks.forceRefreshFeed(getContext(), dirFeed, true);
                 ((MainActivity) getActivity())
                         .showSnackbarAbovePlayer(R.string.add_local_folder_success, Snackbar.LENGTH_SHORT);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
@@ -128,7 +128,7 @@ public class ChaptersFragment extends Fragment {
         disposable = Maybe.create(emitter -> {
             Playable media = controller.getMedia();
             if (media != null) {
-                media.loadChapterMarks();
+                media.loadChapterMarks(getContext());
                 emitter.onSuccess(media);
             } else {
                 emitter.onComplete();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -257,8 +257,14 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                 if (!FeedMenuHandler.onOptionsItemClicked(getActivity(), item, feed)) {
                     switch (item.getItemId()) {
                         case R.id.episode_actions:
+                            int actions = EpisodesApplyActionFragment.ACTION_ALL;
+                            if (feed.isLocalFeed()) {
+                                // turn off download and delete actions for local feed
+                                actions ^= EpisodesApplyActionFragment.ACTION_DOWNLOAD;
+                                actions ^= EpisodesApplyActionFragment.ACTION_DELETE;
+                            }
                             EpisodesApplyActionFragment fragment = EpisodesApplyActionFragment
-                                    .newInstance(feed.getItems());
+                                    .newInstance(feed.getItems(), actions);
                             ((MainActivity)getActivity()).loadChildFragment(fragment);
                             return true;
                         case R.id.rename_item:

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -39,6 +39,7 @@ import de.danoeh.antennapod.adapter.actionbutton.ItemActionButton;
 import de.danoeh.antennapod.adapter.actionbutton.MarkAsPlayedActionButton;
 import de.danoeh.antennapod.adapter.actionbutton.PauseActionButton;
 import de.danoeh.antennapod.adapter.actionbutton.PlayActionButton;
+import de.danoeh.antennapod.adapter.actionbutton.PlayLocalActionButton;
 import de.danoeh.antennapod.adapter.actionbutton.StreamActionButton;
 import de.danoeh.antennapod.adapter.actionbutton.VisitWebsiteActionButton;
 import de.danoeh.antennapod.core.event.DownloadEvent;
@@ -328,6 +329,8 @@ public class ItemFragment extends Fragment {
             }
             if (media.isCurrentlyPlaying()) {
                 actionButton1 = new PauseActionButton(item);
+            } else if (item.getFeed().isLocalFeed()) {
+                actionButton1 = new PlayLocalActionButton(item);
             } else if (media.isDownloaded()) {
                 actionButton1 = new PlayActionButton(item);
             } else {

--- a/app/src/main/res/layout/addfeed.xml
+++ b/app/src/main/res/layout/addfeed.xml
@@ -101,6 +101,20 @@
                     android:text="@string/add_podcast_by_url"/>
 
             <TextView
+                    android:id="@+id/btn_add_local_folder"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:drawablePadding="8dp"
+                    app:drawableStartCompat="?attr/ic_folder"
+                    app:drawableLeftCompat="?attr/ic_folder"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:clickable="true"
+                    android:text="@string/add_local_folder"/>
+
+            <TextView
                     android:id="@+id/btn_search_itunes"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,6 +57,7 @@ android {
 dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation "androidx.media:media:$mediaVersion"
     implementation "androidx.preference:preference:$preferenceVersion"
     implementation "androidx.work:work-runtime:$workManagerVersion"

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/Feed.java
@@ -24,6 +24,7 @@ public class Feed extends FeedFile implements ImageResource {
     public static final int FEEDFILETYPE_FEED = 0;
     public static final String TYPE_RSS2 = "rss";
     public static final String TYPE_ATOM1 = "atom";
+    public static final String PREFIX_LOCAL_FOLDER = "antennapod_local:";
 
     /* title as defined by the feed */
     private String feedTitle;
@@ -551,4 +552,7 @@ public class Feed extends FeedFile implements ImageResource {
         this.lastUpdateFailed = lastUpdateFailed;
     }
 
+    public boolean isLocalFeed() {
+        return download_url.startsWith(PREFIX_LOCAL_FOLDER);
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -375,7 +375,7 @@ public class FeedMedia extends FeedFile implements Playable {
     }
 
     @Override
-    public void loadChapterMarks() {
+    public void loadChapterMarks(Context context) {
         if (item == null && itemID != 0) {
             item = DBReader.getFeedItem(itemID);
         }
@@ -386,10 +386,10 @@ public class FeedMedia extends FeedFile implements Playable {
         if (item.hasChapters()) {
             DBReader.loadChaptersOfFeedItem(item);
         } else {
-            if(localFileAvailable()) {
+            if (localFileAvailable()) {
                 ChapterUtils.loadChaptersFromFileUrl(this);
             } else {
-                ChapterUtils.loadChaptersFromStreamUrl(this);
+                ChapterUtils.loadChaptersFromStreamUrl(this, context);
             }
             if (item.getChapters() != null) {
                 DBWriter.setFeedItem(item);

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -89,7 +89,7 @@ public class LocalFeedUpdater {
         long duration = getFileDuration(file, context);
         long size = file.length();
         FeedMedia media = new FeedMedia(0, item, (int) duration, 0, size, file.getType(),
-                file.getUri().toString(), file.getUri().toString(), true, null, 0, 0);
+                file.getUri().toString(), file.getUri().toString(), false, null, 0, 0);
         item.setMedia(media);
 
         return item;

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -1,0 +1,111 @@
+package de.danoeh.antennapod.core.feed;
+
+import android.content.Context;
+import android.media.MediaMetadataRetriever;
+import android.net.Uri;
+import android.util.Log;
+import androidx.documentfile.provider.DocumentFile;
+import de.danoeh.antennapod.core.service.download.DownloadStatus;
+import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.storage.DBWriter;
+import de.danoeh.antennapod.core.util.DownloadError;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class LocalFeedUpdater {
+
+    public static void updateFeed(Feed feed, Context context) {
+        String uriString = feed.getDownload_url().replace(Feed.PREFIX_LOCAL_FOLDER, "");
+        DocumentFile documentFolder = DocumentFile.fromTreeUri(context, Uri.parse(uriString));
+        if (documentFolder == null) {
+            reportError(feed, "Unable to retrieve document tree");
+            return;
+        }
+        if (!documentFolder.exists() || !documentFolder.canRead()) {
+            reportError(feed, "Cannot read local directory");
+            return;
+        }
+
+        if (feed.getItems() == null) {
+            feed.setItems(new ArrayList<>());
+        }
+        //make sure it is the latest 'version' of this feed from the db (all items etc)
+        feed = DBTasks.updateFeed(context, feed)[0];
+
+        List<DocumentFile> mediaFiles = new ArrayList<>();
+        for (DocumentFile file : documentFolder.listFiles()) {
+            String mime = file.getType();
+            if (mime != null && (mime.startsWith("audio/") || mime.startsWith("video/"))) {
+                mediaFiles.add(file);
+            }
+        }
+
+        List<FeedItem> newItems = feed.getItems();
+        for (DocumentFile f : mediaFiles) {
+            FeedItem found = feedContainsFile(feed, f.getName());
+            if (found != null) {
+                //TODO make sure the media has not changed (type, duration)
+            } else {
+                FeedItem item = createFeedItem(feed, f, context);
+                newItems.add(item);
+            }
+        }
+
+        List<String> iconLocations = Arrays.asList("folder.jpg", "Folder.jpg", "folder.png", "Folder.png");
+        for (String iconLocation : iconLocations) {
+            DocumentFile image = documentFolder.findFile(iconLocation);
+            if (image != null) {
+                feed.setImageUrl(image.getUri().toString());
+                break;
+            }
+        }
+
+        DBTasks.updateFeed(context, feed);
+    }
+
+    private static FeedItem feedContainsFile(Feed feed, String filename) {
+        List<FeedItem> items = feed.getItems();
+        for (FeedItem i : items) {
+            if (i.getMedia() != null && i.getLink().equals(filename)) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    private static FeedItem createFeedItem(Feed feed, DocumentFile file, Context context) {
+        //create item
+        long globalId = 0;
+        Date date = new Date();
+        String uuid = UUID.randomUUID().toString();
+        FeedItem item = new FeedItem(globalId, file.getName(), uuid, file.getName(), date, FeedItem.UNPLAYED, feed);
+        item.setAutoDownload(false);
+
+        //add the media to the item
+        long duration = getFileDuration(file, context);
+        long size = file.length();
+        FeedMedia media = new FeedMedia(0, item, (int) duration, 0, size, file.getType(),
+                file.getUri().toString(), file.getUri().toString(), true, null, 0, 0);
+        item.setMedia(media);
+
+        return item;
+    }
+
+    private static void reportError(Feed feed, String reasonDetailed) {
+        DownloadStatus status = new DownloadStatus(feed, feed.getTitle(),
+                DownloadError.ERROR_IO_ERROR, false, reasonDetailed, true);
+        DBWriter.addDownloadStatus(status);
+        DBWriter.setFeedLastUpdateFailed(feed.getId(), true);
+    }
+
+    private static long getFileDuration(DocumentFile f, Context context) {
+        MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
+        mediaMetadataRetriever.setDataSource(context, f.getUri());
+        String durationStr = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+        return Long.parseLong(durationStr);
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
@@ -9,6 +9,8 @@ import com.bumptech.glide.Registry;
 import com.bumptech.glide.annotation.GlideModule;
 import com.bumptech.glide.load.DecodeFormat;
 import com.bumptech.glide.load.engine.cache.InternalCacheDiskCacheFactory;
+import com.bumptech.glide.load.model.StringLoader;
+import com.bumptech.glide.load.model.UriLoader;
 import com.bumptech.glide.module.AppGlideModule;
 
 import de.danoeh.antennapod.core.util.EmbeddedChapterImage;
@@ -35,5 +37,6 @@ public class ApGlideModule extends AppGlideModule {
     public void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
         registry.replace(String.class, InputStream.class, new ApOkHttpUrlLoader.Factory());
         registry.append(EmbeddedChapterImage.class, ByteBuffer.class, new ChapterImageModelLoader.Factory());
+        registry.append(String.class, InputStream.class, new StringLoader.StreamFactory());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.glide;
 
+import android.content.ContentResolver;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -22,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * @see com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+ * {@see com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader}.
  */
 class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
 
@@ -94,8 +95,9 @@ class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
     }
 
     @Override
-    public boolean handles(@NonNull String s) {
-        return true;
+    public boolean handles(@NonNull String model) {
+        // Leave content URIs to Glide's default loaders
+        return !TextUtils.isEmpty(model) && !model.startsWith(ContentResolver.SCHEME_CONTENT);
     }
 
     private static class NetworkAllowanceInterceptor implements Interceptor {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedSyncTask.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedSyncTask.java
@@ -30,8 +30,7 @@ public class FeedSyncTask {
             return false;
         }
 
-        Feed[] savedFeeds = DBTasks.updateFeed(context, result.feed);
-        Feed savedFeed = savedFeeds[0];
+        Feed savedFeed = DBTasks.updateFeed(context, result.feed, false);
         // If loadAllPages=true, check if another page is available and queue it for download
         final boolean loadAllPages = request.getArguments().getBoolean(DownloadRequester.REQUEST_ARG_LOAD_ALL_PAGES);
         final Feed feed = result.feed;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -311,9 +311,9 @@ public class PlaybackServiceTaskManager {
 
         if (media.getChapters() == null) {
             Completable.create(emitter -> {
-                        media.loadChapterMarks(context);
-                        emitter.onComplete();
-                    })
+                media.loadChapterMarks(context);
+                emitter.onComplete();
+            })
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(() -> callback.onChapterLoaded(media));

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -311,7 +311,7 @@ public class PlaybackServiceTaskManager {
 
         if (media.getChapters() == null) {
             Completable.create(emitter -> {
-                        media.loadChapterMarks();
+                        media.loadChapterMarks(context);
                         emitter.onComplete();
                     })
                     .subscribeOn(Schedulers.io())

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -373,118 +373,133 @@ public final class DBTasks {
      * <p/>
      * This method should NOT be executed on the GUI thread.
      *
-     * @param context  Used for accessing the DB.
-     * @param newFeeds The new Feed objects.
-     * @return The updated Feeds from the database if it already existed, or the new Feed from the parameters otherwise.
+     * @param context Used for accessing the DB.
+     * @param newFeed The new Feed object.
+     * @param removeUnlistedItems The item list in the new Feed object is considered to be exhaustive.
+     *                            I.e. items are removed from the database if they are not in this item list.
+     * @return The updated Feed from the database if it already existed, or the new Feed from the parameters otherwise.
      */
-    public static synchronized Feed[] updateFeed(final Context context,
-                                                 final Feed... newFeeds) {
-        List<Feed> newFeedsList = new ArrayList<>();
-        List<Feed> updatedFeedsList = new ArrayList<>();
-        Feed[] resultFeeds = new Feed[newFeeds.length];
+    public static synchronized Feed updateFeed(Context context, Feed newFeed, boolean removeUnlistedItems) {
+        Feed resultFeed;
+        List<FeedItem> unlistedItems = new ArrayList<>();
+
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
-        for (int feedIdx = 0; feedIdx < newFeeds.length; feedIdx++) {
+        // Look up feed in the feedslist
+        final Feed savedFeed = searchFeedByIdentifyingValueOrID(adapter, newFeed);
+        if (savedFeed == null) {
+            Log.d(TAG, "Found no existing Feed with title "
+                            + newFeed.getTitle() + ". Adding as new one.");
 
-            final Feed newFeed = newFeeds[feedIdx];
+            // Add a new Feed
+            // all new feeds will have the most recent item marked as unplayed
+            FeedItem mostRecent = newFeed.getMostRecentItem();
+            if (mostRecent != null) {
+                mostRecent.setNew();
+            }
 
-            // Look up feed in the feedslist
-            final Feed savedFeed = searchFeedByIdentifyingValueOrID(adapter,
-                    newFeed);
-            if (savedFeed == null) {
-                Log.d(TAG, "Found no existing Feed with title "
-                                + newFeed.getTitle() + ". Adding as new one.");
+            resultFeed = newFeed;
+        } else {
+            Log.d(TAG, "Feed with title " + newFeed.getTitle()
+                        + " already exists. Syncing new with existing one.");
 
-                // Add a new Feed
-                // all new feeds will have the most recent item marked as unplayed
-                FeedItem mostRecent = newFeed.getMostRecentItem();
-                if (mostRecent != null) {
-                    mostRecent.setNew();
+            Collections.sort(newFeed.getItems(), new FeedItemPubdateComparator());
+
+            if (newFeed.getPageNr() == savedFeed.getPageNr()) {
+                if (savedFeed.compareWithOther(newFeed)) {
+                    Log.d(TAG, "Feed has updated attribute values. Updating old feed's attributes");
+                    savedFeed.updateFromOther(newFeed);
                 }
-
-                newFeedsList.add(newFeed);
-                resultFeeds[feedIdx] = newFeed;
             } else {
-                Log.d(TAG, "Feed with title " + newFeed.getTitle()
-                            + " already exists. Syncing new with existing one.");
+                Log.d(TAG, "New feed has a higher page number.");
+                savedFeed.setNextPageLink(newFeed.getNextPageLink());
+            }
+            if (savedFeed.getPreferences().compareWithOther(newFeed.getPreferences())) {
+                Log.d(TAG, "Feed has updated preferences. Updating old feed's preferences");
+                savedFeed.getPreferences().updateFromOther(newFeed.getPreferences());
+            }
 
-                Collections.sort(newFeed.getItems(), new FeedItemPubdateComparator());
+            // get the most recent date now, before we start changing the list
+            FeedItem priorMostRecent = savedFeed.getMostRecentItem();
+            Date priorMostRecentDate = null;
+            if (priorMostRecent != null) {
+                priorMostRecentDate = priorMostRecent.getPubDate();
+            }
 
-                if (newFeed.getPageNr() == savedFeed.getPageNr()) {
-                    if (savedFeed.compareWithOther(newFeed)) {
-                        Log.d(TAG, "Feed has updated attribute values. Updating old feed's attributes");
-                        savedFeed.updateFromOther(newFeed);
+            // Look for new or updated Items
+            for (int idx = 0; idx < newFeed.getItems().size(); idx++) {
+                final FeedItem item = newFeed.getItems().get(idx);
+                FeedItem oldItem = searchFeedItemByIdentifyingValue(savedFeed, item.getIdentifyingValue());
+                if (oldItem == null) {
+                    // item is new
+                    item.setFeed(savedFeed);
+                    item.setAutoDownload(savedFeed.getPreferences().getAutoDownload());
+
+                    if (idx >= savedFeed.getItems().size()) {
+                        savedFeed.getItems().add(item);
+                    } else {
+                        savedFeed.getItems().add(idx, item);
+                    }
+
+                    // only mark the item new if it was published after or at the same time
+                    // as the most recent item
+                    // (if the most recent date is null then we can assume there are no items
+                    // and this is the first, hence 'new')
+                    if (priorMostRecentDate == null
+                            || priorMostRecentDate.before(item.getPubDate())
+                            || priorMostRecentDate.equals(item.getPubDate())) {
+                        Log.d(TAG, "Marking item published on " + item.getPubDate()
+                                + " new, prior most recent date = " + priorMostRecentDate);
+                        item.setNew();
                     }
                 } else {
-                    Log.d(TAG, "New feed has a higher page number.");
-                    savedFeed.setNextPageLink(newFeed.getNextPageLink());
+                    oldItem.updateFromOther(item);
                 }
-                if (savedFeed.getPreferences().compareWithOther(newFeed.getPreferences())) {
-                    Log.d(TAG, "Feed has updated preferences. Updating old feed's preferences");
-                    savedFeed.getPreferences().updateFromOther(newFeed.getPreferences());
-                }
+            }
 
-                // get the most recent date now, before we start changing the list
-                FeedItem priorMostRecent = savedFeed.getMostRecentItem();
-                Date priorMostRecentDate = null;
-                if (priorMostRecent != null) {
-                    priorMostRecentDate = priorMostRecent.getPubDate();
-                }
-
-                // Look for new or updated Items
-                for (int idx = 0; idx < newFeed.getItems().size(); idx++) {
-                    final FeedItem item = newFeed.getItems().get(idx);
-                    FeedItem oldItem = searchFeedItemByIdentifyingValue(savedFeed,
-                            item.getIdentifyingValue());
-                    if (oldItem == null) {
-                        // item is new
-                        item.setFeed(savedFeed);
-                        item.setAutoDownload(savedFeed.getPreferences().getAutoDownload());
-
-                        if (idx >= savedFeed.getItems().size()) {
-                            savedFeed.getItems().add(item);
-                        } else {
-                            savedFeed.getItems().add(idx, item);
-                        }
-
-                        // only mark the item new if it was published after or at the same time
-                        // as the most recent item
-                        // (if the most recent date is null then we can assume there are no items
-                        // and this is the first, hence 'new')
-                        if (priorMostRecentDate == null
-                                || priorMostRecentDate.before(item.getPubDate())
-                                || priorMostRecentDate.equals(item.getPubDate())) {
-                            Log.d(TAG, "Marking item published on " + item.getPubDate()
-                                    + " new, prior most recent date = " + priorMostRecentDate);
-                            item.setNew();
-                        }
-                    } else {
-                        oldItem.updateFromOther(item);
+            // identify items to be removed
+            if (removeUnlistedItems) {
+                Iterator<FeedItem> it = savedFeed.getItems().iterator();
+                while (it.hasNext()) {
+                    FeedItem feedItem = it.next();
+                    if (searchFeedItemByIdentifyingValue(newFeed, feedItem.getIdentifyingValue()) == null) {
+                        unlistedItems.add(feedItem);
+                        it.remove();
                     }
                 }
-                // update attributes
-                savedFeed.setLastUpdate(newFeed.getLastUpdate());
-                savedFeed.setType(newFeed.getType());
-                savedFeed.setLastUpdateFailed(false);
-
-                updatedFeedsList.add(savedFeed);
-                resultFeeds[feedIdx] = savedFeed;
             }
+
+            // update attributes
+            savedFeed.setLastUpdate(newFeed.getLastUpdate());
+            savedFeed.setType(newFeed.getType());
+            savedFeed.setLastUpdateFailed(false);
+
+            resultFeed = savedFeed;
         }
 
         adapter.close();
 
         try {
-            DBWriter.addNewFeed(context, newFeedsList.toArray(new Feed[0])).get();
-            DBWriter.setCompleteFeed(updatedFeedsList.toArray(new Feed[0])).get();
+            if (savedFeed == null) {
+                DBWriter.addNewFeed(context, newFeed).get();
+            } else {
+                DBWriter.setCompleteFeed(savedFeed).get();
+            }
+            if (removeUnlistedItems) {
+                DBWriter.deleteFeedItems(context, unlistedItems).get();
+            }
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
 
-        EventBus.getDefault().post(new FeedListUpdateEvent(updatedFeedsList));
+        if (savedFeed != null) {
+            EventBus.getDefault().post(new FeedListUpdateEvent(savedFeed));
+        } else {
+            EventBus.getDefault().post(new FeedListUpdateEvent(Collections.emptyList()));
+        }
 
-        return resultFeeds;
+        return resultFeed;
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -16,6 +16,7 @@ import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.FeedPreferences;
+import de.danoeh.antennapod.core.feed.LocalFeedUpdater;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.sync.SyncService;
@@ -241,7 +242,12 @@ public final class DBTasks {
                     feed.getPreferences().getUsername(), feed.getPreferences().getPassword());
         }
         f.setId(feed.getId());
-        DownloadRequester.getInstance().downloadFeed(context, f, loadAllPages, force, initiatedByUser);
+
+        if (f.isLocalFeed()) {
+            new Thread(() -> LocalFeedUpdater.updateFeed(f, context)).start();
+        } else {
+            DownloadRequester.getInstance().downloadFeed(context, f, loadAllPages, force, initiatedByUser);
+        }
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -141,48 +141,74 @@ public class DBWriter {
         return dbExec.submit(() -> {
             DownloadRequester requester = DownloadRequester.getInstance();
             final Feed feed = DBReader.getFeed(feedId);
-
-            if (feed != null) {
-                // delete stored media files and mark them as read
-                List<FeedItem> queue = DBReader.getQueue();
-                List<FeedItem> removed = new ArrayList<>();
-                if (feed.getItems() == null) {
-                    DBReader.getFeedItemList(feed);
-                }
-
-                for (FeedItem item : feed.getItems()) {
-                    if (queue.remove(item)) {
-                        removed.add(item);
-                    }
-                    if (item.getMedia() != null && item.getMedia().isDownloaded()) {
-                        deleteFeedMediaSynchronous(context, item.getMedia());
-                    } else if (item.getMedia() != null && requester.isDownloadingFile(item.getMedia())) {
-                        requester.cancelDownload(context, item.getMedia());
-                    }
-                }
-                PodDBAdapter adapter = PodDBAdapter.getInstance();
-                adapter.open();
-                if (removed.size() > 0) {
-                    adapter.setQueue(queue);
-                    for (FeedItem item : removed) {
-                        EventBus.getDefault().post(QueueEvent.irreversibleRemoved(item));
-                    }
-                }
-                adapter.removeFeed(feed);
-                adapter.close();
-
-                SyncService.enqueueFeedRemoved(context, feed.getDownload_url());
-                EventBus.getDefault().post(new FeedListUpdateEvent(feed));
-
-                // we assume we also removed download log entries for the feed or its media files.
-                // especially important if download or refresh failed, as the user should not be able
-                // to retry these
-                EventBus.getDefault().post(DownloadLogEvent.listUpdated());
-
-                BackupManager backupManager = new BackupManager(context);
-                backupManager.dataChanged();
+            if (feed == null) {
+                return;
             }
+
+            // delete stored media files and mark them as read
+            if (feed.getItems() == null) {
+                DBReader.getFeedItemList(feed);
+            }
+            deleteFeedItemsSynchronous(context, feed.getItems());
+
+            // delete feed
+            PodDBAdapter adapter = PodDBAdapter.getInstance();
+            adapter.open();
+            adapter.removeFeed(feed);
+            adapter.close();
+
+            SyncService.enqueueFeedRemoved(context, feed.getDownload_url());
+            EventBus.getDefault().post(new FeedListUpdateEvent(feed));
         });
+    }
+
+    /**
+     * Remove the listed items and their FeedMedia entries.
+     * Deleting media also removes the download log entries.
+     */
+    @NonNull
+    public static Future<?> deleteFeedItems(@NonNull Context context, @NonNull List<FeedItem> items) {
+        return dbExec.submit(() -> deleteFeedItemsSynchronous(context, items) );
+    }
+
+    /**
+     * Remove the listed items and their FeedMedia entries.
+     * Deleting media also removes the download log entries.
+     */
+    private static void deleteFeedItemsSynchronous(@NonNull Context context, @NonNull List<FeedItem> items) {
+        DownloadRequester requester = DownloadRequester.getInstance();
+        List<FeedItem> queue = DBReader.getQueue();
+        List<FeedItem> removedFromQueue = new ArrayList<>();
+        for (FeedItem item : items) {
+            if (queue.remove(item)) {
+                removedFromQueue.add(item);
+            }
+            if (item.getMedia() != null && item.getMedia().isDownloaded()) {
+                deleteFeedMediaSynchronous(context, item.getMedia());
+            } else if (item.getMedia() != null && requester.isDownloadingFile(item.getMedia())) {
+                requester.cancelDownload(context, item.getMedia());
+            }
+        }
+
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        if (!removedFromQueue.isEmpty()) {
+            adapter.setQueue(queue);
+        }
+        adapter.removeFeedItems(items);
+        adapter.close();
+
+        for (FeedItem item : removedFromQueue) {
+            EventBus.getDefault().post(QueueEvent.irreversibleRemoved(item));
+        }
+
+        // we assume we also removed download log entries for the feed or its media files.
+        // especially important if download or refresh failed, as the user should not be able
+        // to retry these
+        EventBus.getDefault().post(DownloadLogEvent.listUpdated());
+
+        BackupManager backupManager = new BackupManager(context);
+        backupManager.dataChanged();
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -14,6 +14,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.apache.commons.io.FileUtils;
@@ -849,6 +850,23 @@ public class PodDBAdapter {
         }
         db.delete(TABLE_NAME_FEED_ITEMS, KEY_ID + "=?",
                 new String[]{String.valueOf(item.getId())});
+    }
+
+    /**
+     * Remove the listed items and their FeedMedia entries.
+     */
+    public void removeFeedItems(@NonNull List<FeedItem> items) {
+        try {
+            db.beginTransactionNonExclusive();
+            for (FeedItem item : items) {
+                removeFeedItem(item);
+            }
+            db.setTransactionSuccessful();
+        } catch (SQLException e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+        } finally {
+            db.endTransaction();
+        }
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -1,10 +1,10 @@
 package de.danoeh.antennapod.core.util;
 
+import android.content.Context;
+import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.Log;
 
-import java.util.zip.CheckedOutputStream;
 import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedInputStream;
@@ -13,7 +13,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,10 +48,10 @@ public class ChapterUtils {
         return chapters.size() - 1;
     }
 
-    public static void loadChaptersFromStreamUrl(Playable media) {
-        ChapterUtils.readID3ChaptersFromPlayableStreamUrl(media);
+    public static void loadChaptersFromStreamUrl(Playable media, Context context) {
+        ChapterUtils.readID3ChaptersFromPlayableStreamUrl(media, context);
         if (media.getChapters() == null) {
-            ChapterUtils.readOggChaptersFromPlayableStreamUrl(media);
+            ChapterUtils.readOggChaptersFromPlayableStreamUrl(media, context);
         }
     }
 
@@ -71,7 +70,7 @@ public class ChapterUtils {
      * Uses the download URL of a media object of a feeditem to read its ID3
      * chapters.
      */
-    private static void readID3ChaptersFromPlayableStreamUrl(Playable p) {
+    private static void readID3ChaptersFromPlayableStreamUrl(Playable p, Context context) {
         if (p == null || p.getStreamUrl() == null) {
             Log.e(TAG, "Unable to read ID3 chapters: media or download URL was null");
             return;
@@ -79,8 +78,8 @@ public class ChapterUtils {
         Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
         CountingInputStream in = null;
         try {
-            URL url = new URL(p.getStreamUrl());
-            in = new CountingInputStream(url.openStream());
+            Uri uri = Uri.parse(p.getStreamUrl());
+            in = new CountingInputStream(context.getContentResolver().openInputStream(uri));
             List<Chapter> chapters = readChaptersFrom(in);
             if (!chapters.isEmpty()) {
                 p.setChapters(chapters);
@@ -142,14 +141,14 @@ public class ChapterUtils {
         return chapters;
     }
 
-    private static void readOggChaptersFromPlayableStreamUrl(Playable media) {
+    private static void readOggChaptersFromPlayableStreamUrl(Playable media, Context context) {
         if (media == null || !media.streamAvailable()) {
             return;
         }
         InputStream input = null;
         try {
-            URL url = new URL(media.getStreamUrl());
-            input = url.openStream();
+            Uri uri = Uri.parse(media.getStreamUrl());
+            input = context.getContentResolver().openInputStream(uri);
             if (input != null) {
                 readOggChaptersFromInputStream(media, input);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.util;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
 import androidx.annotation.NonNull;
@@ -13,6 +14,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
@@ -78,8 +80,13 @@ public class ChapterUtils {
         Log.d(TAG, "Reading id3 chapters from item " + p.getEpisodeTitle());
         CountingInputStream in = null;
         try {
-            Uri uri = Uri.parse(p.getStreamUrl());
-            in = new CountingInputStream(context.getContentResolver().openInputStream(uri));
+            if (p.getStreamUrl().startsWith(ContentResolver.SCHEME_CONTENT)) {
+                Uri uri = Uri.parse(p.getStreamUrl());
+                in = new CountingInputStream(context.getContentResolver().openInputStream(uri));
+            } else {
+                URL url = new URL(p.getStreamUrl());
+                in = new CountingInputStream(url.openStream());
+            }
             List<Chapter> chapters = readChaptersFrom(in);
             if (!chapters.isEmpty()) {
                 p.setChapters(chapters);
@@ -147,8 +154,13 @@ public class ChapterUtils {
         }
         InputStream input = null;
         try {
-            Uri uri = Uri.parse(media.getStreamUrl());
-            input = context.getContentResolver().openInputStream(uri);
+            if (media.getStreamUrl().startsWith(ContentResolver.SCHEME_CONTENT)) {
+                Uri uri = Uri.parse(media.getStreamUrl());
+                input = context.getContentResolver().openInputStream(uri);
+            } else {
+                URL url = new URL(media.getStreamUrl());
+                input = url.openStream();
+            }
             if (input != null) {
                 readOggChaptersFromInputStream(media, input);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/ExternalMedia.java
@@ -103,7 +103,7 @@ public class ExternalMedia implements Playable {
     }
 
     @Override
-    public void loadChapterMarks() {
+    public void loadChapterMarks(Context context) {
 
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -4,11 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
-import androidx.annotation.Nullable;
 import android.util.Log;
-
-import java.util.List;
-
+import androidx.annotation.Nullable;
 import de.danoeh.antennapod.core.asynctask.ImageResource;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.FeedMedia;
@@ -16,6 +13,8 @@ import de.danoeh.antennapod.core.feed.MediaType;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.ShownotesProvider;
+
+import java.util.List;
 
 /**
  * Interface for objects that can be played by the PlaybackService.
@@ -44,7 +43,7 @@ public interface Playable extends Parcelable,
      * Playable objects should load their chapter marks in this method if no
      * local file was available when loadMetadata() was called.
      */
-    void loadChapterMarks();
+    void loadChapterMarks(Context context);
 
     /**
      * Returns the title of the episode that this playable represents

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/RemoteMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/RemoteMedia.java
@@ -129,8 +129,8 @@ public class RemoteMedia implements Playable {
     }
 
     @Override
-    public void loadChapterMarks() {
-        ChapterUtils.loadChaptersFromStreamUrl(this);
+    public void loadChapterMarks(Context context) {
+        ChapterUtils.loadChaptersFromStreamUrl(this, context);
     }
 
     @Override

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -718,6 +718,9 @@
     <string name="discover">Discover</string>
     <string name="discover_more">more »</string>
     <string name="search_powered_by">Search powered by %1$s</string>
+    <string name="add_local_folder">Add local folder</string>
+    <string name="add_local_folder_success">Adding local folder succeeded</string>
+    <string name="local_feed_description">This virtual podcast was created by adding a folder to AntennaPod.</string>
 
     <string name="filter">Filter</string>
     


### PR DESCRIPTION
Replacement for #2991, updated to Storage Access Framework. Needs a lot more work but playback already works. Contributions by others very welcome, just create a PR for this branch in my fork.

Open ToDo issues:

- [x] Play button does not work, only stream button
- [x] Images do not work
- [x] Chapters do not work
- [x] Download button and delete button should not be displayed
- [x] Multi select should handle local files (thanks @damoasda)
- [ ] Embedded covers should be loaded from local files
- [x] Delete removed files (thanks @damoasda)
- [x] Update updated files
- [ ] Do not warn that all files are deleted when removing feed
- [ ] Allow to re-connect the SAF document tree
- [ ] Instead of using a new thread for each local feed, do this in FeedParserExecutor
- [ ] Check that casting works
- [ ] Pressing "open website" on episodes tries to open filename (and fails)
- [ ] Cover image is usually broken (if user does not create `Folder.png`) - use a folder icon as default?
- [ ] Playing an episode that was deleted in the file system crashes the app

Closes #154
Closes #205