### PR TITLE
Local feeds: Hide "Share..." menu item

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -105,6 +105,10 @@ public class FeedItemMenuHandler {
 
         setItemVisibility(menu, R.id.remove_item, fileDownloaded);
 
+        if (selectedItem.getFeed().isLocalFeed()) {
+            setItemVisibility(menu, R.id.share_item, false);
+        }
+
         return true;
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -64,9 +64,6 @@ public class FeedItemMenuHandler {
         if (!ShareUtils.hasLinkToShare(selectedItem)) {
             setItemVisibility(menu, R.id.visit_website_item, false);
         }
-        if (selectedItem.getFeed().isLocalFeed()) {
-            setItemVisibility(menu, R.id.visit_website_item, false);
-        }
 
         boolean fileDownloaded = hasMedia && selectedItem.getMedia().fileExists();
 
@@ -106,6 +103,7 @@ public class FeedItemMenuHandler {
         setItemVisibility(menu, R.id.remove_item, fileDownloaded);
 
         if (selectedItem.getFeed().isLocalFeed()) {
+            setItemVisibility(menu, R.id.visit_website_item, false);
             setItemVisibility(menu, R.id.share_item, false);
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
@@ -51,6 +51,10 @@ public class FeedMenuHandler {
             menu.findItem(R.id.visit_website_item).setVisible(false);
             menu.findItem(R.id.share_link_item).setVisible(false);
         }
+        if (selectedFeed.isLocalFeed()) {
+            // hide complete submenu "Share..." as both sub menu items are not visible
+            menu.findItem(R.id.share_item).setVisible(false);
+        }
 
         return true;
     }


### PR DESCRIPTION
Fixes: "Share episode url" does not work

- Class `FeedMenuHandler`: Hide complete submenu "Share..." as both sub menu items are not visible for local feeds.
- Class `FeedItemMenuHandler`: Hide "Share..." menu item for local feeds.

Contributes to #4287.