### PR TITLE
timing issue with speed settings per podcast  when moving to the next episode when phone is locked

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -965,7 +965,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         @Override
         public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
             PlaybackPreferences.clearCurrentlyPlayingTemporaryPlaybackSpeed();
-
             PlaybackService.this.onPlaybackEnded(mediaType, stopPlaying);
         }
     };

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -964,7 +964,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         @Override
         public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
-            PlaybackPreferences.clearCurrentlyPlayingTemporaryPlaybackSpeed();
             PlaybackService.this.onPlaybackEnded(mediaType, stopPlaying);
         }
     };
@@ -1021,6 +1020,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      */
     private void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
         Log.d(TAG, "Playback ended");
+        PlaybackPreferences.clearCurrentlyPlayingTemporaryPlaybackSpeed();
         if (stopPlaying) {
             taskManager.cancelPositionSaver();
             cancelPositionObserver();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -964,6 +964,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         @Override
         public void onPlaybackEnded(MediaType mediaType, boolean stopPlaying) {
+            PlaybackPreferences.clearCurrentlyPlayingTemporaryPlaybackSpeed();
+
             PlaybackService.this.onPlaybackEnded(mediaType, stopPlaying);
         }
     };
@@ -1058,7 +1060,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      */
     private void onPostPlayback(final Playable playable, boolean ended, boolean skipped,
                                 boolean playingNext) {
-        PlaybackPreferences.clearCurrentlyPlayingTemporaryPlaybackSpeed();
         if (playable == null) {
             Log.e(TAG, "Cannot do post-playback processing: media was null");
             return;


### PR DESCRIPTION
fix #4217

Move the `PlaybackPreferences.clearCurrentlyPlayingTemporaryPlaybackSpeed()` to the synchronous part of the code when the episode ends, reset the speed for the next episode to pick up. 

I think this problem of the podcast speed setting not working when the phone is locked is because of this timing issue.

