### PR TITLE
Reduce coupling between widget and playback service

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
@@ -6,6 +6,7 @@ import androidx.test.annotation.UiThreadTest;
 import androidx.test.filters.LargeTest;
 
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
+import de.danoeh.antennapod.core.widget.WidgetUpdater;
 import org.awaitility.Awaitility;
 import org.greenrobot.eventbus.EventBus;
 import org.junit.After;
@@ -187,8 +188,8 @@ public class PlaybackServiceTaskManagerTest {
             }
 
             @Override
-            public void onWidgetUpdaterTick() {
-
+            public WidgetUpdater.WidgetState requestWidgetState() {
+                return null;
             }
 
             @Override
@@ -248,8 +249,9 @@ public class PlaybackServiceTaskManagerTest {
             }
 
             @Override
-            public void onWidgetUpdaterTick() {
+            public WidgetUpdater.WidgetState requestWidgetState() {
                 countDownLatch.countDown();
+                return null;
             }
 
             @Override
@@ -348,8 +350,8 @@ public class PlaybackServiceTaskManagerTest {
             }
 
             @Override
-            public void onWidgetUpdaterTick() {
-
+            public WidgetUpdater.WidgetState requestWidgetState() {
+                return null;
             }
 
             @Override
@@ -391,8 +393,8 @@ public class PlaybackServiceTaskManagerTest {
             }
 
             @Override
-            public void onWidgetUpdaterTick() {
-
+            public WidgetUpdater.WidgetState requestWidgetState() {
+                return null;
             }
 
             @Override
@@ -449,8 +451,8 @@ public class PlaybackServiceTaskManagerTest {
         }
 
         @Override
-        public void onWidgetUpdaterTick() {
-
+        public WidgetUpdater.WidgetState requestWidgetState() {
+            return null;
         }
 
         @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/WidgetConfigActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/WidgetConfigActivity.java
@@ -19,7 +19,7 @@ import androidx.core.content.ContextCompat;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.receiver.PlayerWidget;
-import de.danoeh.antennapod.core.service.PlayerWidgetJobService;
+import de.danoeh.antennapod.core.widget.WidgetUpdaterJobService;
 
 public class WidgetConfigActivity extends AppCompatActivity {
     private int appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
@@ -127,7 +127,7 @@ public class WidgetConfigActivity extends AppCompatActivity {
         resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
         setResult(RESULT_OK, resultValue);
         finish();
-        PlayerWidgetJobService.updateWidget(this);
+        WidgetUpdaterJobService.performBackgroundUpdate(this);
     }
 
     private int getColorWithAlpha(int color, int opacity) {

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -45,6 +45,11 @@
             android:label="@string/feed_update_receiver_name"
             android:exported="true"
             tools:ignore="ExportedReceiver" /> <!-- allow feeds update to be triggered by external apps -->
+
+        <service
+            android:name=".widget.WidgetUpdaterJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true"/>
     </application>
 
 </manifest>

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/PlayerWidget.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/PlayerWidget.java
@@ -9,7 +9,7 @@ import android.util.Log;
 
 import java.util.Arrays;
 
-import de.danoeh.antennapod.core.service.PlayerWidgetJobService;
+import de.danoeh.antennapod.core.widget.WidgetUpdaterJobService;
 
 public class PlayerWidget extends AppWidgetProvider {
     private static final String TAG = "PlayerWidget";
@@ -25,7 +25,7 @@ public class PlayerWidget extends AppWidgetProvider {
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "onReceive");
         super.onReceive(context, intent);
-        PlayerWidgetJobService.updateWidget(context);
+        WidgetUpdaterJobService.performBackgroundUpdate(context);
     }
 
     @Override
@@ -33,13 +33,14 @@ public class PlayerWidget extends AppWidgetProvider {
         super.onEnabled(context);
         Log.d(TAG, "Widget enabled");
         setEnabled(context, true);
-        PlayerWidgetJobService.updateWidget(context);
+        WidgetUpdaterJobService.performBackgroundUpdate(context);
     }
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
-        Log.d(TAG, "onUpdate() called with: " + "context = [" + context + "], appWidgetManager = [" + appWidgetManager + "], appWidgetIds = [" + Arrays.toString(appWidgetIds) + "]");
-        PlayerWidgetJobService.updateWidget(context);
+        Log.d(TAG, "onUpdate() called with: " + "context = [" + context + "], appWidgetManager = ["
+                + appWidgetManager + "], appWidgetIds = [" + Arrays.toString(appWidgetIds) + "]");
+        WidgetUpdaterJobService.performBackgroundUpdate(context);
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -69,7 +69,6 @@ import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.receiver.MediaButtonReceiver;
-import de.danoeh.antennapod.core.service.PlayerWidgetJobService;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
@@ -81,6 +80,7 @@ import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 import de.danoeh.antennapod.core.util.playback.ExternalMedia;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
+import de.danoeh.antennapod.core.widget.WidgetUpdater;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -801,8 +801,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
 
         @Override
-        public void onWidgetUpdaterTick() {
-            PlayerWidgetJobService.updateWidget(getBaseContext());
+        public WidgetUpdater.WidgetState requestWidgetState() {
+            return new WidgetUpdater.WidgetState(getPlayable(), getStatus(),
+                    getCurrentPosition(), getDuration(), getCurrentPlaybackSpeed());
         }
 
         @Override
@@ -873,9 +874,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             }
 
             IntentUtils.sendLocalBroadcast(getApplicationContext(), ACTION_PLAYER_STATUS_CHANGED);
-            PlayerWidgetJobService.updateWidget(getBaseContext());
             bluetoothNotifyChange(newInfo, AVRCP_ACTION_PLAYER_STATUS_CHANGED);
             bluetoothNotifyChange(newInfo, AVRCP_ACTION_META_CHANGED);
+            taskManager.requestWidgetUpdate();
         }
 
         @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -21,6 +21,7 @@ import java.util.List;
  */
 public interface Playable extends Parcelable,
         ShownotesProvider, ImageResource {
+    public static final int INVALID_TIME = -1;
 
     /**
      * Save information about the playable in a preference so that it can be

--- a/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdaterJobService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdaterJobService.java
@@ -1,0 +1,32 @@
+package de.danoeh.antennapod.core.widget;
+
+import android.content.Context;
+import android.content.Intent;
+import androidx.annotation.NonNull;
+import androidx.core.app.SafeJobIntentService;
+import de.danoeh.antennapod.core.feed.util.PlaybackSpeedUtils;
+import de.danoeh.antennapod.core.service.playback.PlayerStatus;
+import de.danoeh.antennapod.core.util.playback.Playable;
+
+public class WidgetUpdaterJobService extends SafeJobIntentService {
+    private static final int JOB_ID = -17001;
+
+    /**
+     * Loads the current media from the database and updates the widget in a background job.
+     */
+    public static void performBackgroundUpdate(Context context) {
+        enqueueWork(context, WidgetUpdaterJobService.class,
+                WidgetUpdaterJobService.JOB_ID, new Intent(context, WidgetUpdaterJobService.class));
+    }
+
+    @Override
+    protected void onHandleWork(@NonNull Intent intent) {
+        Playable media = Playable.PlayableUtils.createInstanceFromPreferences(getApplicationContext());
+        if (media != null) {
+            WidgetUpdater.updateWidget(this, new WidgetUpdater.WidgetState(media, PlayerStatus.STOPPED,
+                    media.getPosition(), media.getDuration(), PlaybackSpeedUtils.getCurrentPlaybackSpeed(media)));
+        } else {
+            WidgetUpdater.updateWidget(this, new WidgetUpdater.WidgetState(PlayerStatus.STOPPED));
+        }
+    }
+}


### PR DESCRIPTION
Instead of binding to the service, pass the required data. This also
ensures that the widget is updated instantly. JobService had the problem
that the OS sometimes took some seconds before actually executing the
job.