### PR TITLE
Fixed crash when changing theme

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -317,9 +317,8 @@ public class MainActivity extends CastEnabledActivity {
         RatingDialog.init(this);
 
         if (lastTheme != UserPreferences.getNoTitleTheme()) {
-            // Nav drawer is empty for half a second after recreating. Don't confuse users with that.
-            drawerLayout.closeDrawer(navDrawer);
-            recreate();
+            finish();
+            startActivity(new Intent(this, MainActivity.class));
         }
     }
 


### PR DESCRIPTION
Apparently, recreate() brings RxJava in a strange state where errors are directly
thrown instead of relaying them to the error callback. Because of a race condition
in ItemDescriptionFragment.loadData, this throws a NPE.

Closes #4144