### PR TITLE
Hide about screen in copycat applications

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
@@ -22,6 +22,7 @@ public class MainPreferencesFragment extends PreferenceFragmentCompat {
     private static final String PREF_FAQ = "prefFaq";
     private static final String PREF_VIEW_FORUM = "prefViewForum";
     private static final String PREF_SEND_BUG_REPORT = "prefSendBugReport";
+    private static final String PREF_CATEGORY_PROJECT = "project";
     private static final String STATISTICS = "statistics";
     private static final String PREF_ABOUT = "prefAbout";
 
@@ -30,6 +31,13 @@ public class MainPreferencesFragment extends PreferenceFragmentCompat {
         addPreferencesFromResource(R.xml.preferences);
         setupMainScreen();
         setupSearch();
+
+        // If you are writing a spin-off, please update the details on screens like "About" and "Report bug"
+        // and afterwards remove the following lines.
+        String packageName = getContext().getPackageName();
+        if (!"de.danoeh.antennapod".equals(packageName) && !"de.danoeh.antennapod.debug".equals(packageName)) {
+            findPreference(PREF_CATEGORY_PROJECT).setVisible(false);
+        }
     }
 
     @Override

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -44,7 +44,9 @@
             android:title="@string/statistics_label"
             android:icon="?attr/statistics" />
 
-    <PreferenceCategory android:title="@string/project_pref">
+    <PreferenceCategory
+            android:key="project"
+            android:title="@string/project_pref">
         <Preference
             android:key="prefFaq"
             android:title="@string/pref_faq"


### PR DESCRIPTION
Copycat applications regularly forget to update the about screen.
They then still claim to be AntennaPod, linking our developers
and our support channels. This change simply hides the about screen
when detecting an app that is not official.