### PR TITLE
Show "include in auto downloads" dialog after adding a podcast

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -523,7 +523,28 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
                 subscribeButton.setEnabled(true);
                 subscribeButton.setText(R.string.open_podcast);
                 if (didPressSubscribe) {
-                    openFeed();
+                    //Show auto download dialog
+                    didPressSubscribe = false;
+                    if (UserPreferences.isEnableAutodownload()) {
+                        long feedId = getFeedId(feed);
+                        final Feed feed1 = DBReader.getFeed(feedId);
+                        final FeedPreferences feedPreferences = feed1.getPreferences();
+
+                        AlertDialog.Builder dialog = new AlertDialog.Builder(this);
+                        dialog.setTitle(R.string.auto_download_label);
+                        dialog.setMessage(R.string.auto_download_include_message);
+
+                        dialog.setPositiveButton(R.string.yes, (dialog1, which) -> feedPreferences.setAutoDownload(true));
+                        dialog.setNegativeButton(R.string.no, (dialog1, which) -> feedPreferences.setAutoDownload(false));
+                        dialog.setOnDismissListener((listener) -> {
+                            feed1.savePreferences();
+                            openFeed();
+                        });
+
+                        dialog.show();
+                    } else {
+                        openFeed();
+                    }
                 }
             } else {
                 subscribeButton.setEnabled(true);

--- a/app/src/main/res/layout/onlinefeedview_activity.xml
+++ b/app/src/main/res/layout/onlinefeedview_activity.xml
@@ -124,6 +124,17 @@
                         android:focusable="false"
                         android:text="@string/subscribe_label"/>
 
+                <CheckBox
+                        android:id="@+id/checkBoxAutoDownload"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginBottom="4dp"
+                        android:focusable="false"
+                        android:text="@string/auto_download_label"
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
+
                 <Button
                         android:id="@+id/butStopPreview"
                         android:layout_width="match_parent"
@@ -133,7 +144,8 @@
                         android:layout_marginBottom="16dp"
                         android:focusable="false"
                         android:text="@string/stop_preview"
-                        android:visibility="gone" />
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
 
                 <ListView
                         android:id="@+id/listview"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="auto_download_label">Include in auto downloads</string>
     <string name="auto_download_apply_to_items_title">Apply to Previous Episodes</string>
     <string name="auto_download_apply_to_items_message">The new <i>Auto Download</i> setting will automatically be applied to new episodes.\nDo you also want to apply it to previously published episodes?</string>
+    <string name="auto_download_include_message">Should all new (future) episodes of this podcast be automatically downloaded?</string>
     <string name="auto_delete_label">Auto Delete Episode</string>
     <string name="feed_volume_reduction">Volume Reduction</string>
     <string name="feed_volume_reduction_summary">Turn down volume for episodes of this feed: %1$s</string>


### PR DESCRIPTION
Closes #1915 
If Auto Download is globally enabled in settings the following dialog will be shown after adding a new podcast:
![Screen](https://user-images.githubusercontent.com/36813904/95218396-c2141a00-07e3-11eb-84d3-ec9ef38297aa.png)
