### PR TITLE
Fix Android Auto next episode

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.core.service.playback;
 
-import android.app.UiModeManager;
 import android.content.Context;
 import android.media.AudioManager;
 import android.os.PowerManager;
@@ -9,7 +8,6 @@ import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.util.Pair;
 import android.view.SurfaceHolder;
-import android.content.res.Configuration;
 
 import androidx.media.AudioAttributesCompat;
 import androidx.media.AudioFocusRequestCompat;
@@ -262,16 +260,22 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             callback.onMediaChanged(false);
             setPlaybackParams(PlaybackSpeedUtils.getCurrentPlaybackSpeed(media), UserPreferences.isSkipSilence());
             if (stream) {
-                mediaPlayer.setDataSource(media.getStreamUrl());
+                if (playable instanceof FeedMedia) {
+                    FeedMedia feedMedia = (FeedMedia) playable;
+                    FeedPreferences preferences = feedMedia.getItem().getFeed().getPreferences();
+                    mediaPlayer.setDataSource(
+                            media.getStreamUrl(),
+                            preferences.getUsername(),
+                            preferences.getPassword());
+                } else {
+                    mediaPlayer.setDataSource(media.getStreamUrl());
+                }
             } else if (media.getLocalMediaUrl() != null && new File(media.getLocalMediaUrl()).canRead()) {
                 mediaPlayer.setDataSource(media.getLocalMediaUrl());
             } else {
                 throw new IOException("Unable to read local file " + media.getLocalMediaUrl());
             }
-            UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
-            if (uiModeManager.getCurrentModeType() != Configuration.UI_MODE_TYPE_CAR) {
-                setPlayerStatus(PlayerStatus.INITIALIZED, media);
-            }
+            setPlayerStatus(PlayerStatus.INITIALIZED, media);
 
             if (prepareImmediately) {
                 setPlayerStatus(PlayerStatus.PREPARING, media);
@@ -929,6 +933,9 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
             boolean isPlaying = playerStatus == PlayerStatus.PLAYING;
 
+            if (playerStatus != PlayerStatus.INDETERMINATE) {
+                setPlayerStatus(PlayerStatus.INDETERMINATE, media);
+            }
             // we're relying on the position stored in the Playable object for post-playback processing
             if (media != null) {
                 int position = getPosition();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.core.service.playback;
 
+import android.app.UiModeManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.media.AudioManager;
 import android.os.PowerManager;
 import androidx.annotation.NonNull;
@@ -275,7 +277,10 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             } else {
                 throw new IOException("Unable to read local file " + media.getLocalMediaUrl());
             }
-            setPlayerStatus(PlayerStatus.INITIALIZED, media);
+            UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+            if (uiModeManager.getCurrentModeType() != Configuration.UI_MODE_TYPE_CAR) {
+                setPlayerStatus(PlayerStatus.INITIALIZED, media);
+            }
 
             if (prepareImmediately) {
                 setPlayerStatus(PlayerStatus.PREPARING, media);
@@ -933,9 +938,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
             boolean isPlaying = playerStatus == PlayerStatus.PLAYING;
 
-            if (playerStatus != PlayerStatus.INDETERMINATE) {
-                setPlayerStatus(PlayerStatus.INDETERMINATE, media);
-            }
             // we're relying on the position stored in the Playable object for post-playback processing
             if (media != null) {
                 int position = getPosition();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.core.service.playback;
 
+import android.app.UiModeManager;
 import android.content.Context;
 import android.media.AudioManager;
 import android.os.PowerManager;
@@ -8,6 +9,7 @@ import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.util.Pair;
 import android.view.SurfaceHolder;
+import android.content.res.Configuration;
 
 import androidx.media.AudioAttributesCompat;
 import androidx.media.AudioFocusRequestCompat;
@@ -260,22 +262,16 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             callback.onMediaChanged(false);
             setPlaybackParams(PlaybackSpeedUtils.getCurrentPlaybackSpeed(media), UserPreferences.isSkipSilence());
             if (stream) {
-                if (playable instanceof FeedMedia) {
-                    FeedMedia feedMedia = (FeedMedia) playable;
-                    FeedPreferences preferences = feedMedia.getItem().getFeed().getPreferences();
-                    mediaPlayer.setDataSource(
-                            media.getStreamUrl(),
-                            preferences.getUsername(),
-                            preferences.getPassword());
-                } else {
-                    mediaPlayer.setDataSource(media.getStreamUrl());
-                }
+                mediaPlayer.setDataSource(media.getStreamUrl());
             } else if (media.getLocalMediaUrl() != null && new File(media.getLocalMediaUrl()).canRead()) {
                 mediaPlayer.setDataSource(media.getLocalMediaUrl());
             } else {
                 throw new IOException("Unable to read local file " + media.getLocalMediaUrl());
             }
-            setPlayerStatus(PlayerStatus.INITIALIZED, media);
+            UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+            if (uiModeManager.getCurrentModeType() != Configuration.UI_MODE_TYPE_CAR) {
+                setPlayerStatus(PlayerStatus.INITIALIZED, media);
+            }
 
             if (prepareImmediately) {
                 setPlayerStatus(PlayerStatus.PREPARING, media);
@@ -933,9 +929,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
             boolean isPlaying = playerStatus == PlayerStatus.PLAYING;
 
-            if (playerStatus != PlayerStatus.INDETERMINATE) {
-                setPlayerStatus(PlayerStatus.INDETERMINATE, media);
-            }
             // we're relying on the position stored in the Playable object for post-playback processing
             if (media != null) {
                 int position = getPosition();


### PR DESCRIPTION
fix #2965 
squash version of  https://github.com/AntennaPod/AntennaPod/pull/4720

This was a hard one to track down.  Once the player is set to `PlayerStatus.INDETERMINATE` or `PlayerStatus.INITIALIZED`, the car player will not come back.  Remove those 2 lines and it works.

- [x] Fix integration test failures for non-car mode
- [x] Unit test failing de.danoeh.antennapod.core.feed.LocalFeedUpdaterTest > testUpdateFeed_AddMoreItems FAILED

Using Skip
![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/149837/100389507-66dff600-2fe2-11eb-9a11-c7ca29a72a14.gif)

Using fast forward or wait for the episode to finish (BTW, there is a bug with the number of minutes it's showing.
![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/149837/100389654-cd651400-2fe2-11eb-94fe-d3b8f562f0e6.gif)


