### PR TITLE
Fix NullPointerException in FeedItemlistFragment when deleting a podcast

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -358,7 +358,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         if (event.hasChangedFeedUpdateStatus(isUpdatingFeed)) {
             updateSyncProgressBarVisibility();
         }
-        if (adapter != null && update.mediaIds.length > 0) {
+        if (adapter != null && update.mediaIds.length > 0 && feed != null) {
             for (long mediaId : update.mediaIds) {
                 int pos = FeedItemUtil.indexOfItemWithMediaId(feed.getItems(), mediaId);
                 if (pos >= 0) {
@@ -398,7 +398,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onFeedListChanged(FeedListUpdateEvent event) {
-        if (event.contains(feed)) {
+        if (feed != null && event.contains(feed)) {
             updateUi();
         }
     }
@@ -425,7 +425,9 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         }
         recyclerView.setVisibility(View.VISIBLE);
         progressBar.setVisibility(View.GONE);
-        adapter.updateItems(feed.getItems());
+        if (feed != null) {
+            adapter.updateItems(feed.getItems());
+        }
 
         getActivity().supportInvalidateOptionsMenu();
         updateSyncProgressBarVisibility();


### PR DESCRIPTION
**Steps to reproduce:**

1. Start fresh AntennaPod instance (in virtual device)
2. Subscribe any podcast
3. Go to Subscriptions, click on the podcast to see the subscription episodes list (`FeedItemlistFragment`)
4. Click on menu icon, click on "Remove podcast", and click on "Confirm"
5. The podcast is removed, but a NullPointerException occurs and can be seen in Logcat, see excerpt below

```
2020-08-02 21:48:00.881 26457-26457/de.danoeh.antennapod.debug D/MainActivity: loadFragment(tag: EpisodesFragment, args: null)
2020-08-02 21:48:00.882 26457-26457/de.danoeh.antennapod.debug D/NavDrawerFragment: saveLastNavFragment(tag: EpisodesFragment)
2020-08-02 21:48:00.883 26457-26457/de.danoeh.antennapod.debug D/NavDrawerFragment: getLastNavFragment() -> EpisodesFragment
2020-08-02 21:48:00.902 26457-26457/de.danoeh.antennapod.debug E/ItemlistFragment: Unable to refresh header view
2020-08-02 21:48:00.903 26457-26457/de.danoeh.antennapod.debug E/ItemlistFragment: java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List de.danoeh.antennapod.core.feed.Feed.getItems()' on a null object reference
        at de.danoeh.antennapod.fragment.FeedItemlistFragment.displayList(FeedItemlistFragment.java:442)
        at de.danoeh.antennapod.fragment.FeedItemlistFragment.lambda$loadItems$6$FeedItemlistFragment(FeedItemlistFragment.java:559)
        at de.danoeh.antennapod.fragment.-$$Lambda$FeedItemlistFragment$WuKRuvBSpYtx1TIGEJP_bKMpXng.accept(Unknown Source:4)
        at io.reactivex.internal.observers.LambdaObserver.onNext(LambdaObserver.java:63)
        at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.drainNormal(ObservableObserveOn.java:201)
        at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.run(ObservableObserveOn.java:255)
        at io.reactivex.android.schedulers.HandlerScheduler$ScheduledRunnable.run(HandlerScheduler.java:124)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

**Solution:**

This PR adds some `feed != null` checks before the field `feed` is accessed in the class `FeedItemlistFragment`.

Note: The bug isn't severe, a normal user doesn't see a problem when deleting a podcast. But when analyzing an app crash I could see this problem in the log and I'm happy to provide a fix for it.