### PR TITLE
Disable hardware shortcuts when entering text

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -88,6 +88,7 @@ public class MainActivity extends CastEnabledActivity {
     private long lastBackButtonPressTime = 0;
     private RecyclerView.RecycledViewPool recycledViewPool = new RecyclerView.RecycledViewPool();
     private int lastTheme = 0;
+    private boolean hardwareShortcutsEnabled = true;
 
     @NonNull
     public static Intent getIntentToOpenFeed(@NonNull Context context, long feedId) {
@@ -548,8 +549,20 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     //Hardware keyboard support
+    public void enableHardwareShortcuts() {
+        hardwareShortcutsEnabled = true;
+    }
+
+    public void disableHardwareShortcuts() {
+        hardwareShortcutsEnabled = false;
+    }
+
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (!hardwareShortcutsEnabled) {
+            return super.onKeyUp(keyCode, event);
+        }
+
         AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
         Integer customKeyCode = null;
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -61,9 +63,30 @@ public class AddFeedFragment extends Fragment {
 
         combinedFeedSearchBox = root.findViewById(R.id.combinedFeedSearchBox);
         combinedFeedSearchBox.setOnEditorActionListener((v, actionId, event) -> {
+            ((MainActivity) requireActivity()).enableHardwareShortcuts();
             performSearch();
             return true;
         });
+        combinedFeedSearchBox.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void afterTextChanged(Editable s) {
+            }
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                ((MainActivity) requireActivity()).disableHardwareShortcuts();
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+        });
+        combinedFeedSearchBox.setOnFocusChangeListener((view, hasFocus) -> {
+            if (!hasFocus) {
+                ((MainActivity) requireActivity()).enableHardwareShortcuts();
+            }
+        });
+
         root.findViewById(R.id.btn_add_via_url).setOnClickListener(v
                 -> showAddViaUrlDialog());
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/OnlineSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/OnlineSearchFragment.java
@@ -149,12 +149,14 @@ public class OnlineSearchFragment extends Fragment {
         searchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem item) {
+                ((MainActivity) requireActivity()).disableHardwareShortcuts();
                 return true;
             }
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 getActivity().getSupportFragmentManager().popBackStack();
+                ((MainActivity) requireActivity()).enableHardwareShortcuts();
                 return true;
             }
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -181,12 +181,14 @@ public class SearchFragment extends Fragment {
         item.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem item) {
+                ((MainActivity) requireActivity()).disableHardwareShortcuts();
                 return true;
             }
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 getParentFragmentManager().popBackStack();
+                ((MainActivity) requireActivity()).enableHardwareShortcuts();
                 return true;
             }
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/PodcastListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/PodcastListFragment.java
@@ -49,6 +49,7 @@ public abstract class PodcastListFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+        ((MainActivity) requireActivity()).disableHardwareShortcuts();
     }
 
     @Override
@@ -166,5 +167,11 @@ public abstract class PodcastListFragment extends Fragment {
         };
 
         loaderTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        ((MainActivity) requireActivity()).enableHardwareShortcuts();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/TagListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/TagListFragment.java
@@ -31,6 +31,7 @@ public class TagListFragment extends ListFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+        ((MainActivity) requireActivity()).disableHardwareShortcuts();
     }
 
     @Override
@@ -75,6 +76,7 @@ public class TagListFragment extends ListFragment {
     public void onDestroyView() {
         super.onDestroyView();
         cancelLoadTask();
+        ((MainActivity) requireActivity()).enableHardwareShortcuts();
     }
 
     private AsyncTask<Void, Void, List<GpodnetTag>> loadTask;

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/MenuItemUtils.java
@@ -58,12 +58,14 @@ public class MenuItemUtils extends de.danoeh.antennapod.core.menuhandler.MenuIte
                         menu.getItem(i).setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER);
                     }
                 }
+                activity.disableHardwareShortcuts();
                 return true;
             }
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 activity.invalidateOptionsMenu();
+                activity.enableHardwareShortcuts();
                 return true;
             }
         });


### PR DESCRIPTION
As mentioned in #4554 the new hardware shortcuts from #4486 are also called when entering a text into a text-field.
This pull request fixes this, through a temporary disabling of the shortcuts until the text input has been finished.