### PR TITLE
Edit streaming confirmation dialog labels

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/StreamingConfirmationDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/StreamingConfirmationDialog.java
@@ -20,7 +20,7 @@ public class StreamingConfirmationDialog {
         new AlertDialog.Builder(context)
                 .setTitle(R.string.stream_label)
                 .setMessage(R.string.confirm_mobile_streaming_notification_message)
-                .setPositiveButton(R.string.stream_label, (dialog, which) -> stream())
+                .setPositiveButton(R.string.confirm_mobile_streaming_button_once, (dialog, which) -> stream())
                 .setNegativeButton(R.string.confirm_mobile_streaming_button_always, (dialog, which) -> {
                     UserPreferences.setAllowMobileStreaming(true);
                     stream();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -580,7 +580,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setContentIntent(pendingIntentAllowThisTime)
                 .addAction(R.drawable.ic_stream_white,
-                        getString(R.string.stream_label),
+                        getString(R.string.confirm_mobile_streaming_button_once),
                         pendingIntentAllowThisTime)
                 .addAction(R.drawable.ic_stream_white,
                         getString(R.string.confirm_mobile_streaming_button_always),

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -268,7 +268,8 @@
     <string name="confirm_mobile_download_dialog_message">Downloading over mobile data connection is disabled in the settings.\n\nDo you want to allow downloading temporarily?\n\n<small>Your choice will be remembered for 10 minutes.</small></string>
     <string name="confirm_mobile_streaming_notification_title">Confirm Mobile streaming</string>
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
-    <string name="confirm_mobile_streaming_button_always">Always allow</string>
+    <string name="confirm_mobile_streaming_button_always">Always</string>
+    <string name="confirm_mobile_streaming_button_once">Once</string>
     <string name="confirm_mobile_download_dialog_only_add_to_queue">Enqueue</string>
     <string name="confirm_mobile_download_dialog_enable_temporarily">Allow temporarily</string>
 


### PR DESCRIPTION
Resolves #4320. As I understand it, the translations for all languages except the default language (English) are provided by volunteers via Transifex.