### PR TITLE
Fix useragent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ project.ext {
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"
-    audioPlayerVersion = "v1.0.17"
+    audioPlayerVersion = "v2.0.0"
 
     // Google Play build
     wearableSupportVersion = "2.6.0"

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -4,7 +4,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.Log;
 
+import java.net.URLConnection;
 import java.util.zip.CheckedOutputStream;
+
+import de.danoeh.antennapod.core.ClientConfig;
 import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedInputStream;
@@ -80,7 +83,9 @@ public class ChapterUtils {
         CountingInputStream in = null;
         try {
             URL url = new URL(p.getStreamUrl());
-            in = new CountingInputStream(url.openStream());
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setRequestProperty("User-Agent", ClientConfig.USER_AGENT);
+            in = new CountingInputStream(urlConnection.getInputStream());
             List<Chapter> chapters = readChaptersFrom(in);
             if (!chapters.isEmpty()) {
                 p.setChapters(chapters);
@@ -149,7 +154,9 @@ public class ChapterUtils {
         InputStream input = null;
         try {
             URL url = new URL(media.getStreamUrl());
-            input = url.openStream();
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setRequestProperty("User-Agent", ClientConfig.USER_AGENT);
+            input = urlConnection.getInputStream();
             if (input != null) {
                 readOggChaptersFromInputStream(media, input);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -6,6 +6,7 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.SurfaceHolder;
 
+import de.danoeh.antennapod.core.ClientConfig;
 import org.antennapod.audio.MediaPlayer;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
@@ -17,7 +18,7 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
     private static final String TAG = "AudioPlayer";
 
     public AudioPlayer(Context context) {
-        super(context);
+        super(context, true, ClientConfig.USER_AGENT);
         PreferenceManager.getDefaultSharedPreferences(context)
                 .registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
                     if (key.equals(UserPreferences.PREF_MEDIA_PLAYER)) {


### PR DESCRIPTION
- ExoPlayer already used the AntennaPod user agent
- Sonic and Device internal have now been changed to use the AntennaPod user agent
- Something I did not think about earlier: The chapter loader (that is used to load embedded chapters of the media file in case the feed does not support chapter marks) has now been changed to use the AntennaPod user agent

Closes #4240