### PR TITLE
share by timecode

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -67,6 +67,7 @@ public class ShareUtils {
 		String text = getItemShareText(item) + " " + item.getMedia().getDownload_url();
 		if(withPosition) {
 			int pos = item.getMedia().getPosition();
+			text += "#t=" + pos / 1000;
 			text += " [" + Converter.getDurationStringLong(pos) + "]";
 		}
 		shareLink(context, text);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -19,75 +19,77 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 
 /** Utility methods for sharing data */
 public class ShareUtils {
-	private static final String TAG = "ShareUtils";
-	
-	private ShareUtils() {}
-	
-	public static void shareLink(Context context, String text) {
-		Intent i = new Intent(Intent.ACTION_SEND);
-		i.setType("text/plain");
-		i.putExtra(Intent.EXTRA_TEXT, text);
-		context.startActivity(Intent.createChooser(i, context.getString(R.string.share_url_label)));
-	}
+    private static final String TAG = "ShareUtils";
 
-	public static void shareFeedlink(Context context, Feed feed) {
-		shareLink(context, feed.getTitle() + ": " + feed.getLink());
-	}
-	
-	public static void shareFeedDownloadLink(Context context, Feed feed) {
-		shareLink(context, feed.getTitle() + ": " + feed.getDownload_url());
-	}
-
-	public static void shareFeedItemLink(Context context, FeedItem item) {
-		shareFeedItemLink(context, item, false);
-	}
-
-	public static void shareFeedItemDownloadLink(Context context, FeedItem item) {
-		shareFeedItemDownloadLink(context, item, false);
-	}
-
-	private static String getItemShareText(FeedItem item) {
-		return item.getFeed().getTitle() + ": " + item.getTitle();
-	}
-
-    public static boolean hasLinkToShare(FeedItem item) {
-	    return FeedItemUtil.getLinkWithFallback(item) != null;
+    private ShareUtils() {
     }
 
-	public static void shareFeedItemLink(Context context, FeedItem item, boolean withPosition) {
-		String text = getItemShareText(item) + " " + FeedItemUtil.getLinkWithFallback(item);
-		if(withPosition) {
-			int pos = item.getMedia().getPosition();
-			text += " [" + Converter.getDurationStringLong(pos) + "]";
-		}
-		shareLink(context, text);
-	}
+    public static void shareLink(Context context, String text) {
+        Intent i = new Intent(Intent.ACTION_SEND);
+        i.setType("text/plain");
+        i.putExtra(Intent.EXTRA_TEXT, text);
+        context.startActivity(Intent.createChooser(i, context.getString(R.string.share_url_label)));
+    }
 
-	public static void shareFeedItemDownloadLink(Context context, FeedItem item, boolean withPosition) {
-		String text = getItemShareText(item) + " " + item.getMedia().getDownload_url();
-		if(withPosition) {
-			int pos = item.getMedia().getPosition();
-			text += "#t=" + pos / 1000;
-			text += " [" + Converter.getDurationStringLong(pos) + "]";
-		}
-		shareLink(context, text);
-	}
+    public static void shareFeedlink(Context context, Feed feed) {
+        shareLink(context, feed.getTitle() + ": " + feed.getLink());
+    }
 
-	public static void shareFeedItemFile(Context context, FeedMedia media) {
-		Intent i = new Intent(Intent.ACTION_SEND);
-		i.setType(media.getMime_type());
-		Uri fileUri = FileProvider.getUriForFile(context, context.getString(R.string.provider_authority),
-				new File(media.getLocalMediaUrl()));
-		i.putExtra(Intent.EXTRA_STREAM,  fileUri);
-		i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-			List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(i, PackageManager.MATCH_DEFAULT_ONLY);
-			for (ResolveInfo resolveInfo : resInfoList) {
-				String packageName = resolveInfo.activityInfo.packageName;
-				context.grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-			}
-		}
-		context.startActivity(Intent.createChooser(i, context.getString(R.string.share_file_label)));
-		Log.e(TAG, "shareFeedItemFile called");
-	}
+    public static void shareFeedDownloadLink(Context context, Feed feed) {
+        shareLink(context, feed.getTitle() + ": " + feed.getDownload_url());
+    }
+
+    public static void shareFeedItemLink(Context context, FeedItem item) {
+        shareFeedItemLink(context, item, false);
+    }
+
+    public static void shareFeedItemDownloadLink(Context context, FeedItem item) {
+        shareFeedItemDownloadLink(context, item, false);
+    }
+
+    private static String getItemShareText(FeedItem item) {
+        return item.getFeed().getTitle() + ": " + item.getTitle();
+    }
+
+    public static boolean hasLinkToShare(FeedItem item) {
+        return FeedItemUtil.getLinkWithFallback(item) != null;
+    }
+
+    public static void shareFeedItemLink(Context context, FeedItem item, boolean withPosition) {
+        String text = getItemShareText(item) + " " + FeedItemUtil.getLinkWithFallback(item);
+        if (withPosition) {
+            int pos = item.getMedia().getPosition();
+            text += " [" + Converter.getDurationStringLong(pos) + "]";
+        }
+        shareLink(context, text);
+    }
+
+    public static void shareFeedItemDownloadLink(Context context, FeedItem item, boolean withPosition) {
+        String text = getItemShareText(item) + " " + item.getMedia().getDownload_url();
+        if (withPosition) {
+            int pos = item.getMedia().getPosition();
+            text += "#t=" + pos / 1000;
+            text += " [" + Converter.getDurationStringLong(pos) + "]";
+        }
+        shareLink(context, text);
+    }
+
+    public static void shareFeedItemFile(Context context, FeedMedia media) {
+        Intent i = new Intent(Intent.ACTION_SEND);
+        i.setType(media.getMime_type());
+        Uri fileUri = FileProvider.getUriForFile(context, context.getString(R.string.provider_authority),
+                new File(media.getLocalMediaUrl()));
+        i.putExtra(Intent.EXTRA_STREAM,  fileUri);
+        i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            List<ResolveInfo> resInfoList = context.getPackageManager()
+                    .queryIntentActivities(i, PackageManager.MATCH_DEFAULT_ONLY);
+            for (ResolveInfo resolveInfo : resInfoList) {
+                String packageName = resolveInfo.activityInfo.packageName;
+                context.grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            }
+        }
+        context.startActivity(Intent.createChooser(i, context.getString(R.string.share_file_label)));
+        Log.e(TAG, "shareFeedItemFile called");
+    }
 }


### PR DESCRIPTION
fix #2012 

A simple to fix to allow to jump to a timecode when sharing the URL of a feed item with this [SHA](https://github.com/AntennaPod/AntennaPod/commit/afb151eb3f8a83663169d0f1fcce3686be1b53f5)

Then I change TABS to spaces