### PR TITLE
Replacing deprecated default constructor of handler with constructor that accepts Looper

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -9,6 +9,7 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
@@ -182,7 +183,7 @@ public class MainActivity extends CastEnabledActivity {
         SharedPreferences prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE);
         if (prefs.getBoolean(PREF_IS_FIRST_LAUNCH, true)) {
             loadFragment(AddFeedFragment.TAG, null);
-            new Handler().postDelayed(() -> {
+            new Handler(Looper.getMainLooper()).postDelayed(() -> {
                 if (drawerLayout != null) { // Tablet layout does not have a drawer
                     drawerLayout.openDrawer(navDrawer);
                 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.dialog;
 import android.app.Dialog;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -159,7 +160,7 @@ public class PlaybackControlsDialog extends DialogFragment {
         butAudioTracks.setText(audioTracks.get(selectedAudioTrack));
         butAudioTracks.setOnClickListener(v -> {
             controller.setAudioTrack((selectedAudioTrack + 1) % audioTracks.size());
-            new Handler().postDelayed(this::setupAudioTracks, 500);
+            new Handler(Looper.getMainLooper()).postDelayed(this::setupAudioTracks, 500);
         });
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -220,7 +221,7 @@ public abstract class EpisodesListFragment extends Fragment {
         SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
         swipeRefreshLayout.setOnRefreshListener(() -> {
             AutoUpdateManager.runImmediate(requireContext());
-            new Handler().postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
+            new Handler(Looper.getMainLooper()).postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
                     getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
         });
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.graphics.LightingColorFilter;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -216,7 +217,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             } catch (DownloadRequestException e) {
                 e.printStackTrace();
             }
-            new Handler().postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
+            new Handler(Looper.getMainLooper()).postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
                     getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
         });
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.widget.ProgressBar;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
@@ -110,7 +111,7 @@ public class SubscriptionFragment extends Fragment {
         SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
         swipeRefreshLayout.setOnRefreshListener(() -> {
             AutoUpdateManager.runImmediate(requireContext());
-            new Handler().postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
+            new Handler(Looper.getMainLooper()).postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
                     getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
         });
         return root;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -10,6 +10,7 @@ import android.content.IntentFilter;
 import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -178,7 +179,7 @@ public class DownloadService extends Service {
     public void onCreate() {
         Log.d(TAG, "Service started");
         isRunning = true;
-        handler = new Handler();
+        handler = new Handler(Looper.getMainLooper());
         notificationManager = new DownloadServiceNotification(this);
 
         IntentFilter cancelDownloadReceiverFilter = new IntentFilter();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -343,7 +343,7 @@ public class PlaybackServiceTaskManager {
         if (Looper.myLooper() == Looper.getMainLooper()) {
             // Called in main thread => ExoPlayer is used
             // Run on ui thread even if called from schedExecutor
-            Handler handler = new Handler();
+            Handler handler = new Handler(Looper.getMainLooper());
             return () -> handler.post(runnable);
         } else {
             return runnable;
@@ -370,7 +370,7 @@ public class PlaybackServiceTaskManager {
 
             if (UserPreferences.useExoplayer() && Looper.myLooper() == Looper.getMainLooper()) {
                 // Run callbacks in main thread so they can call ExoPlayer methods themselves
-                this.handler = new Handler();
+                this.handler = new Handler(Looper.getMainLooper());
             } else {
                 this.handler = null;
             }


### PR DESCRIPTION
`MainAcitvity` uses default Handler constructor which is deprecated. 
[Handler docs](https://developer.android.com/reference/android/os/Handler#Handler())


It is better to replace it with best constructor matching  situation and for here I had replaced It with Looper accepting one. More specifically providing it `mainLooper()` as it is performing UI operation.

Their are multiple places where this deprecated constructor is being used but for now I had made changes on `MainAcitvity` only, was thinking that first this changes get accepted than it is better to do on remaining ones.