### PR TITLE
Playable Refactoring

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/FeedMedia.java
@@ -28,6 +28,7 @@ import de.danoeh.antennapod.core.util.ChapterUtils;
 import de.danoeh.antennapod.core.util.playback.Playable;
 import de.danoeh.antennapod.core.sync.SyncService;
 import de.danoeh.antennapod.core.sync.model.EpisodeAction;
+import de.danoeh.antennapod.core.util.playback.PlayableException;
 
 public class FeedMedia extends FeedFile implements Playable {
     private static final String TAG = "FeedMedia";

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -38,6 +38,7 @@ import de.danoeh.antennapod.core.util.RewindAfterPauseUtils;
 import de.danoeh.antennapod.core.util.playback.AudioPlayer;
 import de.danoeh.antennapod.core.util.playback.IPlayer;
 import de.danoeh.antennapod.core.util.playback.Playable;
+import de.danoeh.antennapod.core.util.playback.PlayableException;
 import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
 import de.danoeh.antennapod.core.util.playback.VideoPlayer;
 
@@ -288,7 +289,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 onPrepared(startWhenPrepared);
             }
 
-        } catch (Playable.PlayableException | IOException | IllegalStateException e) {
+        } catch (PlayableException | IOException | IllegalStateException e) {
             e.printStackTrace();
             setPlayerStatus(PlayerStatus.ERROR, null);
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -78,6 +78,8 @@ import de.danoeh.antennapod.core.util.NetworkUtils;
 import de.danoeh.antennapod.core.util.gui.NotificationUtils;
 import de.danoeh.antennapod.core.util.playback.ExternalMedia;
 import de.danoeh.antennapod.core.util.playback.Playable;
+import de.danoeh.antennapod.core.util.playback.PlayableException;
+import de.danoeh.antennapod.core.util.playback.PlayableUtils;
 import de.danoeh.antennapod.core.util.playback.PlaybackServiceStarter;
 import de.danoeh.antennapod.core.widget.WidgetUpdater;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
@@ -723,7 +725,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     private void startPlayingFromPreferences() {
-        Observable.fromCallable(() -> Playable.PlayableUtils.createInstanceFromPreferences(getApplicationContext()))
+        Observable.fromCallable(() -> PlayableUtils.createInstanceFromPreferences(getApplicationContext()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
@@ -996,7 +998,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         FeedMedia media = (FeedMedia) currentMedia;
         try {
             media.loadMetadata();
-        } catch (Playable.PlayableException e) {
+        } catch (PlayableException e) {
             Log.e(TAG, "Unable to load metadata to get next in queue", e);
             return null;
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -48,6 +48,7 @@ import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.Permutor;
 import de.danoeh.antennapod.core.util.SortOrder;
 import de.danoeh.antennapod.core.util.playback.Playable;
+import de.danoeh.antennapod.core.util.playback.PlayableUtils;
 
 /**
  * Provides methods for writing data to AntennaPod's database.
@@ -382,7 +383,7 @@ public class DBWriter {
             List<FeedItem> updatedItems = new ArrayList<>();
             ItemEnqueuePositionCalculator positionCalculator =
                     new ItemEnqueuePositionCalculator(UserPreferences.getEnqueueLocation());
-            Playable currentlyPlaying = Playable.PlayableUtils.createInstanceFromPreferences(context);
+            Playable currentlyPlaying = PlayableUtils.createInstanceFromPreferences(context);
             int insertPosition = positionCalculator.calcPosition(queue, currentlyPlaying);
             for (long itemId : itemIds) {
                 if (!itemListContains(queue, itemId)) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/Playable.java
@@ -3,14 +3,10 @@ package de.danoeh.antennapod.core.util.playback;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Parcelable;
-import androidx.preference.PreferenceManager;
-import android.util.Log;
+
 import androidx.annotation.Nullable;
 import de.danoeh.antennapod.core.feed.Chapter;
-import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
-import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
-import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.ShownotesProvider;
 import java.util.Date;
 import java.util.List;
@@ -183,100 +179,4 @@ public interface Playable extends Parcelable, ShownotesProvider {
     @Nullable
     String getImageLocation();
 
-    /**
-     * Provides utility methods for Playable objects.
-     */
-    class PlayableUtils {
-        private PlayableUtils(){}
-
-        private static final String TAG = "PlayableUtils";
-
-        /**
-         * Restores a playable object from a sharedPreferences file. This method might load data from the database,
-         * depending on the type of playable that was restored.
-         *
-         * @return The restored Playable object
-         */
-        @Nullable
-        public static Playable createInstanceFromPreferences(Context context) {
-            long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
-            if (currentlyPlayingMedia != PlaybackPreferences.NO_MEDIA_PLAYING) {
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-                return PlayableUtils.createInstanceFromPreferences(context,
-                        (int) currentlyPlayingMedia, prefs);
-            }
-            return null;
-        }
-
-        /**
-         * Restores a playable object from a sharedPreferences file. This method might load data from the database,
-         * depending on the type of playable that was restored.
-         *
-         * @param type An integer that represents the type of the Playable object
-         *             that is restored.
-         * @param pref The SharedPreferences file from which the Playable object
-         *             is restored
-         * @return The restored Playable object
-         */
-        public static Playable createInstanceFromPreferences(Context context, int type,
-                                                             SharedPreferences pref) {
-            Playable result = null;
-            // ADD new Playable types here:
-            switch (type) {
-                case FeedMedia.PLAYABLE_TYPE_FEEDMEDIA:
-                    result = createFeedMediaInstance(pref);
-                    break;
-                case ExternalMedia.PLAYABLE_TYPE_EXTERNAL_MEDIA:
-                    result = createExternalMediaInstance(pref);
-                    break;
-            }
-            if (result == null) {
-                Log.e(TAG, "Could not restore Playable object from preferences");
-            }
-            return result;
-        }
-
-        private static Playable createFeedMediaInstance(SharedPreferences pref) {
-            Playable result = null;
-            long mediaId = pref.getLong(FeedMedia.PREF_MEDIA_ID, -1);
-            if (mediaId != -1) {
-                result =  DBReader.getFeedMedia(mediaId);
-            }
-            return result;
-        }
-
-        private static Playable createExternalMediaInstance(SharedPreferences pref) {
-            Playable result = null;
-            String source = pref.getString(ExternalMedia.PREF_SOURCE_URL, null);
-            String mediaType = pref.getString(ExternalMedia.PREF_MEDIA_TYPE, null);
-            if (source != null && mediaType != null) {
-                int position = pref.getInt(ExternalMedia.PREF_POSITION, 0);
-                long lastPlayedTime = pref.getLong(ExternalMedia.PREF_LAST_PLAYED_TIME, 0);
-                result = new ExternalMedia(source, MediaType.valueOf(mediaType),
-                        position, lastPlayedTime);
-            }
-            return result;
-        }
-    }
-
-    class PlayableException extends Exception {
-        private static final long serialVersionUID = 1L;
-
-        public PlayableException() {
-            super();
-        }
-
-        public PlayableException(String detailMessage, Throwable throwable) {
-            super(detailMessage, throwable);
-        }
-
-        public PlayableException(String detailMessage) {
-            super(detailMessage);
-        }
-
-        public PlayableException(Throwable throwable) {
-            super(throwable);
-        }
-
-    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlayableException.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlayableException.java
@@ -1,0 +1,13 @@
+package de.danoeh.antennapod.core.util.playback;
+
+/**
+ * Exception thrown by {@link Playable} implementations.
+ */
+public class PlayableException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public PlayableException(String detailMessage) {
+        super(detailMessage);
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlayableUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlayableUtils.java
@@ -1,0 +1,90 @@
+package de.danoeh.antennapod.core.util.playback;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
+
+import de.danoeh.antennapod.core.feed.FeedMedia;
+import de.danoeh.antennapod.core.feed.MediaType;
+import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
+import de.danoeh.antennapod.core.storage.DBReader;
+
+/**
+ * Provides utility methods for Playable objects.
+ */
+public abstract class PlayableUtils {
+
+    private static final String TAG = "PlayableUtils";
+
+    /**
+     * Restores a playable object from a sharedPreferences file. This method might load data from the database,
+     * depending on the type of playable that was restored.
+     *
+     * @return The restored Playable object
+     */
+    @Nullable
+    public static Playable createInstanceFromPreferences(@NonNull Context context) {
+        long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
+        if (currentlyPlayingMedia != PlaybackPreferences.NO_MEDIA_PLAYING) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+            return PlayableUtils.createInstanceFromPreferences((int) currentlyPlayingMedia, prefs);
+        }
+        return null;
+    }
+
+    /**
+     * Restores a playable object from a sharedPreferences file. This method might load data from the database,
+     * depending on the type of playable that was restored.
+     *
+     * @param type An integer that represents the type of the Playable object
+     *             that is restored.
+     * @param pref The SharedPreferences file from which the Playable object
+     *             is restored
+     * @return The restored Playable object
+     */
+    private static Playable createInstanceFromPreferences(int type, SharedPreferences pref) {
+        Playable result;
+        // ADD new Playable types here:
+        switch (type) {
+            case FeedMedia.PLAYABLE_TYPE_FEEDMEDIA:
+                result = createFeedMediaInstance(pref);
+                break;
+            case ExternalMedia.PLAYABLE_TYPE_EXTERNAL_MEDIA:
+                result = createExternalMediaInstance(pref);
+                break;
+            default:
+                result = null;
+                break;
+        }
+        if (result == null) {
+            Log.e(TAG, "Could not restore Playable object from preferences");
+        }
+        return result;
+    }
+
+    private static Playable createFeedMediaInstance(SharedPreferences pref) {
+        Playable result = null;
+        long mediaId = pref.getLong(FeedMedia.PREF_MEDIA_ID, -1);
+        if (mediaId != -1) {
+            result =  DBReader.getFeedMedia(mediaId);
+        }
+        return result;
+    }
+
+    private static Playable createExternalMediaInstance(SharedPreferences pref) {
+        Playable result = null;
+        String source = pref.getString(ExternalMedia.PREF_SOURCE_URL, null);
+        String mediaType = pref.getString(ExternalMedia.PREF_MEDIA_TYPE, null);
+        if (source != null && mediaType != null) {
+            int position = pref.getInt(ExternalMedia.PREF_POSITION, 0);
+            long lastPlayedTime = pref.getLong(ExternalMedia.PREF_LAST_PLAYED_TIME, 0);
+            result = new ExternalMedia(source, MediaType.valueOf(mediaType),
+                    position, lastPlayedTime);
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -28,7 +28,6 @@ import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.service.playback.PlaybackServiceMediaPlayer;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
-import de.danoeh.antennapod.core.util.playback.Playable.PlayableUtils;
 import de.danoeh.antennapod.ui.common.ThemeUtils;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeOnSubscribe;

--- a/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdaterJobService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdaterJobService.java
@@ -8,6 +8,7 @@ import de.danoeh.antennapod.core.feed.util.PlaybackSpeedUtils;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.service.playback.PlayerStatus;
 import de.danoeh.antennapod.core.util.playback.Playable;
+import de.danoeh.antennapod.core.util.playback.PlayableUtils;
 
 public class WidgetUpdaterJobService extends SafeJobIntentService {
     private static final int JOB_ID = -17001;
@@ -22,7 +23,7 @@ public class WidgetUpdaterJobService extends SafeJobIntentService {
 
     @Override
     protected void onHandleWork(@NonNull Intent intent) {
-        Playable media = Playable.PlayableUtils.createInstanceFromPreferences(getApplicationContext());
+        Playable media = PlayableUtils.createInstanceFromPreferences(getApplicationContext());
         if (media != null) {
             WidgetUpdater.updateWidget(this, new WidgetUpdater.WidgetState(media, PlayerStatus.STOPPED,
                     media.getPosition(), media.getDuration(), PlaybackSpeedUtils.getCurrentPlaybackSpeed(media),

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastUtils.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastUtils.java
@@ -10,6 +10,7 @@ import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.common.images.WebImage;
 
+import de.danoeh.antennapod.core.util.playback.PlayableException;
 import de.danoeh.antennapod.core.util.playback.RemoteMedia;
 import java.util.Calendar;
 import java.util.List;
@@ -93,7 +94,7 @@ public class CastUtils {
         MediaMetadata metadata = new MediaMetadata(MediaMetadata.MEDIA_TYPE_GENERIC);
         try{
             media.loadMetadata();
-        } catch (Playable.PlayableException e) {
+        } catch (PlayableException e) {
             Log.e(TAG, "Unable to load FeedMedia metadata", e);
         }
         FeedItem feedItem = media.getItem();
@@ -202,7 +203,7 @@ public class CastUtils {
                         } else {
                             Log.d(TAG, "FeedMedia object obtained does NOT match the MediaInfo provided. id=" + mediaId);
                         }
-                    } catch (Playable.PlayableException e) {
+                    } catch (PlayableException e) {
                         Log.e(TAG, "Unable to load FeedMedia metadata to compare with MediaInfo", e);
                     }
                 } else {

--- a/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/service/playback/RemotePSMP.java
@@ -28,6 +28,7 @@ import de.danoeh.antennapod.core.cast.CastConsumer;
 import de.danoeh.antennapod.core.cast.CastManager;
 import de.danoeh.antennapod.core.cast.CastUtils;
 import de.danoeh.antennapod.core.cast.DefaultCastConsumer;
+import de.danoeh.antennapod.core.util.playback.PlayableException;
 import de.danoeh.antennapod.core.util.playback.RemoteMedia;
 import de.danoeh.antennapod.core.feed.FeedMedia;
 import de.danoeh.antennapod.core.feed.MediaType;
@@ -360,7 +361,7 @@ public class RemotePSMP extends PlaybackServiceMediaPlayer {
             if (prepareImmediately) {
                 prepare();
             }
-        } catch (Playable.PlayableException e) {
+        } catch (PlayableException e) {
             Log.e(TAG, "Error while loading media metadata", e);
             setPlayerStatus(PlayerStatus.STOPPED, null);
         }


### PR DESCRIPTION
Refactoring: Move inner classes `PlayableUtils` and `PlayableException` out of `Playable`.

This was discussed in https://github.com/AntennaPod/AntennaPod/pull/4911#discussion_r568122621.