### PR TITLE
Run DateUtilsTest as Unit Test

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -30,9 +30,12 @@ public class DateUtils {
         }
         String date = input.trim().replace('/', '-').replaceAll("( ){2,}+", " ");
 
+        // remove colon from timezone to avoid differences between Android and Java SimpleDateFormat
+        date = date.replaceAll("([+-]\\d\\d):(\\d\\d)$", "$1$2");
+
         // CEST is widely used but not in the "ISO 8601 Time zone" list. Let's hack around.
-        date = date.replaceAll("CEST$", "+02:00");
-        date = date.replaceAll("CET$", "+01:00");
+        date = date.replaceAll("CEST$", "+0200");
+        date = date.replaceAll("CET$", "+0100");
 
         // some generators use "Sept" for September
         date = date.replaceAll("\\bSept\\b", "Sep");

--- a/core/src/test/java/de/danoeh/antennapod/core/util/DateUtilsTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/DateUtilsTest.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.core.util;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Calendar;
@@ -13,13 +12,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Unit test for {@link DateUtils}.
  */
-@SuppressWarnings("ConstantConditions")
 public class DateUtilsTest {
-
-    @Before
-    public void setUp() {
-        DateUtils.dateFormatParser.setTimeZone(DateUtils.defaultTimezone);
-    }
 
     @Test
     public void testParseDateWithMicroseconds() {
@@ -45,8 +38,8 @@ public class DateUtilsTest {
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 900);
         Date actual = DateUtils.parse("2015-03-28T13:31:04.9");
-        assertEquals(expected.getTime()/1000, actual.getTime()/1000);
-        assertEquals(900, actual.getTime()%1000);
+        assertEquals(expected.getTime() / 1000, actual.getTime() / 1000);
+        assertEquals(900, actual.getTime() % 1000);
     }
 
     @Test
@@ -73,8 +66,8 @@ public class DateUtilsTest {
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 900);
         Date actual = DateUtils.parse("2015-03-28T13:31:04.9 +0700");
-        assertEquals(expected.getTime()/1000, actual.getTime()/1000);
-        assertEquals(900, actual.getTime()%1000);
+        assertEquals(expected.getTime() / 1000, actual.getTime() / 1000);
+        assertEquals(900, actual.getTime() % 1000);
     }
 
     @Test
@@ -122,12 +115,6 @@ public class DateUtilsTest {
         assertEquals(expected, actual);
     }
 
-    /**
-     * Requires Android platform.
-     *
-     * Reason: Standard JDK cannot parse timezone <code>-08:00</code> (ISO 8601 format). It only accepts
-     * <code>-0800</code> (RFC 822 format)
-     */
     @Test
     public void testParseDateWithNoTimezonePadding() {
         GregorianCalendar exp = new GregorianCalendar(2017, 1, 22, 22, 28, 0);

--- a/core/src/test/java/de/danoeh/antennapod/core/util/DateUtilsTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/DateUtilsTest.java
@@ -1,6 +1,6 @@
 package de.danoeh.antennapod.core.util;
 
-import androidx.test.filters.SmallTest;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Calendar;
@@ -12,16 +12,17 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Unit test for {@link DateUtils}.
- *
- * Note: It NEEDS to be run in android devices, i.e., it cannot be run in standard JDK, because
- * the test invokes some android platform-specific behavior in the underlying
- * {@link java.text.SimpleDateFormat} used by {@link DateUtils}.
- *
  */
-@SmallTest
+@SuppressWarnings("ConstantConditions")
 public class DateUtilsTest {
+
+    @Before
+    public void setUp() {
+        DateUtils.dateFormatParser.setTimeZone(DateUtils.defaultTimezone);
+    }
+
     @Test
-    public void testParseDateWithMicroseconds() throws Exception {
+    public void testParseDateWithMicroseconds() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 13, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 963);
@@ -30,7 +31,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithCentiseconds() throws Exception {
+    public void testParseDateWithCentiseconds() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 13, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 960);
@@ -39,7 +40,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithDeciseconds() throws Exception {
+    public void testParseDateWithDeciseconds() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 13, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 900);
@@ -49,7 +50,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithMicrosecondsAndTimezone() throws Exception {
+    public void testParseDateWithMicrosecondsAndTimezone() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 6, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 963);
@@ -58,7 +59,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithCentisecondsAndTimezone() throws Exception {
+    public void testParseDateWithCentisecondsAndTimezone() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 6, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 960);
@@ -67,7 +68,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithDecisecondsAndTimezone() throws Exception {
+    public void testParseDateWithDecisecondsAndTimezone() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 6, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 900);
@@ -77,7 +78,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithTimezoneName() throws Exception {
+    public void testParseDateWithTimezoneName() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 6, 31, 4);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis());
@@ -86,7 +87,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithTimezoneName2() throws Exception {
+    public void testParseDateWithTimezoneName2() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 6, 31, 0);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis());
@@ -95,7 +96,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testParseDateWithTimeZoneOffset() throws Exception {
+    public void testParseDateWithTimeZoneOffset() {
         GregorianCalendar exp = new GregorianCalendar(2015, 2, 28, 12, 16, 12);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis());
@@ -104,7 +105,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testAsctime() throws Exception {
+    public void testAsctime() {
         GregorianCalendar exp = new GregorianCalendar(2011, 4, 25, 12, 33, 0);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis());
@@ -113,7 +114,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void testMultipleConsecutiveSpaces() throws Exception {
+    public void testMultipleConsecutiveSpaces() {
         GregorianCalendar exp = new GregorianCalendar(2010, 2, 23, 6, 6, 26);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis());
@@ -128,7 +129,7 @@ public class DateUtilsTest {
      * <code>-0800</code> (RFC 822 format)
      */
     @Test
-    public void testParseDateWithNoTimezonePadding() throws Exception {
+    public void testParseDateWithNoTimezonePadding() {
         GregorianCalendar exp = new GregorianCalendar(2017, 1, 22, 22, 28, 0);
         exp.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected = new Date(exp.getTimeInMillis() + 2);
@@ -143,7 +144,7 @@ public class DateUtilsTest {
      * @see #testParseDateWithNoTimezonePadding()
      */
     @Test
-    public void testParseDateWithForCest() throws Exception {
+    public void testParseDateWithForCest() {
         GregorianCalendar exp1 = new GregorianCalendar(2017, 0, 28, 22, 0, 0);
         exp1.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date expected1 = new Date(exp1.getTimeInMillis());


### PR DESCRIPTION
Run `DateUtilsTest` as a unit test outside of the emulator.

Important to say that I had to do some changes in the `DateUtils` class because Android ships a modified version of `SimpleDateFormat` that is not fully compatible with the JDK version. Unfortunately, Robolectric hasn't implemented an Android compatible version yet (see https://github.com/robolectric/robolectric/issues/5220).

Contributes to #4569 as it saves CPU resources even if it doesn't use Robolectric.