### PR TITLE
Fix #4775: Illegal connection pointer in Robolectric tests (awaitTermination)

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -73,6 +73,10 @@ public class DBWriter {
     private DBWriter() {
     }
 
+    /**
+     * Wait until all threads are finished to avoid the "Illegal connection pointer" error of
+     * Robolectric. Call this method only for unit tests.
+     */
     public static void tearDownTests() {
         try {
             dbExec.awaitTermination(1, TimeUnit.SECONDS);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.event.DownloadLogEvent;
@@ -70,6 +71,14 @@ public class DBWriter {
     }
 
     private DBWriter() {
+    }
+
+    public static void tearDownTests() {
+        try {
+            dbExec.awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // ignore error
+        }
     }
 
     /**

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
@@ -30,6 +30,7 @@ import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.storage.DBReader;
+import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 import static org.junit.Assert.assertEquals;
@@ -81,6 +82,7 @@ public class LocalFeedUpdaterTest {
 
     @After
     public void tearDown() {
+        DBWriter.tearDownTests();
         PodDBAdapter.tearDownTests();
     }
 


### PR DESCRIPTION
Fixes #4775: Illegal connection pointer in Robolectric tests

Wait for all asynchronous DBWriter methods to be finished before the next unit test method starts:
```java
dbExec.awaitTermination(1, TimeUnit.SECONDS);
```