### PR TITLE
remove media when swipping away item from queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -485,7 +485,8 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
                     final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
                     ScheduledFuture<?> countdown = scheduler.schedule(() -> {
                         if (item.getFeed().getPreferences().getCurrentAutoDelete()
-                                && (!item.isTagged(FeedItem.TAG_FAVORITE) || !UserPreferences.shouldFavoriteKeepEpisode())) {
+                                && (!item.isTagged(FeedItem.TAG_FAVORITE)
+                                || !UserPreferences.shouldFavoriteKeepEpisode())) {
                             Log.d(TAG, "Episode Media Deleted " + item.getMedia().getEpisodeTitle());
                             DBWriter.deleteFeedMediaOfItem(getContext(), item.getMedia().getId());
                         }
@@ -496,7 +497,7 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
                             item.hasMedia() ? R.string.marked_as_read_label : R.string.marked_as_read_no_media_label,
                             Snackbar.LENGTH_LONG)
                             .setAction(getString(R.string.undo), v -> {
-                                if(countdown!= null){
+                                if (countdown != null) {
                                     countdown.cancel(true);
                                     scheduler.shutdown();
                                 }


### PR DESCRIPTION
fix #4750 by deleting the media file unless the user hits undo when a queue item is swiped

- [ ] #2990 Do we want to add an undo when the user clicks remove from queue while doing long click?

I tested this with opening up the Android File Transfer app and looking at the media files.

1. Swipe away an episode, immediately hit Undo, I expect the media file not to be deleted
1. Swipe away an episode, wait 5 seconds, I expect the Undo snack to be gone in < 3 seconds, after 5 seconds the media file is deleted