### PR TITLE
Add plural default resource for download_report_content string.

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
@@ -153,7 +153,7 @@ public class DownloadServiceNotification {
                 iconId = R.drawable.ic_notification_sync_error;
                 intent = ClientConfig.downloadServiceCallbacks.getReportNotificationContentIntent(context);
                 id = R.id.notification_download_report;
-                content = String.format(context.getString(R.string.download_report_content), successfulDownloads, failedDownloads);
+                content = context.getResources().getQuantityString(R.plurals.download_report_content, successfulDownloads, successfulDownloads, failedDownloads);
             }
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
@@ -153,7 +153,11 @@ public class DownloadServiceNotification {
                 iconId = R.drawable.ic_notification_sync_error;
                 intent = ClientConfig.downloadServiceCallbacks.getReportNotificationContentIntent(context);
                 id = R.id.notification_download_report;
-                content = context.getResources().getQuantityString(R.plurals.download_report_content, successfulDownloads, successfulDownloads, failedDownloads);
+                content = context.getResources()
+                        .getQuantityString(R.plurals.download_report_content,
+                                successfulDownloads,
+                                successfulDownloads,
+                                failedDownloads);
             }
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -248,7 +248,10 @@
     </plurals>
     <string name="downloads_processing">Processing downloads</string>
     <string name="download_notification_title">Downloading podcast data</string>
-    <string name="download_report_content">%1$d downloads succeeded, %2$d failed</string>
+    <plurals name="download_report_content">
+        <item quantity="one">%d download succeeded, %d failed</item>
+        <item quantity="other">%d downloads succeeded, %d failed</item>
+    </plurals>
     <string name="download_log_title_unknown">Unknown Title</string>
     <string name="download_type_feed">Feed</string>
     <string name="download_type_media">Media file</string>


### PR DESCRIPTION
Closes #4487 

This PR adds the ability for translators to add plural variants to the `download_report_content` resource string.
 