### PR TITLE
Update AndroidX Media and ExoPlayer

### DIFF
--- a/app/src/play/java/de/danoeh/antennapod/dialog/CustomMRControllerDialog.java
+++ b/app/src/play/java/de/danoeh/antennapod/dialog/CustomMRControllerDialog.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.RemoteException;
 import androidx.annotation.NonNull;
 import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
@@ -74,12 +73,8 @@ public class CustomMRControllerDialog extends MediaRouteControllerDialog {
         super(context, theme);
         mediaRouter = MediaRouter.getInstance(getContext());
         token = mediaRouter.getMediaSessionToken();
-        try {
-            if (token != null) {
-                mediaController = new MediaControllerCompat(getContext(), token);
-            }
-        } catch (RemoteException e) {
-            Log.e(TAG, "Error creating media controller", e);
+        if (token != null) {
+            mediaController = new MediaControllerCompat(getContext(), token);
         }
 
         if (mediaController != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
     // AndroidX
     annotationVersion = "1.1.0"
     appcompatVersion = "1.2.0"
-    mediaVersion = "1.1.0"
+    mediaVersion = "1.2.1"
     preferenceVersion = "1.1.1"
     workManagerVersion = "2.3.4"
     googleMaterialVersion = "1.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ project.ext {
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"
+    exoplayerVersion = "2.12.2"
     audioPlayerVersion = "v2.0.0"
 
     // Only used for free builds. This version should be updated regularly.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,7 +93,8 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.8'
+    implementation "com.google.android.exoplayer:exoplayer-core:$exoplayerVersion"
+    implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayerVersion"
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     // Add casting features

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -138,7 +138,7 @@ public class ExoPlayerWrapper implements IPlayer {
 
     @Override
     public void pause() {
-        exoPlayer.setPlayWhenReady(false);
+        exoPlayer.pause();
     }
 
     @Override
@@ -225,7 +225,7 @@ public class ExoPlayerWrapper implements IPlayer {
 
     @Override
     public void start() {
-        exoPlayer.setPlayWhenReady(true);
+        exoPlayer.play();
         // Can't set params when paused - so always set it on start in case they changed
         exoPlayer.setPlaybackParameters(playbackParameters);
     }


### PR DESCRIPTION
- Updated AndroidX Media 1.1.0 -> 1.2.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/media))
- Updated ExoPlayer 2.11.8 -> 2.12.2 ([changelog](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md))
- Use `play` and `pause` convenience methods introduced in 2.12.0

([Here](https://github.com/google/ExoPlayer/commit/e9511a56eadd20bbee3ddf369b98d37a630a04fc)'s where onSeekProcessed was deprecated)

I built an APK and tested; there were no negative effects as far as I can tell.