### PR TITLE
Fix error inflating class RadioButton when opening Subscriptions filter dialog

### DIFF
--- a/core/src/main/res/color/filter_dialog_background_dark.xml
+++ b/core/src/main/res/color/filter_dialog_background_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/accent_dark" android:state_checked="true"/>
-    <item android:color="@color/dialog_filter_inactive_dark" />
-</selector>

--- a/core/src/main/res/color/filter_dialog_background_light.xml
+++ b/core/src/main/res/color/filter_dialog_background_light.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/accent_light" android:state_checked="true" />
-    <item android:color="@color/dialog_filter_inactive_light" />
-</selector>

--- a/core/src/main/res/drawable/filter_dialog_background_dark.xml
+++ b/core/src/main/res/drawable/filter_dialog_background_dark.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/accent_dark" android:state_checked="true"/>
+    <item android:drawable="@color/dialog_filter_inactive_dark" />
+</selector>

--- a/core/src/main/res/drawable/filter_dialog_background_light.xml
+++ b/core/src/main/res/drawable/filter_dialog_background_light.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/accent_light" android:state_checked="true" />
+    <item android:drawable="@color/dialog_filter_inactive_light" />
+</selector>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -74,7 +74,7 @@
         <item name="ic_volume_adaption">@drawable/ic_volume_adaption_black</item>
         <item name="scrollbar_thumb">@drawable/scrollbar_thumb_light</item>
         <item name="filter_dialog_clear">@color/filter_dialog_clear_light</item>
-        <item name="filter_dialog_button_background">@color/filter_dialog_background_light</item>
+        <item name="filter_dialog_button_background">@drawable/filter_dialog_background_light</item>
     </style>
 
     <style name="Theme.AntennaPod.Dark" parent="Theme.Base.AntennaPod.Dark">
@@ -151,7 +151,7 @@
         <item name="ic_volume_adaption">@drawable/ic_volume_adaption_white</item>
         <item name="scrollbar_thumb">@drawable/scrollbar_thumb_dark</item>
         <item name="filter_dialog_clear">@color/filter_dialog_clear_dark</item>
-        <item name="filter_dialog_button_background">@color/filter_dialog_background_dark</item>
+        <item name="filter_dialog_button_background">@drawable/filter_dialog_background_dark</item>
     </style>
 
     <style name="Theme.AntennaPod.TrueBlack" parent="Theme.Base.AntennaPod.TrueBlack">


### PR DESCRIPTION
This fixes defect 4430. It converts the filter dialog's color state lists to state list drawables for filter background colors. This eliminates an incompatibility on earlier Android OS versions (https://stackoverflow.com/questions/3953606/how-to-specify-background-color-in-color-state-list-resources)

Closes #4430