### PR TITLE
Fix cover image cut off in landscape mode

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -208,7 +208,7 @@ public class CoverFragment extends Fragment {
                 imgvCover.setLayoutParams(params);
             }
         } else {
-            double percentageHeight = ratio * 0.8;
+            double percentageHeight = ratio * 0.6;
             mainContainer.setOrientation(LinearLayout.HORIZONTAL);
             if (newConfig.screenHeightDp > 0) {
                 params.height = (int) (convertDpToPixel(newConfig.screenHeightDp) * percentageHeight);


### PR DESCRIPTION
After the larger tab navigation, the landscape mode is cutting off the image in the playing mode.
related to my fav fix :D https://github.com/AntennaPod/AntennaPod/pull/4292/files

See before

<img width="358" alt="Screen Shot 2021-01-26 at 10 39 31 PM" src="https://user-images.githubusercontent.com/149837/105953055-63d7a500-6027-11eb-86b0-dd2a256092dd.png">

and after my fix

<img width="350" alt="Screen Shot 2021-01-26 at 10 39 37 PM" src="https://user-images.githubusercontent.com/149837/105953065-6934ef80-6027-11eb-9c67-d9422d9729c4.png">

