### PR TITLE
Add "Forward Button Rewinds" option

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/PlaybackPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/PlaybackPreferencesFragment.java
@@ -8,6 +8,7 @@ import androidx.collection.ArrayMap;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SwitchPreferenceCompat;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.PreferenceActivity;
 import de.danoeh.antennapod.core.event.UnreadItemsUpdateEvent;
@@ -21,6 +22,8 @@ import java.util.Map;
 import org.greenrobot.eventbus.EventBus;
 
 public class PlaybackPreferencesFragment extends PreferenceFragmentCompat {
+    private static final String PREF_HARDWARE_FORWARD_BUTTON_REWINDS = "prefHardwareForwardButtonRewinds";
+    private static final String PREF_HARDWARE_FORWARD_BUTTON_SKIPS = "prefHardwareForwardButtonSkips";
     private static final String PREF_PLAYBACK_SPEED_LAUNCHER = "prefPlaybackSpeedLauncher";
     private static final String PREF_PLAYBACK_REWIND_DELTA_LAUNCHER = "prefPlaybackRewindDeltaLauncher";
     private static final String PREF_PLAYBACK_FAST_FORWARD_DELTA_LAUNCHER = "prefPlaybackFastForwardDeltaLauncher";
@@ -43,6 +46,23 @@ public class PlaybackPreferencesFragment extends PreferenceFragmentCompat {
 
     private void setupPlaybackScreen() {
         final Activity activity = getActivity();
+
+        // The "Forward Button Rewinds" and "Forward Button Skips" options are
+        // mutually exclusive. When one is turned on the other one is turned off.
+        SwitchPreferenceCompat forwardRewinds = findPreference(PREF_HARDWARE_FORWARD_BUTTON_REWINDS);
+        SwitchPreferenceCompat forwardSkips = findPreference(PREF_HARDWARE_FORWARD_BUTTON_SKIPS);
+        forwardRewinds.setOnPreferenceChangeListener((preference, newValue) -> {
+            if ((Boolean) newValue == true) {
+                forwardSkips.setChecked(false);
+            }
+            return true;
+        });
+        forwardSkips.setOnPreferenceChangeListener((preference, newValue) -> {
+            if ((Boolean) newValue == true) {
+                forwardRewinds.setChecked(false);
+            }
+            return true;
+        });
 
         findPreference(PREF_PLAYBACK_SPEED_LAUNCHER).setOnPreferenceClickListener(preference -> {
             new VariableSpeedDialog().show(getChildFragmentManager(), null);

--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -47,6 +47,12 @@
         <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
+                android:key="prefHardwareForwardButtonRewinds"
+                android:summary="@string/pref_hardwareForwardButtonRewinds_sum"
+                android:title="@string/pref_hardwareForwardButtonRewinds_title"/>
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:enabled="true"
                 android:key="prefHardwareForwardButtonSkips"
                 android:summary="@string/pref_hardwareForwardButtonSkips_sum"
                 android:title="@string/pref_hardwareForwardButtonSkips_title"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -76,7 +76,8 @@ public class UserPreferences {
     public static final String PREF_PAUSE_ON_HEADSET_DISCONNECT = "prefPauseOnHeadsetDisconnect";
     public static final String PREF_UNPAUSE_ON_HEADSET_RECONNECT = "prefUnpauseOnHeadsetReconnect";
     private static final String PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT = "prefUnpauseOnBluetoothReconnect";
-    private static final String PREF_HARDWARE_FOWARD_BUTTON_SKIPS = "prefHardwareForwardButtonSkips";
+    private static final String PREF_HARDWARE_FORWARD_BUTTON_REWINDS = "prefHardwareForwardButtonRewinds";
+    private static final String PREF_HARDWARE_FORWARD_BUTTON_SKIPS = "prefHardwareForwardButtonSkips";
     private static final String PREF_HARDWARE_PREVIOUS_BUTTON_RESTARTS = "prefHardwarePreviousButtonRestarts";
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
     public static final String PREF_SKIP_KEEPS_EPISODE = "prefSkipKeepsEpisode";
@@ -373,8 +374,12 @@ public class UserPreferences {
         return prefs.getBoolean(PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT, false);
     }
 
+    public static boolean shouldHardwareButtonRewind() {
+        return prefs.getBoolean(PREF_HARDWARE_FORWARD_BUTTON_REWINDS, false);
+    }
+
     public static boolean shouldHardwareButtonSkip() {
-        return prefs.getBoolean(PREF_HARDWARE_FOWARD_BUTTON_SKIPS, false);
+        return prefs.getBoolean(PREF_HARDWARE_FORWARD_BUTTON_SKIPS, false);
     }
 
     public static boolean shouldHardwarePreviousButtonRestart() {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -674,6 +674,11 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     // assume the skip command comes from a notification or the lockscreen
                     // a >| skip button should actually skip
                     mediaPlayer.skip();
+                } else if (UserPreferences.shouldHardwareButtonRewind()) {
+                    // if the skip command comes from a (bluetooth) media
+                    // button and the user has enabled "Forward Button Rewinds"
+                    // then rewind here instead of fast-forwarding
+                    mediaPlayer.seekDelta(-UserPreferences.getRewindSecs() * 1000);
                 } else {
                     // assume skip command comes from a (bluetooth) media button
                     // user actually wants to fast-forward

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -376,6 +376,8 @@
     <string name="pref_pauseOnDisconnect_sum">Pause playback when headphones or bluetooth are disconnected</string>
     <string name="pref_unpauseOnHeadsetReconnect_sum">Resume playback when the headphones are reconnected</string>
     <string name="pref_unpauseOnBluetoothReconnect_sum">Resume playback when bluetooth reconnects</string>
+    <string name="pref_hardwareForwardButtonRewinds_title">Forward Button Rewinds</string>
+    <string name="pref_hardwareForwardButtonRewinds_sum">If your bluetooth-connected device only has a forward button you might prefer that button to rewind instead of fast-fowarding</string>
     <string name="pref_hardwareForwardButtonSkips_title">Forward Button Skips</string>
     <string name="pref_hardwareForwardButtonSkips_sum">When pressing a forward button on a bluetooth-connected device skip to the next episode instead of fast-forwarding</string>
     <string name="pref_hardwarePreviousButtonRestarts_title">Previous button restarts</string>


### PR DESCRIPTION
Some true wireless earbuds including the Huawei FreeBuds 3 only have a
forward button but no rewind button. Users might prefer rewind over
fast-forward. This commit introduces the "Forward Button Rewinds" option
which makes the physical forward button act as a rewind button.

Discussion started in #4834.

![image](https://user-images.githubusercontent.com/8438790/104103047-59d04b00-52a0-11eb-8a35-b7b3b1556d3c.png)

Closes #4834