### PR TITLE
Be more verbose about invalid type errors

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -561,13 +561,11 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.setTitle(R.string.error_label);
             if (errorMsg != null) {
-                builder.setMessage(getString(R.string.error_msg_prefix) + errorMsg);
+                builder.setMessage(errorMsg);
             } else {
-                builder.setMessage(R.string.error_msg_prefix);
+                builder.setMessage(R.string.download_error_error_unknown);
             }
-            builder.setPositiveButton(android.R.string.ok,
-                    (dialog, which) -> dialog.cancel()
-            );
+            builder.setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.cancel());
             builder.setOnDismissListener(dialog -> {
                 setResult(RESULT_ERROR);
                 finish();

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/UnsupportedFeedtypeException.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/UnsupportedFeedtypeException.java
@@ -36,6 +36,9 @@ public class UnsupportedFeedtypeException extends Exception {
         if (message != null) {
             return message;
         } else if (type == TypeGetter.Type.INVALID) {
+            if ("html".equals(rootElement)) {
+                return "The server returned a website, not a podcast feed";
+            }
             return "Invalid type";
         } else {
             return "Type " + type + " not supported";


### PR DESCRIPTION
In the last few hours, 2 people contacted me because they inserted a website address instead of a podcast feed address. Make error message more easy to understand: "The server returned a website, not a podcast feed" instead of just "Invalid type".