### PR TITLE
Added a setting to keep screen awake during podcast playback

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.ImageButton;
 import android.widget.ProgressBar;
 import android.widget.SeekBar;
@@ -36,6 +37,7 @@ import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.util.PlaybackSpeedUtils;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
+import de.danoeh.antennapod.core.service.playback.PlayerStatus;
 import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.IntentUtils;
 import de.danoeh.antennapod.core.util.TimeSpeedConverter;
@@ -284,6 +286,17 @@ public class AudioPlayerFragment extends Fragment implements
         txtvPlaybackSpeed.setVisibility(View.VISIBLE);
     }
 
+    protected void updateWakeLock() {
+        boolean isWakeLockEnabled = UserPreferences.IsWakeLockEnabled();
+        boolean isPlayerPlaying = controller.getStatus() == PlayerStatus.PLAYING;
+
+        if (isWakeLockEnabled && isPlayerPlaying) {
+            AudioPlayerFragment.this.getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        } else {
+            AudioPlayerFragment.this.getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
+    }
+
     private void loadMediaInfo() {
         if (disposable != null) {
             disposable.dispose();
@@ -391,6 +404,7 @@ public class AudioPlayerFragment extends Fragment implements
         }
         updatePosition(new PlaybackPositionEvent(controller.getPosition(), controller.getDuration()));
         updatePlaybackSpeedButton(media);
+        updateWakeLock();
         setupOptionsMenu(media);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -287,7 +287,7 @@ public class AudioPlayerFragment extends Fragment implements
     }
 
     protected void updateWakeLock() {
-        boolean isWakeLockEnabled = UserPreferences.IsWakeLockEnabled();
+        boolean isWakeLockEnabled = UserPreferences.isWakeLockEnabled();
         boolean isPlayerPlaying = controller.getStatus() == PlayerStatus.PLAYING;
 
         if (isWakeLockEnabled && isPlayerPlaying) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -291,9 +291,13 @@ public class AudioPlayerFragment extends Fragment implements
         boolean isPlayerPlaying = controller.getStatus() == PlayerStatus.PLAYING;
 
         if (isWakeLockEnabled && isPlayerPlaying) {
-            AudioPlayerFragment.this.getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            AudioPlayerFragment.this.getActivity()
+                    .getWindow()
+                    .addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         } else {
-            AudioPlayerFragment.this.getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            AudioPlayerFragment.this.getActivity()
+                    .getWindow()
+                    .clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
     }
 

--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -78,6 +78,12 @@
                 android:key="prefStreamOverDownload"
                 android:summary="@string/pref_stream_over_download_sum"
                 android:title="@string/pref_stream_over_download_title"/>
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:enabled="true"
+                android:key="prefWakelockPlayer"
+                android:summary="@string/pref_wakelock_message"
+                android:title="@string/pref_wakelock_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/queue_label">

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -994,7 +994,7 @@ public class UserPreferences {
     /**
      * Evaluates whether wake lock during playback is enabled on the preferences.
      */
-    public static boolean IsWakeLockEnabled() {
+    public static boolean isWakeLockEnabled() {
         return prefs.getBoolean(PREF_WAKELOCK_PLAYER, false);
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -134,6 +134,7 @@ public class UserPreferences {
     // Experimental
     private static final String PREF_STEREO_TO_MONO = "PrefStereoToMono";
     public static final String PREF_CAST_ENABLED = "prefCast"; //Used for enabling Chromecast support
+    public static final String PREF_WAKELOCK_PLAYER = "prefWakelockPlayer";
     public static final int EPISODE_CLEANUP_QUEUE = -1;
     public static final int EPISODE_CLEANUP_NULL = -2;
     public static final int EPISODE_CLEANUP_DEFAULT = 0;
@@ -988,6 +989,13 @@ public class UserPreferences {
      */
     public static boolean isCastEnabled() {
         return prefs.getBoolean(PREF_CAST_ENABLED, false);
+    }
+
+    /**
+     * Evaluates whether wake lock during playback is enabled on the preferences.
+     */
+    public static boolean IsWakeLockEnabled() {
+        return prefs.getBoolean(PREF_WAKELOCK_PLAYER, false);
     }
 
     public enum VideoBackgroundBehavior {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -520,6 +520,8 @@
     <string name="pref_cast_title">Chromecast support</string>
     <string name="pref_cast_message_play_flavor">Enable support for remote media playback on Cast devices (such as Chromecast, Audio Speakers or Android TV)</string>
     <string name="pref_cast_message_free_flavor">Chromecast requires third party proprietary libraries that are disabled in this version of AntennaPod</string>
+    <string name="pref_wakelock_title">Keep screen awake</string>
+    <string name="pref_wakelock_message">If on, keep the screen awake while the player is visible during playback.</string>
     <string name="pref_enqueue_downloaded_title">Enqueue Downloaded</string>
     <string name="pref_enqueue_downloaded_summary">Add downloaded episodes to the queue</string>
     <string name="media_player_builtin">Built-in Android player (deprecated) </string>


### PR DESCRIPTION
I have added the ability to keep the screen awake during playback if the user has chosen to toggle the respective setting.

Files Changed: 

- preferences_playback.xml
    - I've added a new SwitchPreferenceCompat boolean preference under Playback => Player Control called Keep Screen Awake. Defaults to false.
- UserPreferences.java
    - I've added a static string with the preference key name
    - Added a IsWakeLockEnabled method to return the preference value.
- strings.xml
    - Added two new string to hold the preference title and subtitle (message): pref_wakelock_title and pref_wakelock_message
- AudioPlayerFragment.java
    - Added reference to android.view.Window manager so that I can set the wakelock flags
    - Added reference to de.danoeh.antennapod.core.service.playback.PlayerStatus to get access to player status enum
    - Added a function called updateWakeLock that handles the wakelock logic. If setting from above is true and player is currently playing set the wakelock on, else set it off.
    - Updated the updateUi function to call the updateWakeLock

Related issue: #4912 