### PR TITLE
Fix #4765: Disable autoDownload for local feeds

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedPreferences.java
@@ -122,7 +122,7 @@ public class FeedPreferences {
     }
 
     /**
-     * Compare another FeedPreferences with this one. The feedID, autoDownload and AutoDeleteAction attribute are excluded from the
+     * Compare another FeedPreferences with this one. The feedID and AutoDeleteAction attribute are excluded from the
      * comparison.
      *
      * @return True if the two objects are different.
@@ -137,11 +137,14 @@ public class FeedPreferences {
         if (!TextUtils.equals(password, other.password)) {
             return true;
         }
+        if (autoDownload != other.autoDownload) {
+            return true;
+        }
         return false;
     }
 
     /**
-     * Update this FeedPreferences object from another one. The feedID, autoDownload and AutoDeleteAction attributes are excluded
+     * Update this FeedPreferences object from another one. The feedID and AutoDeleteAction attributes are excluded
      * from the update.
      */
     public void updateFromOther(FeedPreferences other) {
@@ -149,6 +152,7 @@ public class FeedPreferences {
             return;
         this.username = other.username;
         this.password = other.password;
+        this.autoDownload = other.autoDownload;
     }
 
     public long getFeedID() {


### PR DESCRIPTION
Fixes #4765: Automatic download feature needs to be disabled for local podcasts

I'm not 100% sure that the fix has no unexpected side-effects, because the JavaDoc of `FeedPreferences.compareWithOther()` and `FeedPreferences.updateFromOther()` explicitly mentioned that the `autoDownload` attribute is excluded from comparison/update. At least in my tests it worked fine.