### PR TITLE
Fixed #4235 by enabling swiping actions on locked queue list

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -20,23 +20,17 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
     private static final String TAG = "QueueRecyclerAdapter";
 
     private final ItemTouchHelper itemTouchHelper;
-    private boolean locked;
-    private boolean keepSorted;
+    private boolean dragDropEnabled;
+
 
     public QueueRecyclerAdapter(MainActivity mainActivity, ItemTouchHelper itemTouchHelper) {
         super(mainActivity);
         this.itemTouchHelper = itemTouchHelper;
-        locked = UserPreferences.isQueueLocked();
-        keepSorted = UserPreferences.isQueueKeepSorted();
+        dragDropEnabled = ! (UserPreferences.isQueueKeepSorted() || UserPreferences.isQueueLocked());
     }
 
-    public void setLocked(boolean locked) {
-        this.locked = locked;
-        notifyDataSetChanged();
-    }
-
-    public void setKeepSorted(boolean keepSorted) {
-        this.keepSorted = keepSorted;
+    public void updateDragDropEnabled() {
+        dragDropEnabled = ! (UserPreferences.isQueueKeepSorted() || UserPreferences.isQueueLocked());
         notifyDataSetChanged();
     }
 
@@ -51,7 +45,7 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
             return false;
         };
 
-        if (locked || keepSorted) {
+        if (!dragDropEnabled) {
             holder.dragHandle.setVisibility(View.GONE);
             holder.dragHandle.setOnTouchListener(null);
             holder.coverHolder.setOnTouchListener(null);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/QueueRecyclerAdapter.java
@@ -21,15 +21,22 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
 
     private final ItemTouchHelper itemTouchHelper;
     private boolean locked;
+    private boolean keepSorted;
 
     public QueueRecyclerAdapter(MainActivity mainActivity, ItemTouchHelper itemTouchHelper) {
         super(mainActivity);
         this.itemTouchHelper = itemTouchHelper;
         locked = UserPreferences.isQueueLocked();
+        keepSorted = UserPreferences.isQueueKeepSorted();
     }
 
     public void setLocked(boolean locked) {
         this.locked = locked;
+        notifyDataSetChanged();
+    }
+
+    public void setKeepSorted(boolean keepSorted) {
+        this.keepSorted = keepSorted;
         notifyDataSetChanged();
     }
 
@@ -44,7 +51,7 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
             return false;
         };
 
-        if (locked) {
+        if (locked || keepSorted) {
             holder.dragHandle.setVisibility(View.GONE);
             holder.dragHandle.setOnTouchListener(null);
             holder.coverHolder.setOnTouchListener(null);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -515,7 +515,7 @@ public class QueueFragment extends Fragment {
 
                 @Override
                 public boolean isItemViewSwipeEnabled() {
-                    return !UserPreferences.isQueueLocked();
+                    return true;
                 }
 
                 @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -16,7 +16,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
@@ -340,10 +339,10 @@ public class QueueFragment extends Fragment {
                         SortOrder sortOrder = UserPreferences.getQueueKeepSortedOrder();
                         DBWriter.reorderQueue(sortOrder, true);
                         if (recyclerAdapter != null) {
-                            recyclerAdapter.setKeepSorted(true);
+                            recyclerAdapter.updateDragDropEnabled();
                         }
                     } else if (recyclerAdapter != null) {
-                        recyclerAdapter.setKeepSorted(UserPreferences.isQueueKeepSorted());
+                        recyclerAdapter.updateDragDropEnabled();
                     }
                     getActivity().invalidateOptionsMenu();
                     return true;
@@ -386,7 +385,7 @@ public class QueueFragment extends Fragment {
         UserPreferences.setQueueLocked(locked);
         getActivity().supportInvalidateOptionsMenu();
         if (recyclerAdapter != null) {
-            recyclerAdapter.setLocked(locked);
+            recyclerAdapter.updateDragDropEnabled();
         }
         if (locked) {
             ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.queue_locked, Snackbar.LENGTH_SHORT);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -340,10 +340,10 @@ public class QueueFragment extends Fragment {
                         SortOrder sortOrder = UserPreferences.getQueueKeepSortedOrder();
                         DBWriter.reorderQueue(sortOrder, true);
                         if (recyclerAdapter != null) {
-                            recyclerAdapter.setLocked(true);
+                            recyclerAdapter.setKeepSorted(true);
                         }
                     } else if (recyclerAdapter != null) {
-                        recyclerAdapter.setLocked(UserPreferences.isQueueLocked());
+                        recyclerAdapter.setKeepSorted(UserPreferences.isQueueKeepSorted());
                     }
                     getActivity().invalidateOptionsMenu();
                     return true;
@@ -515,7 +515,7 @@ public class QueueFragment extends Fragment {
 
                 @Override
                 public boolean isItemViewSwipeEnabled() {
-                    return true;
+                    return !UserPreferences.isQueueLocked();
                 }
 
                 @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -628,8 +628,7 @@ public class UserPreferences {
     }
 
     public static boolean isQueueLocked() {
-        return prefs.getBoolean(PREF_QUEUE_LOCKED, false)
-                || isQueueKeepSorted();
+        return prefs.getBoolean(PREF_QUEUE_LOCKED, false);
     }
 
     public static void setFastForwardSecs(int secs) {


### PR DESCRIPTION
Simple modification that enables swiping actions in queue lists when "keep sorted" option is checked.

Fixes #4235