### PR TITLE
use full URL for custom gpodder server

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/discovery/GpodnetPodcastSearcher.java
+++ b/app/src/main/java/de/danoeh/antennapod/discovery/GpodnetPodcastSearcher.java
@@ -18,7 +18,7 @@ public class GpodnetPodcastSearcher implements PodcastSearcher {
         return Single.create((SingleOnSubscribe<List<PodcastSearchResult>>) subscriber -> {
             try {
                 GpodnetService service = new GpodnetService(AntennapodHttpClient.getHttpClient(),
-                        GpodnetPreferences.getHostname());
+                        GpodnetPreferences.getHosturl());
                 List<GpodnetPodcast> gpodnetPodcasts = service.searchPodcasts(query, 0);
                 List<PodcastSearchResult> results = new ArrayList<>();
                 for (GpodnetPodcast podcast : gpodnetPodcasts) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/PodcastListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/PodcastListFragment.java
@@ -71,7 +71,7 @@ public abstract class PodcastListFragment extends Fragment {
             protected List<GpodnetPodcast> doInBackground(Void... params) {
                 try {
                     GpodnetService service = new GpodnetService(AntennapodHttpClient.getHttpClient(),
-                            GpodnetPreferences.getHostname());
+                            GpodnetPreferences.getHosturl());
                     return loadPodcastData(service);
                 } catch (GpodnetServiceException e) {
                     exception = e;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/TagListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/gpodnet/TagListFragment.java
@@ -54,7 +54,7 @@ public class TagListFragment extends ListFragment {
             @Override
             protected List<GpodnetTag> doInBackground(Void... params) {
                 GpodnetService service = new GpodnetService(AntennapodHttpClient.getHttpClient(),
-                        GpodnetPreferences.getHostname());
+                        GpodnetPreferences.getHosturl());
                 try {
                     return service.getTopTags(COUNT);
                 } catch (GpodnetServiceException e) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderAuthenticationFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderAuthenticationFragment.java
@@ -82,6 +82,7 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         final Button selectHost = view.findViewById(R.id.chooseHostButton);
         final RadioGroup serverRadioGroup = view.findViewById(R.id.serverRadioGroup);
         final EditText serverUrlText = view.findViewById(R.id.serverUrlText);
+
         if (!GpodnetService.DEFAULT_BASE_HOST.equals(GpodnetPreferences.getHosturl())) {
             serverUrlText.setText(GpodnetPreferences.getHosturl());
         }
@@ -108,10 +109,14 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         final TextView txtvError = view.findViewById(R.id.credentialsError);
         final ProgressBar progressBar = view.findViewById(R.id.progBarLogin);
         final TextView createAccount = view.findViewById(R.id.createAccountButton);
+        final TextView createAccountWarning = view.findViewById(R.id.createAccountWarning);
 
         createAccount.setPaintFlags(createAccount.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
         createAccount.setOnClickListener(v -> IntentUtils.openInBrowser(getContext(), "https://gpodder.net/register/"));
 
+        if (GpodnetPreferences.getHosturl().startsWith("http://")) {
+            createAccountWarning.setVisibility(View.VISIBLE);
+        };
         password.setOnEditorActionListener((v, actionID, event) ->
                 actionID == EditorInfo.IME_ACTION_GO && login.performClick());
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderAuthenticationFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderAuthenticationFragment.java
@@ -82,8 +82,8 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         final Button selectHost = view.findViewById(R.id.chooseHostButton);
         final RadioGroup serverRadioGroup = view.findViewById(R.id.serverRadioGroup);
         final EditText serverUrlText = view.findViewById(R.id.serverUrlText);
-        if (!GpodnetService.DEFAULT_BASE_HOST.equals(GpodnetPreferences.getHostname())) {
-            serverUrlText.setText(GpodnetPreferences.getHostname());
+        if (!GpodnetService.DEFAULT_BASE_HOST.equals(GpodnetPreferences.getHosturl())) {
+            serverUrlText.setText(GpodnetPreferences.getHosturl());
         }
         final TextInputLayout serverUrlTextInput = view.findViewById(R.id.serverUrlTextInput);
         serverRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
@@ -91,12 +91,12 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         });
         selectHost.setOnClickListener(v -> {
             if (serverRadioGroup.getCheckedRadioButtonId() == R.id.customServerRadio) {
-                GpodnetPreferences.setHostname(serverUrlText.getText().toString());
+                GpodnetPreferences.setHosturl(serverUrlText.getText().toString());
             } else {
-                GpodnetPreferences.setHostname(GpodnetService.DEFAULT_BASE_HOST);
+                GpodnetPreferences.setHosturl(GpodnetService.DEFAULT_BASE_HOST);
             }
-            service = new GpodnetService(AntennapodHttpClient.getHttpClient(), GpodnetPreferences.getHostname());
-            getDialog().setTitle(GpodnetPreferences.getHostname());
+            service = new GpodnetService(AntennapodHttpClient.getHttpClient(), GpodnetPreferences.getHosturl());
+            getDialog().setTitle(GpodnetPreferences.getHosturl());
             advance();
         });
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderAuthenticationFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderAuthenticationFragment.java
@@ -116,7 +116,7 @@ public class GpodderAuthenticationFragment extends DialogFragment {
 
         if (GpodnetPreferences.getHosturl().startsWith("http://")) {
             createAccountWarning.setVisibility(View.VISIBLE);
-        };
+        }
         password.setOnEditorActionListener((v, actionID, event) ->
                 actionID == EditorInfo.IME_ACTION_GO && login.performClick());
 

--- a/app/src/main/res/layout/gpodnetauth_credentials.xml
+++ b/app/src/main/res/layout/gpodnetauth_credentials.xml
@@ -29,6 +29,15 @@
                 android:text="@string/create_account"/>
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/createAccountWarning"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/gpodnetauth_encryption_warning"
+        android:textColor="#F44336"
+        android:textStyle="bold"
+        android:visibility="invisible" />
+
     <com.google.android.material.textfield.TextInputLayout
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/gpodnetauth_credentials.xml
+++ b/app/src/main/res/layout/gpodnetauth_credentials.xml
@@ -30,13 +30,13 @@
     </LinearLayout>
 
     <TextView
-        android:id="@+id/createAccountWarning"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/gpodnetauth_encryption_warning"
-        android:textColor="#F44336"
-        android:textStyle="bold"
-        android:visibility="invisible" />
+            android:id="@+id/createAccountWarning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/gpodnetauth_encryption_warning"
+            android:textColor="#F44336"
+            android:textStyle="bold"
+            android:visibility="invisible" />
 
     <com.google.android.material.textfield.TextInputLayout
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/GpodnetPreferences.java
@@ -26,7 +26,7 @@ public class GpodnetPreferences {
     private static String username;
     private static String password;
     private static String deviceID;
-    private static String hostname;
+    private static String hosturl;
 
     private static boolean preferencesLoaded = false;
 
@@ -40,7 +40,7 @@ public class GpodnetPreferences {
             username = prefs.getString(PREF_GPODNET_USERNAME, null);
             password = prefs.getString(PREF_GPODNET_PASSWORD, null);
             deviceID = prefs.getString(PREF_GPODNET_DEVICEID, null);
-            hostname = checkGpodnetHostname(prefs.getString(PREF_GPODNET_HOSTNAME, GpodnetService.DEFAULT_BASE_HOST));
+            hosturl = prefs.getString(PREF_GPODNET_HOSTNAME, GpodnetService.DEFAULT_BASE_HOST);
 
             preferencesLoaded = true;
         }
@@ -82,17 +82,16 @@ public class GpodnetPreferences {
         writePreference(PREF_GPODNET_DEVICEID, deviceID);
     }
 
-    public static String getHostname() {
+    public static String getHosturl() {
         ensurePreferencesLoaded();
-        return hostname;
+        return hosturl;
     }
 
-    public static void setHostname(String value) {
-        value = checkGpodnetHostname(value);
-        if (!value.equals(hostname)) {
+    public static void setHosturl(String value) {
+        if (!value.equals(hosturl)) {
             logout();
             writePreference(PREF_GPODNET_HOSTNAME, value);
-            hostname = value;
+            hosturl = value;
         }
     }
 
@@ -113,13 +112,4 @@ public class GpodnetPreferences {
         UserPreferences.setGpodnetNotificationsEnabled();
     }
 
-    private static String checkGpodnetHostname(String value) {
-        int startIndex = 0;
-        if (value.startsWith("http://")) {
-            startIndex = "http://".length();
-        } else if (value.startsWith("https://")) {
-            startIndex = "https://".length();
-        }
-        return value.substring(startIndex);
-    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/sync/SyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/SyncService.java
@@ -80,7 +80,7 @@ public class SyncService extends Worker {
         if (!GpodnetPreferences.loggedIn()) {
             return Result.success();
         }
-        syncServiceImpl = new GpodnetService(AntennapodHttpClient.getHttpClient(), GpodnetPreferences.getHostname());
+        syncServiceImpl = new GpodnetService(AntennapodHttpClient.getHttpClient(), GpodnetPreferences.getHosturl());
         SharedPreferences.Editor prefs = getApplicationContext().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
                 .edit();
         prefs.putLong(PREF_LAST_SYNC_ATTEMPT_TIMESTAMP, System.currentTimeMillis()).apply();

--- a/core/src/main/java/de/danoeh/antennapod/core/sync/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/gpoddernet/GpodnetService.java
@@ -77,9 +77,9 @@ public class GpodnetService implements ISyncService {
                 this.basePort = Integer.parseInt(m.group(3));    // regex -> can only be digits
             }
         } else {
-            // no match
+            // URL does not match regex: use it anyway -> this will cause an exception on connect
             this.baseScheme = "https";
-            this.baseHost = baseHosturl;    // use original (malformed) URL -> this will cause an exception on connect
+            this.baseHost = baseHosturl;
             this.basePort = 443;
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/sync/gpoddernet/GpodnetService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/gpoddernet/GpodnetService.java
@@ -79,7 +79,7 @@ public class GpodnetService implements ISyncService {
         } else {
             // no match
             this.baseScheme = "https";
-            this.baseHost = "invalid_host_url.xyz";
+            this.baseHost = baseHosturl;    // use original (malformed) URL -> this will cause an exception on connect
             this.basePort = 443;
         }
 

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -819,5 +819,4 @@
   <string name="on_demand_config_setting_changed">Einstellung erfolgreich aktualisiert.</string>
   <string name="on_demand_config_stream_text">Es sieht so aus als würdest du viel streamen. Möchtest du in Listen den Streamen-Button anzeigen?</string>
   <string name="on_demand_config_download_text">Es sieht so aus als würdest du viel herunterladen. Möchtest du in Listen den Herunterladen-Button anzeigen?</string>
-    <string name="gpodnetauth_encryption_warning">Passwort und Daten sind nicht verschlüsselt!</string>
 </resources>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -819,4 +819,5 @@
   <string name="on_demand_config_setting_changed">Einstellung erfolgreich aktualisiert.</string>
   <string name="on_demand_config_stream_text">Es sieht so aus als würdest du viel streamen. Möchtest du in Listen den Streamen-Button anzeigen?</string>
   <string name="on_demand_config_download_text">Es sieht so aus als würdest du viel herunterladen. Möchtest du in Listen den Herunterladen-Button anzeigen?</string>
+    <string name="gpodnetauth_encryption_warning">Passwort und Daten sind nicht verschlüsselt!</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -653,6 +653,7 @@
     <string name="gpodnet_search_hint">Search gpodder.net</string>
     <string name="gpodnetauth_login_title">Login</string>
     <string name="gpodnetauth_login_butLabel">Login</string>
+    <string name="gpodnetauth_encryption_warning">Password and data are not encrypted!</string>
     <string name="create_account">Create account</string>
     <string name="username_label">Username</string>
     <string name="password_label">Password</string>


### PR DESCRIPTION
It is possible to select a custom sync server for AntennaPod.  However AntennaPod ignores the schema and port number in that URL and uses `https:` and port 443 for all servers.

This is fine for the default server (https://gpodder.net) but it prevents any server in a LAN to take over from gpodder.net as that site seems to be very busy lately and synchronization fails more often than not.

The software behind gpodder.net is open source and available at https://github.com/gpodder/mygpo.  

I managed to set it up, but failed to point AntennaPod to my server.  The reasons being:

 - A normal user can only access ports >= 1024.
 - On a LAN server you could only use self-signed certificates for https - which will most likely fail Androids certificate checks (as it does with other software).

# Current situation

 - The software behind the Preference screen lets you define a custom server but it removes the scheme from the URL.
 - The class that access the server uses the hard-coded values of port 443 and `https` regardless of the original URL.
 
# Changes made

 - The patched version uses not only the hostname but the entire URL (with scheme and port number) and stores it in the preferences instead of the original hostname.
 - The name of the variable holding this value has been changed from `hostname` to `hosturl` to reflect its new content ...
 - ... so has the name of the getter function `getHostname` -> `getHosturl`
 - If a scheme is omitted in the URL it defaults to `https` (like the original function).
 - If a port number is omitted it defaults to the default port of the scheme (443 for `https`, 80 for `http`).
 - The `GpodnetService` functions now use the scheme, hostname and port defined in the URL.
 - The function `checkGpodnetHostname` has been deleted, as its only purpose was to remove the scheme identifier.  The check it was used in still works with the full length URL.
 - The URL is decomposed in the constructor of `GpodnetService` which may fail. As the surrounding app doesn't catch any exceptions the invalid URL will be changed to "https://invalid_host_url.xyz" to indicate this situation.  Let's hope nobody does register this domain ... :-)
 
# Known issues

 - If you specify `http://` in the custom server URL the communication is now unencrypted including username and password (that was the point of this patch). As `http://` should only be used in a local LAN setting the risk is minimal.  However, don't use credentials that are valid elsewhere.
 - In the old version there is no check for the validity of the URL.  If the URL is invalid an error message appears when the app tries to contact the server.
 - In patched version the URL is checked earlier (in the constructor of `GpodnetService`). If fails siltently, but any invalid URL will be replaced by "https://invalid_host_url.xyz" is used to indicate this error condition.

Closes #4809