### PR TITLE
Partially revert "Performance improvements"

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -22,14 +22,7 @@ public class DateUtils {
     private DateUtils(){}
 
     private static final String TAG = "DateUtils";
-
     private static final TimeZone defaultTimezone = TimeZone.getTimeZone("GMT");
-    private static final SimpleDateFormat dateFormatParser = new SimpleDateFormat("", Locale.US);
-
-    static {
-        dateFormatParser.setLenient(false);
-        dateFormatParser.setTimeZone(defaultTimezone);
-    }
 
     public static Date parse(final String input) {
         if (input == null) {
@@ -99,12 +92,16 @@ public class DateUtils {
                 "EEE d MMM yyyy HH:mm:ss 'GMT'Z (z)"
         };
 
+        SimpleDateFormat parser = new SimpleDateFormat("", Locale.US);
+        parser.setLenient(false);
+        parser.setTimeZone(defaultTimezone);
+
         ParsePosition pos = new ParsePosition(0);
         for (String pattern : patterns) {
-            dateFormatParser.applyPattern(pattern);
+            parser.applyPattern(pattern);
             pos.setIndex(0);
             try {
-                Date result = dateFormatParser.parse(date, pos);
+                Date result = parser.parse(date, pos);
                 if (result != null && pos.getIndex() == date.length()) {
                     return result;
                 }


### PR DESCRIPTION
Some problems with wrong dates might be caused by the
static date parser no longer being thread safe.

This partially reverts commit 77ef2393365e0ff7621321f725a18ac858e50cbf.

Might cause #4648 but I can not reproduce the bug, so this is just a wild guess.