### PR TITLE
Displayed full podcast title on podcast info screen

### DIFF
--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -37,7 +37,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:ellipsize="end"
-                    android:maxLines="2"
+                    android:maxLines="4"
                     android:shadowColor="@color/black"
                     android:shadowRadius="2"
                     android:textColor="@color/white"


### PR DESCRIPTION
Fixes #4799 : Display full podcast title to podcast info screen
The maxlines for the podcast title increased from 2 to 4.