### PR TITLE
Use maintained iconify fork

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -169,8 +169,8 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    implementation 'com.blackboardtheory:android-iconify-fontawesome:3.0.1-SNAPSHOT'
-    implementation 'com.blackboardtheory:android-iconify-material:3.0.1-SNAPSHOT'
+    implementation "com.blackboardtheory:android-iconify-fontawesome:$iconifyVersion"
+    implementation "com.blackboardtheory:android-iconify-material:$iconifyVersion"
     implementation 'com.yqritc:recyclerview-flexibledivider:1.4.0'
     implementation 'com.github.shts:TriangleLabelView:1.1.2'
     implementation 'com.leinardi.android:speed-dial:3.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -169,8 +169,8 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    implementation "com.joanzapata.iconify:android-iconify-fontawesome:$iconifyVersion"
-    implementation "com.joanzapata.iconify:android-iconify-material:$iconifyVersion"
+    implementation 'com.blackboardtheory:android-iconify-fontawesome:3.0.1-SNAPSHOT'
+    implementation 'com.blackboardtheory:android-iconify-material:3.0.1-SNAPSHOT'
     implementation 'com.yqritc:recyclerview-flexibledivider:1.4.0'
     implementation 'com.github.shts:TriangleLabelView:1.1.2'
     implementation 'com.leinardi.android:speed-dial:3.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 
     gradle.projectsEvaluated {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     gradle.projectsEvaluated {
@@ -65,7 +65,7 @@ project.ext {
     eventbusVersion = "3.2.0"
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
-    iconifyVersion = "2.2.2"
+    iconifyVersion = "3.0.1-SNAPSHOT"
     audioPlayerVersion = "v2.0.0"
 
     // Google Play build


### PR DESCRIPTION
As Iconify is unmaintained and has not received any updates since 2 years,  bdevereaux created a fork, where he updated the icons. The functionality is not changed, only the icons were updated.
More here: https://github.com/bdevereaux/android-iconify