### PR TITLE
Hardware keyboard support 

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -540,21 +540,6 @@ public class MainActivity extends CastEnabledActivity {
                 //Go Forward
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
                 break;
-            case KeyEvent.KEYCODE_M:
-                //Mute/Unmute
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
-                } else {
-                    if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
-                        //Unmute
-                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,
-                                audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
-                    } else {
-                        //Mute
-                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0);
-                    }
-                }
-                break;
             case KeyEvent.KEYCODE_DPAD_UP:
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -524,29 +524,41 @@ public class MainActivity extends CastEnabledActivity {
         Integer customKeyCode = null;
 
         switch (keyCode) {
-            case KeyEvent.KEYCODE_ENTER: //Fallthrough
-            case KeyEvent.KEYCODE_SPACE:
+            case KeyEvent.KEYCODE_P:
                 //Play/Pause
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
                 break;
-            case KeyEvent.KEYCODE_DPAD_LEFT:
+            case KeyEvent.KEYCODE_J: //Fallthrough
+            case KeyEvent.KEYCODE_A:
+            case KeyEvent.KEYCODE_COMMA:
                 //Go Back
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_REWIND;
                 break;
-            case KeyEvent.KEYCODE_DPAD_RIGHT:
+            case KeyEvent.KEYCODE_K: //Fallthrough
+            case KeyEvent.KEYCODE_D:
+            case KeyEvent.KEYCODE_PERIOD:
                 //Go Forward
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
                 break;
-            case KeyEvent.KEYCODE_DPAD_UP:
+            case KeyEvent.KEYCODE_PLUS: //Fallthrough
+            case KeyEvent.KEYCODE_W:
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
                 return true;
-            case KeyEvent.KEYCODE_DPAD_DOWN:
+            case KeyEvent.KEYCODE_MINUS: //Fallthrough
+            case KeyEvent.KEYCODE_S:
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
                 return true;
+            case KeyEvent.KEYCODE_M:
+                //Mute/Unmute
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
+                    return true;
+                }
+                break;
         }
 
         if (customKeyCode != null) {

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -541,22 +541,21 @@ public class MainActivity extends CastEnabledActivity {
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
-                break;
+                return true;
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
-                break;
-            default:
-                return super.onKeyUp(keyCode, event);
+                return true;
         }
 
         if (customKeyCode != null) {
             Intent intent = new Intent(this, PlaybackService.class);
             intent.putExtra(MediaButtonReceiver.EXTRA_KEYCODE, customKeyCode);
             ContextCompat.startForegroundService(this, intent);
+            return true;
         }
-        return true;
+        return super.onKeyUp(keyCode, event);
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -525,35 +525,29 @@ public class MainActivity extends CastEnabledActivity {
 
         switch (keyCode) {
             case KeyEvent.KEYCODE_P:
-                //Play/Pause
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
                 break;
             case KeyEvent.KEYCODE_J: //Fallthrough
             case KeyEvent.KEYCODE_A:
             case KeyEvent.KEYCODE_COMMA:
-                //Go Back
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_REWIND;
                 break;
             case KeyEvent.KEYCODE_K: //Fallthrough
             case KeyEvent.KEYCODE_D:
             case KeyEvent.KEYCODE_PERIOD:
-                //Go Forward
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
                 break;
             case KeyEvent.KEYCODE_PLUS: //Fallthrough
             case KeyEvent.KEYCODE_W:
-                //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
                 return true;
             case KeyEvent.KEYCODE_MINUS: //Fallthrough
             case KeyEvent.KEYCODE_S:
-                //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
                 return true;
             case KeyEvent.KEYCODE_M:
-                //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
                     return true;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -520,9 +520,6 @@ public class MainActivity extends CastEnabledActivity {
     //Hardware keyboard support
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        Intent serviceIntent = new Intent(this, PlaybackService.class);
-        serviceIntent.putExtra(MediaButtonReceiver.EXTRA_HARDWAREBUTTON, true);
-
         AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
         Integer customKeyCode = null;
 
@@ -555,8 +552,10 @@ public class MainActivity extends CastEnabledActivity {
         }
 
         if (customKeyCode != null) {
-            serviceIntent.putExtra(MediaButtonReceiver.EXTRA_KEYCODE, customKeyCode);
-            ContextCompat.startForegroundService(this, serviceIntent);
+            Intent intent = new Intent(this, PlaybackService.class);
+            intent.putExtra(MediaButtonReceiver.EXTRA_HARDWAREBUTTON, true);
+            intent.putExtra(MediaButtonReceiver.EXTRA_KEYCODE, customKeyCode);
+            ContextCompat.startForegroundService(this, intent);
         }
         return true;
     }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -555,7 +555,7 @@ public class MainActivity extends CastEnabledActivity {
             case KeyEvent.KEYCODE_M:
                 //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
                     return true;
                 }
                 break;

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -553,7 +553,6 @@ public class MainActivity extends CastEnabledActivity {
 
         if (customKeyCode != null) {
             Intent intent = new Intent(this, PlaybackService.class);
-            intent.putExtra(MediaButtonReceiver.EXTRA_HARDWAREBUTTON, true);
             intent.putExtra(MediaButtonReceiver.EXTRA_KEYCODE, customKeyCode);
             ContextCompat.startForegroundService(this, intent);
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -547,7 +547,8 @@ public class MainActivity extends CastEnabledActivity {
                 } else {
                     if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
                         //Unmute
-                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
+                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,
+                                audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
                     } else {
                         //Mute
                         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0);
@@ -556,11 +557,13 @@ public class MainActivity extends CastEnabledActivity {
                 break;
             case KeyEvent.KEYCODE_DPAD_UP:
                 //Raise volume
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
                 break;
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 //Raise volume
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
                 break;
             default:
                 return super.onKeyUp(keyCode, event);

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -549,7 +549,8 @@ public class MainActivity extends CastEnabledActivity {
                 return true;
             case KeyEvent.KEYCODE_M:
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                            AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
                     return true;
                 }
                 break;

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -489,7 +489,6 @@ public class VideoplayerActivity extends MediaplayerActivity {
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
         AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
-        Float videoPercent = null;
 
         switch (keyCode) {
             case KeyEvent.KEYCODE_ENTER: //Fallthrough
@@ -497,82 +496,50 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 //Play/Pause
                 onPlayPause();
                 toggleVideoControlsVisibility();
-                break;
+                return true;
             case KeyEvent.KEYCODE_DPAD_LEFT:
                 //Go Back
                 onRewind();
                 showSkipAnimation(false);
-                break;
+                return true;
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 //Go Forward
                 onFastForward();
                 showSkipAnimation(true);
-                break;
+                return true;
             case KeyEvent.KEYCODE_M:
                 //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
-                } else {
-                    return super.onKeyUp(keyCode, event);
+                    return true;
                 }
                 break;
             case KeyEvent.KEYCODE_DPAD_UP:
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
-                break;
+                return true;
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
-                break;
+                return true;
             case KeyEvent.KEYCODE_ESCAPE:
             case KeyEvent.KEYCODE_F:
                 //Exit fullscreen mode
                 onBackPressed();
-                break;
+                return true;
             case KeyEvent.KEYCODE_P:
                 //Toggle picture-in-picture mode
                 compatEnterPictureInPicture();
-                break;
-            //Go to x% of video:
-            case KeyEvent.KEYCODE_0:
-                videoPercent = 0f;
-                break;
-            case KeyEvent.KEYCODE_1:
-                videoPercent = 0.1f;
-                break;
-            case KeyEvent.KEYCODE_2:
-                videoPercent = 0.2f;
-                break;
-            case KeyEvent.KEYCODE_3:
-                videoPercent = 0.3f;
-                break;
-            case KeyEvent.KEYCODE_4:
-                videoPercent = 0.4f;
-                break;
-            case KeyEvent.KEYCODE_5:
-                videoPercent = 0.5f;
-                break;
-            case KeyEvent.KEYCODE_6:
-                videoPercent = 0.6f;
-                break;
-            case KeyEvent.KEYCODE_7:
-                videoPercent = 0.7f;
-                break;
-            case KeyEvent.KEYCODE_8:
-                videoPercent = 0.8f;
-                break;
-            case KeyEvent.KEYCODE_9:
-                videoPercent = 0.9f;
-                break;
-            default:
-                return super.onKeyUp(keyCode, event);
+                return true;
         }
 
-        if (videoPercent != null) {
-            controller.seekTo((int) (videoPercent * controller.getDuration()));
+        //Go to x% of video:
+        if (keyCode >= KeyEvent.KEYCODE_0 && keyCode <= KeyEvent.KEYCODE_9) {
+            controller.seekTo((int) (0.1f * (keyCode - KeyEvent.KEYCODE_0) * controller.getDuration()));
+            return true;
         }
-        return true;
+        return super.onKeyUp(keyCode, event);
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -515,7 +515,8 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 } else {
                     if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
                         //Unmute
-                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
+                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,
+                                audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
                     } else {
                         //Mute
                         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0);
@@ -524,11 +525,13 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 break;
             case KeyEvent.KEYCODE_DPAD_UP:
                 //Raise volume
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
                 break;
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 //Raise volume
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
                 break;
             case KeyEvent.KEYCODE_ESCAPE:
             case KeyEvent.KEYCODE_F:
@@ -574,8 +577,9 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 return super.onKeyUp(keyCode, event);
         }
 
-        if (videoPercent != null)
+        if (videoPercent != null) {
             controller.seekTo((int) (videoPercent * controller.getDuration()));
+        }
         return true;
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -535,7 +535,7 @@ public class VideoplayerActivity extends MediaplayerActivity {
             case KeyEvent.KEYCODE_M:
                 //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
                     return true;
                 }
                 break;

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -528,7 +528,8 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 return true;
             case KeyEvent.KEYCODE_M:
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                            AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
                     return true;
                 }
                 break;

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -493,47 +493,40 @@ public class VideoplayerActivity extends MediaplayerActivity {
         switch (keyCode) {
             case KeyEvent.KEYCODE_P: //Fallthrough
             case KeyEvent.KEYCODE_SPACE:
-                //Play/Pause
                 onPlayPause();
                 toggleVideoControlsVisibility();
                 return true;
             case KeyEvent.KEYCODE_J: //Fallthrough
             case KeyEvent.KEYCODE_A:
             case KeyEvent.KEYCODE_COMMA:
-                //Go Back
                 onRewind();
                 showSkipAnimation(false);
                 return true;
             case KeyEvent.KEYCODE_K: //Fallthrough
             case KeyEvent.KEYCODE_D:
             case KeyEvent.KEYCODE_PERIOD:
-                //Go Forward
                 onFastForward();
                 showSkipAnimation(true);
                 return true;
-            case KeyEvent.KEYCODE_F:
+            case KeyEvent.KEYCODE_F: //Fallthrough
             case KeyEvent.KEYCODE_ESCAPE:
                 //Exit fullscreen mode
                 onBackPressed();
                 return true;
             case KeyEvent.KEYCODE_I:
-                //Toggle picture-in-picture mode
                 compatEnterPictureInPicture();
                 return true;
             case KeyEvent.KEYCODE_PLUS: //Fallthrough
             case KeyEvent.KEYCODE_W:
-                //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
                 return true;
             case KeyEvent.KEYCODE_MINUS: //Fallthrough
             case KeyEvent.KEYCODE_S:
-                //Raise volume
                 audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
                         AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
                 return true;
             case KeyEvent.KEYCODE_M:
-                //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, AudioManager.FLAG_SHOW_UI);
                     return true;

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -512,11 +512,6 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
-                } else {
-                    if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) > 0) {
-                        //Mute
-                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0);
-                    }
                 }
                 break;
             case KeyEvent.KEYCODE_DPAD_UP:

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -513,11 +513,7 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
                 } else {
-                    if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
-                        //Unmute
-                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,
-                                audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
-                    } else {
+                    if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) > 0) {
                         //Mute
                         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0);
                     }
@@ -536,7 +532,7 @@ public class VideoplayerActivity extends MediaplayerActivity {
             case KeyEvent.KEYCODE_ESCAPE:
             case KeyEvent.KEYCODE_F:
                 //Exit fullscreen mode
-                onOptionsItemSelected(new ActionMenuItem(this, 0, android.R.id.home, 0, 0, ""));
+                onBackPressed();
                 break;
             case KeyEvent.KEYCODE_P:
                 //Toggle picture-in-picture mode

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -512,6 +512,8 @@ public class VideoplayerActivity extends MediaplayerActivity {
                 //Mute/Unmute
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
+                } else {
+                    return super.onKeyUp(keyCode, event);
                 }
                 break;
             case KeyEvent.KEYCODE_DPAD_UP:

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -491,21 +491,46 @@ public class VideoplayerActivity extends MediaplayerActivity {
         AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
 
         switch (keyCode) {
-            case KeyEvent.KEYCODE_ENTER: //Fallthrough
+            case KeyEvent.KEYCODE_P: //Fallthrough
             case KeyEvent.KEYCODE_SPACE:
                 //Play/Pause
                 onPlayPause();
                 toggleVideoControlsVisibility();
                 return true;
-            case KeyEvent.KEYCODE_DPAD_LEFT:
+            case KeyEvent.KEYCODE_J: //Fallthrough
+            case KeyEvent.KEYCODE_A:
+            case KeyEvent.KEYCODE_COMMA:
                 //Go Back
                 onRewind();
                 showSkipAnimation(false);
                 return true;
-            case KeyEvent.KEYCODE_DPAD_RIGHT:
+            case KeyEvent.KEYCODE_K: //Fallthrough
+            case KeyEvent.KEYCODE_D:
+            case KeyEvent.KEYCODE_PERIOD:
                 //Go Forward
                 onFastForward();
                 showSkipAnimation(true);
+                return true;
+            case KeyEvent.KEYCODE_F:
+            case KeyEvent.KEYCODE_ESCAPE:
+                //Exit fullscreen mode
+                onBackPressed();
+                return true;
+            case KeyEvent.KEYCODE_I:
+                //Toggle picture-in-picture mode
+                compatEnterPictureInPicture();
+                return true;
+            case KeyEvent.KEYCODE_PLUS: //Fallthrough
+            case KeyEvent.KEYCODE_W:
+                //Raise volume
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
+                return true;
+            case KeyEvent.KEYCODE_MINUS: //Fallthrough
+            case KeyEvent.KEYCODE_S:
+                //Raise volume
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
                 return true;
             case KeyEvent.KEYCODE_M:
                 //Mute/Unmute
@@ -514,25 +539,6 @@ public class VideoplayerActivity extends MediaplayerActivity {
                     return true;
                 }
                 break;
-            case KeyEvent.KEYCODE_DPAD_UP:
-                //Raise volume
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                        AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
-                return true;
-            case KeyEvent.KEYCODE_DPAD_DOWN:
-                //Raise volume
-                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                        AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
-                return true;
-            case KeyEvent.KEYCODE_ESCAPE:
-            case KeyEvent.KEYCODE_F:
-                //Exit fullscreen mode
-                onBackPressed();
-                return true;
-            case KeyEvent.KEYCODE_P:
-                //Toggle picture-in-picture mode
-                compatEnterPictureInPicture();
-                return true;
         }
 
         //Go to x% of video:

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -3,14 +3,18 @@ package de.danoeh.antennapod.activity;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
+import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.AnimationSet;
 import android.view.animation.ScaleAnimation;
 import android.widget.ImageView;
+
+import androidx.appcompat.view.menu.ActionMenuItem;
 import androidx.core.view.WindowCompat;
 import androidx.appcompat.app.ActionBar;
 import android.text.TextUtils;
@@ -480,4 +484,96 @@ public class VideoplayerActivity extends MediaplayerActivity {
 
     }
 
+
+    //Hardware keyboard support
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
+        Float videoPercent = null;
+
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_ENTER: //Fallthrough
+            case KeyEvent.KEYCODE_SPACE:
+                //Play/Pause
+                onPlayPause();
+                toggleVideoControlsVisibility();
+                break;
+            case KeyEvent.KEYCODE_DPAD_LEFT:
+                //Go Back
+                onRewind();
+                break;
+            case KeyEvent.KEYCODE_DPAD_RIGHT:
+                //Go Forward
+                onFastForward();
+                break;
+            case KeyEvent.KEYCODE_M:
+                //Mute/Unmute
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_TOGGLE_MUTE, 0);
+                } else {
+                    if (audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
+                        //Unmute
+                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
+                    } else {
+                        //Mute
+                        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0);
+                    }
+                }
+                break;
+            case KeyEvent.KEYCODE_DPAD_UP:
+                //Raise volume
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
+                break;
+            case KeyEvent.KEYCODE_DPAD_DOWN:
+                //Raise volume
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
+                break;
+            case KeyEvent.KEYCODE_ESCAPE:
+            case KeyEvent.KEYCODE_F:
+                //Exit fullscreen mode
+                onOptionsItemSelected(new ActionMenuItem(this, 0, android.R.id.home, 0, 0, ""));
+                break;
+            case KeyEvent.KEYCODE_P:
+                //Toggle picture-in-picture mode
+                compatEnterPictureInPicture();
+                break;
+            //Go to x% of video:
+            case KeyEvent.KEYCODE_0:
+                videoPercent = 0f;
+                break;
+            case KeyEvent.KEYCODE_1:
+                videoPercent = 0.1f;
+                break;
+            case KeyEvent.KEYCODE_2:
+                videoPercent = 0.2f;
+                break;
+            case KeyEvent.KEYCODE_3:
+                videoPercent = 0.3f;
+                break;
+            case KeyEvent.KEYCODE_4:
+                videoPercent = 0.4f;
+                break;
+            case KeyEvent.KEYCODE_5:
+                videoPercent = 0.5f;
+                break;
+            case KeyEvent.KEYCODE_6:
+                videoPercent = 0.6f;
+                break;
+            case KeyEvent.KEYCODE_7:
+                videoPercent = 0.7f;
+                break;
+            case KeyEvent.KEYCODE_8:
+                videoPercent = 0.8f;
+                break;
+            case KeyEvent.KEYCODE_9:
+                videoPercent = 0.9f;
+                break;
+            default:
+                return super.onKeyUp(keyCode, event);
+        }
+
+        if (videoPercent != null)
+            controller.seekTo((int) (videoPercent * controller.getDuration()));
+        return true;
+    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -501,10 +501,12 @@ public class VideoplayerActivity extends MediaplayerActivity {
             case KeyEvent.KEYCODE_DPAD_LEFT:
                 //Go Back
                 onRewind();
+                showSkipAnimation(false);
                 break;
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 //Go Forward
                 onFastForward();
+                showSkipAnimation(true);
                 break;
             case KeyEvent.KEYCODE_M:
                 //Mute/Unmute


### PR DESCRIPTION
Closes #3337 
# Shortcuts:

### Audio (`MainActivity`):
| Key | Action |
| -- | -- |
|`P` <del>`Space`/`Enter`</del>(Conflicting with dpad navigation) | Play/Pause|
| `J`/`A`/`,` | Rewind media |
| `K`/`D`/`.` | Forward media |
| `+`/`W` | Raise media volume (channel) |
| `-`/`S` | Lower media volume (channel) |
| `M` | Mute/unmute (toggle) media (volume channel; only on API > 23) |

### Video (`VideoPlayerActivity`):
| Key | Action |
| -- | -- |
| `P`/`Space`<del>/`Enter`</del>(Just to be save) | Play/Pause |
| `J`/`A`/`,` | Rewind media |
| `K`/`D`/`.` | Forward media |
| `F`/`Esc` | Exit video player |
| `i` | Enter picture-in-picture mode |
| `0`-`9` | Go to 0-90% of the video |
| `+`/`W` | Raise media volume (channel) |
| `-`/`S` | Lower media volume (channel) |
| `M` | Mute/unmute (toggle) media (volume channel; only on API > 23) |