### PR TITLE
WIP: Dynamical navigation drawer size

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
         android:theme="@style/Theme.AntennaPod.Splash"
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"
-        android:logo="@mipmap/ic_launcher">
+        android:logo="@mipmap/ic_launcher"
+        android:resizeableActivity="true">
 
 
         <meta-data android:name="android.webkit.WebView.MetricsOptOut"
@@ -49,6 +50,11 @@
         <meta-data
             android:name="com.google.android.backup.api_key"
             android:value="AEdPqrEAAAAI3a05VToCTlqBymJrbFGaKQMvF-bBAuLsOdavBA"/>
+
+        <!-- Version < 3.0. DeX Mode and Screen Mirroring support -->
+        <meta-data android:name="com.samsung.android.keepalive.density" android:value="true"/>
+        <!-- Version >= 3.0. DeX Dual Mode support -->
+        <meta-data android:name="com.samsung.android.multidisplay.keep_process_alive" android:value="true"/>
 
         <activity
             android:name=".activity.SplashActivity"
@@ -73,7 +79,7 @@
 
         <activity
             android:name=".activity.MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|density|uiMode|keyboard|navigation"
             android:windowSoftInputMode="stateHidden"
             android:launchMode="singleTask"
             android:label="@string/app_name">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,8 +36,7 @@
         android:theme="@style/Theme.AntennaPod.Splash"
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"
-        android:logo="@mipmap/ic_launcher"
-        android:resizeableActivity="true">
+        android:logo="@mipmap/ic_launcher">
 
 
         <meta-data android:name="android.webkit.WebView.MetricsOptOut"
@@ -50,11 +49,6 @@
         <meta-data
             android:name="com.google.android.backup.api_key"
             android:value="AEdPqrEAAAAI3a05VToCTlqBymJrbFGaKQMvF-bBAuLsOdavBA"/>
-
-        <!-- Version < 3.0. DeX Mode and Screen Mirroring support -->
-        <meta-data android:name="com.samsung.android.keepalive.density" android:value="true"/>
-        <!-- Version >= 3.0. DeX Dual Mode support -->
-        <meta-data android:name="com.samsung.android.multidisplay.keep_process_alive" android:value="true"/>
 
         <activity
             android:name=".activity.SplashActivity"
@@ -79,7 +73,7 @@
 
         <activity
             android:name=".activity.MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|density|uiMode|keyboard|navigation"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
             android:windowSoftInputMode="stateHidden"
             android:launchMode="singleTask"
             android:label="@string/app_name">

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
@@ -96,6 +97,7 @@ public class MainActivity extends CastEnabledActivity {
 
         drawerLayout = findViewById(R.id.drawer_layout);
         navDrawer = findViewById(R.id.navDrawerFragment);
+        navDrawer.getLayoutParams().width = (int) (getScreenWidth() * getDefaultNavDrawerScreenPercentage());
 
         final FragmentManager fm = getSupportFragmentManager();
         fm.addOnBackStackChangedListener(() -> {
@@ -323,6 +325,17 @@ public class MainActivity extends CastEnabledActivity {
         if (drawerToggle != null) { // Tablet layout does not have a drawer
             drawerToggle.onConfigurationChanged(newConfig);
         }
+        navDrawer.getLayoutParams().width = (int) (getScreenWidth() * getDefaultNavDrawerScreenPercentage());
+    }
+
+    private int getScreenWidth() {
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+        return displayMetrics.widthPixels;
+    }
+
+    private float getDefaultNavDrawerScreenPercentage() {
+        return getResources().getInteger(R.integer.nav_drawer_screen_size_percent) * 0.01f;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -331,7 +331,7 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     private void setNavDrawerSize() {
-        if (isTablet()) {
+        if (drawerToggle == null) { // Tablet layout does not have a drawer
             return;
         }
         float screenPercent = getResources().getInteger(R.integer.nav_drawer_screen_size_percent) * 0.01f;
@@ -345,12 +345,6 @@ public class MainActivity extends CastEnabledActivity {
         DisplayMetrics displayMetrics = new DisplayMetrics();
         getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
         return displayMetrics.widthPixels;
-    }
-
-    private boolean isTablet() {
-        return (getResources().getConfiguration().screenLayout
-                & Configuration.SCREENLAYOUT_SIZE_MASK)
-                >= Configuration.SCREENLAYOUT_SIZE_LARGE;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -331,15 +331,13 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     private void setNavDrawerSize() {
+        if (isTablet())
+            return;
         float screenPercent = getResources().getInteger(R.integer.nav_drawer_screen_size_percent) * 0.01f;
         int width = (int) (getScreenWidth() * screenPercent);
-        int maxWidth = (int) dpInPx(getResources().getInteger(R.integer.nav_drawer_max_screen_size_dp));
+        int maxWidth = (int) getResources().getDimension(R.dimen.nav_drawer_max_screen_size);
 
-        if (width > maxWidth) {
-            width = maxWidth;
-        }
-
-        navDrawer.getLayoutParams().width = width;
+        navDrawer.getLayoutParams().width = Math.min(width, maxWidth);
     }
 
     private int getScreenWidth() {
@@ -348,13 +346,10 @@ public class MainActivity extends CastEnabledActivity {
         return displayMetrics.widthPixels;
     }
 
-    private float dpInPx(int dp) {
-        Resources r = getResources();
-        return TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP,
-                dp,
-                r.getDisplayMetrics()
-        );
+    private boolean isTablet() {
+        return (getResources().getConfiguration().screenLayout
+                & Configuration.SCREENLAYOUT_SIZE_MASK)
+                >= Configuration.SCREENLAYOUT_SIZE_LARGE;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -5,11 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -97,7 +99,7 @@ public class MainActivity extends CastEnabledActivity {
 
         drawerLayout = findViewById(R.id.drawer_layout);
         navDrawer = findViewById(R.id.navDrawerFragment);
-        navDrawer.getLayoutParams().width = (int) (getScreenWidth() * getDefaultNavDrawerScreenPercentage());
+        setNavDrawerSize();
 
         final FragmentManager fm = getSupportFragmentManager();
         fm.addOnBackStackChangedListener(() -> {
@@ -325,7 +327,19 @@ public class MainActivity extends CastEnabledActivity {
         if (drawerToggle != null) { // Tablet layout does not have a drawer
             drawerToggle.onConfigurationChanged(newConfig);
         }
-        navDrawer.getLayoutParams().width = (int) (getScreenWidth() * getDefaultNavDrawerScreenPercentage());
+        setNavDrawerSize();
+    }
+
+    private void setNavDrawerSize() {
+        float screenPercent = getResources().getInteger(R.integer.nav_drawer_screen_size_percent) * 0.01f;
+        int width = (int) (getScreenWidth() * screenPercent);
+        int maxWidth = (int) dpInPx(getResources().getInteger(R.integer.nav_drawer_max_screen_size_dp));
+
+        if (width > maxWidth) {
+            width = maxWidth;
+        }
+
+        navDrawer.getLayoutParams().width = width;
     }
 
     private int getScreenWidth() {
@@ -334,8 +348,13 @@ public class MainActivity extends CastEnabledActivity {
         return displayMetrics.widthPixels;
     }
 
-    private float getDefaultNavDrawerScreenPercentage() {
-        return getResources().getInteger(R.integer.nav_drawer_screen_size_percent) * 0.01f;
+    private float dpInPx(int dp) {
+        Resources r = getResources();
+        return TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                dp,
+                r.getDisplayMetrics()
+        );
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -331,8 +331,9 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     private void setNavDrawerSize() {
-        if (isTablet())
+        if (isTablet()) {
             return;
+        }
         float screenPercent = getResources().getInteger(R.integer.nav_drawer_screen_size_percent) * 0.01f;
         int width = (int) (getScreenWidth() * screenPercent);
         int maxWidth = (int) getResources().getDimension(R.dimen.nav_drawer_max_screen_size);

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -37,8 +37,6 @@
             android:id="@+id/navDrawerFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginEnd="24dp"
-            android:layout_marginRight="24dp"
             android:layout_gravity="start"
             android:orientation="vertical" />
 

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -2,5 +2,4 @@
 <resources>
     <integer name="subscriptions_default_num_of_columns">3</integer>
     <integer name="nav_drawer_screen_size_percent">80</integer>
-    <integer name="nav_drawer_max_screen_size_dp">480</integer>
 </resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="subscriptions_default_num_of_columns">3</integer>
+    <integer name="nav_drawer_screen_size_percent">80</integer>
 </resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -2,4 +2,5 @@
 <resources>
     <integer name="subscriptions_default_num_of_columns">3</integer>
     <integer name="nav_drawer_screen_size_percent">80</integer>
+    <integer name="nav_drawer_max_screen_size_dp">480</integer>
 </resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -38,4 +38,6 @@
     <dimen name="media_router_controller_playback_control_start_padding">24dp</dimen>
     <dimen name="media_router_controller_bottom_margin">8dp</dimen>
 
+    <dimen name="nav_drawer_max_screen_size">480dp</dimen>
+
 </resources>


### PR DESCRIPTION
While adding support for samsung's DeX (#4343 ), the issue appeared that the navigation drawer is too large on wide screens.
This could be solved by a screen-size-dynamical drawer size or a maximum width.