### PR TITLE
Add episodes to sleep timer

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -138,7 +138,8 @@ public class SleepTimerDialog extends DialogFragment {
                 if (spTimeUnit.getSelectedItemPosition() >= 3) {
                     int timeValue = Integer.parseInt(etxtTime.getText().toString());
                     if (timeValue > DBReader.getQueueIDList().size()) {
-                        Snackbar.make(content, R.string.time_dialog_invalid_episodes_input, Snackbar.LENGTH_LONG).show();
+                        Snackbar.make(content,
+                                R.string.time_dialog_invalid_episodes_input, Snackbar.LENGTH_LONG).show();
                         return;
                     }
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
@@ -18,7 +18,7 @@ public class SleepTimerPreferences {
     private static final String PREF_SHAKE_TO_RESET = "ShakeToReset";
     private static final String PREF_AUTO_ENABLE = "AutoEnable";
 
-    private static final TimeUnit[] UNITS = { TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS };
+    private static final TimeUnit[] UNITS = {TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS, TimeUnit.MILLISECONDS};
 
     private static final String DEFAULT_VALUE = "15";
     private static final int DEFAULT_TIME_UNIT = 1;
@@ -50,6 +50,10 @@ public class SleepTimerPreferences {
     public static long timerMillis() {
         long value = Long.parseLong(lastTimerValue());
         return UNITS[lastTimerTimeUnit()].toMillis(value);
+    }
+
+    public static boolean isEpisodesEnabled() {
+        return lastTimerTimeUnit() == 3;
     }
 
     public static void setVibrate(boolean vibrate) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -570,6 +570,12 @@ public class PlaybackController {
         }
     }
 
+    public void setSleepTimerEpisodes(int time) {
+        if (playbackService != null) {
+            playbackService.setSleepTimerEpisodes(time);
+        }
+    }
+
     public void seekToChapter(Chapter chapter) {
         if (playbackService != null) {
             playbackService.seekToChapter(chapter);

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -604,11 +604,13 @@
     <string name="disable_sleeptimer_label">Disable sleep timer</string>
     <string name="sleep_timer_label">Sleep timer</string>
     <string name="time_dialog_invalid_input">Invalid input, time has to be an integer</string>
+    <string name="time_dialog_invalid_episodes_input">Invalid input, not enough episodes in queue</string>
     <string name="shake_to_reset_label">Shake to reset</string>
     <string name="timer_vibration_label">Vibrate shortly before end</string>
     <string name="time_seconds">seconds</string>
     <string name="time_minutes">minutes</string>
     <string name="time_hours">hours</string>
+    <string name="time_episodes">episodes</string>
     <plurals name="time_seconds_quantified">
         <item quantity="one">1 second</item>
         <item quantity="other">%d seconds</item>


### PR DESCRIPTION
Continuation of #4535 

Closes #4535 
Closes #2146 

This adds the basic functionality to the sleep timer to stop after the end of the `x`th episode.
I think this is ready for a short review, however there are two "bugs" with the checkboxes:
 1) `Vibrate shortly before end`: The phone now vibrates when the last episode starts
 2) `Auto-enable`: After the playback ended the auto-enable option is triggered and reenables the sleep timer, but nothing is playing.