### PR TITLE
Fix #4765: Disable autoDownload for local feeds (master branch)

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APDownloadAlgorithm.java
@@ -65,7 +65,7 @@ public class APDownloadAlgorithm implements AutomaticDownloadAlgorithm {
                 Iterator<FeedItem> it = candidates.iterator();
                 while (it.hasNext()) {
                     FeedItem item = it.next();
-                    if (!item.isAutoDownloadable()) {
+                    if (!item.isAutoDownloadable() || item.getFeed().isLocalFeed()) {
                         it.remove();
                     }
                 }


### PR DESCRIPTION
Fixes #4765: Automatic download feature needs to be disabled for local podcasts

Provides a careful fix for the master branch as suggested in #4777.