### PR TITLE
When doing Auto Skip to End, do the right thing

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -212,7 +212,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     private Disposable positionEventTimer;
     private PlaybackServiceNotificationBuilder notificationBuilder;
 
-    private long autoSkippedFeedMediaId = -1;
+    private String autoSkippedFeedMediaId = null;
 
     /**
      * Used for Lollipop notifications, Android Wear, and Android Auto.
@@ -1046,18 +1046,21 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             Log.d(TAG, "smart mark as played");
         }
 
+        boolean autoSkipped = false;
+        if (autoSkippedFeedMediaId != null && autoSkippedFeedMediaId.equals(item.getIdentifyingValue())) {
+            autoSkippedFeedMediaId = null;
+            autoSkipped = true;
+        }
+
         if (ended || smartMarkAsPlayed) {
             media.onPlaybackCompleted(getApplicationContext());
         } else {
             media.onPlaybackPause(getApplicationContext());
         }
 
-        if (autoSkippedFeedMediaId >= 0 && autoSkippedFeedMediaId == media.getId()) {
-            ended = true;
-        }
-
         if (item != null) {
             if (ended || smartMarkAsPlayed
+                    || autoSkipped
                     || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
                 // only mark the item as played if we're not keeping it anyways
                 DBWriter.markItemPlayed(item, FeedItem.PLAYED, ended);
@@ -1118,8 +1121,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             Toast toast = Toast.makeText(context, skipMesg, Toast.LENGTH_LONG);
             toast.show();
 
-            this.autoSkippedFeedMediaId = feedMedia.getItem().getId();
-            mediaPlayer.seekTo(duration);
+            this.autoSkippedFeedMediaId = feedMedia.getItem().getIdentifyingValue();
+            mediaPlayer.skip();
         }
    }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1109,7 +1109,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         FeedPreferences preferences = feedMedia.getItem().getFeed().getPreferences();
         int skipEnd = preferences.getFeedSkipEnding();
         if (skipEnd > 0
-                && skipEnd < getDuration()
+                && skipEnd * 1000 < getDuration()
                 && (remainingTime - (skipEnd * 1000) > 0)
                 && ((remainingTime - skipEnd * 1000) < (getCurrentPlaybackSpeed() * 1000))) {
             Log.d(TAG, "skipEndingIfNecessary: Skipping the remaining " + remainingTime + " " + skipEnd * 1000 + " speed " + getCurrentPlaybackSpeed());
@@ -1119,7 +1119,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             toast.show();
 
             this.autoSkippedFeedMediaId = feedMedia.getItem().getId();
-            mediaPlayer.skip();
+            mediaPlayer.seekTo(duration);
         }
    }
 


### PR DESCRIPTION
close #4276

* Smart Mark As Played -> 30 secs
* Keep Skip Episodes -> on
* Auto Skip -> on
* Delete removes from Queue -> on
* Skip End for podcast -> 31 secs

1) The item will be removed from the queue
2) The playback location history will be retain where the item was autoSkip at
3) Instead of pretending to 'end' the episode, we will stop playing, pretend we skipped, mark item as played

Also fixed a bug that was using media.getId(), media.getItem.get() - which both are wrong. Using the string from `getIdentifyingValue()` instead