### PR TITLE
Added spinner to time_dialog to allow the user to opt into permitting…

### DIFF
--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -114,11 +114,27 @@
             android:orientation="vertical"
             android:layout_marginTop="8dp">
 
-        <CheckBox
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
                 android:id="@+id/cbShakeToReset"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
                 android:text="@string/shake_to_reset_label"/>
+
+            <Spinner
+                android:id="@+id/spShakeBehaviour"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_alignParentEnd="true"/>
+
+        </RelativeLayout>
 
         <CheckBox
                 android:id="@+id/cbVibrate"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
@@ -16,12 +16,18 @@ public class SleepTimerPreferences {
     private static final String PREF_TIME_UNIT = "LastTimeUnit";
     private static final String PREF_VIBRATE = "Vibrate";
     private static final String PREF_SHAKE_TO_RESET = "ShakeToReset";
+    private static final String PREF_SHAKE_BEHAVIOUR = "lastShakeBehaviour";
     private static final String PREF_AUTO_ENABLE = "AutoEnable";
 
     private static final TimeUnit[] UNITS = { TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS };
 
     private static final String DEFAULT_VALUE = "15";
     private static final int DEFAULT_TIME_UNIT = 1;
+
+    private static final int SHAKE_BEHAVIOUR_FADEOUT = 0;
+    private static final int SHAKE_BEHAVIOUR_ANYTIME = 1;
+
+    private static final int DEFAULT_SHAKE_BEHAVIOUR = SHAKE_BEHAVIOUR_FADEOUT;
 
     private static SharedPreferences prefs;
 
@@ -64,8 +70,20 @@ public class SleepTimerPreferences {
         prefs.edit().putBoolean(PREF_SHAKE_TO_RESET, shakeToReset).apply();
     }
 
+    public static void setShakeBehaviour(int shakeBehaviour) {
+        prefs.edit().putInt(PREF_SHAKE_BEHAVIOUR, shakeBehaviour).apply();
+    }
+
     public static boolean shakeToReset() {
         return prefs.getBoolean(PREF_SHAKE_TO_RESET, true);
+    }
+
+    public static int shakeBehaviour() {
+        return prefs.getInt(PREF_SHAKE_BEHAVIOUR, DEFAULT_SHAKE_BEHAVIOUR);
+    }
+
+    public static boolean allowShake(boolean almostExpired) {
+        return shakeToReset() && (almostExpired || (shakeBehaviour() == SHAKE_BEHAVIOUR_ANYTIME));
     }
 
     public static void setAutoEnable(boolean autoEnable) {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -606,6 +606,8 @@
     <string name="sleep_timer_label">Sleep timer</string>
     <string name="time_dialog_invalid_input">Invalid input, time has to be an integer</string>
     <string name="shake_to_reset_label">Shake to reset</string>
+    <string name="shake_during_fadeout">During fadeout</string>
+    <string name="shake_anytime">Anytime</string>
     <string name="timer_vibration_label">Vibrate shortly before end</string>
     <string name="time_seconds">seconds</string>
     <string name="time_minutes">minutes</string>


### PR DESCRIPTION
… shake to reset (sleep timer) at any time during the sleep timer.

Will resolve #4824
Will resolve #4825

Details:
	The spinner defaults to "During fadeout" to preserve the original behaviour. If the user opts into the new behaviour by selecting "Anytime" from the spinner, they can shake the reset the sleep timer at any time during the countdown, rather than only during the fadeout. I think this is especially userful for users who do not use the "vibrate" feature of the sleep timer, as the audio fadeout alone can be quite subtle and easily missed.
	This also fixes an issue with the existing sleep timer behaviour - currently the sleep timer will not respect the user unchecking the "shake to reset" option during the fadeout, as the ShakeListener has already been registered, and the callback does not check if the user has enabled shake to reset.