### PR TITLE
add option "do not add playing episodes to the queue"

### DIFF
--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -87,6 +87,12 @@
                 android:key="prefEnqueueDownloaded"
                 android:summary="@string/pref_enqueue_downloaded_summary"
                 android:title="@string/pref_enqueue_downloaded_title" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="prefAutoAddPlaying"
+            android:summary="@string/pref_auto_enqueue_playing_media_summary"
+            android:title="@string/pref_auto_enqueue_playing_media_title" />
         <ListPreference
                 android:defaultValue="BACK"
                 android:entries="@array/enqueue_location_options"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -89,6 +89,7 @@ public class UserPreferences {
     public static final String PREF_VIDEO_BEHAVIOR = "prefVideoBehavior";
     private static final String PREF_TIME_RESPECTS_SPEED = "prefPlaybackTimeRespectsSpeed";
     public static final String PREF_STREAM_OVER_DOWNLOAD = "prefStreamOverDownload";
+    private static final String PREF_AUTO_ADD_PLAYING_MEDIA = "prefAutoAddPlaying";
 
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
@@ -1057,5 +1058,9 @@ public class UserPreferences {
         prefs.edit()
                 .putString(PREF_QUEUE_KEEP_SORTED_ORDER, sortOrder.name())
                 .apply();
+    }
+
+    public static boolean getAutoAddPlayingMedia() {
+        return prefs.getBoolean(PREF_AUTO_ADD_PLAYING_MEDIA, true);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1728,7 +1728,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     private void addPlayableToQueue(Playable playable) {
-        if (playable instanceof FeedMedia) {
+        if (playable instanceof FeedMedia && UserPreferences.getAutoAddPlayingMedia()) {
             long itemId = ((FeedMedia) playable).getItem().getId();
             DBWriter.addQueueItem(this, false, false, itemId);
         }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -522,6 +522,8 @@
     <string name="back_button_go_to_page_title">Select page</string>
     <string name="pref_delete_removes_from_queue_title">Delete removes from Queue</string>
     <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from the queue when it is deleted.</string>
+    <string name="pref_auto_enqueue_playing_media_title">Auto Enqueue Playing</string>
+    <string name="pref_auto_enqueue_playing_media_summary">Automatically add currently playing episodes to the queue.</string>
 
     <!-- About screen -->
     <string name="about_pref">About</string>


### PR DESCRIPTION
Some users, including me, just want to listen to a podcast and do not want that it gets automatically added to the queue.
Futhermore I only want to see episodes showing up in the queue if I manually add them.

This adds the matching "auto enqueue playing" media setting.
Closes #3246