### PR TITLE
Don't reserve icon space for settings without icons

### DIFF
--- a/app/src/main/res/values-sw360dp/resource-overrides.xml
+++ b/app/src/main/res/values-sw360dp/resource-overrides.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources, MissingDefaultResource">
+    <bool name="config_materialPreferenceIconSpaceReserved" tools:override="true">false</bool>
+</resources>


### PR DESCRIPTION
Makes settings look more aesthetically pleasing and symmetrical (margin and padding-wise).

Here's an APK for your example.
[antennapod-reserved-space.zip](https://github.com/AntennaPod/AntennaPod/files/5299652/antennapod-reserved-space.zip)


![image](https://user-images.githubusercontent.com/32376686/94569984-53abe680-023c-11eb-9cfa-fb10e97a9baf.png)
