### PR TITLE
Use any image for local folders

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -116,33 +116,24 @@ public class LocalFeedUpdater {
      */
     @NonNull
     static String getImageUrl(@NonNull Context context, @NonNull DocumentFile documentFolder) {
-        String imageUrl = null;
-
         // look for special file names
         for (String iconLocation : PREFERRED_FEED_IMAGE_FILENAMES) {
             DocumentFile image = documentFolder.findFile(iconLocation);
             if (image != null) {
-                imageUrl = image.getUri().toString();
-                break;
+                return image.getUri().toString();
             }
         }
 
         // use the first image in the folder if existing
-        if (imageUrl == null) {
-            for (DocumentFile file : documentFolder.listFiles()) {
-                String mime = file.getType();
-                if (mime != null && (mime.startsWith("image/jpeg") || mime.startsWith("image/png"))) {
-                    imageUrl = file.getUri().toString();
-                    break;
-                }
+        for (DocumentFile file : documentFolder.listFiles()) {
+            String mime = file.getType();
+            if (mime != null && (mime.startsWith("image/jpeg") || mime.startsWith("image/png"))) {
+                return file.getUri().toString();
             }
         }
 
         // use default icon as fallback
-        if (imageUrl == null) {
-            imageUrl = getDefaultIconUrl(context);
-        }
-        return imageUrl;
+        return getDefaultIconUrl(context);
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -6,15 +6,13 @@ import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
 import androidx.documentfile.provider.DocumentFile;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -33,6 +31,8 @@ import de.danoeh.antennapod.core.util.DateUtils;
 import de.danoeh.antennapod.core.util.DownloadError;
 
 public class LocalFeedUpdater {
+
+    static final String[] PREFERRED_FEED_IMAGE_FILENAMES = { "folder.jpg", "Folder.jpg", "folder.png", "Folder.png" };
 
     public static void updateFeed(Feed feed, Context context) {
         try {
@@ -97,18 +97,7 @@ public class LocalFeedUpdater {
             }
         }
 
-        List<String> iconLocations = Arrays.asList("folder.jpg", "Folder.jpg", "folder.png", "Folder.png");
-        for (String iconLocation : iconLocations) {
-            DocumentFile image = documentFolder.findFile(iconLocation);
-            if (image != null) {
-                feed.setImageUrl(image.getUri().toString());
-                break;
-            }
-        }
-        if (StringUtils.isBlank(feed.getImageUrl())) {
-            // set default feed image
-            feed.setImageUrl(getDefaultIconUrl(context));
-        }
+        feed.setImageUrl(getImageUrl(context, documentFolder));
 
         feed.getPreferences().setAutoDownload(false);
         feed.getPreferences().setAutoDeleteAction(FeedPreferences.AutoDeleteAction.NO);
@@ -120,6 +109,40 @@ public class LocalFeedUpdater {
         // deleting played state or position in case the folder is temporarily unavailable.
         boolean removeUnlistedItems = (newItems.size() >= 1);
         DBTasks.updateFeed(context, feed, removeUnlistedItems);
+    }
+
+    /**
+     * Returns the image URL for the local feed.
+     */
+    @NonNull
+    static String getImageUrl(@NonNull Context context, @NonNull DocumentFile documentFolder) {
+        String imageUrl = null;
+
+        // look for special file names
+        for (String iconLocation : PREFERRED_FEED_IMAGE_FILENAMES) {
+            DocumentFile image = documentFolder.findFile(iconLocation);
+            if (image != null) {
+                imageUrl = image.getUri().toString();
+                break;
+            }
+        }
+
+        // use the first image in the folder if existing
+        if (imageUrl == null) {
+            for (DocumentFile file : documentFolder.listFiles()) {
+                String mime = file.getType();
+                if (mime != null && (mime.startsWith("image/jpeg") || mime.startsWith("image/png"))) {
+                    imageUrl = file.getUri().toString();
+                    break;
+                }
+            }
+        }
+
+        // use default icon as fallback
+        if (imageUrl == null) {
+            imageUrl = getDefaultIconUrl(context);
+        }
+        return imageUrl;
     }
 
     /**
@@ -161,7 +184,7 @@ public class LocalFeedUpdater {
         return item;
     }
 
-    private static void loadMetadata(FeedItem item, DocumentFile file, Context context) throws Exception {
+    private static void loadMetadata(FeedItem item, DocumentFile file, Context context) {
         MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
         mediaMetadataRetriever.setDataSource(context, file.getUri());
 

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
@@ -185,20 +185,19 @@ public class LocalFeedUpdaterTest {
     }
 
     @Test
-    public void testGetImageUrl_NoImage() {
+    public void testGetImageUrl_EmptyFolder() {
+        DocumentFile documentFolder = mockDocumentFolder();
+        String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
         String defaultImageName = context.getResources().getResourceEntryName(R.raw.local_feed_default_icon);
-        {
-            // empty folder
-            DocumentFile documentFolder = mockDocumentFolder();
-            String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
-            assertThat(imageUrl, endsWith(defaultImageName));
-        }
-        {
-            // no image file, with audio file
-            DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"));
-            String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
-            assertThat(imageUrl, endsWith(defaultImageName));
-        }
+        assertThat(imageUrl, endsWith(defaultImageName));
+    }
+
+    @Test
+    public void testGetImageUrl_NoImageButAudioFiles() {
+        DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"));
+        String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
+        String defaultImageName = context.getResources().getResourceEntryName(R.raw.local_feed_default_icon);
+        assertThat(imageUrl, endsWith(defaultImageName));
     }
 
     @Test
@@ -212,36 +211,36 @@ public class LocalFeedUpdaterTest {
     }
 
     @Test
-    public void testGetImageUrl_OtherImageFilename() {
-        {
-            // .jpg file
-            DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
-                    mockDocumentFile("my-image.jpg", "image/jpeg"));
-            String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
-            assertThat(imageUrl, endsWith("my-image.jpg"));
-        }
-        {
-            // .jpeg file
-            DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
-                    mockDocumentFile("my-image.jpeg", "image/jpeg"));
-            String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
-            assertThat(imageUrl, endsWith("my-image.jpeg"));
-        }
-        {
-            // .png file
-            DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
-                    mockDocumentFile("my-image.png", "image/png"));
-            String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
-            assertThat(imageUrl, endsWith("my-image.png"));
-        }
-        {
-            // unsupported image type
-            DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
-                    mockDocumentFile("my-image.svg", "image/svg+xml"));
-            String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
-            String defaultImageName = context.getResources().getResourceEntryName(R.raw.local_feed_default_icon);
-            assertThat(imageUrl, endsWith(defaultImageName));
-        }
+    public void testGetImageUrl_OtherImageFilenameJpg() {
+        DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
+                mockDocumentFile("my-image.jpg", "image/jpeg"));
+        String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
+        assertThat(imageUrl, endsWith("my-image.jpg"));
+    }
+
+    @Test
+    public void testGetImageUrl_OtherImageFilenameJpeg() {
+        DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
+                mockDocumentFile("my-image.jpeg", "image/jpeg"));
+        String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
+        assertThat(imageUrl, endsWith("my-image.jpeg"));
+    }
+
+    @Test
+    public void testGetImageUrl_OtherImageFilenamePng() {
+        DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
+                mockDocumentFile("my-image.png", "image/png"));
+        String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
+        assertThat(imageUrl, endsWith("my-image.png"));
+    }
+
+    @Test
+    public void testGetImageUrl_OtherImageFilenameUnsupportedMimeType() {
+        DocumentFile documentFolder = mockDocumentFolder(mockDocumentFile("audio.mp3", "audio/mp3"),
+                mockDocumentFile("my-image.svg", "image/svg+xml"));
+        String imageUrl = LocalFeedUpdater.getImageUrl(context, documentFolder);
+        String defaultImageName = context.getResources().getResourceEntryName(R.raw.local_feed_default_icon);
+        assertThat(imageUrl, endsWith(defaultImageName));
     }
 
     /**

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
@@ -35,9 +35,10 @@ import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 
 import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -96,7 +97,7 @@ public class LocalFeedUpdaterTest {
     public void testUpdateFeed_AddNewFeed() {
         // check for empty database
         List<Feed> feedListBefore = DBReader.getFeedList();
-        assertTrue(feedListBefore.isEmpty());
+        assertThat(feedListBefore, is(empty()));
 
         callUpdateFeed(LOCAL_FEED_DIR2);
 
@@ -142,7 +143,7 @@ public class LocalFeedUpdaterTest {
         callUpdateFeed(LOCAL_FEED_DIR2);
 
         Feed feedAfter = verifySingleFeedInDatabase();
-        assertTrue(feedAfter.getImageUrl().contains("local-feed2/folder.png"));
+        assertThat(feedAfter.getImageUrl(), endsWith("local-feed2/folder.png"));
     }
 
     /**
@@ -154,7 +155,7 @@ public class LocalFeedUpdaterTest {
 
         Feed feedAfter = verifySingleFeedInDatabase();
         String resourceEntryName = context.getResources().getResourceEntryName(R.raw.local_feed_default_icon);
-        assertTrue(feedAfter.getImageUrl().contains(resourceEntryName));
+        assertThat(feedAfter.getImageUrl(), endsWith(resourceEntryName));
     }
 
     /**


### PR DESCRIPTION
Accepts any local folder file of MIME type `image/jpeg` or `image/png` as the local feed image.

If the local folder contains an image with file name `folder.jpg`, `Folder.jpg`, `folder.png`, or `Folder.png` it is taken with preference.

If there is no image file the default local feed image (`res/raw/local_feed_default_icon.png`) is used.

Resolves #4804.