### PR TITLE
Fix Robolectric error "Android SDK 30 requires Java 9 (have Java 8)"

### DIFF
--- a/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowMediaMetadataRetriever;
 
 import java.io.IOException;
@@ -33,7 +34,6 @@ import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -44,6 +44,7 @@ import static org.robolectric.Shadows.shadowOf;
  * Test local feeds handling in class LocalFeedUpdater.
  */
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
 public class LocalFeedUpdaterTest {
 
     /**


### PR DESCRIPTION
When running the unit tests in class `LocalFeedUpdaterTest` I get the error message:
`Failed to create a Robolectric sandbox: Android SDK 30 requires Java 9 (have Java 8)`

After the upgrade to Android API level 30 in `build.gradle` Robolectric expects to use Java 9, but we still are using Java 8.

This pull request provides a simple solution for that, no need to upgrade to Java 9 now.