### PR TITLE
Close keyboard in dialogs

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/FeedPreferenceSkipDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/FeedPreferenceSkipDialog.java
@@ -1,7 +1,9 @@
 package de.danoeh.antennapod.dialog;
 
+import android.app.Activity;
 import android.content.Context;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import androidx.appcompat.app.AlertDialog;
 import de.danoeh.antennapod.R;
@@ -10,12 +12,13 @@ import de.danoeh.antennapod.R;
  * Displays a dialog with a username and password text field and an optional checkbox to save username and preferences.
  */
 public abstract class FeedPreferenceSkipDialog extends AlertDialog.Builder {
+    private View rootView;
 
     public FeedPreferenceSkipDialog(Context context, int skipIntroInitialValue,
                                     int skipEndInitialValue) {
         super(context);
         setTitle(R.string.pref_feed_skip);
-        View rootView = View.inflate(context, R.layout.feed_pref_skip_dialog, null);
+        rootView = View.inflate(context, R.layout.feed_pref_skip_dialog, null);
         setView(rootView);
 
         final EditText etxtSkipIntro = rootView.findViewById(R.id.etxtSkipIntro);
@@ -42,6 +45,11 @@ public abstract class FeedPreferenceSkipDialog extends AlertDialog.Builder {
             }
             onConfirmed(skipIntro, skipEnding);
         });
+    }
+
+    public void closeKeyboard(){
+        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(rootView.getWindowToken(), 0);
     }
 
     protected abstract void onConfirmed(int skipIntro, int skipEndig);

--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.dialog;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -32,6 +33,7 @@ public class SleepTimerDialog extends DialogFragment {
     private PlaybackController controller;
     private Disposable timeUpdater;
 
+    private View content;
     private EditText etxtTime;
     private Spinner spTimeUnit;
     private LinearLayout timeSetup;
@@ -76,11 +78,11 @@ public class SleepTimerDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        View content = View.inflate(getContext(), R.layout.time_dialog, null);
+        content = View.inflate(getContext(), R.layout.time_dialog, null);
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
         builder.setTitle(R.string.sleep_timer_label);
         builder.setView(content);
-        builder.setPositiveButton(R.string.close_label, null);
+        builder.setPositiveButton(R.string.close_label, (view, which) -> closeKeyboard());
 
         etxtTime = content.findViewById(R.id.etxtTime);
         spTimeUnit = content.findViewById(R.id.spTimeUnit);
@@ -137,6 +139,7 @@ public class SleepTimerDialog extends DialogFragment {
                 if (controller != null) {
                     controller.setSleepTimer(time);
                 }
+                closeKeyboard();
             } catch (NumberFormatException e) {
                 e.printStackTrace();
                 Snackbar.make(content, R.string.time_dialog_invalid_input, Snackbar.LENGTH_LONG).show();
@@ -152,5 +155,10 @@ public class SleepTimerDialog extends DialogFragment {
         timeSetup.setVisibility(controller.sleepTimerActive() ? View.GONE : View.VISIBLE);
         timeDisplay.setVisibility(controller.sleepTimerActive() ? View.VISIBLE : View.GONE);
         time.setText(Converter.getDurationStringLong((int) controller.getSleepTimerTimeLeft()));
+    }
+
+    public void closeKeyboard() {
+        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(content.getWindowToken(), 0);
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -177,6 +177,7 @@ public class FeedSettingsFragment extends Fragment {
                                 new SkipIntroEndingChangedEvent(feedPreferences.getFeedSkipIntro(),
                                         feedPreferences.getFeedSkipEnding(),
                                         feed.getId()));
+                        closeKeyboard();
                     }
                 }.show();
                 return false;


### PR DESCRIPTION
Automatically close the keyboard after the confirm button has been pressed.
The trick is, that `hideSoftInputFromWindow` must use the view of the dialog.

Closes #4394 
Closes #4208 
Please tell me other dialogs that need this functionality, too.