### PR TITLE
Explain the automatic download mode on the settings page.

### DIFF
--- a/app/src/main/res/xml/preferences_autodownload.xml
+++ b/app/src/main/res/xml/preferences_autodownload.xml
@@ -6,6 +6,7 @@
     <de.danoeh.antennapod.preferences.MasterSwitchPreference
             android:key="prefEnableAutoDl"
             android:title="@string/pref_automatic_download_title"
+            android:summary="@string/pref_automatic_download_explanation"
             search:summary="@string/pref_automatic_download_sum"
             android:defaultValue="false"/>
     <ListPreference

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -412,6 +412,7 @@
     <string name="pref_set_theme_sum">Change the appearance of AntennaPod.</string>
     <string name="pref_automatic_download_title">Automatic Download</string>
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes.</string>
+    <string name="pref_automatic_download_explanation">Will automaticlly download new episodes up to the configured \'Episode Cache\' limit. It will not download old, but still unplayed episodes and therefore cannot be used to clear a backlog of episodes. You can turn it off per-feed in the subscription settings.</string>
     <string name="pref_autodl_wifi_filter_title">Enable Wi-Fi filter</string>
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>


### PR DESCRIPTION
The page is fairly short, so being a bit more verbose here should be ok.
This should help dummies like Yours Truly to more easily figure out how
and why AntennaPod downloads episodes.

Explanation provided by corecode@ in issue #1077.