### PR TITLE
Use material info icon in filter messages

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -67,7 +67,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         super.onFragmentLoaded(episodes);
 
         if (feedItemFilter.getValues().length > 0) {
-            txtvInformation.setText("{fa-info-circle} " + this.getString(R.string.filtered_label));
+            txtvInformation.setText("{md-info-outline} " + this.getString(R.string.filtered_label));
             Iconify.addIcons(txtvInformation);
             txtvInformation.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -466,7 +466,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                     RelativeLayout.LayoutParams p = (RelativeLayout.LayoutParams) txtvInformation.getLayoutParams();
                     p.addRule(RelativeLayout.BELOW, R.id.txtvFailure);
                 }
-                txtvInformation.setText("{fa-info-circle} " + this.getString(R.string.filtered_label));
+                txtvInformation.setText("{md-info-outline} " + this.getString(R.string.filtered_label));
                 Iconify.addIcons(txtvInformation);
                 txtvInformation.setOnClickListener((l) -> {
                     FilterDialog filterDialog = new FilterDialog(requireContext(), feed.getItemFilter()) {


### PR DESCRIPTION
Hi @ByteHamster because you said in #3675 that the icon in the filtered message looks a bit old, I changed it to the material icon, which I think looks better and I use the same icon in the subscription filter.

Screenshot (md-info-outline):
![filter_icon](https://user-images.githubusercontent.com/36813904/88956113-65006300-d28c-11ea-8bb3-9b80b8eee2d9.png)

Of course there is also an outfilled icon (md-info):
![filter2](https://user-images.githubusercontent.com/36813904/88956264-a7c23b00-d28c-11ea-8aef-29d3514aef28.png)

