### PR TITLE
Run more util tests with Robolectric (2)

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -75,7 +75,7 @@ public class NavListAdapter extends BaseAdapter
     }
 
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals(UserPreferences.PREF_HIDDEN_DRAWER_ITEMS)) {
+        if (UserPreferences.PREF_HIDDEN_DRAWER_ITEMS.equals(key)) {
             loadItems();
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
@@ -100,7 +100,7 @@ public class PlaybackPreferences implements SharedPreferences.OnSharedPreference
     }
 
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals(PREF_CURRENT_PLAYER_STATUS)) {
+        if (PREF_CURRENT_PLAYER_STATUS.equals(key)) {
             EventBus.getDefault().post(new PlayerStatusEvent());
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FileNameGenerator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FileNameGenerator.java
@@ -13,7 +13,7 @@ import java.security.NoSuchAlgorithmException;
 /** Generates valid filenames for a given string. */
 public class FileNameGenerator {
     @VisibleForTesting
-    public static final int MAX_FILENAME_LENGTH = 255; // Limited by ext4
+    public static final int MAX_FILENAME_LENGTH = 242; // limited by CircleCI
     private static final int MD5_HEX_LENGTH = 32;
 
     private static final char[] validChars =

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -20,7 +20,7 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
         super(context, true, ClientConfig.USER_AGENT);
         PreferenceManager.getDefaultSharedPreferences(context)
                 .registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
-                    if (key.equals(UserPreferences.PREF_MEDIA_PLAYER)) {
+                    if (UserPreferences.PREF_MEDIA_PLAYER.equals(key)) {
                         checkMpi();
                     }
                 });

--- a/core/src/test/java/de/danoeh/antennapod/core/util/FilenameGeneratorTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/FilenameGeneratorTest.java
@@ -4,7 +4,6 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import android.text.TextUtils;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
@@ -24,21 +23,21 @@ public class FilenameGeneratorTest {
     }
 
     @Test
-    public void testGenerateFileName() throws IOException {
+    public void testGenerateFileName() throws Exception {
         String result = FileNameGenerator.generateFileName("abc abc");
         assertEquals(result, "abc abc");
         createFiles(result);
     }
 
     @Test
-    public void testGenerateFileName1() throws IOException {
+    public void testGenerateFileName1() throws Exception {
         String result = FileNameGenerator.generateFileName("ab/c: <abc");
         assertEquals(result, "abc abc");
         createFiles(result);
     }
 
     @Test
-    public void testGenerateFileName2() throws IOException {
+    public void testGenerateFileName2() throws Exception {
         String result = FileNameGenerator.generateFileName("abc abc ");
         assertEquals(result, "abc abc");
         createFiles(result);
@@ -69,7 +68,7 @@ public class FilenameGeneratorTest {
     }
 
     @Test
-    public void testLongFilename() throws IOException {
+    public void testLongFilename() throws Exception {
         String longName = StringUtils.repeat("x", 20 + FileNameGenerator.MAX_FILENAME_LENGTH);
         String result = FileNameGenerator.generateFileName(longName);
         assertTrue(result.length() <= FileNameGenerator.MAX_FILENAME_LENGTH);
@@ -87,16 +86,13 @@ public class FilenameGeneratorTest {
 
     /**
      * Tests if files can be created.
-     *
-     * @throws IOException
      */
-    private void createFiles(String name) throws IOException {
+    private void createFiles(String name) throws Exception {
         File cache = InstrumentationRegistry.getInstrumentation().getTargetContext().getExternalCacheDir();
         File testFile = new File(cache, name);
-        testFile.mkdir();
+        assertTrue(testFile.mkdir());
         assertTrue(testFile.exists());
-        testFile.delete();
+        assertTrue(testFile.delete());
         assertTrue(testFile.createNewFile());
     }
-
 }

--- a/core/src/test/java/de/danoeh/antennapod/core/util/FilenameGeneratorTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/FilenameGeneratorTest.java
@@ -1,22 +1,22 @@
-package de.test.antennapod.util;
+package de.danoeh.antennapod.core.util;
 
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.SmallTest;
 import android.text.TextUtils;
 
 import java.io.File;
 import java.io.IOException;
 
-import de.danoeh.antennapod.core.util.FileNameGenerator;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@SmallTest
+@RunWith(RobolectricTestRunner.class)
 public class FilenameGeneratorTest {
 
     public FilenameGeneratorTest() {

--- a/core/src/test/java/de/danoeh/antennapod/core/util/URLCheckerTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/URLCheckerTest.java
@@ -115,7 +115,7 @@ public class URLCheckerTest {
     }
 
     @Test
-    public void testProtocolRelativeUrlIsHttpsWithAPSubscribeProtocol() {
+    public void testProtocolRelativeUrlIsHttpsWithApSubscribeProtocol() {
         final String in = "//example.com";
         final String inBase = "antennapod-subscribe://https://examplebase.com";
         final String out = URLChecker.prepareURL(in, inBase);

--- a/core/src/test/java/de/danoeh/antennapod/core/util/URLCheckerTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/URLCheckerTest.java
@@ -1,17 +1,17 @@
-package de.test.antennapod.util;
+package de.danoeh.antennapod.core.util;
 
-import androidx.test.filters.SmallTest;
-import de.danoeh.antennapod.core.util.URLChecker;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test class for URLChecker
+ * Test class for {@link URLChecker}
  */
-@SmallTest
+@RunWith(RobolectricTestRunner.class)
 public class URLCheckerTest {
 
     @Test
@@ -78,7 +78,7 @@ public class URLCheckerTest {
     }
 
     @Test
-    public void testAntennaPodSubscribeProtocolNoScheme() throws Exception {
+    public void testAntennaPodSubscribeProtocolNoScheme() {
         final String in = "antennapod-subscribe://example.com";
         final String out = URLChecker.prepareURL(in);
         assertEquals("http://example.com", out);
@@ -92,14 +92,14 @@ public class URLCheckerTest {
     }
 
     @Test
-    public void testAntennaPodSubscribeProtocolWithScheme() throws Exception {
+    public void testAntennaPodSubscribeProtocolWithScheme() {
         final String in = "antennapod-subscribe://https://example.com";
         final String out = URLChecker.prepareURL(in);
         assertEquals("https://example.com", out);
     }
 
     @Test
-    public void testProtocolRelativeUrlIsAbsolute() throws Exception {
+    public void testProtocolRelativeUrlIsAbsolute() {
         final String in = "https://example.com";
         final String inBase = "http://examplebase.com";
         final String out = URLChecker.prepareURL(in, inBase);
@@ -107,7 +107,7 @@ public class URLCheckerTest {
     }
 
     @Test
-    public void testProtocolRelativeUrlIsRelativeHttps() throws Exception {
+    public void testProtocolRelativeUrlIsRelativeHttps() {
         final String in = "//example.com";
         final String inBase = "https://examplebase.com";
         final String out = URLChecker.prepareURL(in, inBase);
@@ -115,7 +115,7 @@ public class URLCheckerTest {
     }
 
     @Test
-    public void testProtocolRelativeUrlIsHttpsWithAPSubscribeProtocol() throws Exception {
+    public void testProtocolRelativeUrlIsHttpsWithAPSubscribeProtocol() {
         final String in = "//example.com";
         final String inBase = "antennapod-subscribe://https://examplebase.com";
         final String out = URLChecker.prepareURL(in, inBase);
@@ -123,7 +123,7 @@ public class URLCheckerTest {
     }
 
     @Test
-    public void testProtocolRelativeUrlBaseUrlNull() throws Exception {
+    public void testProtocolRelativeUrlBaseUrlNull() {
         final String in = "example.com";
         final String out = URLChecker.prepareURL(in, null);
         assertEquals("http://example.com", out);

--- a/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
@@ -17,9 +17,9 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.storage.DBReader;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
@@ -35,12 +35,6 @@ import static org.junit.Assert.assertTrue;
 public class TimelineTest {
 
     private Context context;
-
-    @BeforeClass
-    public static void beforeClass() {
-        //noinspection ResultOfMethodCallIgnored
-        Mockito.mockStatic(DBReader.class);
-    }
 
     @Before
     public void setUp() {
@@ -59,74 +53,98 @@ public class TimelineTest {
     }
 
     @Test
-    public void testProcessShownotesAddTimecodeHHMMSSNoChapters() {
+    public void testProcessShownotesAddTimecodeHhmmssNoChapters() {
         final String timeStr = "10:11:12";
         final long time = 3600 * 1000 * 10 + 60 * 1000 * 11 + 12 * 1000;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
-    public void testProcessShownotesAddTimecodeHHMMSSMoreThen24HoursNoChapters() {
+    public void testProcessShownotesAddTimecodeHhmmssMoreThen24HoursNoChapters() {
         final String timeStr = "25:00:00";
         final long time = 25 * 60 * 60 * 1000;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
-    public void testProcessShownotesAddTimecodeHHMMNoChapters() {
+    public void testProcessShownotesAddTimecodeHhmmNoChapters() {
         final String timeStr = "10:11";
         final long time = 3600 * 1000 * 10 + 60 * 1000 * 11;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
-    public void testProcessShownotesAddTimecodeMMSSNoChapters() {
+    public void testProcessShownotesAddTimecodeMmssNoChapters() {
         final String timeStr = "10:11";
         final long time = 10 * 60 * 1000 + 11 * 1000;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", 11 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
-    public void testProcessShownotesAddTimecodeHMMSSNoChapters() {
+    public void testProcessShownotesAddTimecodeHmmssNoChapters() {
         final String timeStr = "2:11:12";
         final long time = 2 * 60 * 60 * 1000 + 11 * 60 * 1000 + 12 * 1000;
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
-    public void testProcessShownotesAddTimecodeMSSNoChapters() {
+    public void testProcessShownotesAddTimecodeMssNoChapters() {
         final String timeStr = "1:12";
         final long time = 60 * 1000 + 12 * 1000;
 
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", 2 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
@@ -136,9 +154,13 @@ public class TimelineTest {
         String originalText = "<p> Some test text with a timecode " + timeStr + " here.</p>";
         Playable p = newTestPlayable(null, originalText, time);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        Document d = Jsoup.parse(res);
-        assertEquals("Should not parse time codes that equal duration", 0, d.body().getElementsByTag("a").size());
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            Document d = Jsoup.parse(res);
+            assertEquals("Should not parse time codes that equal duration", 0, d.body().getElementsByTag("a").size());
+        }
     }
 
     @Test
@@ -148,9 +170,13 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStrings[0] + " here. Hey look another one " + timeStrings[1] + " here!</p>", 2 * 60 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{ 10 * 60 * 1000 + 12 * 1000,
-                60 * 60 * 1000 + 10 * 60 * 1000 + 12 * 1000 }, timeStrings);
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{10 * 60 * 1000 + 12 * 1000,
+                    60 * 60 * 1000 + 10 * 60 * 1000 + 12 * 1000}, timeStrings);
+        }
     }
 
     @Test
@@ -162,8 +188,12 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStrings[0] + " here. Hey look another one " + timeStrings[1] + " here!</p>", 3 * 60 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{ 10 * 60 * 1000 + 12 * 1000, 2 * 60 * 1000 + 12 * 1000 }, timeStrings);
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{10 * 60 * 1000 + 12 * 1000, 2 * 60 * 1000 + 12 * 1000}, timeStrings);
+        }
     }
 
     @Test
@@ -174,8 +204,12 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode ("
                 + timeStr + ") here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
@@ -186,8 +220,12 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode ["
                 + timeStr + "] here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
@@ -198,8 +236,12 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode <"
                 + timeStr + "> here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
+        }
     }
 
     @Test
@@ -214,8 +256,12 @@ public class TimelineTest {
 
         Playable p = newTestPlayable(null, shownotes.toString(), Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        String res = t.processShownotes();
-        checkLinkCorrect(res, new long[0], new String[0]);
+        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
+            String res = t.processShownotes();
+            checkLinkCorrect(res, new long[0], new String[0]);
+        }
     }
 
     private void checkLinkCorrect(String res, long[] timecodes, String[] timecodeStr) {

--- a/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
@@ -16,6 +16,7 @@ import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.storage.DBReader;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,10 +36,19 @@ import static org.junit.Assert.assertTrue;
 public class TimelineTest {
 
     private Context context;
+    MockedStatic<DBReader> dbReaderMock;
 
     @Before
     public void setUp() {
         context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        // mock DBReader, because Timeline.processShownotes() calls FeedItem.loadShownotes()
+        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
+        dbReaderMock = Mockito.mockStatic(DBReader.class);
+    }
+
+    @After
+    public void tearDown() {
+        dbReaderMock.close();
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -60,12 +70,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -76,12 +82,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -92,12 +94,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -108,12 +106,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", 11 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -123,12 +117,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -139,12 +129,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStr + " here.</p>", 2 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -154,13 +140,9 @@ public class TimelineTest {
         String originalText = "<p> Some test text with a timecode " + timeStr + " here.</p>";
         Playable p = newTestPlayable(null, originalText, time);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            Document d = Jsoup.parse(res);
-            assertEquals("Should not parse time codes that equal duration", 0, d.body().getElementsByTag("a").size());
-        }
+        String res = t.processShownotes();
+        Document d = Jsoup.parse(res);
+        assertEquals("Should not parse time codes that equal duration", 0, d.body().getElementsByTag("a").size());
     }
 
     @Test
@@ -170,13 +152,9 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStrings[0] + " here. Hey look another one " + timeStrings[1] + " here!</p>", 2 * 60 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{10 * 60 * 1000 + 12 * 1000,
-                    60 * 60 * 1000 + 10 * 60 * 1000 + 12 * 1000}, timeStrings);
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{10 * 60 * 1000 + 12 * 1000,
+                60 * 60 * 1000 + 10 * 60 * 1000 + 12 * 1000}, timeStrings);
     }
 
     @Test
@@ -188,12 +166,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode "
                 + timeStrings[0] + " here. Hey look another one " + timeStrings[1] + " here!</p>", 3 * 60 * 60 * 1000);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{10 * 60 * 1000 + 12 * 1000, 2 * 60 * 1000 + 12 * 1000}, timeStrings);
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{10 * 60 * 1000 + 12 * 1000, 2 * 60 * 1000 + 12 * 1000}, timeStrings);
     }
 
     @Test
@@ -204,12 +178,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode ("
                 + timeStr + ") here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -220,12 +190,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode ["
                 + timeStr + "] here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -236,12 +202,8 @@ public class TimelineTest {
         Playable p = newTestPlayable(null, "<p> Some test text with a timecode <"
                 + timeStr + "> here.</p>", Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[]{time}, new String[]{timeStr});
     }
 
     @Test
@@ -256,12 +218,8 @@ public class TimelineTest {
 
         Playable p = newTestPlayable(null, shownotes.toString(), Integer.MAX_VALUE);
         Timeline t = new Timeline(context, p);
-        // mock DBReader, because processShownotes() calls FeedItem.loadShownotes()
-        // which calls DBReader.loadDescriptionOfFeedItem(), but we don't need the database here
-        try (MockedStatic<DBReader> ignored = Mockito.mockStatic(DBReader.class)) {
-            String res = t.processShownotes();
-            checkLinkCorrect(res, new long[0], new String[0]);
-        }
+        String res = t.processShownotes();
+        checkLinkCorrect(res, new long[0], new String[0]);
     }
 
     private void checkLinkCorrect(String res, long[] timecodes, String[] timecodeStr) {

--- a/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/playback/TimelineTest.java
@@ -1,9 +1,8 @@
-package de.test.antennapod.util.playback;
+package de.danoeh.antennapod.core.util.playback;
 
 import android.content.Context;
 
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.SmallTest;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -15,10 +14,14 @@ import java.util.List;
 import de.danoeh.antennapod.core.feed.Chapter;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
-import de.danoeh.antennapod.core.util.playback.Playable;
-import de.danoeh.antennapod.core.util.playback.Timeline;
+import de.danoeh.antennapod.core.storage.DBReader;
+
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -26,18 +29,25 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test class for timeline.
+ * Test class for {@link Timeline}.
  */
-@SmallTest
+@RunWith(RobolectricTestRunner.class)
 public class TimelineTest {
 
     private Context context;
+
+    @BeforeClass
+    public static void beforeClass() {
+        //noinspection ResultOfMethodCallIgnored
+        Mockito.mockStatic(DBReader.class);
+    }
 
     @Before
     public void setUp() {
         context = InstrumentationRegistry.getInstrumentation().getTargetContext();
     }
 
+    @SuppressWarnings("SameParameterValue")
     private Playable newTestPlayable(List<Chapter> chapters, String shownotes, int duration) {
         FeedItem item = new FeedItem(0, "Item", "item-id", "http://example.com/item", new Date(), FeedItem.PLAYED, null);
         item.setChapters(chapters);

--- a/core/src/test/java/de/danoeh/antennapod/core/util/syndication/FeedDiscovererTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/syndication/FeedDiscovererTest.java
@@ -1,26 +1,28 @@
-package de.test.antennapod.util.syndication;
+package de.danoeh.antennapod.core.util.syndication;
 
 import androidx.test.platform.app.InstrumentationRegistry;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.nio.charset.Charset;
-import java.util.Map;
-
-import de.danoeh.antennapod.core.util.syndication.FeedDiscoverer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test class for FeedDiscoverer
+ * Test class for {@link FeedDiscoverer}
  */
+@RunWith(RobolectricTestRunner.class)
 public class FeedDiscovererTest {
 
     private FeedDiscoverer fd;
@@ -28,10 +30,11 @@ public class FeedDiscovererTest {
     private File testDir;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         fd = new FeedDiscoverer();
         testDir = new File(InstrumentationRegistry
                 .getInstrumentation().getTargetContext().getFilesDir(), "FeedDiscovererTest");
+        //noinspection ResultOfMethodCallIgnored
         testDir.mkdir();
         assertTrue(testDir.exists());
     }
@@ -41,6 +44,7 @@ public class FeedDiscovererTest {
         FileUtils.deleteDirectory(testDir);
     }
 
+    @SuppressWarnings("SameParameterValue")
     private String createTestHtmlString(String rel, String type, String href, String title) {
         return String.format("<html><head><title>Test</title><link rel=\"%s\" type=\"%s\" href=\"%s\" title=\"%s\"></head><body></body></html>",
                 rel, type, href, title);
@@ -69,7 +73,7 @@ public class FeedDiscovererTest {
         } else {
             File testFile = new File(testDir, "feed");
             FileOutputStream out = new FileOutputStream(testFile);
-            IOUtils.write(html, out, Charset.forName("UTF-8"));
+            IOUtils.write(html, out, StandardCharsets.UTF_8);
             out.close();
             res = fd.findLinks(testFile, base);
         }


### PR DESCRIPTION
Run more util test classes with Robolectric outside of the Android emulator (replaces #4808):

- `FeedDiscovererTest`
- `FilenameGeneratorTest`
- `TimelineTest`
- `URLCheckerTest`

Additionally, it sets the maximum file name length in `FileNameGenerator` to 242 as CircleCI has a limitation there. (See discussion in #4808.)

Contributes to #4569.