### PR TITLE
Remove Feedburner intent-filter

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -217,21 +217,6 @@
                 <data android:pathPattern=".*\\.atom"/>
             </intent-filter>
 
-            <!-- Feedburner URLs -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-
-                <data android:scheme="http"/>
-                <data android:scheme="https"/>
-                <data android:host="feeds.feedburner.com"/>
-                <data android:host="feedproxy.google.com"/>
-                <data android:host="feeds2.feedburner.com"/>
-                <data android:host="feedsproxy.google.com"/>
-            </intent-filter>
-
             <!-- Files with mimeType rss/xml/atom -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
Hijacks FeedBurner click-tracking for blogs and news sites (unrelated to podcasts) links from all over the web. It’s also super-annoying to be pulled into AntennaPod when I click on a link from my RSS reader.

The implementation assumes the domains are only used to serve feeds. They proxy images and handle click-tracking for Feedburner. Other uses are served under the path prefix `/~`. However, there is no way to exclude a path prefix from the intent-filter. This regex could do the job, but there is no support for regex. `/[^~]+`

Example URL that’s affected by this:
`https://feeds.feedburner.com/~r/$feedname/$clicktracking_id`

These pop up on Facebook, Twitter, and all over the place as people syndicate their feeds around the web. 