### PR TITLE
Improve readability. Use consistent capitalization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ You can use the [AntennaPod Forum](https://forum.antennapod.org/) for discussion
 
 Bug reports and feature requests can be submitted [here](https://github.com/AntennaPod/AntennaPod/issues) (please read the [instructions](https://github.com/AntennaPod/AntennaPod/blob/master/CONTRIBUTING.md) on how to report a bug and how to submit a feature request first!).
 
-## Help test AntennaPod
-AntennaPod has many users and we don't want them to run into trouble when we add a new feature. It's important that we have a significant group test our app, so that we know all possible combinations of phones, Android versions and use cases work as expected. Check out our wiki how to join our [Alpha and Beta testing programmes](https://github.com/AntennaPod/AntennaPod/wiki/Help-test-AntennaPod)!
+## Help to test AntennaPod
+AntennaPod has many users and we don't want them to run into trouble when we add a new feature. It's important that we have a significant group test our app, so that we know all possible combinations of phones, Android versions and use cases work as expected. Check out our wiki on how to join our [Alpha and Beta testing programmes](https://github.com/AntennaPod/AntennaPod/wiki/Help-test-AntennaPod)!
 
 ## License
 
@@ -30,5 +30,5 @@ If you want to translate AntennaPod into another language, you can visit the [Tr
 
 ## Building AntennaPod
 
-Information on how to build AntennaPod can be found in the [Wiki](https://github.com/AntennaPod/AntennaPod/wiki/Building-AntennaPod).
+Information on how to build AntennaPod can be found in the [wiki](https://github.com/AntennaPod/AntennaPod/wiki/Building-AntennaPod).
 


### PR DESCRIPTION
- Improve readability: The words I added make it easier to read the sentence or phrase.
- Use consistent capitalization: `wiki` is spelled in lower case before, also I see no reason to capitalize it.