### PR TITLE
Remove free build hack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
           build-steps:
             - run:
                 name: Build free (for F-Droid)
-                command: ./gradlew assembleFreeRelease -PdisablePreDex -PfreeBuild
+                command: ./gradlew assembleFreeRelease -PdisablePreDex
 
   static-analysis:
     jobs:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,14 +156,7 @@ android {
 }
 
 dependencies {
-    freeImplementation project(":core")
-    // free build hack: skip some dependencies
-    if (!doFreeBuild()) {
-        playImplementation project(":core")
-        implementation 'com.google.android.play:core:1.8.0'
-    } else {
-        System.out.println("app: free build hack, skipping some dependencies")
-    }
+    implementation project(":core")
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
@@ -199,6 +192,8 @@ dependencies {
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
     implementation 'com.github.skydoves:balloon:1.1.5'
 
+    // Non-free dependencies:
+    playImplementation 'com.google.android.play:core:1.8.0'
     compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
 
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -85,11 +85,6 @@ wrapper {
     gradleVersion = "6.3"
 }
 
-// free build hack: common functions
-def doFreeBuild() {
-    return hasProperty("freeBuild")
-}
-
 apply plugin: "checkstyle"
 checkstyle {
     toolVersion '8.24'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -96,17 +96,12 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.11.8'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
-    // Add casting features
-    // free build hack: skip some dependencies
-    if (!doFreeBuild()) {
-        playApi 'com.google.android.libraries.cast.companionlibrary:ccl:2.9.1'
-        api 'androidx.mediarouter:mediarouter:1.0.0'
-        playApi 'com.google.android.gms:play-services-cast:8.4.0'
-        api "com.google.android.support:wearable:$wearableSupportVersion"
-        compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
-    } else {
-        System.out.println("core: free build hack, skipping some dependencies")
-    }
+    // Non-free dependencies:
+    playApi 'com.google.android.libraries.cast.companionlibrary:ccl:2.9.1'
+    playApi 'androidx.mediarouter:mediarouter:1.0.0'
+    playApi 'com.google.android.gms:play-services-cast:8.4.0'
+    playApi "com.google.android.support:wearable:$wearableSupportVersion"
+    compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
 
     // bundle conscrypt with free builds
     freeImplementation "org.conscrypt:conscrypt-android:$conscryptVersion"


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
The F-Droid build fails because they do not like the line `implementation 'com.google.android.play:core:1.8.0'`, even if it's surrounded by a check. See https://forum.antennapod.org/t/version-2-1-3-on-f-droid/703/

Also closes #4457