### PR TITLE
Removed upToDateWhen of copyLicense task

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -206,7 +206,6 @@ task copyLicense(type: Copy) {
     rename { String fileName ->
         fileName + ".txt"
     }
-    outputs.upToDateWhen { false }
 }
 
 preBuild.dependsOn copyLicense


### PR DESCRIPTION
This was originally added because the task was also responsible for copying the current git commit hash to the "about" screen. The commit was later moved to a `buildConfigField`, so this can now be removed again.

Closes #4317