### PR TITLE
Remove IF NOT EXISTS from index create statements

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -195,11 +195,11 @@ public class PodDBAdapter {
             + TABLE_NAME_FEED_ITEMS + "_" + KEY_FEED + " ON " + TABLE_NAME_FEED_ITEMS + " ("
             + KEY_FEED + ")";
 
-    static final String CREATE_INDEX_FEEDITEMS_PUBDATE = "CREATE INDEX IF NOT EXISTS "
+    static final String CREATE_INDEX_FEEDITEMS_PUBDATE = "CREATE INDEX "
             + TABLE_NAME_FEED_ITEMS + "_" + KEY_PUBDATE + " ON " + TABLE_NAME_FEED_ITEMS + " ("
             + KEY_PUBDATE + ")";
 
-    static final String CREATE_INDEX_FEEDITEMS_READ = "CREATE INDEX IF NOT EXISTS "
+    static final String CREATE_INDEX_FEEDITEMS_READ = "CREATE INDEX "
             + TABLE_NAME_FEED_ITEMS + "_" + KEY_READ + " ON " + TABLE_NAME_FEED_ITEMS + " ("
             + KEY_READ + ")";
 


### PR DESCRIPTION
`onCreate()` should only ever be called once, where the tables and
indices are created. Any other changes need to happen via `onUpgrade()`,
so we can safely remove `IF NOT EXISTS`.

When importing any database into the app (e.g. if it gets corrupted and
is recreated with `sqlite3 old-database.db ".dump"`), it first needs to
be set back to the correct version. This can be done in sqlite with:

    $ sqlite3 old-database.db "PRAGMA user_version"
    <old-db-version>
    $ sqlite3 new-database.db "PRAGMA user_version = <old-db-version>"

For more context, see this PR: https://github.com/AntennaPod/AntennaPod/pull/4585