### PR TITLE
fix bug with how we count downloaded media, show a meaningful messages

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -30,6 +30,7 @@ import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.SortOrder;
 import de.danoeh.antennapod.core.util.ThemeUtils;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -436,13 +437,18 @@ public class EpisodesApplyActionFragment extends Fragment implements Toolbar.OnM
     }
 
     private void deleteChecked() {
+        int countHasMedia = 0;
+        int countNoMedia = 0;
         for (long id : checkedIds.toArray()) {
             FeedItem episode = idMap.get(id);
-            if (episode.hasMedia()) {
+            if (episode.hasMedia() && episode.getMedia().isDownloaded()) {
+                countHasMedia++;
                 DBWriter.deleteFeedMediaOfItem(getActivity(), episode.getMedia().getId());
+            } else {
+                countNoMedia++;
             }
         }
-        close(R.plurals.deleted_episode_batch_label, checkedIds.size());
+        closeMore(R.plurals.deleted_multi_episode_batch_label, countNoMedia, countHasMedia);
     }
 
     private void close(@PluralsRes int msgId, int numItems) {
@@ -451,4 +457,16 @@ public class EpisodesApplyActionFragment extends Fragment implements Toolbar.OnM
         getActivity().getSupportFragmentManager().popBackStack();
     }
 
+    private void closeMore(@PluralsRes int msgId, int countNoMedia, int countHasMedia) {
+        try {
+            ((MainActivity) getActivity()).showSnackbarAbovePlayer(
+                    getResources().getQuantityString(msgId,
+                            countHasMedia,
+                            (countHasMedia+countNoMedia), countHasMedia, 232),
+                    Snackbar.LENGTH_LONG);
+        } catch (Exception e) {
+            Log.d(TAG, e.toString());
+        }
+        getActivity().getSupportFragmentManager().popBackStack();
+    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -458,15 +458,11 @@ public class EpisodesApplyActionFragment extends Fragment implements Toolbar.OnM
     }
 
     private void closeMore(@PluralsRes int msgId, int countNoMedia, int countHasMedia) {
-        try {
-            ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                    getResources().getQuantityString(msgId,
-                            countHasMedia,
-                            (countHasMedia + countNoMedia), countHasMedia),
-                    Snackbar.LENGTH_LONG);
-        } catch (Exception e) {
-            Log.d(TAG, e.toString());
-        }
+        ((MainActivity) getActivity()).showSnackbarAbovePlayer(
+                getResources().getQuantityString(msgId,
+                        (countHasMedia + countNoMedia),
+                        (countHasMedia + countNoMedia), countHasMedia),
+                Snackbar.LENGTH_LONG);
         getActivity().getSupportFragmentManager().popBackStack();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -462,7 +462,7 @@ public class EpisodesApplyActionFragment extends Fragment implements Toolbar.OnM
             ((MainActivity) getActivity()).showSnackbarAbovePlayer(
                     getResources().getQuantityString(msgId,
                             countHasMedia,
-                            (countHasMedia+countNoMedia), countHasMedia, 232),
+                            (countHasMedia + countNoMedia), countHasMedia),
                     Snackbar.LENGTH_LONG);
         } catch (Exception e) {
             Log.d(TAG, e.toString());

--- a/core/src/main/res/values-br/strings.xml
+++ b/core/src/main/res/values-br/strings.xml
@@ -161,13 +161,6 @@
   <string name="delete_label">Dilemel</string>
   <string name="delete_failed">N\'haller ket dilemel ar restr. Gallout a rit klask adloc\'hañ.</string>
   <string name="delete_episode_label">Dilemel ar rann</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d rann dilamet </item>
-    <item quantity="two">%d rann dilamet </item>
-    <item quantity="few">%d rann dilamet </item>
-    <item quantity="many">%d rann dilamet </item>
-    <item quantity="other">%d rann dilamet </item>
-  </plurals>
   <string name="remove_new_flag_label">Tennañ ar merk \"nevez\"</string>
   <string name="removed_new_flag_label">Tennet eo bet ar merk \"nevez\"</string>
   <string name="mark_read_label">Merkañ evel lennet</string>

--- a/core/src/main/res/values-ca/strings.xml
+++ b/core/src/main/res/values-ca/strings.xml
@@ -149,10 +149,6 @@
   <string name="delete_label">Esborrar</string>
   <string name="delete_failed">No s\'ha pogut esborrar el fitxer. Reiniciar el dispositiu pot ajudar.</string>
   <string name="delete_episode_label">Esborrar episodi.</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episodi esborrat.</item>
-    <item quantity="other">%d episodis esborrats.</item>
-  </plurals>
   <string name="remove_new_flag_label">Retirar bandera de \"nou\"</string>
   <string name="removed_new_flag_label">Retirada bandera de \"nou\"</string>
   <string name="mark_read_label">Marca com a llegit</string>

--- a/core/src/main/res/values-cs/strings.xml
+++ b/core/src/main/res/values-cs/strings.xml
@@ -158,12 +158,6 @@
   <string name="delete_label">Smazat</string>
   <string name="delete_failed">Nelze smazat soubor. Restart přístroje může pomoci.</string>
   <string name="delete_episode_label">Smazat epizodu</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d epizoda stažena.</item>
-    <item quantity="few">%d epizody staženy.</item>
-    <item quantity="many">%d epizod staženo.</item>
-    <item quantity="other">%d epizod staženo.</item>
-  </plurals>
   <string name="remove_new_flag_label">Odstranit příznak „nová“</string>
   <string name="removed_new_flag_label">Příznak „nová“ odstraněn</string>
   <string name="mark_read_label">Označit jako poslechnuté</string>

--- a/core/src/main/res/values-da/strings.xml
+++ b/core/src/main/res/values-da/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Slet</string>
   <string name="delete_failed">Kan ikke slette fil. En genstart af enheden vil sandsynligvis hjælpe.</string>
   <string name="delete_episode_label">Slet udsendelse</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d udsendelse slettet.</item>
-    <item quantity="other">%d udsendelser slettet.</item>
-  </plurals>
   <string name="remove_new_flag_label">Fjern \"ny\"-markering</string>
   <string name="removed_new_flag_label">Fjernet \"ny\"-markering</string>
   <string name="mark_read_label">Marker som afspillet</string>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -154,10 +154,6 @@
   <string name="delete_label">Löschen</string>
   <string name="delete_failed">Die Datei kann nicht gelöscht werden. Eventuell hilft es, das Gerät neu zu starten.</string>
   <string name="delete_episode_label">Episode löschen</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d Episode gelöscht.</item>
-    <item quantity="other">%d Episoden gelöscht.</item>
-  </plurals>
   <string name="remove_new_flag_label">\"Neu\"-Markierung entfernen</string>
   <string name="removed_new_flag_label">\"Neu\"-Markierung entfernt</string>
   <string name="mark_read_label">Als gespielt markieren</string>

--- a/core/src/main/res/values-es/strings.xml
+++ b/core/src/main/res/values-es/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Borrar</string>
   <string name="delete_failed">No se puede borrar el fichero. Reiniciar el dispositivo podría ayudar.</string>
   <string name="delete_episode_label">Borrar Episodio</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%depisodio borrado.</item>
-    <item quantity="other">%depisodios borrados.</item>
-  </plurals>
   <string name="remove_new_flag_label">Eliminar marca \"nuevo\"</string>
   <string name="removed_new_flag_label">Eliminada marca \"nuevo\"</string>
   <string name="mark_read_label">Marcar como reproducido</string>

--- a/core/src/main/res/values-et/strings.xml
+++ b/core/src/main/res/values-et/strings.xml
@@ -149,10 +149,6 @@
   <string name="delete_label">Kustuta</string>
   <string name="delete_failed">Faili ei saa kustutada. Aidata võib seadme taaskäivitamine.</string>
   <string name="delete_episode_label">Kustuta saade</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">Kustutati %d saade.</item>
-    <item quantity="other">Kustutati %d saadet.</item>
-  </plurals>
   <string name="remove_new_flag_label">Eemalda silt \"uus\"</string>
   <string name="removed_new_flag_label">Eemaldati silt \"uus\"</string>
   <string name="mark_read_label">Märgi kuulatuks</string>

--- a/core/src/main/res/values-eu/strings.xml
+++ b/core/src/main/res/values-eu/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Ezabatu</string>
   <string name="delete_failed">Ezin da fitxategia ezabatu. Gailua berrabiarazteak lagun dezake.</string>
   <string name="delete_episode_label">Saioa ezabatu</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%dsaio ezabatua.</item>
-    <item quantity="other">%d saio ezabatuak.</item>
-  </plurals>
   <string name="remove_new_flag_label">Kendu \"berria\" ikurra</string>
   <string name="removed_new_flag_label">\"Berria\" ikurra kendu da</string>
   <string name="mark_read_label">Markatu ikusita bezala</string>

--- a/core/src/main/res/values-fa/strings.xml
+++ b/core/src/main/res/values-fa/strings.xml
@@ -149,10 +149,6 @@
   <string name="delete_label">حذف</string>
   <string name="delete_failed">پرونده حذف نشد. راه‌اندازی مجدد دستگاه می‌تواند کمک کند.</string>
   <string name="delete_episode_label">حذف قسمت</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d قسمت حذف شد.</item>
-    <item quantity="other">%d قسمت حذف شد.</item>
-  </plurals>
   <string name="remove_new_flag_label">حذف نشان «جدید»</string>
   <string name="removed_new_flag_label">نشان «جدید» حذف شد</string>
   <string name="mark_read_label">علامت‌گذاری به‌عنوان پخش‌شده</string>

--- a/core/src/main/res/values-fi/strings.xml
+++ b/core/src/main/res/values-fi/strings.xml
@@ -149,10 +149,6 @@
   <string name="delete_label">Poista</string>
   <string name="delete_failed">Ei voida poistaa tiedostoa. Laitteen uudelleenkäynnistys saattaa auttaa.</string>
   <string name="delete_episode_label">Poista jakso</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d jakso poistettu.</item>
-    <item quantity="other">%d jaksoa poistettu.</item>
-  </plurals>
   <string name="remove_new_flag_label">Poista \"uusi\"-lippu</string>
   <string name="removed_new_flag_label">Poistettiin \"uusi\"-lippu</string>
   <string name="mark_read_label">Merkitse soitetuksi</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Supprimer</string>
   <string name="delete_failed">Suppression du fichier impossible. Redémarrer pourrait aider.</string>
   <string name="delete_episode_label">Suppression de l\'épisode</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d épisode supprimé.</item>
-    <item quantity="other">%d épisodes supprimés.</item>
-  </plurals>
   <string name="remove_new_flag_label">Ne plus considérer nouveau</string>
   <string name="removed_new_flag_label">Le statut \"nouveau\" a été supprimé</string>
   <string name="mark_read_label">Marquer comme lu</string>

--- a/core/src/main/res/values-gl/strings.xml
+++ b/core/src/main/res/values-gl/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Borrar</string>
   <string name="delete_failed">Non se puido eliminar o ficheiro. Reiniciar o dispositivo podería axudar.</string>
   <string name="delete_episode_label">Eliminar episodio</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episodio eliminado.</item>
-    <item quantity="other">%d episodios eliminados.</item>
-  </plurals>
   <string name="remove_new_flag_label">Quitar marca \"novo\"</string>
   <string name="removed_new_flag_label">Eliminouse marca \"novo\"</string>
   <string name="mark_read_label">Marcar como reproducido</string>

--- a/core/src/main/res/values-hu/strings.xml
+++ b/core/src/main/res/values-hu/strings.xml
@@ -149,10 +149,6 @@
   <string name="delete_label">Törlés</string>
   <string name="delete_failed">A fájl nem törölhető. Az eszköz újraindítása segíthet a probléma megoldásában.</string>
   <string name="delete_episode_label">Epizód törlése</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d epizód törölve. </item>
-    <item quantity="other">%d epizód törölve.</item>
-  </plurals>
   <string name="remove_new_flag_label">Az „új” jelző eltávolítása</string>
   <string name="removed_new_flag_label">Az „új” jelző eltávolítva</string>
   <string name="mark_read_label">Megjelölés lejátszottként</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -153,10 +153,6 @@
   <string name="delete_label">Elimina</string>
   <string name="delete_failed">Impossibile eliminare il file. Prova a riavviare il dispositivo.</string>
   <string name="delete_episode_label">Elimina episodio</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episodio eliminato.</item>
-    <item quantity="other">%d episodi eliminati.</item>
-  </plurals>
   <string name="remove_new_flag_label">Rimuovi flag \"nuovo\"</string>
   <string name="removed_new_flag_label">Flag \"nuovo\" rimosso</string>
   <string name="mark_read_label">Segna come riprodotto</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -168,12 +168,6 @@
   <string name="delete_label">מחיקה</string>
   <string name="delete_failed">לא ניתן למחוק קובץ. הפעלת המכשיר מחדש עשויה לסייע.</string>
   <string name="delete_episode_label">מחיקת פרק</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">פרק אחד נמחק.</item>
-    <item quantity="two">%d פרקים נמחקו.</item>
-    <item quantity="many">%d פרקים נמחקו.</item>
-    <item quantity="other">%d פרקים נמחקו.</item>
-  </plurals>
   <string name="remove_new_flag_label">הסרת הסימון „חדש”</string>
   <string name="removed_new_flag_label">הוסר הסימון „חדש”</string>
   <string name="mark_read_label">סימון כנצפה</string>

--- a/core/src/main/res/values-ja/strings.xml
+++ b/core/src/main/res/values-ja/strings.xml
@@ -141,9 +141,6 @@
   <string name="delete_label">削除</string>
   <string name="delete_failed">ファイルを削除できません。デバイスを再起動してみてください。</string>
   <string name="delete_episode_label">エピソードを削除</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="other">%d エピソードを削除しました。</item>
-  </plurals>
   <string name="remove_new_flag_label">\"新規\" フラグを削除</string>
   <string name="removed_new_flag_label">\"新規\" フラグを削除しました</string>
   <string name="mark_read_label">再生済としてマーク</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -145,9 +145,6 @@
   <string name="delete_label">삭제</string>
   <string name="delete_failed">파일을 삭제할 수 없습니다. 장치를 재부팅하면 동작할 수도 있습니다.</string>
   <string name="delete_episode_label">에피소드 삭제</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="other">%d개 에피소드 삭제함.</item>
-  </plurals>
   <string name="remove_new_flag_label">\"신규\" 플래그 제거</string>
   <string name="removed_new_flag_label">\"신규\" 플래그 제거함</string>
   <string name="mark_read_label">재생했다고 표시</string>

--- a/core/src/main/res/values-lt/strings.xml
+++ b/core/src/main/res/values-lt/strings.xml
@@ -157,12 +157,6 @@
   <string name="delete_label">Ištrinti</string>
   <string name="delete_failed">Nepavyksta ištrinti failo. Įrenginio paleidimas iš naujo gali padėti.</string>
   <string name="delete_episode_label">Ištrinti epizodą</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d epizodas ištrintas.</item>
-    <item quantity="few">%d epizodai ištrinti.</item>
-    <item quantity="many">%d epizodai ištrinti.</item>
-    <item quantity="other">%d epizodai ištrinti.</item>
-  </plurals>
   <string name="remove_new_flag_label">Pašalinti „naujas“ gairelę</string>
   <string name="removed_new_flag_label">„naujas“ gairelė pašalinta</string>
   <string name="mark_read_label">Pažymėti kaip perklausytą</string>

--- a/core/src/main/res/values-nb/strings.xml
+++ b/core/src/main/res/values-nb/strings.xml
@@ -151,10 +151,6 @@
   <string name="delete_label">Slett</string>
   <string name="delete_failed">Kan ikke slette filen. Omstart av enheten kan hjelpe.</string>
   <string name="delete_episode_label">Slett episode</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episode slettet.</item>
-    <item quantity="other">%d episode slettet.</item>
-  </plurals>
   <string name="remove_new_flag_label">Fjern \"Ny\"-markering</string>
   <string name="removed_new_flag_label">Fjernet \"Ny\"-markering</string>
   <string name="mark_read_label">Marker som avspilt</string>

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Verwijderen</string>
   <string name="delete_failed">Kan bestand niet verwijderen; start je apparaat opnieuw op.</string>
   <string name="delete_episode_label">Aflevering verwijderen</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d aflevering verwijderd.</item>
-    <item quantity="other">%d afleveringen verwijderd.</item>
-  </plurals>
   <string name="remove_new_flag_label">\'Nieuw\'-label verwijderen</string>
   <string name="removed_new_flag_label">\'Nieuw\'-label is verwijderd</string>
   <string name="mark_read_label">Als afgespeeld markeren</string>

--- a/core/src/main/res/values-pl/strings.xml
+++ b/core/src/main/res/values-pl/strings.xml
@@ -157,12 +157,6 @@
   <string name="delete_label">Usuń</string>
   <string name="delete_failed">Nie można usunąć pliku. Restart urządzenia może w tym pomóc.</string>
   <string name="delete_episode_label">Usuń odcinek</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">Usunięto %d odcinek. </item>
-    <item quantity="few">Usunięto %d odcinki(ów). </item>
-    <item quantity="many">Usunięto %d odcinki(ów). </item>
-    <item quantity="other">Usunięto %d odcinki(ów). </item>
-  </plurals>
   <string name="remove_new_flag_label">Usuń flagę \"nowy\"</string>
   <string name="removed_new_flag_label">Usunięto flagę \"nowy\"</string>
   <string name="mark_read_label">Oznacz jako odtworzone</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -149,10 +149,6 @@
   <string name="delete_label">Deletar</string>
   <string name="delete_failed">Não foi possível deletar o arquivo. Experimente reiniciar o dispositivo.</string>
   <string name="delete_episode_label">Apagar Episódio</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episódio apagado.</item>
-    <item quantity="other">%d episódios apagados.</item>
-  </plurals>
   <string name="remove_new_flag_label">Remover etiqueta de \"novo\"</string>
   <string name="removed_new_flag_label">Etiqueta de \"novo\" removida</string>
   <string name="mark_read_label">Marcar como reproduzido</string>

--- a/core/src/main/res/values-pt/strings.xml
+++ b/core/src/main/res/values-pt/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Eliminar</string>
   <string name="delete_failed">Episódio não eliminado. Tente reiniciar o dispositivo.</string>
   <string name="delete_episode_label">Eliminar episódio</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episódio eliminado.</item>
-    <item quantity="other">%d episódios eliminados.</item>
-  </plurals>
   <string name="remove_new_flag_label">Remover a marca \"novo\"</string>
   <string name="removed_new_flag_label">A marca \"novo\" foi removida</string>
   <string name="mark_read_label">Marcar como reproduzido</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -157,12 +157,6 @@
   <string name="delete_label">Удалить</string>
   <string name="delete_failed">Невозможно удалить файл. Попробуйте перезагрузить устройство.</string>
   <string name="delete_episode_label">Удалить выпуск</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d выпуск удален.</item>
-    <item quantity="few">%d выпуска удалены.</item>
-    <item quantity="many">%d выпусков удалены.</item>
-    <item quantity="other">%d выпусков удалено.</item>
-  </plurals>
   <string name="remove_new_flag_label">Убрать пометку «Новый»</string>
   <string name="removed_new_flag_label">Пометка «Новый» убрана</string>
   <string name="mark_read_label">Отметить как прослушанное</string>

--- a/core/src/main/res/values-sv/strings.xml
+++ b/core/src/main/res/values-sv/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Ta bort</string>
   <string name="delete_failed">Kunde inte ta bort filen. Testa att starta om enheten.</string>
   <string name="delete_episode_label">Radera episod</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">1%d episod raderad.</item>
-    <item quantity="other">1%d episder raderade.</item>
-  </plurals>
   <string name="remove_new_flag_label">Ta bort \"ny\"-flagga</string>
   <string name="removed_new_flag_label">Tog bort \"ny\"-flagga</string>
   <string name="mark_read_label">Markera som spelad</string>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -160,10 +160,6 @@
   <string name="delete_label">Sil</string>
   <string name="delete_failed">Dosya silinemiyor. Cihazı yeniden başlatmak yardımcı olabilir.</string>
   <string name="delete_episode_label">Delete Episode</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d episode deleted.</item>
-    <item quantity="other">%d episodes deleted.</item>
-  </plurals>
   <string name="remove_new_flag_label">Remove \"new\" flag</string>
   <string name="removed_new_flag_label">Removed \"new\" flag</string>
   <string name="mark_read_label">Oynatıldı olarak işaretle</string>

--- a/core/src/main/res/values-uk/strings.xml
+++ b/core/src/main/res/values-uk/strings.xml
@@ -137,12 +137,6 @@
   <string name="delete_label">Видалити</string>
   <string name="delete_failed">Файл не видалено. Можливо, перезавантаження пристрою допоможе.</string>
   <string name="delete_episode_label">Видалити епізод</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="one">%d епізод видалено.</item>
-    <item quantity="few">%dепізода видалено. </item>
-    <item quantity="many">%dепізодів видалено. </item>
-    <item quantity="other">%d епізодів видалено.</item>
-  </plurals>
   <string name="mark_read_label">Позначити як відтворений</string>
   <string name="marked_as_read_label">Позначено як відтворений</string>
   <plurals name="marked_read_batch_label">

--- a/core/src/main/res/values-zh-rCN/strings.xml
+++ b/core/src/main/res/values-zh-rCN/strings.xml
@@ -156,9 +156,6 @@
   <string name="delete_label">删除</string>
   <string name="delete_failed">无法删除文件。重启可能解决该问题。</string>
   <string name="delete_episode_label">删除节目</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="other">已删除%d个节目</item>
-  </plurals>
   <string name="remove_new_flag_label">移除“新的”标签</string>
   <string name="removed_new_flag_label">已移除“新的”标签</string>
   <string name="mark_read_label">标记已播放</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -145,9 +145,6 @@
   <string name="delete_label">刪除</string>
   <string name="delete_failed">刪除文件失敗。重啟設備試試看。</string>
   <string name="delete_episode_label">刪除這一集</string>
-  <plurals name="deleted_episode_batch_label">
-    <item quantity="other">已刪除 %d 集。</item>
-  </plurals>
   <string name="remove_new_flag_label">移除「新」的標記</string>
   <string name="removed_new_flag_label">已移除「新」的標記</string>
   <string name="mark_read_label">標記為已播放</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -178,6 +178,11 @@
         <item quantity="one">%d episode deleted.</item>
         <item quantity="other">%d episodes deleted.</item>
     </plurals>
+    <plurals name="deleted_multi_episode_batch_label">
+        <item quantity="zero">%d episodes selected, %d deleted. Only downloaded files removed.</item>
+        <item quantity="one">%d episodes selected, %d deleted. Only downloaded files removed.</item>
+        <item quantity="other">%d episodes selected, %d deleted. Only downloaded files removed.</item>
+    </plurals>
     <string name="remove_new_flag_label">Remove \"new\" flag</string>
     <string name="removed_new_flag_label">Removed \"new\" flag</string>
     <string name="mark_read_label">Mark as played</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -179,9 +179,8 @@
         <item quantity="other">%d episodes deleted.</item>
     </plurals>
     <plurals name="deleted_multi_episode_batch_label">
-        <item quantity="zero">%d episodes selected, %d deleted. Only downloaded files removed.</item>
-        <item quantity="one">%d episodes selected, %d deleted. Only downloaded files removed.</item>
-        <item quantity="other">%d episodes selected, %d deleted. Only downloaded files removed.</item>
+        <item quantity="one">%d episode selected, %d download deleted.</item>
+        <item quantity="other">%d episodes selected, %d download(s) deleted.</item>
     </plurals>
     <string name="remove_new_flag_label">Remove \"new\" flag</string>
     <string name="removed_new_flag_label">Removed \"new\" flag</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -174,10 +174,6 @@
     <string name="delete_label">Delete</string>
     <string name="delete_failed">Unable to delete file. Rebooting the device could help.</string>
     <string name="delete_episode_label">Delete Episode</string>
-    <plurals name="deleted_episode_batch_label">
-        <item quantity="one">%d episode deleted.</item>
-        <item quantity="other">%d episodes deleted.</item>
-    </plurals>
     <plurals name="deleted_multi_episode_batch_label">
         <item quantity="one">%d episode selected, %d download deleted.</item>
         <item quantity="other">%d episodes selected, %d download(s) deleted.</item>


### PR DESCRIPTION
fix #4697 

Show a meaningful message about how many were selected and how many were deleted

Also fixed a bug with how we determined whether an episode is downloaded