### PR TITLE
Fix 'Visit website' button crashes app if there is no browser installed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/VisitWebsiteActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/VisitWebsiteActionButton.java
@@ -8,6 +8,7 @@ import androidx.annotation.AttrRes;
 import androidx.annotation.StringRes;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.feed.FeedItem;
+import de.danoeh.antennapod.core.util.IntentUtils;
 
 public class VisitWebsiteActionButton extends ItemActionButton {
 
@@ -29,8 +30,7 @@ public class VisitWebsiteActionButton extends ItemActionButton {
 
     @Override
     public void onClick(Context context) {
-        Uri uri = Uri.parse(item.getLink());
-        context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+        IntentUtils.openInBrowser(context, item.getLink());
     }
 
     @Override


### PR DESCRIPTION
Changed VisitWebsiteActionButton onClick method to use IntentUtils class.