### PR TITLE
Move remaining preference to AndroidX preference

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/entities/ExternalMediaTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/entities/ExternalMediaTest.java
@@ -2,7 +2,7 @@ package de.test.antennapod.entities;
 
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.filters.LargeTest;

--- a/app/src/androidTest/java/de/test/antennapod/playback/PlaybackTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/playback/PlaybackTest.java
@@ -3,7 +3,7 @@ package de.test.antennapod.playback;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.view.View;
 
 import androidx.test.filters.LargeTest;

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBCleanupTests.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBCleanupTests.java
@@ -2,7 +2,7 @@ package de.test.antennapod.storage;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBNullCleanupAlgorithmTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBNullCleanupAlgorithmTest.java
@@ -2,7 +2,7 @@ package de.test.antennapod.storage;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/DBWriterTest.java
@@ -3,7 +3,7 @@ package de.test.antennapod.storage;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import androidx.core.util.Consumer;

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -3,7 +3,7 @@ package de.test.antennapod.ui;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.StringRes;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;

--- a/app/src/androidTest/java/de/test/antennapod/ui/SpeedChangeTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/SpeedChangeTest.java
@@ -3,7 +3,7 @@ package de.test.antennapod.ui;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import de.danoeh.antennapod.R;

--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -14,7 +14,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.event.settings.SkipIntroEndingChangedEvent;
@@ -322,7 +322,7 @@ public class FeedSettingsFragment extends Fragment {
         }
 
         private void setupKeepUpdatedPreference() {
-            SwitchPreference pref = findPreference("keepUpdated");
+            SwitchPreferenceCompat pref = findPreference("keepUpdated");
 
             pref.setChecked(feedPreferences.getKeepUpdated());
             pref.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -336,7 +336,7 @@ public class FeedSettingsFragment extends Fragment {
 
         private void setupAutoDownloadGlobalPreference() {
             if (!UserPreferences.isEnableAutodownload()) {
-                SwitchPreference autodl = findPreference("autoDownload");
+                SwitchPreferenceCompat autodl = findPreference("autoDownload");
                 autodl.setChecked(false);
                 autodl.setEnabled(false);
                 autodl.setSummary(R.string.auto_download_disabled_globally);
@@ -345,7 +345,7 @@ public class FeedSettingsFragment extends Fragment {
         }
 
         private void setupAutoDownloadPreference() {
-            SwitchPreference pref = findPreference("autoDownload");
+            SwitchPreferenceCompat pref = findPreference("autoDownload");
 
             pref.setEnabled(UserPreferences.isEnableAutodownload());
             if (UserPreferences.isEnableAutodownload()) {

--- a/app/src/main/java/de/danoeh/antennapod/preferences/MasterSwitchPreference.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/MasterSwitchPreference.java
@@ -4,7 +4,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Build;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
 import androidx.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -12,7 +12,7 @@ import android.widget.TextView;
 
 import de.danoeh.antennapod.R;
 
-public class MasterSwitchPreference extends SwitchPreference {
+public class MasterSwitchPreference extends SwitchPreferenceCompat {
 
     public MasterSwitchPreference(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -2,7 +2,7 @@ package de.danoeh.antennapod.preferences;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.CrashReportWriter;

--- a/app/src/main/java/de/danoeh/antennapod/spa/SPAUtil.java
+++ b/app/src/main/java/de/danoeh/antennapod/spa/SPAUtil.java
@@ -3,7 +3,7 @@ package de.danoeh.antennapod.spa;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 
 import de.danoeh.antennapod.BuildConfig;

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:key="feedSettingsScreen">
 
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:key="keepUpdated"
             android:icon="?attr/navigation_refresh"
             android:title="@string/keep_updated"
@@ -45,7 +45,7 @@
             android:key="volumeReduction"/>
 
     <PreferenceCategory android:title="@string/auto_download_settings_label">
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:key="autoDownload"
                 android:title="@string/auto_download_label"/>
         <Preference

--- a/app/src/main/res/xml/preferences_autodownload.xml
+++ b/app/src/main/res/xml/preferences_autodownload.xml
@@ -22,12 +22,12 @@
             android:title="@string/pref_episode_cleanup_title"
             android:summary="@string/pref_episode_cleanup_summary"
             android:entryValues="@array/episode_cleanup_values"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:key="prefEnableAutoDownloadOnBattery"
             android:title="@string/pref_automatic_download_on_battery_title"
             android:summary="@string/pref_automatic_download_on_battery_sum"
             android:defaultValue="true"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:key="prefEnableAutoDownloadWifiFilter"
             android:title="@string/pref_autodl_wifi_filter_title"
             android:summary="@string/pref_autodl_wifi_filter_sum"/>

--- a/app/src/main/res/xml/preferences_gpodder.xml
+++ b/app/src/main/res/xml/preferences_gpodder.xml
@@ -26,7 +26,7 @@
     <Preference
             android:key="pref_gpodnet_hostname"
             android:title="@string/pref_gpodnet_sethostname_title"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:key="pref_gpodnet_notifications"
             android:title="@string/pref_gpodnet_notifications_title"
             android:summary="@string/pref_gpodnet_notifications_sum"

--- a/app/src/main/res/xml/preferences_network.xml
+++ b/app/src/main/res/xml/preferences_network.xml
@@ -29,13 +29,13 @@
                 numberpicker:maxValue="50"
                 android:key="prefParallelDownloads"
                 android:title="@string/pref_parallel_downloads_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefShowDownloadReport"
                 android:summary="@string/pref_showDownloadReport_sum"
                 android:title="@string/pref_showDownloadReport_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefShowAutoDownloadReport"

--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -2,33 +2,33 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/interruptions">
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefPauseOnHeadsetDisconnect"
                 android:summary="@string/pref_pauseOnDisconnect_sum"
                 android:title="@string/pref_pauseOnHeadsetDisconnect_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:dependency="prefPauseOnHeadsetDisconnect"
                 android:key="prefUnpauseOnHeadsetReconnect"
                 android:summary="@string/pref_unpauseOnHeadsetReconnect_sum"
                 android:title="@string/pref_unpauseOnHeadsetReconnect_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:dependency="prefPauseOnHeadsetDisconnect"
                 android:key="prefUnpauseOnBluetoothReconnect"
                 android:summary="@string/pref_unpauseOnBluetoothReconnect_sum"
                 android:title="@string/pref_unpauseOnBluetoothReconnect_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefPauseForFocusLoss"
                 android:summary="@string/pref_pausePlaybackForFocusLoss_sum"
                 android:title="@string/pref_pausePlaybackForFocusLoss_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefResumeAfterCall"
@@ -44,13 +44,13 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/playback_control">
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefHardwareForwardButtonSkips"
                 android:summary="@string/pref_hardwareForwardButtonSkips_sum"
                 android:title="@string/pref_hardwareForwardButtonSkips_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefHardwarePreviousButtonRestarts"
@@ -68,12 +68,12 @@
                 android:key="prefPlaybackSpeedLauncher"
                 android:summary="@string/pref_playback_speed_sum"
                 android:title="@string/playback_speed"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="prefPlaybackTimeRespectsSpeed"
                 android:summary="@string/pref_playback_time_respects_speed_sum"
                 android:title="@string/pref_playback_time_respects_speed_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="prefStreamOverDownload"
                 android:summary="@string/pref_stream_over_download_sum"
@@ -81,7 +81,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/queue_label">
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefEnqueueDownloaded"
@@ -93,7 +93,7 @@
                 android:entryValues="@array/enqueue_location_values"
                 android:key="prefEnqueueLocation"
                 android:title="@string/pref_enqueue_location_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefFollowQueue"
@@ -106,7 +106,7 @@
                 android:key="prefSmartMarkAsPlayedSecs"
                 android:summary="@string/pref_smart_mark_as_played_sum"
                 android:title="@string/pref_smart_mark_as_played_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefSkipKeepsEpisode"
@@ -125,7 +125,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/experimental_pref">
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefCast"

--- a/app/src/main/res/xml/preferences_storage.xml
+++ b/app/src/main/res/xml/preferences_storage.xml
@@ -13,19 +13,19 @@
             android:key="prefImageCacheSize"
             android:summary="@string/pref_image_cache_size_sum"
             android:defaultValue="100"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefAutoDelete"
             android:summary="@string/pref_auto_delete_sum"
             android:title="@string/pref_auto_delete_title"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:defaultValue="true"
             android:enabled="true"
             android:key="prefFavoriteKeepsEpisode"
             android:summary="@string/pref_favorite_keeps_episodes_sum"
             android:title="@string/pref_favorite_keeps_episodes_title"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefDeleteRemovesFromQueue"

--- a/app/src/main/res/xml/preferences_user_interface.xml
+++ b/app/src/main/res/xml/preferences_user_interface.xml
@@ -14,7 +14,7 @@
                 android:key="prefHiddenDrawerItems"
                 android:summary="@string/pref_nav_drawer_items_sum"
                 android:title="@string/pref_nav_drawer_items_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:title="@string/pref_episode_cover_title"
                 android:key="prefEpisodeCover"
                 android:summary="@string/pref_episode_cover_summary"
@@ -42,13 +42,13 @@
             android:summary="@string/pref_filter_feed_sum" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/external_elements">
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefExpandNotify"
                 android:summary="@string/pref_expandNotify_sum"
                 android:title="@string/pref_expandNotify_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefPersistNotify"
@@ -58,7 +58,7 @@
                 android:key="prefCompactNotificationButtons"
                 android:summary="@string/pref_compact_notification_buttons_sum"
                 android:title="@string/pref_compact_notification_buttons_title"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"
                 android:key="prefLockscreenBackground"

--- a/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
+++ b/app/src/play/java/de/danoeh/antennapod/activity/CastEnabledActivity.java
@@ -3,7 +3,7 @@ package de.danoeh.antennapod.activity;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
@@ -2,7 +2,7 @@ package de.danoeh.antennapod.core.preferences;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import android.util.Log;
 import de.danoeh.antennapod.core.event.PlayerStatusEvent;

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Build;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -19,7 +19,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Vibrator;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -2,7 +2,7 @@ package de.danoeh.antennapod.core.util.playback;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.SurfaceHolder;
 

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -3,7 +3,7 @@ package de.danoeh.antennapod.core.util.playback;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Parcelable;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.Nullable;
 import android.util.Log;
 


### PR DESCRIPTION
Nothing really changed here either.

If you are curious, here is the code difference between SwitchPreference and SwitchPreferenceCompat (generated using WinMerge).

[SwitchPreference diff.zip](https://github.com/AntennaPod/AntennaPod/files/5144769/SwitchPreference.diff.zip)


