### PR TITLE
Replace sort icon with multi select icon in top bar of episodes screen

### DIFF
--- a/app/src/main/res/menu/feedlist.xml
+++ b/app/src/main/res/menu/feedlist.xml
@@ -7,7 +7,7 @@
         android:icon="?attr/ic_sort"
         android:menuCategory="container"
         android:title="@string/sort"
-        custom:showAsAction="always">
+        custom:showAsAction="never">
     </item>
     <item
         android:id="@+id/filter_items"
@@ -15,6 +15,13 @@
         android:menuCategory="container"
         android:title="@string/filter"
         custom:showAsAction="always">
+    </item>
+    <item
+        android:id="@+id/episode_actions"
+        android:menuCategory="container"
+        android:icon="?attr/checkbox_multiple"
+        android:title="@string/multi_select"
+        custom:showAsAction="always|collapseActionView">
     </item>
     <item
         android:id="@+id/refresh_item"
@@ -36,14 +43,6 @@
         custom:showAsAction="always|collapseActionView"
         custom:actionViewClass="androidx.appcompat.widget.SearchView"
         android:title="@string/search_label"/>
-
-    <item
-        android:id="@+id/episode_actions"
-        android:menuCategory="container"
-        android:icon="?attr/checkbox_multiple"
-        android:title="@string/multi_select"
-        custom:showAsAction="collapseActionView">
-    </item>
     <item
         android:id="@+id/visit_website_item"
         android:icon="?attr/location_web_site"


### PR DESCRIPTION
I personally need the multi select feature every time I add a new podcast, just to mark all episodes, except the last five, as played.
In newer versions the multi select button has moved to the three dot list but I would prefer just replacing the sort with the multi select icon because I think many people just set the sort once global and do not use this option ever again, instead of the multi select button, which I use every time.
