### PR TITLE
Fixed "Searching within single podcast shows other podcasts #4488"

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -259,7 +259,15 @@ public class SearchFragment extends Fragment {
                     progressBar.setVisibility(View.GONE);
                     this.results = results.first;
                     adapter.updateItems(results.first);
-                    adapterFeeds.updateData(results.second);
+                    if(getArguments().getLong(ARG_FEED,0)==0)
+                    {
+                        adapterFeeds.updateData(results.second);
+                    }
+                    else
+                    {
+
+                        adapterFeeds.updateData(null);
+                    }
                     String query = getArguments().getString(ARG_QUERY);
                     emptyViewHandler.setMessage(getString(R.string.no_results_for_query, query));
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -260,7 +260,7 @@ public class SearchFragment extends Fragment {
                     progressBar.setVisibility(View.GONE);
                     this.results = results.first;
                     adapter.updateItems(results.first);
-                    if (getArguments().getLong(ARG_FEED , 0) == 0) {
+                    if (getArguments().getLong(ARG_FEED, 0) == 0) {
                         adapterFeeds.updateData(results.second);
                     } else {
                         adapterFeeds.updateData(Collections.emptyList());

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -43,6 +43,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -262,11 +263,10 @@ public class SearchFragment extends Fragment {
                     if(getArguments().getLong(ARG_FEED,0)==0)
                     {
                         adapterFeeds.updateData(results.second);
-                    }
-                    else
+                    }else
                     {
 
-                        adapterFeeds.updateData(null);
+                        adapterFeeds.updateData(Collections.emptyList());
                     }
                     String query = getArguments().getString(ARG_QUERY);
                     emptyViewHandler.setMessage(getString(R.string.no_results_for_query, query));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -260,12 +260,9 @@ public class SearchFragment extends Fragment {
                     progressBar.setVisibility(View.GONE);
                     this.results = results.first;
                     adapter.updateItems(results.first);
-                    if(getArguments().getLong(ARG_FEED,0)==0)
-                    {
+                    if (getArguments().getLong(ARG_FEED , 0) == 0) {
                         adapterFeeds.updateData(results.second);
-                    }else
-                    {
-
+                    } else {
                         adapterFeeds.updateData(Collections.emptyList());
                     }
                     String query = getArguments().getString(ARG_QUERY);


### PR DESCRIPTION
Since the single SearchFragment is used for searching items at both within a podcast fragment and at Episode Fragment, only difference arises is the passage of feed, episode page pushes 0 and the podcast page pushes the particular value)

Hence, A check is placed when retrieving search results for the feed value and The Feed recycler Data is appropriately handled

Closes #4488