### PR TITLE
Update ExoPlayer to 2.11.8

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.10.8'
+    implementation 'com.google.android.exoplayer:exoplayer:2.11.8'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     // Add casting features

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -8,7 +8,6 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
@@ -76,9 +75,11 @@ public class ExoPlayerWrapper implements IPlayer {
                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS);
         loadControl.setBackBuffer(UserPreferences.getRewindSecs() * 1000 + 500, true);
-        trackSelector = new DefaultTrackSelector();
-        exoPlayer = ExoPlayerFactory.newSimpleInstance(context, new DefaultRenderersFactory(context),
-                trackSelector, loadControl.createDefaultLoadControl());
+        trackSelector = new DefaultTrackSelector(context);
+        exoPlayer = new SimpleExoPlayer.Builder(context, new DefaultRenderersFactory(context))
+                .setTrackSelector(trackSelector)
+                .setLoadControl(loadControl.createDefaultLoadControl())
+                .build();
         exoPlayer.setSeekParameters(SeekParameters.EXACT);
         exoPlayer.addListener(new Player.EventListener() {
             @Override


### PR DESCRIPTION
This mimics an update I did for Slide [here](https://github.com/ccrama/Slide/commit/f3e402d24ded46fa5a290ad5c1dc903749e8e1e8).

This update won't cause any problems. I've thoroughly tested (this and [other](https://github.com/ccrama/Slide/pull/3233/commits/f61d3bd6b84ed9413637c2a4c34a804eba274498)) ExoPlayer updates and deprecation fixes in Slide debug builds, and there have been zero problems (if anything, better performance).

Of course, you can wait until after 2.0.0 is released to merge this if you wish.
