### PR TITLE
Fix buffering indicator sometimes sticking

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -102,6 +102,7 @@ public class VideoplayerActivity extends MediaplayerActivity {
         if (!PictureInPictureUtil.isInPictureInPictureMode(this)) {
             videoControlsHider.stop();
         }
+        progressIndicator.setVisibility(View.GONE); // Controller released; we will not receive buffering updates
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -386,6 +386,7 @@ public class AudioPlayerFragment extends Fragment implements
         super.onStop();
         controller.release();
         controller = null;
+        progressIndicator.setVisibility(View.GONE); // Controller released; we will not receive buffering updates
         EventBus.getDefault().unregister(this);
         if (disposable != null) {
             disposable.dispose();


### PR DESCRIPTION
We currently have no method to actively query the buffering state.
Remove indicator if we can no longer receive updates.

Closes #4148