### PR TITLE
Fix hardware buttons registered as lockscreen/notification taps

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
@@ -15,6 +15,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
 	private static final String TAG = "MediaButtonReceiver";
 	public static final String EXTRA_KEYCODE = "de.danoeh.antennapod.core.service.extra.MediaButtonReceiver.KEYCODE";
 	public static final String EXTRA_SOURCE = "de.danoeh.antennapod.core.service.extra.MediaButtonReceiver.SOURCE";
+	public static final String EXTRA_HARDWAREBUTTON = "de.danoeh.antennapod.core.service.extra.MediaButtonReceiver.HARDWAREBUTTON";
 
 	public static final String NOTIFY_BUTTON_RECEIVER = "de.danoeh.antennapod.NOTIFY_BUTTON_RECEIVER";
 
@@ -30,6 +31,12 @@ public class MediaButtonReceiver extends BroadcastReceiver {
 			Intent serviceIntent = new Intent(context, PlaybackService.class);
 			serviceIntent.putExtra(EXTRA_KEYCODE, event.getKeyCode());
 			serviceIntent.putExtra(EXTRA_SOURCE, event.getSource());
+			//detect if this is a hardware button press
+			if (event.getEventTime() > 0 || event.getDownTime() > 0) {
+				serviceIntent.putExtra(EXTRA_HARDWAREBUTTON, true);
+			} else {
+				serviceIntent.putExtra(EXTRA_HARDWAREBUTTON, false);
+			}
 			ContextCompat.startForegroundService(context, serviceIntent);
 		}
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -450,6 +450,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         notificationManager.cancel(R.id.notification_streaming_confirmation);
 
         final int keycode = intent.getIntExtra(MediaButtonReceiver.EXTRA_KEYCODE, -1);
+        final boolean hardwareButton = intent.getBooleanExtra(MediaButtonReceiver.EXTRA_HARDWAREBUTTON, false);
         final boolean castDisconnect = intent.getBooleanExtra(EXTRA_CAST_DISCONNECT, false);
         Playable playable = intent.getParcelableExtra(EXTRA_PLAYABLE);
         if (keycode == -1 && playable == null && !castDisconnect) {
@@ -463,8 +464,15 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             stateManager.stopForeground(true);
         } else {
             if (keycode != -1) {
-                Log.d(TAG, "Received media button event");
-                boolean handled = handleKeycode(keycode, true);
+                boolean notificationButton;
+                if (hardwareButton) {
+                    Log.d(TAG, "Received hardware button event");
+                    notificationButton = false;
+                } else {
+                    Log.d(TAG, "Received media button event");
+                    notificationButton = true;
+                }
+                boolean handled = handleKeycode(keycode, notificationButton);
                 if (!handled && !stateManager.hasReceivedValidStartCommand()) {
                     stateManager.stopService();
                     return Service.START_NOT_STICKY;


### PR DESCRIPTION
This should solve #1560 for some platforms where it still was a problem. Instead of assuming all calls to onReceiver() for MediaButtonReceiver are made by "software" buttons (like the playback controls on lockscreen), it now checks if the intent has a non-zero eventTime or downTime, which seems to be a good indicator that it's actually caused by a real button.

I've tested this on Android 4.4, 5.1 and 10. The controls on the lockscreen still function correctly and it solves #1560 on the device I had that was still affected (the problem of a long press on volume up/down with the screen of would skip track instead of jumping forwards/backwards).

Note: I don't have a blutooth music controller so I've not been able to check if the functionality remains as expected. This should probably be tested before pulling this officially. (but from what I understand the bluetooth skip button was already handled as jumping forward, so I don't think it's even affected by this code).

Closes #1560