### PR TITLE
Fixed disappearing drawer toggle

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -186,16 +186,16 @@ public class MainActivity extends CastEnabledActivity {
         }
     };
 
-    public void setupToolbarToggle(@Nullable Toolbar toolbar) {
+    public void setupToolbarToggle(@NonNull Toolbar toolbar, boolean displayUpArrow) {
         if (drawerLayout != null) { // Tablet layout does not have a drawer
             drawerLayout.removeDrawerListener(drawerToggle);
             drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, toolbar,
                     R.string.drawer_open, R.string.drawer_close);
             drawerLayout.addDrawerListener(drawerToggle);
             drawerToggle.syncState();
-            drawerToggle.setDrawerIndicatorEnabled(getSupportFragmentManager().getBackStackEntryCount() == 0);
+            drawerToggle.setDrawerIndicatorEnabled(!displayUpArrow);
             drawerToggle.setToolbarNavigationClickListener(v -> getSupportFragmentManager().popBackStack());
-        } else if (getSupportFragmentManager().getBackStackEntryCount() == 0) {
+        } else if (!displayUpArrow) {
             toolbar.setNavigationIcon(null);
         } else {
             toolbar.setNavigationIcon(ThemeUtils.getDrawableFromAttr(this, R.attr.homeAsUpIndicator));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
@@ -50,9 +50,11 @@ public class AddFeedFragment extends Fragment {
     public static final String TAG = "AddFeedFragment";
     private static final int REQUEST_CODE_CHOOSE_OPML_IMPORT_PATH = 1;
     private static final int REQUEST_CODE_ADD_LOCAL_FOLDER = 2;
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     private AddfeedBinding viewBinding;
     private MainActivity activity;
+    private boolean displayUpArrow;
 
     @Override
     @Nullable
@@ -64,7 +66,11 @@ public class AddFeedFragment extends Fragment {
         activity = (MainActivity) getActivity();
 
         Toolbar toolbar = viewBinding.toolbar;
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
 
         viewBinding.searchItunesButton.setOnClickListener(v
                 -> activity.loadChildFragment(OnlineSearchFragment.newInstance(ItunesPodcastSearcher.class)));
@@ -117,6 +123,12 @@ public class AddFeedFragment extends Fragment {
         viewBinding.searchButton.setOnClickListener(view -> performSearch());
 
         return viewBinding.getRoot();
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     private void showAddViaUrlDialog() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/DownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/DownloadsFragment.java
@@ -28,16 +28,17 @@ public class DownloadsFragment extends PagedToolbarFragment {
     public static final String TAG = "DownloadsFragment";
 
     public static final String ARG_SELECTED_TAB = "selected_tab";
+    private static final String PREF_LAST_TAB_POSITION = "tab_position";
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     public static final int POS_RUNNING = 0;
     private static final int POS_COMPLETED = 1;
     public static final int POS_LOG = 2;
     private static final int TOTAL_COUNT = 3;
 
-    private static final String PREF_LAST_TAB_POSITION = "tab_position";
-
     private ViewPager2 viewPager;
     private TabLayout tabLayout;
+    private boolean displayUpArrow;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -48,7 +49,11 @@ public class DownloadsFragment extends PagedToolbarFragment {
         Toolbar toolbar = root.findViewById(R.id.toolbar);
         toolbar.setTitle(R.string.downloads_label);
         toolbar.inflateMenu(R.menu.downloads);
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
 
         viewPager = root.findViewById(R.id.viewpager);
         viewPager.setAdapter(new DownloadsPagerAdapter(this));
@@ -79,6 +84,12 @@ public class DownloadsFragment extends PagedToolbarFragment {
         viewPager.setCurrentItem(lastPosition, false);
 
         return root;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesFragment.java
@@ -24,6 +24,7 @@ public class EpisodesFragment extends PagedToolbarFragment {
 
     public static final String TAG = "EpisodesFragment";
     private static final String PREF_LAST_TAB_POSITION = "tab_position";
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     private static final int POS_NEW_EPISODES = 0;
     private static final int POS_ALL_EPISODES = 1;
@@ -31,6 +32,7 @@ public class EpisodesFragment extends PagedToolbarFragment {
     private static final int TOTAL_COUNT = 3;
 
     private TabLayout tabLayout;
+    private boolean displayUpArrow;
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -44,7 +46,11 @@ public class EpisodesFragment extends PagedToolbarFragment {
         toolbar.setTitle(R.string.episodes_label);
         toolbar.inflateMenu(R.menu.episodes);
         MenuItemUtils.setupSearchItem(toolbar.getMenu(), (MainActivity) getActivity(), 0, "");
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
 
         ViewPager2 viewPager = rootView.findViewById(R.id.viewpager);
         viewPager.setAdapter(new EpisodesPagerAdapter(this));
@@ -86,6 +92,12 @@ public class EpisodesFragment extends PagedToolbarFragment {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putInt(PREF_LAST_TAB_POSITION, tabLayout.getSelectedTabPosition());
         editor.apply();
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     static class EpisodesPagerAdapter extends FragmentStateAdapter {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -88,6 +88,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         Toolbar.OnMenuItemClickListener {
     private static final String TAG = "ItemlistFragment";
     private static final String ARGUMENT_FEED_ID = "argument.de.danoeh.antennapod.feed_id";
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     private FeedItemListAdapter adapter;
     private MoreContentListFooterUtil nextPageLoader;
@@ -105,6 +106,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     private View header;
     private Toolbar toolbar;
     private ToolbarIconTintManager iconTintManager;
+    private boolean displayUpArrow;
 
     private long feedID;
     private Feed feed;
@@ -145,7 +147,11 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         toolbar = root.findViewById(R.id.toolbar);
         toolbar.inflateMenu(R.menu.feedlist);
         toolbar.setOnMenuItemClickListener(this);
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
         refreshToolbarState();
 
         recyclerView = root.findViewById(R.id.recyclerView);
@@ -228,6 +234,12 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             disposable.dispose();
         }
         adapter = null;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     private final MenuItemUtils.UpdateRefreshMenuItemChecker updateRefreshMenuItemChecker = new MenuItemUtils.UpdateRefreshMenuItemChecker() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 public class PlaybackHistoryFragment extends Fragment implements Toolbar.OnMenuItemClickListener {
     public static final String TAG = "PlaybackHistoryFragment";
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     private List<FeedItem> playbackHistory;
     private PlaybackHistoryListAdapter adapter;
@@ -49,6 +50,7 @@ public class PlaybackHistoryFragment extends Fragment implements Toolbar.OnMenuI
     private EmptyViewHandler emptyView;
     private ProgressBar progressBar;
     private Toolbar toolbar;
+    private boolean displayUpArrow;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -63,7 +65,11 @@ public class PlaybackHistoryFragment extends Fragment implements Toolbar.OnMenuI
         toolbar = root.findViewById(R.id.toolbar);
         toolbar.setTitle(R.string.playback_history_label);
         toolbar.setOnMenuItemClickListener(this);
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
         toolbar.inflateMenu(R.menu.playback_history);
         refreshToolbarState();
 
@@ -96,6 +102,12 @@ public class PlaybackHistoryFragment extends Fragment implements Toolbar.OnMenuI
         if (disposable != null) {
             disposable.dispose();
         }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
@@ -67,6 +68,7 @@ import static de.danoeh.antennapod.dialog.EpisodesApplyActionFragment.ACTION_REM
  */
 public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickListener {
     public static final String TAG = "QueueFragment";
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     private TextView infoBar;
     private EpisodeItemListRecyclerView recyclerView;
@@ -74,6 +76,7 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
     private EmptyViewHandler emptyView;
     private ProgressBar progLoading;
     private Toolbar toolbar;
+    private boolean displayUpArrow;
 
     private List<FeedItem> queue;
 
@@ -420,7 +423,11 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
         View root = inflater.inflate(R.layout.queue_fragment, container, false);
         toolbar = root.findViewById(R.id.toolbar);
         toolbar.setOnMenuItemClickListener(this);
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
         toolbar.inflateMenu(R.menu.queue);
         MenuItemUtils.setupSearchItem(toolbar.getMenu(), (MainActivity) getActivity(), 0, "");
         refreshToolbarState();
@@ -528,6 +535,12 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
         progLoading.setVisibility(View.VISIBLE);
 
         return root;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     private void onFragmentLoaded(final boolean restoreScrollPosition) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.widget.ProgressBar;
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
@@ -66,6 +67,8 @@ public class SubscriptionFragment extends Fragment implements Toolbar.OnMenuItem
     public static final String TAG = "SubscriptionFragment";
     private static final String PREFS = "SubscriptionFragment";
     private static final String PREF_NUM_COLUMNS = "columns";
+    private static final String KEY_UP_ARROW = "up_arrow";
+
     private static final int MIN_NUM_COLUMNS = 2;
     private static final int[] COLUMN_CHECKBOX_IDS = {
             R.id.subscription_num_columns_2,
@@ -84,6 +87,7 @@ public class SubscriptionFragment extends Fragment implements Toolbar.OnMenuItem
 
     private int mPosition = -1;
     private boolean isUpdatingFeeds = false;
+    private boolean displayUpArrow;
 
     private Disposable disposable;
     private SharedPreferences prefs;
@@ -102,7 +106,11 @@ public class SubscriptionFragment extends Fragment implements Toolbar.OnMenuItem
         View root = inflater.inflate(R.layout.fragment_subscriptions, container, false);
         toolbar = root.findViewById(R.id.toolbar);
         toolbar.setOnMenuItemClickListener(this);
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar);
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
         toolbar.inflateMenu(R.menu.subscriptions);
         for (int i = 0; i < COLUMN_CHECKBOX_IDS.length; i++) {
             // Do this in Java to localize numbers
@@ -127,6 +135,12 @@ public class SubscriptionFragment extends Fragment implements Toolbar.OnMenuItem
                     getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
         });
         return root;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     private void refreshToolbarState() {


### PR DESCRIPTION
When the activity is recreated after it was stopped in background,
the BackStackEntryCount is the same for all fragments. The one that
should display the toggle therefore thinks it shouldn't. This change
saves the button state now. This is only needed for top-level fragments.

Closes #4853