### PR TITLE
Clarify 'downloads' statistic

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="statistics_reset_data_msg">This will erase the history of duration played for all episodes. Are you sure you want to proceed?</string>
 
     <!-- Download Statistics fragment -->
-    <string name="total_size_downloaded_podcasts">Total size of downloaded podcasts:</string>
+    <string name="total_size_downloaded_podcasts">Total size of episodes on the device:</string>
 
     <!-- Main activity -->
     <string name="drawer_open">Open menu</string>


### PR DESCRIPTION
"Total size of downloaded podcasts" might be interpreted as the total cumulative size of all episodes ever downloaded. This is to improve the string so it's clear that it's about the episodes currently on the device.