### PR TITLE
Fixed crash when item has no feed

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -154,6 +154,7 @@ public final class DBReader {
             Feed feed = feedIndex.get(item.getFeedId());
             if (feed == null) {
                 Log.w(TAG, "No match found for item with ID " + item.getId() + ". Feed ID was " + item.getFeedId());
+                feed = new Feed("", "", "Error: Item without feed");
             }
             item.setFeed(feed);
         }


### PR DESCRIPTION
Apparently, there are ways to end up with items that have no feed.
This hotfix prevents the app from crashing but it does not solve the
reason for items without feeds.