### PR TITLE
Do not warn that all files are deleted when removing a local feed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -279,7 +279,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                                     ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null);
                                 }
                             };
-                            int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg : R.string.feed_delete_confirmation_msg;
+                            int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg
+                                    : R.string.feed_delete_confirmation_msg;
                             ConfirmationDialog conDialog = new ConfirmationDialog(getActivity(),
                                     R.string.remove_feed_label,
                                     getString(messageId, feed.getTitle())) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -279,9 +279,10 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                                     ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null);
                                 }
                             };
+                            int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg : R.string.feed_delete_confirmation_msg;
                             ConfirmationDialog conDialog = new ConfirmationDialog(getActivity(),
                                     R.string.remove_feed_label,
-                                    getString(R.string.feed_delete_confirmation_msg, feed.getTitle())) {
+                                    getString(messageId, feed.getTitle())) {
 
                                 @Override
                                 public void onConfirmButtonPressed(

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NavDrawerFragment.java
@@ -199,7 +199,8 @@ public class NavDrawerFragment extends Fragment implements AdapterView.OnItemCli
                         }
                     }
                 };
-                int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg : R.string.feed_delete_confirmation_msg;
+                int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg
+                        : R.string.feed_delete_confirmation_msg;
                 ConfirmationDialog conDialog = new ConfirmationDialog(getContext(),
                         R.string.remove_feed_label,
                         getString(messageId, feed.getTitle())) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NavDrawerFragment.java
@@ -199,9 +199,10 @@ public class NavDrawerFragment extends Fragment implements AdapterView.OnItemCli
                         }
                     }
                 };
+                int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg : R.string.feed_delete_confirmation_msg;
                 ConfirmationDialog conDialog = new ConfirmationDialog(getContext(),
                         R.string.remove_feed_label,
-                        getString(R.string.feed_delete_confirmation_msg, feed.getTitle())) {
+                        getString(messageId, feed.getTitle())) {
                     @Override
                     public void onConfirmButtonPressed(DialogInterface dialog) {
                         dialog.dismiss();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -270,7 +270,8 @@ public class SubscriptionFragment extends Fragment {
             }
         };
 
-        int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg : R.string.feed_delete_confirmation_msg;
+        int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg
+                : R.string.feed_delete_confirmation_msg;
         String message = getString(messageId, feed.getTitle());
         ConfirmationDialog dialog = new ConfirmationDialog(getContext(), R.string.remove_feed_label, message) {
             @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -270,7 +270,8 @@ public class SubscriptionFragment extends Fragment {
             }
         };
 
-        String message = getString(R.string.feed_delete_confirmation_msg, feed.getTitle());
+        int messageId = feed.isLocalFeed() ? R.string.feed_delete_confirmation_local_msg : R.string.feed_delete_confirmation_msg;
+        String message = getString(messageId, feed.getTitle());
         ConfirmationDialog dialog = new ConfirmationDialog(getContext(), R.string.remove_feed_label, message) {
             @Override
             public void onConfirmButtonPressed(DialogInterface clickedDialog) {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="share_item_url_label">Share Media File URL</string>
     <string name="share_item_url_with_position_label">Share Media File URL with Position</string>
     <string name="feed_delete_confirmation_msg">Please confirm that you want to delete the podcast \"%1$s\" and ALL its episodes (including downloaded episodes).</string>
+    <string name="feed_delete_confirmation_local_msg">Please confirm that you want to remove the podcast \"%1$s\". The files in the local source folder will not be deleted.</string>
     <string name="feed_remover_msg">Removing podcast</string>
     <string name="load_complete_feed">Refresh complete podcast</string>
     <string name="multi_select">Multi select</string>


### PR DESCRIPTION
Show a different warning message if a local feed is about to be deleted.
Introduce a new message key `feed_delete_confirmation_local_msg` that needs to be translated.

Contributes to #4287.