### PR TITLE
Fix MainActivityTest.testAddFeed() timeout failure

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -2,16 +2,14 @@ package de.test.antennapod.ui;
 
 import android.app.Activity;
 import android.content.Intent;
-import androidx.test.platform.app.InstrumentationRegistry;
+
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
 import com.robotium.solo.Solo;
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
-import de.danoeh.antennapod.core.feed.Feed;
-import de.danoeh.antennapod.core.storage.PodDBAdapter;
-import de.test.antennapod.EspressoTestUtils;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,6 +17,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.core.feed.Feed;
+import de.danoeh.antennapod.core.storage.PodDBAdapter;
+import de.test.antennapod.EspressoTestUtils;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -28,18 +32,17 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.ActivityResultMatchers.hasResultCode;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static de.test.antennapod.EspressoTestUtils.clickPreference;
 import static de.test.antennapod.EspressoTestUtils.openNavDrawer;
-import static de.test.antennapod.EspressoTestUtils.waitForView;
+import static de.test.antennapod.EspressoTestUtils.waitForViewGlobally;
 import static org.hamcrest.Matchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
- * User interface tests for MainActivity
+ * User interface tests for MainActivity.
  */
 @RunWith(AndroidJUnit4.class)
 public class MainActivityTest {
@@ -48,19 +51,19 @@ public class MainActivityTest {
     private UITestUtils uiTestUtils;
 
     @Rule
-    public IntentsTestRule<MainActivity> mActivityRule = new IntentsTestRule<>(MainActivity.class, false, false);
+    public IntentsTestRule<MainActivity> activityRule = new IntentsTestRule<>(MainActivity.class, false, false);
 
     @Before
     public void setUp() throws IOException {
         EspressoTestUtils.clearPreferences();
         EspressoTestUtils.clearDatabase();
 
-        mActivityRule.launchActivity(new Intent());
+        activityRule.launchActivity(new Intent());
 
         uiTestUtils = new UITestUtils(InstrumentationRegistry.getInstrumentation().getTargetContext());
         uiTestUtils.setup();
 
-        solo = new Solo(InstrumentationRegistry.getInstrumentation(), mActivityRule.getActivity());
+        solo = new Solo(InstrumentationRegistry.getInstrumentation(), activityRule.getActivity());
     }
 
     @After
@@ -71,6 +74,7 @@ public class MainActivityTest {
 
     @Test
     public void testAddFeed() throws Exception {
+        // connect to podcast feed
         uiTestUtils.addHostedFeedData();
         final Feed feed = uiTestUtils.hostedFeeds.get(0);
         openNavDrawer();
@@ -78,9 +82,14 @@ public class MainActivityTest {
         onView(withId(R.id.addViaUrlButton)).perform(scrollTo(), click());
         onView(withId(R.id.urlEditText)).perform(replaceText(feed.getDownload_url()));
         onView(withText(R.string.confirm_label)).perform(scrollTo(), click());
+
+        // subscribe podcast
         Espresso.closeSoftKeyboard();
+        waitForViewGlobally(withText(R.string.subscribe_label), 15000);
         onView(withText(R.string.subscribe_label)).perform(click());
-        onView(isRoot()).perform(waitForView(withId(R.id.butShowSettings), 5000));
+
+        // wait for podcast feed item list
+        waitForViewGlobally(withId(R.id.butShowSettings), 15000);
     }
 
     @Test
@@ -100,7 +109,7 @@ public class MainActivityTest {
         onView(allOf(withId(R.id.toolbar), isDisplayed())).check(
                 matches(hasDescendant(withText(R.string.subscriptions_label))));
         solo.goBack();
-        assertThat(mActivityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
+        assertThat(activityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
     }
 
     @Test
@@ -113,7 +122,7 @@ public class MainActivityTest {
         solo.goBackToActivity(MainActivity.class.getSimpleName());
         solo.goBack();
         solo.goBack();
-        assertTrue(((MainActivity)solo.getCurrentActivity()).isDrawerOpen());
+        assertTrue(((MainActivity) solo.getCurrentActivity()).isDrawerOpen());
     }
 
     @Test
@@ -127,7 +136,7 @@ public class MainActivityTest {
         solo.goBack();
         solo.goBack();
         solo.goBack();
-        assertThat(mActivityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
+        assertThat(activityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
     }
 
     @Test
@@ -142,7 +151,7 @@ public class MainActivityTest {
         solo.goBack();
         onView(withText(R.string.yes)).perform(click());
         Thread.sleep(100);
-        assertThat(mActivityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
+        assertThat(activityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
     }
 
     @Test
@@ -155,6 +164,6 @@ public class MainActivityTest {
         solo.goBackToActivity(MainActivity.class.getSimpleName());
         solo.goBack();
         solo.goBack();
-        assertThat(mActivityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
+        assertThat(activityRule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
     }
 }


### PR DESCRIPTION
On CircleCI the following UI test fails frequently:

```
de.test.antennapod.ui.MainActivityTest > testAddFeed[test(AVD) - 9] FAILED 
	androidx.test.espresso.PerformException: Error performing 'wait for a specific view for5000 millis.' on view 'is a root view.'.
	at androidx.test.espresso.PerformException$Builder.build(PerformException.java:86)
```

As the feed download seems to be very slow the code has to reliably wait until the target view becomes visible. For this I introduced the helper method `EspressoTestUtils.waitForViewGlobally()` that doesn't stick to the current view root.

Also I made some small code changes to satisfy Checkstyle.

Contributes to #4194.