### PR TITLE
Stripping accents before generating file name

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/util/FilenameGeneratorTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/FilenameGeneratorTest.java
@@ -21,32 +21,28 @@ import static org.junit.Assert.assertTrue;
 @SmallTest
 public class FilenameGeneratorTest {
 
-    private static final String VALID1 = "abc abc";
-    private static final String INVALID1 = "ab/c: <abc";
-    private static final String INVALID2 = "abc abc ";
-
     public FilenameGeneratorTest() {
         super();
     }
 
     @Test
     public void testGenerateFileName() throws IOException {
-        String result = FileNameGenerator.generateFileName(VALID1);
-        assertEquals(result, VALID1);
+        String result = FileNameGenerator.generateFileName("abc abc");
+        assertEquals(result, "abc abc");
         createFiles(result);
     }
 
     @Test
     public void testGenerateFileName1() throws IOException {
-        String result = FileNameGenerator.generateFileName(INVALID1);
-        assertEquals(result, VALID1);
+        String result = FileNameGenerator.generateFileName("ab/c: <abc");
+        assertEquals(result, "abc abc");
         createFiles(result);
     }
 
     @Test
     public void testGenerateFileName2() throws IOException {
-        String result = FileNameGenerator.generateFileName(INVALID2);
-        assertEquals(result, VALID1);
+        String result = FileNameGenerator.generateFileName("abc abc ");
+        assertEquals(result, "abc abc");
         createFiles(result);
     }
 
@@ -60,6 +56,12 @@ public class FilenameGeneratorTest {
     public void testFeedTitleContainsDash() {
         String result = FileNameGenerator.generateFileName("Left - Right");
         assertEquals("Left - Right", result);
+    }
+
+    @Test
+    public void testFeedTitleContainsAccents() {
+        String result = FileNameGenerator.generateFileName("Äàáâãå");
+        assertEquals("Aaaaaa", result);
     }
 
     @Test
@@ -97,14 +99,6 @@ public class FilenameGeneratorTest {
         assertTrue(testFile.exists());
         testFile.delete();
         assertTrue(testFile.createNewFile());
-
-    }
-
-    @After
-    public void tearDown() {
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        File f = new File(context.getExternalCacheDir(), VALID1);
-        f.delete();
     }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FileNameGenerator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FileNameGenerator.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.VisibleForTesting;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
@@ -29,6 +30,7 @@ public class FileNameGenerator {
      * characters of the given string.
      */
     public static String generateFileName(String string) {
+        string = StringUtils.stripAccents(string);
         StringBuilder buf = new StringBuilder();
         for (int i = 0; i < string.length(); i++) {
             char c = string.charAt(i);


### PR DESCRIPTION
This change makes the situation in #1688 better for languages that use letters with accents (`Äàáâãå`). It does not change the situation when using languages like Farsi.