### PR TITLE
Run DbNullCleanupAlgorithmTest with Robolectric

### DIFF
--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbNullCleanupAlgorithmTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbNullCleanupAlgorithmTest.java
@@ -1,4 +1,4 @@
-package de.test.antennapod.storage;
+package de.danoeh.antennapod.core.storage;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -11,16 +11,15 @@ import java.util.Date;
 import java.util.List;
 
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.SmallTest;
 import de.danoeh.antennapod.core.feed.Feed;
 import de.danoeh.antennapod.core.feed.FeedItem;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
-import de.danoeh.antennapod.core.storage.DBTasks;
-import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -28,32 +27,17 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests that the APNullCleanupAlgorithm is working correctly.
  */
-@SmallTest
-public class DBNullCleanupAlgorithmTest {
+@RunWith(RobolectricTestRunner.class)
+public class DbNullCleanupAlgorithmTest {
 
-    private static final String TAG = "DBNullCleanupAlgorithmTest";
     private static final int EPISODE_CACHE_SIZE = 5;
 
     private Context context;
 
     private File destFolder;
 
-    @After
-    public void tearDown() throws Exception {
-        assertTrue(PodDBAdapter.deleteDatabase());
-
-        cleanupDestFolder(destFolder);
-        assertTrue(destFolder.delete());
-    }
-
-    private void cleanupDestFolder(File destFolder) {
-        for (File f : destFolder.listFiles()) {
-            assertTrue(f.delete());
-        }
-    }
-
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         destFolder = context.getExternalCacheDir();
         cleanupDestFolder(destFolder);
@@ -68,35 +52,51 @@ public class DBNullCleanupAlgorithmTest {
         adapter.open();
         adapter.close();
 
-        SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).edit();
+        SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(context
+                .getApplicationContext()).edit();
         prefEdit.putString(UserPreferences.PREF_EPISODE_CACHE_SIZE, Integer.toString(EPISODE_CACHE_SIZE));
-        prefEdit.putString(UserPreferences.PREF_EPISODE_CLEANUP, Integer.toString(UserPreferences.EPISODE_CLEANUP_NULL));
+        prefEdit.putString(UserPreferences.PREF_EPISODE_CLEANUP,
+                Integer.toString(UserPreferences.EPISODE_CLEANUP_NULL));
         prefEdit.commit();
 
         UserPreferences.init(context);
     }
 
+    @After
+    public void tearDown() {
+        assertTrue(PodDBAdapter.deleteDatabase());
+
+        cleanupDestFolder(destFolder);
+        assertTrue(destFolder.delete());
+    }
+
+    private void cleanupDestFolder(File destFolder) {
+        //noinspection ConstantConditions
+        for (File f : destFolder.listFiles()) {
+            assertTrue(f.delete());
+        }
+    }
+
     /**
      * A test with no items in the queue, but multiple items downloaded.
      * The null algorithm should never delete any items, even if they're played and not in the queue.
-     * @throws IOException
      */
     @Test
     public void testPerformAutoCleanupShouldNotDelete() throws IOException {
-        final int NUM_ITEMS = EPISODE_CACHE_SIZE * 2;
+        final int numItems = EPISODE_CACHE_SIZE * 2;
 
         Feed feed = new Feed("url", null, "title");
         List<FeedItem> items = new ArrayList<>();
         feed.setItems(items);
         List<File> files = new ArrayList<>();
-        for (int i = 0; i < NUM_ITEMS; i++) {
+        for (int i = 0; i < numItems; i++) {
             FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
 
             File f = new File(destFolder, "file " + i);
             assertTrue(f.createNewFile());
             files.add(f);
             item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true,
-                    new Date(NUM_ITEMS - i), 0, 0));
+                    new Date(numItems - i), 0, 0));
             items.add(item);
         }
 
@@ -108,6 +108,7 @@ public class DBNullCleanupAlgorithmTest {
         assertTrue(feed.getId() != 0);
         for (FeedItem item : items) {
             assertTrue(item.getId() != 0);
+            //noinspection ConstantConditions
             assertTrue(item.getMedia().getId() != 0);
         }
         DBTasks.performAutoCleanup(context);


### PR DESCRIPTION
Run `DbNullCleanupAlgorithmTest` with Robolectric outside of the Android emulator.

Contributes to #4569.