### PR TITLE
added readonly message for feed items w/o media

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -17,7 +17,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.core.text.TextUtilsCompat;
 import androidx.core.util.ObjectsCompat;
 import androidx.core.view.ViewCompat;
@@ -71,7 +70,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -120,6 +118,7 @@ public class ItemFragment extends Fragment {
     private View butAction2;
     private ItemActionButton actionButton1;
     private ItemActionButton actionButton2;
+    private View noMediaLabel;
 
     private Disposable disposable;
     private PlaybackController controller;
@@ -169,6 +168,7 @@ public class ItemFragment extends Fragment {
         butAction2Icon = layout.findViewById(R.id.butAction2Icon);
         butAction1Text = layout.findViewById(R.id.butAction1Text);
         butAction2Text = layout.findViewById(R.id.butAction2Text);
+        noMediaLabel = layout.findViewById(R.id.noMediaLabel);
 
         butAction1.setOnClickListener(v -> {
             if (actionButton1 instanceof StreamActionButton && !UserPreferences.isStreamOverDownload()
@@ -319,7 +319,9 @@ public class ItemFragment extends Fragment {
         if (media == null) {
             actionButton1 = new MarkAsPlayedActionButton(item);
             actionButton2 = new VisitWebsiteActionButton(item);
+            noMediaLabel.setVisibility(View.VISIBLE);
         } else {
+            noMediaLabel.setVisibility(View.GONE);
             if (media.getDuration() > 0) {
                 txtvDuration.setText(Converter.getDurationStringLong(media.getDuration()));
                 txtvDuration.setContentDescription(

--- a/app/src/main/res/layout/feeditem_fragment.xml
+++ b/app/src/main/res/layout/feeditem_fragment.xml
@@ -172,7 +172,7 @@
             android:layout_height="wrap_content"
             android:visibility="gone"
             android:textAlignment="center"
-            android:background="@color/light_gray"
+            android:background="?android:attr/dividerVertical"
             android:text="@string/no_media_label"/>
 
         <View

--- a/app/src/main/res/layout/feeditem_fragment.xml
+++ b/app/src/main/res/layout/feeditem_fragment.xml
@@ -166,6 +166,15 @@
             </LinearLayout>
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/noMediaLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:textAlignment="center"
+            android:background="@color/light_gray"
+            android:text="@string/no_media_label"/>
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingTranslation">
 
+    <string name="no_media_label">Item does not contain a media file</string>
+
+
     <!-- Activity and fragment titles -->
     <string name="app_name" translate="false">AntennaPod</string>
     <string name="provider_authority" translate="false">de.danoeh.antennapod.provider</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -3,8 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingTranslation">
 
-
-
     <!-- Activity and fragment titles -->
     <string name="app_name" translate="false">AntennaPod</string>
     <string name="provider_authority" translate="false">de.danoeh.antennapod.provider</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingTranslation">
 
-    <string name="no_media_label">Item does not contain a media file</string>
 
 
     <!-- Activity and fragment titles -->
@@ -291,6 +290,7 @@
     <string name="player_go_to_picture_in_picture">Picture-in-picture mode</string>
     <string name="unknown_media_key">AntennaPod - Unknown media key: %1$d</string>
     <string name="error_file_not_found">File not found</string>
+    <string name="no_media_label">Item does not contain a media file</string>
 
     <!-- Queue operations -->
     <string name="lock_queue">Lock Queue</string>


### PR DESCRIPTION
fix #2682 I add a TextView to the feeditem_fragment with a read-only message and set the visibility in ItemFragment.updateButtons() based on if media is null or not.

as this is my first pull request, any suggestions you can offer in the process is appreciated. thanks