### PR TITLE
Bugfix: Read feed if read feeditem by URL for update database

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -134,7 +134,7 @@ public final class DBReader {
      *
      * @param items The FeedItems whose Feed-objects should be loaded.
      */
-    private static void loadFeedDataOfFeedItemList(List<FeedItem> items) {
+    public static void loadFeedDataOfFeedItemList(List<FeedItem> items) {
         List<Feed> feeds = getFeedList();
 
         Map<Long, Feed> feedIndex = new ArrayMap<>(feeds.size());
@@ -550,7 +550,7 @@ public final class DBReader {
      * @param podcastUrl the corresponding feed's url
      * @param episodeUrl the feed item's url
      * @return The FeedItem or null if the FeedItem could not be found.
-     *          Does NOT load additional attributes like queue state.
+     *          Does NOT load additional attributes like feed or queue state.
      */
     @Nullable
     private static FeedItem getFeedItemByUrl(final String podcastUrl, final String episodeUrl, PodDBAdapter adapter) {
@@ -561,7 +561,6 @@ public final class DBReader {
             }
             List<FeedItem> list = extractItemlistFromCursor(adapter, cursor);
             if (!list.isEmpty()) {
-                loadFeedDataOfFeedItemList(list);
                 return list.get(0);
             }
             return null;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -550,7 +550,7 @@ public final class DBReader {
      * @param podcastUrl the corresponding feed's url
      * @param episodeUrl the feed item's url
      * @return The FeedItem or null if the FeedItem could not be found.
-     *          Does NOT load additional attributes like feed or queue state.
+     *          Does NOT load additional attributes like queue state.
      */
     @Nullable
     private static FeedItem getFeedItemByUrl(final String podcastUrl, final String episodeUrl, PodDBAdapter adapter) {
@@ -561,6 +561,7 @@ public final class DBReader {
             }
             List<FeedItem> list = extractItemlistFromCursor(adapter, cursor);
             if (!list.isEmpty()) {
+                loadFeedDataOfFeedItemList(list);
                 return list.get(0);
             }
             return null;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -789,6 +789,7 @@ public class DBWriter {
             adapter.open();
             adapter.setFeedItemlist(items);
             adapter.close();
+            EventBus.getDefault().post(FeedItemEvent.updated(items));
         });
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/sync/SyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/SyncService.java
@@ -474,6 +474,7 @@ public class SyncService extends Worker {
             }
         }
         DBWriter.removeQueueItem(getApplicationContext(), false, queueToBeRemoved.toArray());
+        DBReader.loadFeedDataOfFeedItemList(updatedItems);
         DBWriter.setItemList(updatedItems);
     }
 


### PR DESCRIPTION
With commit 6e3d012a8ae6c6ffa6609cfc851dcc022eff26ef the function `getFeedItemByUrl` was renamed and only reads `FeedItem` but not the additional attribute of `Feed`. This function is used in `SyncService` for updating played and position information. This commit was for speedup sync but there is a bug. Updating `FeedItem` wasn't possible because of  `setFeedItem` in `PodDBAdapter` needs the `Feed` for updating the database:
https://github.com/AntennaPod/AntennaPod/blob/f3bf708e260822645a65963ff402794cb0cca66e/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java#L636

There I found a `NullPointerException` which was cached anywhere and not handled. The updates where not committed to database.

Also I have added `FeedItemEvent.updated` for synced `FeedItems` to see updated episodes if you are within the feed with list of episodes.

Closes #4459 