### PR TITLE
Update Search Bar

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
@@ -35,6 +35,7 @@ public class MenuItemUtils extends de.danoeh.antennapod.core.menuhandler.MenuIte
         MenuItem searchItem = menu.findItem(R.id.action_search);
         final SearchView sv = (SearchView) searchItem.getActionView();
         sv.setBackgroundColor(ThemeUtils.getColorFromAttr(activity, android.R.attr.windowBackground));
+        sv.setAlpha(0.75f);
         sv.setQueryHint(activity.getString(R.string.search_label));
         sv.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -84,7 +84,7 @@
     <style name="Theme.Base.AntennaPod.Dark" parent="Theme.MaterialComponents">
         <item name="colorAccent">@color/accent_dark</item>
         <item name="colorSecondary">@color/accent_dark</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorOnSecondary">@color/white</item>
         <item name="colorPrimary">@color/accent_dark</item>
         <item name="colorPrimaryDark">@color/background_darktheme</item>
         <item name="android:windowBackground">@color/background_darktheme</item>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -84,7 +84,7 @@
     <style name="Theme.Base.AntennaPod.Dark" parent="Theme.MaterialComponents">
         <item name="colorAccent">@color/accent_dark</item>
         <item name="colorSecondary">@color/accent_dark</item>
-        <item name="colorOnSecondary">@color/white</item>
+        <item name="colorOnSecondary">@color/black</item>
         <item name="colorPrimary">@color/accent_dark</item>
         <item name="colorPrimaryDark">@color/background_darktheme</item>
         <item name="android:windowBackground">@color/background_darktheme</item>


### PR DESCRIPTION
The color of the counter and the fab in the subscriptions screen change its text color when switching from light to dark theme, but the background is always the same.
I fixed this through settings the `colorOnSecondary` attribute to `@color/white` in the dark theme.

Before:
![Screen Before](https://user-images.githubusercontent.com/36813904/96372695-971cb500-1157-11eb-98ec-0593af502074.png)

After:
![ScreenAfter](https://user-images.githubusercontent.com/36813904/96372700-9e43c300-1157-11eb-905c-c7d9ee9bcf8d.png)

Furthermore the search bar in the feed item list screen has now a transparency of 75%, which, I think looks better:
![screenTitle](https://user-images.githubusercontent.com/36813904/96372721-ba476480-1157-11eb-9834-0e6892e4baa5.png)

Another issue I ran into, when testing the search bar is, that the new shortcuts from #4486 were also triggered when entering some text into the search bar, because these views are displayed through the `MainActivity`. In any dialogs with an `EditText` view the shortcuts were not called.
I will fix this in another pull request, through a method that temporary disables the shortcuts.