### PR TITLE
Run ExternalMediaTest with Robolectric

### DIFF
--- a/core/src/test/java/de/danoeh/antennapod/core/util/playback/ExternalMediaTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/playback/ExternalMediaTest.java
@@ -1,28 +1,31 @@
-package de.test.antennapod.entities;
+package de.danoeh.antennapod.core.util.playback;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.SharedPreferences;
 import androidx.preference.PreferenceManager;
 
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.SmallTest;
 import de.danoeh.antennapod.core.feed.MediaType;
-import de.danoeh.antennapod.core.util.playback.ExternalMedia;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link ExternalMedia} entity.
  */
-@SmallTest
+@RunWith(RobolectricTestRunner.class)
 public class ExternalMediaTest {
 
     private static final int NOT_SET = -1;
+    private static final int POSITION = 50;
+    private static final int LAST_PLAYED_TIME = 1650;
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         clearSharedPrefs();
     }
 
@@ -35,14 +38,12 @@ public class ExternalMediaTest {
     }
 
     private SharedPreferences getDefaultSharedPrefs() {
-        return PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        return PreferenceManager.getDefaultSharedPreferences(context);
     }
 
     @Test
     public void testSaveCurrentPositionUpdatesPreferences() {
-        final int POSITION = 50;
-        final int LAST_PLAYED_TIME = 1650;
-
         assertEquals(NOT_SET, getDefaultSharedPrefs().getInt(ExternalMedia.PREF_POSITION, NOT_SET));
         assertEquals(NOT_SET, getDefaultSharedPrefs().getLong(ExternalMedia.PREF_LAST_PLAYED_TIME, NOT_SET));
 


### PR DESCRIPTION
Run `ExternalMediaTest` as a unit test outside of the emulator.

Contributes to #4569.