### PR TITLE
Show retry button if QuickFeedDiscovery failed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QuickFeedDiscoveryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QuickFeedDiscoveryFragment.java
@@ -9,7 +9,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
+import android.widget.Button;
 import android.widget.GridView;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import de.danoeh.antennapod.R;
@@ -33,6 +35,7 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
     private FeedDiscoverAdapter adapter;
     private GridView discoverGridLayout;
     private TextView errorTextView;
+    private LinearLayout errorView;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -44,7 +47,10 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
 
         discoverGridLayout = root.findViewById(R.id.discover_grid);
         progressBar = root.findViewById(R.id.discover_progress_bar);
-        errorTextView = root.findViewById(R.id.discover_error);
+        errorView = root.findViewById(R.id.discover_error);
+        errorTextView = root.findViewById(R.id.discover_error_txtV);
+        Button errorRetry = root.findViewById(R.id.discover_error_retry_btn);
+        errorRetry.setOnClickListener((listener) -> loadToplist());
 
         adapter = new FeedDiscoverAdapter((MainActivity) getActivity());
         discoverGridLayout.setAdapter(adapter);
@@ -81,19 +87,19 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
     private void loadToplist() {
         progressBar.setVisibility(View.VISIBLE);
         discoverGridLayout.setVisibility(View.INVISIBLE);
-        errorTextView.setVisibility(View.GONE);
+        errorView.setVisibility(View.GONE);
 
         ItunesTopListLoader loader = new ItunesTopListLoader(getContext());
         disposable = loader.loadToplist(NUM_SUGGESTIONS)
                 .subscribe(podcasts -> {
-                    errorTextView.setVisibility(View.GONE);
+                    errorView.setVisibility(View.GONE);
                     progressBar.setVisibility(View.GONE);
                     discoverGridLayout.setVisibility(View.VISIBLE);
                     adapter.updateData(podcasts);
                 }, error -> {
                     Log.e(TAG, Log.getStackTraceString(error));
                     errorTextView.setText(error.getLocalizedMessage());
-                    errorTextView.setVisibility(View.VISIBLE);
+                    errorView.setVisibility(View.VISIBLE);
                     progressBar.setVisibility(View.GONE);
                     discoverGridLayout.setVisibility(View.INVISIBLE);
                 });

--- a/app/src/main/res/layout/quick_feed_discovery.xml
+++ b/app/src/main/res/layout/quick_feed_discovery.xml
@@ -4,6 +4,7 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        xmlns:tools="http://schemas.android.com/tools"
         android:orientation="vertical">
 
     <LinearLayout
@@ -54,12 +55,32 @@
                 android:layout_centerInParent="true"
                 android:layout_marginTop="30dp"/>
 
-        <TextView
+        <LinearLayout
                 android:id="@+id/discover_error"
-                android:textColor="@color/download_failed_red"
                 android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
-                android:layout_height="wrap_content"/>
+                android:gravity="center"
+                android:orientation="vertical">
+
+            <TextView
+                    android:id="@+id/discover_error_txtV"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:layout_margin="16dp"
+                    android:textSize="@dimen/text_size_small"
+                    tools:text="Error message"
+                    tools:background="@android:color/holo_red_light" />
+
+            <Button
+                    android:id="@+id/discover_error_retry_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:text="@string/retry_label"
+                    tools:background="@android:color/holo_red_light" />
+        </LinearLayout>
 
     </RelativeLayout>
 


### PR DESCRIPTION
This adds a retry button to the `QuickFeedDiscoveryFragment` if there is any kind of error.
![Screen](https://user-images.githubusercontent.com/36813904/94372135-d3c23700-00ea-11eb-925c-9c8e64a76f25.png)
Closes #4227 