### PR TITLE
Check Auto Download preference on the feed before auto downloading

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/CancelDownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/CancelDownloadActionButton.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.adapter.actionbutton;
 import android.content.Context;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
-import android.widget.Toast;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.model.feed.FeedItem;
@@ -35,8 +34,8 @@ public class CancelDownloadActionButton extends ItemActionButton {
         FeedMedia media = item.getMedia();
         DownloadRequester.getInstance().cancelDownload(context, media);
         if (UserPreferences.isEnableAutodownload()) {
-            DBWriter.setFeedItemAutoDownload(media.getItem(), false);
-            Toast.makeText(context, R.string.download_canceled_autodownload_enabled_msg, Toast.LENGTH_LONG).show();
+            item.setAutoDownload(false);
+            DBWriter.setFeedItem(item);
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/DownloadLogFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/DownloadLogFragment.java
@@ -11,7 +11,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -23,7 +22,6 @@ import de.danoeh.antennapod.adapter.DownloadLogAdapter;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.event.DownloadLogEvent;
 import de.danoeh.antennapod.core.event.DownloaderUpdate;
-import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.DownloadService;
 import de.danoeh.antennapod.core.service.download.DownloadStatus;
@@ -34,6 +32,7 @@ import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.download.AutoUpdateManager;
 import de.danoeh.antennapod.menuhandler.MenuItemUtils;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.view.EmptyViewHandler;
 import io.reactivex.Observable;
@@ -111,13 +110,11 @@ public class DownloadLogFragment extends ListFragment {
             DownloadRequest downloadRequest = ((Downloader) item).getDownloadRequest();
             DownloadRequester.getInstance().cancelDownload(getActivity(), downloadRequest.getSource());
 
-            if (downloadRequest.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA
-                    && UserPreferences.isEnableAutodownload()) {
+            if (downloadRequest.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
                 FeedMedia media = DBReader.getFeedMedia(downloadRequest.getFeedfileId());
-                DBWriter.setFeedItemAutoDownload(media.getItem(), false);
-
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                        R.string.download_canceled_autodownload_enabled_msg, Toast.LENGTH_SHORT);
+                FeedItem feedItem = media.getItem();
+                feedItem.setAutoDownload(false);
+                DBWriter.setFeedItem(feedItem);
             }
         } else if (item instanceof DownloadStatus) {
             DownloadStatus status = (DownloadStatus) item;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.fragment;
 
-import android.content.Context;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -16,7 +14,6 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SwitchPreferenceCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.event.settings.SkipIntroEndingChangedEvent;
 import de.danoeh.antennapod.core.event.settings.SpeedPresetChangedEvent;
 import de.danoeh.antennapod.core.event.settings.VolumeAdaptionChangedEvent;
@@ -384,8 +381,6 @@ public class FeedSettingsFragment extends Fragment {
                 feedPreferences.setAutoDownload(checked);
                 DBWriter.setFeedPreferences(feedPreferences);
                 updateAutoDownloadEnabled();
-                ApplyToEpisodesDialog dialog = new ApplyToEpisodesDialog(getActivity(), checked);
-                dialog.createNewDialog().show();
                 pref.setChecked(checked);
                 return false;
             });
@@ -416,23 +411,6 @@ public class FeedSettingsFragment extends Fragment {
                 pref.setChecked(checked);
                 return false;
             });
-        }
-
-        private class ApplyToEpisodesDialog extends ConfirmationDialog {
-            private final boolean autoDownload;
-
-            ApplyToEpisodesDialog(Context context, boolean autoDownload) {
-                super(context, R.string.auto_download_apply_to_items_title,
-                        R.string.auto_download_apply_to_items_message);
-                this.autoDownload = autoDownload;
-                setPositiveText(R.string.yes);
-                setNegativeText(R.string.no);
-            }
-
-            @Override
-            public void onConfirmButtonPressed(DialogInterface dialog) {
-                DBWriter.setFeedsItemsAutoDownload(feed, autoDownload);
-            }
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -65,14 +65,6 @@ public class FeedItemMenuHandler {
         setItemVisibility(menu, R.id.mark_unread_item, selectedItem.isPlayed());
         setItemVisibility(menu, R.id.reset_position, hasMedia && selectedItem.getMedia().getPosition() != 0);
 
-        if (!UserPreferences.isEnableAutodownload() || fileDownloaded || selectedItem.getFeed().isLocalFeed()) {
-            setItemVisibility(menu, R.id.activate_auto_download, false);
-            setItemVisibility(menu, R.id.deactivate_auto_download, false);
-        } else {
-            setItemVisibility(menu, R.id.activate_auto_download, !selectedItem.getAutoDownload());
-            setItemVisibility(menu, R.id.deactivate_auto_download, selectedItem.getAutoDownload());
-        }
-
         // Display proper strings when item has no media
         if (hasMedia) {
             setItemTitle(menu, R.id.mark_read_item, R.string.mark_read_label);
@@ -205,14 +197,6 @@ public class FeedItemMenuHandler {
                     IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
                 }
                 DBWriter.markItemPlayed(selectedItem, FeedItem.UNPLAYED, true);
-                break;
-            case R.id.activate_auto_download:
-                selectedItem.setAutoDownload(true);
-                DBWriter.setFeedItemAutoDownload(selectedItem, true);
-                break;
-            case R.id.deactivate_auto_download:
-                selectedItem.setAutoDownload(false);
-                DBWriter.setFeedItemAutoDownload(selectedItem, false);
                 break;
             case R.id.visit_website_item:
                 IntentUtils.openInBrowser(context, FeedItemUtil.getLinkWithFallback(selectedItem));

--- a/app/src/main/res/menu/feeditem_options.xml
+++ b/app/src/main/res/menu/feeditem_options.xml
@@ -50,18 +50,6 @@
         custom:showAsAction="collapseActionView"
         android:title="@string/reset_position">
     </item>
-
-    <item
-        android:id="@+id/activate_auto_download"
-        custom:showAsAction="collapseActionView"
-        android:title="@string/activate_auto_download">
-    </item>
-    <item
-        android:id="@+id/deactivate_auto_download"
-        custom:showAsAction="collapseActionView"
-        android:title="@string/deactivate_auto_download">
-    </item>
-
     <item
         android:id="@+id/visit_website_item"
         android:icon="@drawable/ic_web"

--- a/app/src/main/res/menu/feeditemlist_context.xml
+++ b/app/src/main/res/menu/feeditemlist_context.xml
@@ -51,16 +51,6 @@
         android:title="@string/reset_position" />
 
     <item
-        android:id="@+id/activate_auto_download"
-        android:menuCategory="container"
-        android:title="@string/activate_auto_download" />
-
-    <item
-        android:id="@+id/deactivate_auto_download"
-        android:menuCategory="container"
-        android:title="@string/deactivate_auto_download" />
-
-    <item
         android:id="@+id/visit_website_item"
         android:menuCategory="container"
         android:title="@string/visit_website_label" />

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/AutomaticDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/AutomaticDownloadAlgorithm.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import de.danoeh.antennapod.model.feed.FeedFilter;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/AutomaticDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/AutomaticDownloadAlgorithm.java
@@ -55,8 +55,9 @@ public class AutomaticDownloadAlgorithm {
                 candidates.addAll(queue);
                 for (FeedItem newItem : newItems) {
                     FeedPreferences feedPrefs = newItem.getFeed().getPreferences();
-                    FeedFilter feedFilter = feedPrefs.getFilter();
-                    if (!candidates.contains(newItem) && feedFilter.shouldAutoDownload(newItem)) {
+                    if (feedPrefs.getAutoDownload()
+                            && !candidates.contains(newItem)
+                            && feedPrefs.getFilter().shouldAutoDownload(newItem)) {
                         candidates.add(newItem);
                     }
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -440,7 +440,6 @@ public final class DBTasks {
                 if (oldItem == null) {
                     // item is new
                     item.setFeed(savedFeed);
-                    item.setAutoDownload(savedFeed.getPreferences().getAutoDownload());
 
                     if (idx >= savedFeed.getItems().size()) {
                         savedFeed.getItems().add(item);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -945,23 +945,6 @@ public class DBWriter {
         });
     }
 
-    /**
-     * Sets the 'auto_download'-attribute of specific FeedItem.
-     *
-     * @param feedItem     FeedItem.
-     * @param autoDownload true enables auto download, false disables it
-     */
-    public static Future<?> setFeedItemAutoDownload(final FeedItem feedItem,
-                                                    final boolean autoDownload) {
-        return dbExec.submit(() -> {
-            final PodDBAdapter adapter = PodDBAdapter.getInstance();
-            adapter.open();
-            adapter.setFeedItemAutoDownload(feedItem, autoDownload ? 1 : 0);
-            adapter.close();
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-        });
-    }
-
     public static Future<?> saveFeedItemAutoDownloadFailed(final FeedItem feedItem) {
         return dbExec.submit(() -> {
             int failedAttempts = feedItem.getFailedAutoDownloadAttempts() + 1;
@@ -980,25 +963,6 @@ public class DBWriter {
             EventBus.getDefault().post(new UnreadItemsUpdateEvent());
         });
     }
-
-    /**
-     * Sets the 'auto_download'-attribute of specific FeedItem.
-     *
-     * @param feed         This feed's episodes will be processed.
-     * @param autoDownload If true, auto download will be enabled for the feed's episodes. Else,
-     */
-    public static Future<?> setFeedsItemsAutoDownload(final Feed feed,
-                                                      final boolean autoDownload) {
-        Log.d(TAG, (autoDownload ? "Enabling" : "Disabling") + " auto download for items of feed " + feed.getId());
-        return dbExec.submit(() -> {
-            final PodDBAdapter adapter = PodDBAdapter.getInstance();
-            adapter.open();
-            adapter.setFeedsItemsAutoDownload(feed, autoDownload);
-            adapter.close();
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-        });
-    }
-
 
     /**
      * Set filter of the feed

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -768,13 +768,6 @@ public class PodDBAdapter {
                 new String[]{String.valueOf(feedItem.getId())});
     }
 
-    public void setFeedsItemsAutoDownload(Feed feed, boolean autoDownload) {
-        final String sql = "UPDATE " + TABLE_NAME_FEED_ITEMS
-                + " SET " + KEY_AUTO_DOWNLOAD + "=" + (autoDownload ? "1" : "0")
-                + " WHERE " + KEY_FEED + "=" + feed.getId();
-        db.execSQL(sql);
-    }
-
     public void setFavorites(List<FeedItem> favorites) {
         ContentValues values = new ContentValues();
         try {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -101,8 +101,6 @@
     <string name="close_label">Close</string>
     <string name="retry_label">Retry</string>
     <string name="auto_download_label">Include in auto downloads</string>
-    <string name="auto_download_apply_to_items_title">Apply to Previous Episodes</string>
-    <string name="auto_download_apply_to_items_message">The new <i>Auto Download</i> setting will automatically be applied to new episodes.\nDo you also want to apply it to previously published episodes?</string>
     <string name="auto_delete_label">Auto Delete Episode</string>
     <string name="feed_volume_reduction">Volume Reduction</string>
     <string name="feed_volume_reduction_summary">Turn down volume for episodes of this feed: %1$s</string>
@@ -224,8 +222,6 @@
     <string name="remove_from_favorite_label">Remove from Favorites</string>
     <string name="visit_website_label">Visit Website</string>
     <string name="skip_episode_label">Skip episode</string>
-    <string name="activate_auto_download">Activate Auto Download</string>
-    <string name="deactivate_auto_download">Deactivate Auto Download</string>
     <string name="reset_position">Reset Playback Position</string>
     <string name="removed_item">Item removed</string>
     <string name="no_items_selected">No items selected</string>
@@ -254,7 +250,6 @@
     <string name="download_error_wrong_size">The server connection was lost before completing the download</string>
     <string name="download_error_blocked">The download was blocked by another app on your device.</string>
     <string name="download_error_certificate">Unable to establish a secure connection. This can mean that another app on your device blocked the download, or that something is wrong with the server certificates.</string>
-    <string name="download_canceled_autodownload_enabled_msg">Download canceled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="auto_download_report_title">Auto-downloads completed</string>
     <string name="download_error_io_error">IO Error</string>


### PR DESCRIPTION
AutoDownlaoding previously assumed that the filters had been initialised, which is not necessarily the case now that users can disable "Include in Auto Downloads" before subscribing to a new feed. This created the following problem (only present in the  develop branch):

1. Enable Auto Downloads in the Global User Preferences.
2. View a new feed (e.g. from discovery or online search).
2. Uncheck "Include in Auto Downloads".
3. Tap "Subscribe".

The "Include in Auto Download" setting is correctly set in the feed preferences (to not auto download this feed), but the newest episode of the podcast begins to automatically download.

This could be related to issue #4800

It may be preferable to instead (or also) initialise the filters when subscribing to a new feed.

(I did not know whether or not to create an issue for this as the problem is only apparent in develop).

Closes #5045