### PR TITLE
send Authorization header to be able to stream password protected media

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -29,7 +29,6 @@ import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
-import com.google.android.exoplayer2.upstream.HttpDataSource;
 
 import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.preferences.UserPreferences;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.core.service.playback;
 
 import android.content.Context;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import com.google.android.exoplayer2.C;
@@ -196,7 +197,7 @@ public class ExoPlayerWrapper implements IPlayer {
                 DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                 true);
 
-        if (user != null && password != null && user.length() > 0  && password.length() > 0) {
+        if (!TextUtils.isEmpty(user) && !TextUtils.isEmpty(password)) {
             httpDataSourceFactory.getDefaultRequestProperties().set("Authorization",
                     HttpDownloader.encodeCredentials(
                             user,

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -205,13 +205,10 @@ public class ExoPlayerWrapper implements IPlayer {
                             "ISO-8859-1"));
         }
         DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(context, null, httpDataSourceFactory);
-        HttpDataSource httpDataSource = httpDataSourceFactory.createDataSource();
-
         DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
         extractorsFactory.setConstantBitrateSeekingEnabled(true);
         ProgressiveMediaSource.Factory f = new ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory);
         mediaSource = f.createMediaSource(Uri.parse(s));
-
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -187,7 +187,8 @@ public class ExoPlayerWrapper implements IPlayer {
         exoPlayer.setAudioAttributes(b.build());
     }
 
-    public void setDataSource(String s, String user, String password) throws IllegalArgumentException, IllegalStateException {
+    public void setDataSource(String s, String user, String password)
+            throws IllegalArgumentException, IllegalStateException {
         Log.d(TAG, "setDataSource: " + s);
         DefaultHttpDataSourceFactory httpDataSourceFactory = new DefaultHttpDataSourceFactory(
                 ClientConfig.USER_AGENT, null,
@@ -195,12 +196,12 @@ public class ExoPlayerWrapper implements IPlayer {
                 DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                 true);
 
-        if (user != null || password != null) {
+        if (user != null && password != null && user.length() > 0  && password.length() > 0) {
             httpDataSourceFactory.getDefaultRequestProperties().set("Authorization",
-                    HttpDownloader.encodeCredentials(user,
+                    HttpDownloader.encodeCredentials(
+                            user,
                             password,
                             "ISO-8859-1"));
-
         }
         DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(context, null, httpDataSourceFactory);
         HttpDataSource httpDataSource = httpDataSourceFactory.createDataSource();
@@ -211,6 +212,7 @@ public class ExoPlayerWrapper implements IPlayer {
         mediaSource = f.createMediaSource(Uri.parse(s));
 
     }
+
     @Override
     public void setDataSource(String s) throws IllegalArgumentException, IllegalStateException {
         setDataSource(s, null, null);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -260,7 +260,16 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             callback.onMediaChanged(false);
             setPlaybackParams(PlaybackSpeedUtils.getCurrentPlaybackSpeed(media), UserPreferences.isSkipSilence());
             if (stream) {
-                mediaPlayer.setDataSource(media.getStreamUrl());
+                if (playable instanceof FeedMedia) {
+                    FeedMedia feedMedia = (FeedMedia) playable;
+                    FeedPreferences preferences = feedMedia.getItem().getFeed().getPreferences();
+                    mediaPlayer.setDataSource(
+                            media.getStreamUrl(),
+                            preferences.getUsername(),
+                            preferences.getPassword());
+                } else {
+                    mediaPlayer.setDataSource(media.getStreamUrl());
+                }
             } else if (media.getLocalMediaUrl() != null && new File(media.getLocalMediaUrl()).canRead()) {
                 mediaPlayer.setDataSource(media.getLocalMediaUrl());
             } else {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -64,4 +64,8 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
     public int getSelectedAudioTrack() {
         return -1;
     }
+
+    @Override
+    public void setDataSource(String streamUrl, String username, String password) {
+    };
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -10,6 +10,7 @@ import org.antennapod.audio.MediaPlayer;
 
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -67,5 +68,14 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
 
     @Override
     public void setDataSource(String streamUrl, String username, String password) {
+        try {
+            setDataSource(streamUrl);
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, e.toString());
+        } catch (IllegalStateException e) {
+            Log.e(TAG, e.toString());
+        } catch(IOException e) {
+            Log.e(TAG, e.toString());
+        }
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -74,7 +74,7 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
             Log.e(TAG, e.toString());
         } catch (IllegalStateException e) {
             Log.e(TAG, e.toString());
-        } catch(IOException e) {
+        } catch (IOException e) {
             Log.e(TAG, e.toString());
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -67,15 +67,7 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
     }
 
     @Override
-    public void setDataSource(String streamUrl, String username, String password) {
-        try {
-            setDataSource(streamUrl);
-        } catch (IllegalArgumentException e) {
-            Log.e(TAG, e.toString());
-        } catch (IllegalStateException e) {
-            Log.e(TAG, e.toString());
-        } catch (IOException e) {
-            Log.e(TAG, e.toString());
-        }
+    public void setDataSource(String streamUrl, String username, String password) throws IOException {
+        setDataSource(streamUrl);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/AudioPlayer.java
@@ -67,5 +67,5 @@ public class AudioPlayer extends MediaPlayer implements IPlayer {
 
     @Override
     public void setDataSource(String streamUrl, String username, String password) {
-    };
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/IPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/IPlayer.java
@@ -35,6 +35,8 @@ public interface IPlayer {
     void setDataSource(String path) throws IllegalStateException, IOException,
             IllegalArgumentException, SecurityException;
 
+    void setDataSource(String streamUrl, String username, String password) throws IOException;
+
     void setDisplay(SurfaceHolder sh);
 
     void setPlaybackParams(float speed, boolean skipSilence);
@@ -54,6 +56,4 @@ public interface IPlayer {
     void setAudioTrack(int track);
 
     int getSelectedAudioTrack();
-
-    void setDataSource(String streamUrl, String username, String password);
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/IPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/IPlayer.java
@@ -54,4 +54,6 @@ public interface IPlayer {
     void setAudioTrack(int track);
 
     int getSelectedAudioTrack();
+
+    void setDataSource(String streamUrl, String username, String password);
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
@@ -52,4 +52,8 @@ public class VideoPlayer extends MediaPlayer implements IPlayer {
     public int getSelectedAudioTrack() {
         return -1;
     }
+
+    @Override
+    public void setDataSource(String streamUrl, String username, String password) {
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
@@ -55,15 +55,7 @@ public class VideoPlayer extends MediaPlayer implements IPlayer {
     }
 
     @Override
-    public void setDataSource(String streamUrl, String username, String password) {
-        try {
-            setDataSource(streamUrl);
-        } catch (IllegalArgumentException e) {
-            Log.e(TAG, e.toString());
-        } catch (IllegalStateException e) {
-            Log.e(TAG, e.toString());
-        } catch (IOException e) {
-            Log.e(TAG, e.toString());
-        }
+    public void setDataSource(String streamUrl, String username, String password) throws IOException {
+        setDataSource(streamUrl);
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/VideoPlayer.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.util.playback;
 import android.media.MediaPlayer;
 import android.util.Log;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,5 +56,14 @@ public class VideoPlayer extends MediaPlayer implements IPlayer {
 
     @Override
     public void setDataSource(String streamUrl, String username, String password) {
+        try {
+            setDataSource(streamUrl);
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, e.toString());
+        } catch (IllegalStateException e) {
+            Log.e(TAG, e.toString());
+        } catch (IOException e) {
+            Log.e(TAG, e.toString());
+        }
     }
 }


### PR DESCRIPTION
fix #2268

Adding basic auth during streaming

- [x] Make it work for ExoPlayer
- [x] NO Make it work for Android player
- [x] NO Make it work for Sonic Media player

These pages helped me figure out ExoPlayer and Http headers
* https://stackoverflow.com/questions/31162441/setting-headers-for-streaming-mp4-video-and-playing-files-with-exoplayer
* https://stackoverflow.com/questions/28700391/using-cache-in-exoplayer
* https://stackoverflow.com/questions/21906749/stream-authenticated-video-with-mediaplayer-on-android
* https://github.com/google/ExoPlayer/issues/5371