### PR TITLE
Refactoring: Remove callback functions with constant value

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/config/DownloadServiceCallbacksImpl.java
+++ b/app/src/main/java/de/danoeh/antennapod/config/DownloadServiceCallbacksImpl.java
@@ -54,9 +54,4 @@ public class DownloadServiceCallbacksImpl implements DownloadServiceCallbacks {
         return PendingIntent.getActivity(context, R.id.pending_intent_download_service_autodownload_report,
                 intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
-
-    @Override
-    public boolean shouldCreateReport() {
-        return true;
-    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/config/PlaybackServiceCallbacksImpl.java
+++ b/app/src/main/java/de/danoeh/antennapod/config/PlaybackServiceCallbacksImpl.java
@@ -22,10 +22,4 @@ public class PlaybackServiceCallbacksImpl implements PlaybackServiceCallbacks {
             return i;
         }
     }
-
-    @Override
-    public boolean useQueue() {
-        return true;
-    }
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/DownloadServiceCallbacks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/DownloadServiceCallbacks.java
@@ -37,7 +37,7 @@ public interface DownloadServiceCallbacks {
      * <p/>
      * The PendingIntent takes users to an activity where they can look at all successful and failed downloads.
      *
-     * @return A non-null PendingIntent for the notification or null if shouldCreateReport()==false
+     * @return A non-null PendingIntent for the notification
      */
     PendingIntent getReportNotificationContentIntent(Context context);
 
@@ -47,14 +47,8 @@ public interface DownloadServiceCallbacks {
      * <p/>
      * The PendingIntent takes users to an activity where they can look at their episode queue.
      *
-     * @return A non-null PendingIntent for the notification or null if shouldCreateReport()==false
+     * @return A non-null PendingIntent for the notification
      */
     PendingIntent getAutoDownloadReportNotificationContentIntent(Context context);
-
-    /**
-     * Returns true if the DownloadService should create a report that shows the number of failed
-     * downloads when the service shuts down.
-     */
-    boolean shouldCreateReport();
 }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/PlaybackServiceCallbacks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/PlaybackServiceCallbacks.java
@@ -19,11 +19,4 @@ public interface PlaybackServiceCallbacks {
      * @return A non-null activity intent.
      */
     Intent getPlayerActivityIntent(Context context, MediaType mediaType, boolean remotePlayback);
-
-    /**
-     * Returns true if the PlaybackService should load new episodes from the queue when playback ends
-     * and false if the PlaybackService should ignore the queue and load no more episodes when playback
-     * finishes.
-     */
-    boolean useQueue();
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -205,8 +205,7 @@ public class DownloadService extends Service {
         isRunning = false;
 
         boolean showAutoDownloadReport = UserPreferences.showAutoDownloadReport();
-        if (ClientConfig.downloadServiceCallbacks.shouldCreateReport()
-                && (UserPreferences.showDownloadReport() || showAutoDownloadReport)) {
+        if (UserPreferences.showDownloadReport() || showAutoDownloadReport) {
             notificationManager.updateReport(reportQueue, showAutoDownloadReport);
             reportQueue.clear();
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -973,10 +973,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             Log.d(TAG, "getNextInQueue(), but playable not an instance of FeedMedia, so not proceeding");
             return null;
         }
-        if (!ClientConfig.playbackServiceCallbacks.useQueue()) {
-            Log.d(TAG, "getNextInQueue(), but queue not in use by this app");
-            return null;
-        }
         Log.d(TAG, "getNextInQueue()");
         FeedMedia media = (FeedMedia) currentMedia;
         try {


### PR DESCRIPTION
Just a small refactoring: Remove callback functions with constant return value:

* `DownloadServiceCallbacksImpl.shouldCreateReport()`
* `PlaybackServiceCallbacksImpl.useQueue()`

Contributes to #4661.