### PR TITLE
Fixed issue #4473 of progress bar being highlighted

### DIFF
--- a/app/src/main/res/layout/audioplayer_fragment.xml
+++ b/app/src/main/res/layout/audioplayer_fragment.xml
@@ -67,7 +67,8 @@
                 android:max="500"
                 tools:progress="100"
                 android:layout_marginLeft="8dp"
-                android:layout_marginRight="8dp" />
+                android:layout_marginRight="8dp"
+                android:clickable="true"/>
 
         <RelativeLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Resolved issue #4473 concerning progress bar being highlighted when other areas are clicked.