### PR TITLE
Migrate away from jcenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     implementation "com.joanzapata.iconify:android-iconify-fontawesome:$iconifyVersion"
     implementation "com.joanzapata.iconify:android-iconify-material:$iconifyVersion"
     implementation 'com.github.shts:TriangleLabelView:1.1.2'
-    implementation 'com.leinardi.android:speed-dial:3.1.1'
+    implementation 'com.github.leinardi:FloatingActionButtonSpeedDial:3.1.1'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
     implementation 'com.github.mfietz:fyydlin:v0.5.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -191,7 +191,6 @@ dependencies {
 
     implementation "com.joanzapata.iconify:android-iconify-fontawesome:$iconifyVersion"
     implementation "com.joanzapata.iconify:android-iconify-material:$iconifyVersion"
-    implementation 'com.yqritc:recyclerview-flexibledivider:1.4.0'
     implementation 'com.github.shts:TriangleLabelView:1.1.2'
     implementation 'com.leinardi.android:speed-dial:3.1.1'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"

--- a/app/src/main/assets/licenses.xml
+++ b/app/src/main/assets/licenses.xml
@@ -91,12 +91,6 @@
         license="Apache 2.0"
         licenseText="LICENSE_APACHE-2.0.txt" />
     <library
-        name="RecyclerView-FlexibleDivider"
-        author="yqritc"
-        website="https://github.com/yqritc/RecyclerView-FlexibleDivider"
-        license="Apache 2.0"
-        licenseText="LICENSE_APACHE-2.0.txt" />
-    <library
         name="RxAndroid"
         author="ReactiveX"
         website="https://github.com/ReactiveX/RxAndroid"

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ChaptersFragment.java
@@ -8,9 +8,9 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.adapter.ChaptersListAdapter;
 import de.danoeh.antennapod.core.event.PlaybackPositionEvent;
@@ -45,7 +45,8 @@ public class ChaptersFragment extends Fragment {
         RecyclerView recyclerView = root.findViewById(R.id.recyclerView);
         layoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(layoutManager);
-        recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(getActivity()).build());
+        recyclerView.addItemDecoration(new DividerItemDecoration(recyclerView.getContext(),
+                layoutManager.getOrientation()));
 
         adapter = new ChaptersListAdapter(getActivity(), pos -> {
             if (controller.getStatus() != PlayerStatus.PLAYING) {

--- a/app/src/main/java/de/danoeh/antennapod/view/EpisodeItemListRecyclerView.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/EpisodeItemListRecyclerView.java
@@ -6,9 +6,9 @@ import android.content.res.Configuration;
 import android.util.AttributeSet;
 import android.view.View;
 import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
 import de.danoeh.antennapod.R;
 import io.reactivex.annotations.Nullable;
 
@@ -39,7 +39,7 @@ public class EpisodeItemListRecyclerView extends RecyclerView {
         layoutManager.setRecycleChildrenOnDetach(true);
         setLayoutManager(layoutManager);
         setHasFixedSize(true);
-        addItemDecoration(new HorizontalDividerItemDecoration.Builder(getContext()).build());
+        addItemDecoration(new DividerItemDecoration(getContext(), layoutManager.getOrientation()));
         setClipToPadding(false);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
@@ -15,8 +15,9 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
+        jcenter()
     }
 
     gradle.projectsEvaluated {


### PR DESCRIPTION
Migrate 
- recyclerview-flexibledivider (unmaintained, replaced the library)
- leinardi speed-dial (Available on [Jitpack](https://github.com/leinardi/FloatingActionButtonSpeedDial/issues/159))

Contributes to #4930