### PR TITLE
Avoid the stuck download notification

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -172,8 +172,7 @@ public class DownloadService extends Service {
             setupNotificationUpdaterIfNecessary();
             syncExecutor.execute(() -> onDownloadQueued(intent));
         } else if (numberOfDownloads.get() == 0) {
-            stopForeground(true);
-            stopSelf();
+            shutdown();
         } else {
             Log.d(TAG, "onStartCommand: Unknown intent");
         }
@@ -226,10 +225,6 @@ public class DownloadService extends Service {
             downloadPostFuture.cancel(true);
         }
         unregisterReceiver(cancelDownloadReceiver);
-
-        stopForeground(true);
-        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        nm.cancel(R.id.notification_downloading);
 
         // if this was the initial gpodder sync, i.e. we just synced the feeds successfully,
         // it is now time to sync the episode actions
@@ -550,14 +545,7 @@ public class DownloadService extends Service {
 
         if (numberOfDownloads.get() <= 0 && DownloadRequester.getInstance().hasNoDownloads()) {
             Log.d(TAG, "Attempting shutdown");
-            stopForeground(true);
-            stopSelf();
-
-            // Trick to hide the notification more quickly when the service is stopped
-            // Without this, the second-last update of the notification stays for 3 seconds after onDestroy returns
-            notificationUpdater.run();
-            NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-            nm.cancel(R.id.notification_downloading);
+            shutdown();
         }
     }
 
@@ -646,5 +634,15 @@ public class DownloadService extends Service {
             downloadPostFuture = schedExecutor.scheduleAtFixedRate(
                     new PostDownloaderTask(downloads), 1, 1, TimeUnit.SECONDS);
         }
+    }
+
+    private void shutdown() {
+        // If the service was run for a very short time, the system may delay closing
+        // the notification. Set the notification text now so that a misleading message
+        // is not left on the notification.
+        notificationUpdater.run();
+        cancelNotificationUpdater();
+        stopForeground(true);
+        stopSelf();
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
@@ -53,7 +53,7 @@ public class DownloadServiceNotification {
         String contentTitle = context.getString(R.string.download_notification_title);
         String downloadsLeft = (numDownloads > 0)
                 ? context.getResources().getQuantityString(R.plurals.downloads_left, numDownloads, numDownloads)
-                : context.getString(R.string.downloads_processing);
+                : context.getString(R.string.service_shutting_down);
         String bigText = compileNotificationString(downloads);
 
         notificationCompatBuilder.setContentTitle(contentTitle);

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -270,7 +270,7 @@
         <item quantity="one">%d download left</item>
         <item quantity="other">%d downloads left</item>
     </plurals>
-    <string name="downloads_processing">Processing downloads</string>
+    <string name="service_shutting_down">Service shutting down</string>
     <string name="download_notification_title">Downloading podcast data</string>
     <plurals name="download_report_content">
         <item quantity="one">%d download succeeded, %d failed</item>


### PR DESCRIPTION
Cancel the periodic updater before calling stopForeground so
that the notification can't come back after it has been closed.

Remove the workaround for API 30 slow notification closing because
it can cause a stuck notification. However, in order to avoid misleading
text being left on the notification if it closes slowly, ensure that
the "0 downloads" text is written to the notification when shutting down.

Fixes #4556