### PR TITLE
Make it easier to understand why downloads failed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/DownloadLogAdapter.java
@@ -68,16 +68,14 @@ public class DownloadLogAdapter extends BaseAdapter {
             holder.icon.setContentDescription(context.getString(R.string.download_successful));
             holder.secondaryActionButton.setVisibility(View.INVISIBLE);
             holder.reason.setVisibility(View.GONE);
+            holder.tapForDetails.setVisibility(View.GONE);
         } else {
             holder.icon.setTextColor(ContextCompat.getColor(context, R.color.download_failed_red));
             holder.icon.setText("{fa-times-circle}");
             holder.icon.setContentDescription(context.getString(R.string.error_label));
-            String reasonText = status.getReason().getErrorString(context);
-            if (status.getReasonDetailed() != null) {
-                reasonText += ": " + status.getReasonDetailed();
-            }
-            holder.reason.setText(reasonText);
+            holder.reason.setText(status.getReason().getErrorString(context));
             holder.reason.setVisibility(View.VISIBLE);
+            holder.tapForDetails.setVisibility(View.VISIBLE);
 
             if (newerWasSuccessful(position, status.getFeedfileType(), status.getFeedfileId())) {
                 holder.secondaryActionButton.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/DownloadItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/DownloadItemViewHolder.java
@@ -20,6 +20,7 @@ public class DownloadItemViewHolder extends RecyclerView.ViewHolder {
     public final TextView type;
     public final TextView date;
     public final TextView reason;
+    public final TextView tapForDetails;
 
     public DownloadItemViewHolder(Context context, ViewGroup parent) {
         super(LayoutInflater.from(context).inflate(R.layout.downloadlog_item, parent, false));
@@ -27,6 +28,7 @@ public class DownloadItemViewHolder extends RecyclerView.ViewHolder {
         type = itemView.findViewById(R.id.txtvType);
         icon = itemView.findViewById(R.id.txtvIcon);
         reason = itemView.findViewById(R.id.txtvReason);
+        tapForDetails = itemView.findViewById(R.id.txtvTapForDetails);
         secondaryActionButton = itemView.findViewById(R.id.secondaryActionButton);
         secondaryActionIcon = itemView.findViewById(R.id.secondaryActionIcon);
         title = itemView.findViewById(R.id.txtvTitle);

--- a/app/src/main/res/layout/downloadlog_item.xml
+++ b/app/src/main/res/layout/downloadlog_item.xml
@@ -83,6 +83,14 @@
                 android:textColor="?android:attr/textColorSecondary"
                 tools:text="@string/design_time_downloaded_log_failure_reason"/>
 
+        <TextView
+                android:id="@+id/txtvTapForDetails"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:textColor="?android:attr/textColorSecondary"
+                android:text="@string/download_error_tap_for_details"/>
+
     </LinearLayout>
 
     <include layout="@layout/secondary_action"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceNotification.java
@@ -109,6 +109,23 @@ public class DownloadServiceNotification {
         return sb.toString();
     }
 
+    private String createFailedDownloadNotificationContent(List<DownloadStatus> statuses) {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < statuses.size(); i++) {
+            if (statuses.get(i).isSuccessful()) {
+                continue;
+            }
+            sb.append("• ").append(statuses.get(i).getTitle());
+            sb.append(": ").append(statuses.get(i).getReason().getErrorString(context));
+            if (i != statuses.size() - 1) {
+                sb.append("\n");
+            }
+        }
+
+        return sb.toString();
+    }
+
     /**
      * Creates a notification at the end of the service lifecycle to notify the
      * user about the number of completed downloads. A report will only be
@@ -156,11 +173,7 @@ public class DownloadServiceNotification {
                 iconId = R.drawable.ic_notification_sync_error;
                 intent = ClientConfig.downloadServiceCallbacks.getReportNotificationContentIntent(context);
                 id = R.id.notification_download_report;
-                content = context.getResources()
-                        .getQuantityString(R.plurals.download_report_content,
-                                successfulDownloads,
-                                successfulDownloads,
-                                failedDownloads);
+                content = createFailedDownloadNotificationContent(reportQueue);
             }
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -267,6 +267,9 @@ public class HttpDownloader extends Downloader {
                         onFail(DownloadError.ERROR_IO_BLOCKED, e.getMessage());
                         return;
                     }
+                } else if (message.contains("Trust anchor for certification path not found")) {
+                    onFail(DownloadError.ERROR_CERTIFICATE, e.getMessage());
+                    return;
                 }
             }
             onFail(DownloadError.ERROR_IO_ERROR, e.getMessage());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/HttpDownloader.java
@@ -137,6 +137,9 @@ public class HttpDownloader extends Downloader {
                 } else if (response.code() == HttpURLConnection.HTTP_FORBIDDEN) {
                     error = DownloadError.ERROR_FORBIDDEN;
                     details = String.valueOf(response.code());
+                } else if (response.code() == HttpURLConnection.HTTP_NOT_FOUND) {
+                    error = DownloadError.ERROR_NOT_FOUND;
+                    details = String.valueOf(response.code());
                 } else {
                     error = DownloadError.ERROR_HTTP_DATA_ERROR;
                     details = String.valueOf(response.code());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedParserTask.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedParserTask.java
@@ -58,6 +58,9 @@ public class FeedParserTask implements Callable<FeedHandlerResult> {
             e.printStackTrace();
             successful = false;
             reason = DownloadError.ERROR_UNSUPPORTED_TYPE;
+            if ("html".equalsIgnoreCase(e.getRootElement())) {
+                reason = DownloadError.ERROR_UNSUPPORTED_TYPE_HTML;
+            }
             reasonDetailed = e.getMessage();
         } catch (InvalidFeedException e) {
             e.printStackTrace();

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/UnsupportedFeedtypeException.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/handler/UnsupportedFeedtypeException.java
@@ -36,9 +36,6 @@ public class UnsupportedFeedtypeException extends Exception {
         if (message != null) {
             return message;
         } else if (type == TypeGetter.Type.INVALID) {
-            if ("html".equals(rootElement)) {
-                return "The server returned a website, not a podcast feed";
-            }
             return "Invalid type";
         } else {
             return "Type " + type + " not supported";

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
@@ -26,7 +26,8 @@ public enum DownloadError {
     ERROR_IO_WRONG_SIZE(17, R.string.download_error_wrong_size),
     ERROR_IO_BLOCKED(18, R.string.download_error_blocked),
     ERROR_UNSUPPORTED_TYPE_HTML(19, R.string.download_error_unsupported_type_html),
-    ERROR_NOT_FOUND(20, R.string.download_error_not_found);
+    ERROR_NOT_FOUND(20, R.string.download_error_not_found),
+    ERROR_CERTIFICATE(21, R.string.download_error_certificate);
 
     private final int code;
     private final int resId;

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
@@ -23,7 +23,8 @@ public enum DownloadError {
     ERROR_UNAUTHORIZED(14, R.string.download_error_unauthorized),
     ERROR_FILE_TYPE(15, R.string.download_error_file_type_type),
     ERROR_FORBIDDEN(16, R.string.download_error_forbidden),
-    ERROR_IO_WRONG_SIZE(17, R.string.download_wrong_size);
+    ERROR_IO_WRONG_SIZE(17, R.string.download_wrong_size),
+    ERROR_IO_BLOCKED(18, R.string.download_blocked);
 
     private final int code;
     private final int resId;

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
@@ -6,51 +6,50 @@ import de.danoeh.antennapod.core.R;
 
 /** Utility class for Download Errors. */
 public enum DownloadError {
-	SUCCESS(0, R.string.download_successful),
-	ERROR_PARSER_EXCEPTION(1, R.string.download_error_parser_exception),
-	ERROR_UNSUPPORTED_TYPE(2, R.string.download_error_unsupported_type),
-	ERROR_CONNECTION_ERROR(3, R.string.download_error_connection_error),
-	ERROR_MALFORMED_URL(4, R.string.download_error_error_unknown),
-	ERROR_IO_ERROR(5, R.string.download_error_io_error),
-	ERROR_FILE_EXISTS(6, R.string.download_error_error_unknown),
-	ERROR_DOWNLOAD_CANCELLED(7, R.string.download_error_error_unknown),
-	ERROR_DEVICE_NOT_FOUND(8, R.string.download_error_device_not_found),
-	ERROR_HTTP_DATA_ERROR(9, R.string.download_error_http_data_error),
-	ERROR_NOT_ENOUGH_SPACE(10, R.string.download_error_insufficient_space),
-	ERROR_UNKNOWN_HOST(11, R.string.download_error_unknown_host),
-	ERROR_REQUEST_ERROR(12, R.string.download_error_request_error),
-	ERROR_DB_ACCESS_ERROR(13, R.string.download_error_db_access),
-	ERROR_UNAUTHORIZED(14, R.string.download_error_unauthorized),
-	ERROR_FILE_TYPE(15, R.string.download_error_file_type_type),
-	ERROR_FORBIDDEN(16, R.string.download_error_forbidden),
-	ERROR_IO_WRONG_SIZE(17, R.string.download_wrong_size);
+    SUCCESS(0, R.string.download_successful),
+    ERROR_PARSER_EXCEPTION(1, R.string.download_error_parser_exception),
+    ERROR_UNSUPPORTED_TYPE(2, R.string.download_error_unsupported_type),
+    ERROR_CONNECTION_ERROR(3, R.string.download_error_connection_error),
+    ERROR_MALFORMED_URL(4, R.string.download_error_error_unknown),
+    ERROR_IO_ERROR(5, R.string.download_error_io_error),
+    ERROR_FILE_EXISTS(6, R.string.download_error_error_unknown),
+    ERROR_DOWNLOAD_CANCELLED(7, R.string.download_error_error_unknown),
+    ERROR_DEVICE_NOT_FOUND(8, R.string.download_error_device_not_found),
+    ERROR_HTTP_DATA_ERROR(9, R.string.download_error_http_data_error),
+    ERROR_NOT_ENOUGH_SPACE(10, R.string.download_error_insufficient_space),
+    ERROR_UNKNOWN_HOST(11, R.string.download_error_unknown_host),
+    ERROR_REQUEST_ERROR(12, R.string.download_error_request_error),
+    ERROR_DB_ACCESS_ERROR(13, R.string.download_error_db_access),
+    ERROR_UNAUTHORIZED(14, R.string.download_error_unauthorized),
+    ERROR_FILE_TYPE(15, R.string.download_error_file_type_type),
+    ERROR_FORBIDDEN(16, R.string.download_error_forbidden),
+    ERROR_IO_WRONG_SIZE(17, R.string.download_wrong_size);
 
-	private final int code;
-	private final int resId;
+    private final int code;
+    private final int resId;
 
-	DownloadError(int code, int resId) {
-		this.code = code;
-		this.resId = resId;
-	}
+    DownloadError(int code, int resId) {
+        this.code = code;
+        this.resId = resId;
+    }
 
-	/** Return DownloadError from its associated code. */
-	public static DownloadError fromCode(int code) {
-		for (DownloadError reason : values()) {
-			if (reason.getCode() == code) {
-				return reason;
-			}
-		}
-		throw new IllegalArgumentException("unknown code: " + code);
-	}
+    /** Return DownloadError from its associated code. */
+    public static DownloadError fromCode(int code) {
+        for (DownloadError reason : values()) {
+            if (reason.getCode() == code) {
+                return reason;
+            }
+        }
+        throw new IllegalArgumentException("unknown code: " + code);
+    }
 
-	/** Get machine-readable code. */
-	public int getCode() {
-		return code;
-	}
+    /** Get machine-readable code. */
+    public int getCode() {
+        return code;
+    }
 
-	/** Get a human-readable string. */
-	public String getErrorString(Context context) {
-		return context.getString(resId);
-	}
-
+    /** Get a human-readable string. */
+    public String getErrorString(Context context) {
+        return context.getString(resId);
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DownloadError.java
@@ -13,7 +13,7 @@ public enum DownloadError {
     ERROR_MALFORMED_URL(4, R.string.download_error_error_unknown),
     ERROR_IO_ERROR(5, R.string.download_error_io_error),
     ERROR_FILE_EXISTS(6, R.string.download_error_error_unknown),
-    ERROR_DOWNLOAD_CANCELLED(7, R.string.download_error_error_unknown),
+    ERROR_DOWNLOAD_CANCELLED(7, R.string.download_canceled_msg),
     ERROR_DEVICE_NOT_FOUND(8, R.string.download_error_device_not_found),
     ERROR_HTTP_DATA_ERROR(9, R.string.download_error_http_data_error),
     ERROR_NOT_ENOUGH_SPACE(10, R.string.download_error_insufficient_space),
@@ -23,8 +23,10 @@ public enum DownloadError {
     ERROR_UNAUTHORIZED(14, R.string.download_error_unauthorized),
     ERROR_FILE_TYPE(15, R.string.download_error_file_type_type),
     ERROR_FORBIDDEN(16, R.string.download_error_forbidden),
-    ERROR_IO_WRONG_SIZE(17, R.string.download_wrong_size),
-    ERROR_IO_BLOCKED(18, R.string.download_blocked);
+    ERROR_IO_WRONG_SIZE(17, R.string.download_error_wrong_size),
+    ERROR_IO_BLOCKED(18, R.string.download_error_blocked),
+    ERROR_UNSUPPORTED_TYPE_HTML(19, R.string.download_error_unsupported_type_html),
+    ERROR_NOT_FOUND(20, R.string.download_error_not_found);
 
     private final int code;
     private final int resId;

--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -156,7 +156,6 @@
   <string name="hide_not_queued_episodes_label">ليس ضمن لائحة الاستماع</string>
   <string name="hide_has_media_label">فيها وسائط</string>
   <string name="filtered_label">مصفى</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} التحديث الأخير فشل</string>
   <string name="open_podcast">افتح البودكاست</string>
   <string name="please_wait_for_data">نرجو الانتظار حتى يتم تحميل البيانات</string>
   <!--actions on feeditems-->
@@ -237,16 +236,12 @@
   <string name="download_error_details">تفاصيل</string>
   <string name="download_error_details_message">%1$s \n\nURL الملف:\n%2$s</string>
   <string name="download_error_device_not_found">جهاز التخزين غير موجود</string>
-  <string name="download_error_insufficient_space">مساحة غير كافية</string>
   <string name="download_error_http_data_error">خطاء فى بيانات HTTP</string>
   <string name="download_error_error_unknown">خطاء غير معروف</string>
-  <string name="download_error_parser_exception">خطأ تلقيم</string>
   <string name="download_error_unsupported_type">نمط قناة غير مدعوم</string>
   <string name="download_error_connection_error">خطاء فى الاتصال</string>
-  <string name="download_error_unknown_host">المضيف غير معروف</string>
   <string name="download_error_unauthorized">خطاء فى التحقق</string>
   <string name="download_error_file_type_type">خطأ في نوع الملف</string>
-  <string name="download_error_forbidden">ممنوع</string>
   <string name="download_canceled_msg">ألغي التنزيل</string>
   <string name="download_canceled_autodownload_enabled_msg">ألغي التنزيل\nمعطل <i>التنزيل التلقائي</i> لهذه المادة</string>
   <string name="download_report_title">أنتهى التنزيل مع خطأ (او أكثر)</string>
@@ -264,16 +259,7 @@
     <item quantity="many">%d تنزيلات بقت</item>
     <item quantity="other">%d تنزيلات بقت</item>
   </plurals>
-  <string name="downloads_processing">نعالج التنزيلات</string>
   <string name="download_notification_title">تنزيل بيانات البودكاست</string>
-  <plurals name="download_report_content">
-    <item quantity="zero">%d تنزيلة نجحت, %d فشلت</item>
-    <item quantity="one">%d تنزيلة نجحت, %d فشلت</item>
-    <item quantity="two">%d تنزيلان نجحا, %d فشلت</item>
-    <item quantity="few">%d تنزيلات نجحت, %d فشلت</item>
-    <item quantity="many">%d تنزيلات نجحت, %d فشلت</item>
-    <item quantity="other">%d تنزيلات نجحت, %d فشلت</item>
-  </plurals>
   <string name="download_log_title_unknown">عنوان غير معروف</string>
   <string name="download_type_feed">قناة</string>
   <string name="download_type_media">ملف وسائط</string>

--- a/core/src/main/res/values-br/strings.xml
+++ b/core/src/main/res/values-br/strings.xml
@@ -142,7 +142,6 @@
   <string name="hide_not_queued_episodes_label">N\'emañ ket el lost</string>
   <string name="hide_has_media_label">Gant ur media</string>
   <string name="filtered_label">Silet</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} C\'hwitet war an azgrenaat diwezhañ</string>
   <string name="open_podcast">Digeriñ ar podskignad</string>
   <string name="please_wait_for_data">Gortozit dibenn pellgargadur ar roadennoù</string>
   <!--actions on feeditems-->
@@ -218,16 +217,12 @@
   <string name="download_error_details">Munudoù</string>
   <string name="download_error_details_message">%1$s \n\nURL ar restr:\n%2$s</string>
   <string name="download_error_device_not_found">N\'eo ket bet kavet ar c\'hadaviñ</string>
-  <string name="download_error_insufficient_space">N\'eus ket trawalc\'h a blas</string>
   <string name="download_error_http_data_error">Fazi roadennoù HTTP</string>
   <string name="download_error_error_unknown">Fazi dianav</string>
-  <string name="download_error_parser_exception">Kemennadenn Fazi</string>
   <string name="download_error_unsupported_type">Doare lanv anskor</string>
   <string name="download_error_connection_error">Fazi kennaskañ</string>
-  <string name="download_error_unknown_host">Ostiz dianav</string>
   <string name="download_error_unauthorized">Fazi dilesa</string>
   <string name="download_error_file_type_type">Fazi rizh ar restr</string>
-  <string name="download_error_forbidden">Difennet</string>
   <string name="download_canceled_msg">Pellgargadur nullet</string>
   <string name="download_canceled_autodownload_enabled_msg">Pellgargadur nullet\nDiweredekaet ar <i>pellgargadur emgefreek</i> evit an elfenn-mañ</string>
   <string name="download_report_title">Pellgargañ echuet gant fazi(où)</string>
@@ -244,7 +239,6 @@
     <item quantity="many">%d a bellgargadurioù a chom</item>
     <item quantity="other">%d pellgargadur a chom</item>
   </plurals>
-  <string name="downloads_processing">O keweriañ ar pellgargadennoù</string>
   <string name="download_notification_title">O pellgargañ roadennoù ar podskignad</string>
   <string name="download_log_title_unknown">Titl dianav</string>
   <string name="download_type_feed">Lanv</string>

--- a/core/src/main/res/values-ca/strings.xml
+++ b/core/src/main/res/values-ca/strings.xml
@@ -133,7 +133,6 @@
   <string name="hide_not_queued_episodes_label">No en cua</string>
   <string name="hide_has_media_label">Conté medis</string>
   <string name="filtered_label">Filtrat</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Darrera actualització fallida</string>
   <string name="open_podcast">Obrir podcast</string>
   <string name="please_wait_for_data">Per favor, espera fins a que les dades estiguen carregades</string>
   <!--actions on feeditems-->
@@ -194,16 +193,12 @@
   <string name="download_error_details">Detalls</string>
   <string name="download_error_details_message">%1$s \n\nURL del fitxer:\n%2$s</string>
   <string name="download_error_device_not_found">No s\'ha trobat cap dispositiu d\'emmagatzemament</string>
-  <string name="download_error_insufficient_space">No hi ha prou espai</string>
   <string name="download_error_http_data_error">Error de dades HTTP</string>
   <string name="download_error_error_unknown">Error desconegut</string>
-  <string name="download_error_parser_exception">Error de l\'analitzador</string>
   <string name="download_error_unsupported_type">Tipus de canal no suportat</string>
   <string name="download_error_connection_error">Error de connexió</string>
-  <string name="download_error_unknown_host">Amfitrió desconegut</string>
   <string name="download_error_unauthorized">Error d\'autenticació</string>
   <string name="download_error_file_type_type">Error de tipus de fitxer</string>
-  <string name="download_error_forbidden">Prohibit</string>
   <string name="download_canceled_msg">S\'ha cancel·lat la baixada</string>
   <string name="download_canceled_autodownload_enabled_msg">Baixada cancel·lada\nDesactivada les <i>baixades automàtiques</i> per aquest element</string>
   <string name="download_report_title">Baixades completades amb error(s)</string>
@@ -217,7 +212,6 @@
     <item quantity="one">%d baixada pendent</item>
     <item quantity="other">%d baixades pendents</item>
   </plurals>
-  <string name="downloads_processing">S\'estan processant les baixades</string>
   <string name="download_notification_title">S\'estan baixant les dades del podcast</string>
   <string name="download_log_title_unknown">Títol desconegut</string>
   <string name="download_type_feed">Canal</string>

--- a/core/src/main/res/values-cs/strings.xml
+++ b/core/src/main/res/values-cs/strings.xml
@@ -158,7 +158,6 @@
   <string name="hide_not_queued_episodes_label">Mimo frontu</string>
   <string name="hide_has_media_label">Obsahuje média</string>
   <string name="filtered_label">Filtrované</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Poslední aktualizace selhala</string>
   <string name="open_podcast">Otevřít podcast</string>
   <string name="please_wait_for_data">Počkejte prosím na dokončení načítání</string>
   <!--actions on feeditems-->
@@ -229,16 +228,12 @@
   <string name="download_error_details">Detaily</string>
   <string name="download_error_details_message">%1$s \n\nURL souboru:\n%2$s</string>
   <string name="download_error_device_not_found">Úložné zařízení nenalezeno</string>
-  <string name="download_error_insufficient_space">Nedostatek volného místa</string>
   <string name="download_error_http_data_error">HTTP chyba</string>
   <string name="download_error_error_unknown">Neznámá chyba</string>
-  <string name="download_error_parser_exception">Výjimka parseru</string>
   <string name="download_error_unsupported_type">Nepodporovaný typ kanálu</string>
   <string name="download_error_connection_error">Chyba spojení</string>
-  <string name="download_error_unknown_host">Neznámý host</string>
   <string name="download_error_unauthorized">Chyba přihlášení</string>
   <string name="download_error_file_type_type">Chyba typu souboru</string>
-  <string name="download_error_forbidden">Zákázáno</string>
   <string name="download_canceled_msg">Stahování zrušeno</string>
   <string name="download_canceled_autodownload_enabled_msg">Stahování zrušeno\nVypnuto <i>automatické stahování</i> této položky</string>
   <string name="download_report_title">Stahování dokončeno s chybou</string>
@@ -254,14 +249,7 @@
     <item quantity="many">%d čekajících na stažení</item>
     <item quantity="other">%d čekajících na stažení</item>
   </plurals>
-  <string name="downloads_processing">Probíhá stahování</string>
   <string name="download_notification_title">Stahuji podcast data</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d úspěšné stažení, %d selhalo</item>
-    <item quantity="few">%d úspěšná stažení, %d selhala</item>
-    <item quantity="many">%d úspěšných stažení, %d selhalo</item>
-    <item quantity="other">%d úspěšných stažení, %d selhalo</item>
-  </plurals>
   <string name="download_log_title_unknown">Neznámý název</string>
   <string name="download_type_feed">Kanál</string>
   <string name="download_type_media">Soubor</string>

--- a/core/src/main/res/values-da/strings.xml
+++ b/core/src/main/res/values-da/strings.xml
@@ -163,7 +163,6 @@
   <string name="hide_not_queued_episodes_label">Ikke sat i kø</string>
   <string name="hide_has_media_label">Har medier</string>
   <string name="filtered_label">Filtrerede</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Sidste opdatering fejlede</string>
   <string name="open_podcast">Åbn podcast</string>
   <string name="please_wait_for_data">Vær venlig og vent til data\'et er indlæst</string>
   <!--actions on feeditems-->
@@ -228,16 +227,12 @@
   <string name="download_error_details">Detaljer</string>
   <string name="download_error_details_message">%1$s \n\nFil-URL:\n%2$s</string>
   <string name="download_error_device_not_found">Kan ikke finde lagerenhed</string>
-  <string name="download_error_insufficient_space">Ikke nok plads</string>
   <string name="download_error_http_data_error">HTTP-datafejl</string>
   <string name="download_error_error_unknown">Ukendt fejl</string>
-  <string name="download_error_parser_exception">Parser-undtagelse</string>
   <string name="download_error_unsupported_type">Feedets type er ikke understøttet</string>
   <string name="download_error_connection_error">Forbindelsesfejl</string>
-  <string name="download_error_unknown_host">Ukendt vært</string>
   <string name="download_error_unauthorized">Godkendelsesfejl</string>
   <string name="download_error_file_type_type">Filtypefejl</string>
-  <string name="download_error_forbidden">Adgang nægtet</string>
   <string name="download_canceled_msg">Overførsel annulleret</string>
   <string name="download_canceled_autodownload_enabled_msg">Overførsel annulleret\n<i>Automatisk overførsel</i> blev slået fra for dette element</string>
   <string name="download_report_title">Overførsler afsluttet med fejl</string>
@@ -251,12 +246,7 @@
     <item quantity="one">%d overførsel mangler</item>
     <item quantity="other">%d overførsler mangler</item>
   </plurals>
-  <string name="downloads_processing">Bearbejder overførte data</string>
   <string name="download_notification_title">Henter podcast-data</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d overførsel lykkedes, %d fejlede</item>
-    <item quantity="other">%d overførsler lykkedes, %d fejlede</item>
-  </plurals>
   <string name="download_log_title_unknown">Ukendt titel</string>
   <string name="download_type_feed">Feed</string>
   <string name="download_type_media">Mediefil</string>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -164,7 +164,6 @@
   <string name="hide_not_queued_episodes_label">Nicht in Warteschlange</string>
   <string name="hide_has_media_label">Hat Medien</string>
   <string name="filtered_label">Gefiltert</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Aktualisierung fehlgeschlagen</string>
   <string name="open_podcast">Podcast öffnen</string>
   <string name="please_wait_for_data">Bitte warte, bis die Daten geladen sind</string>
   <!--actions on feeditems-->
@@ -229,18 +228,13 @@
   <string name="download_error_details">Details</string>
   <string name="download_error_details_message">%1$s \n\nDatei-URL:\n%2$s</string>
   <string name="download_error_device_not_found">Speichermedium nicht gefunden</string>
-  <string name="download_error_insufficient_space">Zu wenig Speicherplatz</string>
   <string name="download_error_http_data_error">HTTP Datenfehler</string>
   <string name="download_error_error_unknown">Unbekannter Fehler</string>
-  <string name="download_error_parser_exception">Parserfehler</string>
   <string name="download_error_unsupported_type">Nicht unterstützter Feed-Typ</string>
   <string name="download_error_connection_error">Verbindungsfehler</string>
-  <string name="download_error_unknown_host">Unbekannter Host</string>
   <string name="download_error_unauthorized">Authentifizierungsfehler</string>
   <string name="download_error_file_type_type">Dateityp-Fehler</string>
-  <string name="download_error_forbidden">Verboten</string>
   <string name="download_canceled_msg">Download abgebrochen</string>
-  <string name="download_wrong_size">Die Verbindung zum Server wurde unterbrochen bevor der Download abgeschlossen werden konnte.</string>
   <string name="download_canceled_autodownload_enabled_msg">Download abgebrochen\n<i>Automatischen Download</i> für diese Episode deaktiviert</string>
   <string name="download_report_title">Downloads endeten mit Fehler(n)</string>
   <string name="auto_download_report_title">Automatisches Herunterladen abgeschlossen</string>
@@ -253,12 +247,7 @@
     <item quantity="one">%d Download übrig</item>
     <item quantity="other">%d Downloads übrig</item>
   </plurals>
-  <string name="downloads_processing">Verarbeite Downloads</string>
   <string name="download_notification_title">Lade Podcast-Daten</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d Download erfolgreich, %d fehlgeschlagen</item>
-    <item quantity="other">%d Downloads erfolgreich, %d fehlgeschlagen</item>
-  </plurals>
   <string name="download_log_title_unknown">Unbekannter Titel</string>
   <string name="download_type_feed">Feed</string>
   <string name="download_type_media">Mediendatei</string>

--- a/core/src/main/res/values-es/strings.xml
+++ b/core/src/main/res/values-es/strings.xml
@@ -164,7 +164,6 @@
   <string name="hide_not_queued_episodes_label">No en cola</string>
   <string name="hide_has_media_label">Tiene multimedia</string>
   <string name="filtered_label">Filtrados</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Error en la última actualización</string>
   <string name="open_podcast">Abrir pódcast</string>
   <string name="please_wait_for_data">Esperando a que los datos carguen</string>
   <!--actions on feeditems-->
@@ -229,18 +228,13 @@
   <string name="download_error_details">Detalles</string>
   <string name="download_error_details_message">%1$s \n\nURL de archivo:\n%2$s</string>
   <string name="download_error_device_not_found">No se ha encontrado un dispositivo de almacenamiento</string>
-  <string name="download_error_insufficient_space">Espacio insuficiente</string>
   <string name="download_error_http_data_error">Error de datos HTTP</string>
   <string name="download_error_error_unknown">Error desconocido</string>
-  <string name="download_error_parser_exception">Excepción del analizador</string>
   <string name="download_error_unsupported_type">Tipo de canal no admitido</string>
   <string name="download_error_connection_error">Error de conexión</string>
-  <string name="download_error_unknown_host">Host desconocido</string>
   <string name="download_error_unauthorized">Error de autenticación</string>
   <string name="download_error_file_type_type">Tipo de archivo erróneo</string>
-  <string name="download_error_forbidden">Prohibido</string>
   <string name="download_canceled_msg">Descarga cancelada</string>
-  <string name="download_wrong_size">La conexión con el servidor se perdió antes de completar la descarga</string>
   <string name="download_canceled_autodownload_enabled_msg">Descarga cancelada\nSe desactivó la <i>descarga automática</i> en este elemento</string>
   <string name="download_report_title">Descargas completadas con error(es)</string>
   <string name="auto_download_report_title">Descargas automáticas completadas</string>
@@ -253,12 +247,7 @@
     <item quantity="one">Queda %d descarga</item>
     <item quantity="other">Quedan %d descargas</item>
   </plurals>
-  <string name="downloads_processing">Procesando descargas</string>
   <string name="download_notification_title">Descargando datos del pódcast</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d descarga exitosa, %d fallidas</item>
-    <item quantity="other">%d descargas exitosas, %d fallidas</item>
-  </plurals>
   <string name="download_log_title_unknown">Título desconocido</string>
   <string name="download_type_feed">Canal</string>
   <string name="download_type_media">Archivo multimedia</string>

--- a/core/src/main/res/values-et/strings.xml
+++ b/core/src/main/res/values-et/strings.xml
@@ -160,7 +160,6 @@
   <string name="hide_not_queued_episodes_label">Pole järjekorras</string>
   <string name="hide_has_media_label">On meediafaile</string>
   <string name="filtered_label">Filtreeritud</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Viimane värskendamine ebaõnnestus</string>
   <string name="open_podcast">Ava taskuhääling</string>
   <string name="please_wait_for_data">Palun oota andmete laadimist</string>
   <!--actions on feeditems-->
@@ -221,16 +220,12 @@
   <string name="download_error_details">Üksikasjad</string>
   <string name="download_error_details_message">%1$s \n\nFaili URL:\n%2$s</string>
   <string name="download_error_device_not_found">Salvestuskohta ei leitud</string>
-  <string name="download_error_insufficient_space">Pole piisavalt ruumi</string>
   <string name="download_error_http_data_error">HTTP andmete viga</string>
   <string name="download_error_error_unknown">Tundmatu tõrge</string>
-  <string name="download_error_parser_exception">Parsimise järjekord</string>
   <string name="download_error_unsupported_type">Toetamata uudisvoo tüüp</string>
   <string name="download_error_connection_error">Ühenduse viga</string>
-  <string name="download_error_unknown_host">Tundmatu host</string>
   <string name="download_error_unauthorized">Autentimise viga</string>
   <string name="download_error_file_type_type">Failitüübi viga</string>
-  <string name="download_error_forbidden">Keelatud</string>
   <string name="download_canceled_msg">Allalaadimine on tühistatud</string>
   <string name="download_canceled_autodownload_enabled_msg">Allalaadimine tühistati\nKeelati selle saate <i>automaatne allalaadimine</i></string>
   <string name="download_report_title">Allalaadimised lõpetati veaga (vigadega)</string>
@@ -244,12 +239,7 @@
     <item quantity="one">%d allalaadimine jäänud</item>
     <item quantity="other">%d allalaadimist jäänud</item>
   </plurals>
-  <string name="downloads_processing">Allalaadimiste töötlemine</string>
   <string name="download_notification_title">Taskuhäälingu andmete allalaadimine</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d allalaadimine õnnestus, %d ebaõnnestus</item>
-    <item quantity="other">%d allalaadimist õnnestus, %d ebaõnnestus</item>
-  </plurals>
   <string name="download_log_title_unknown">Tundmatu pealkiri</string>
   <string name="download_type_feed">Uudisvoog</string>
   <string name="download_type_media">Meediafail</string>

--- a/core/src/main/res/values-eu/strings.xml
+++ b/core/src/main/res/values-eu/strings.xml
@@ -165,7 +165,6 @@
   <string name="hide_not_queued_episodes_label">Ez dago ilaran</string>
   <string name="hide_has_media_label">Media du</string>
   <string name="filtered_label">Iragaziak</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Errorea azken eguneraketan</string>
   <string name="open_podcast">Ireki podcasta</string>
   <string name="please_wait_for_data">Mesedez, itxaron datuak kargatu arte</string>
   <!--actions on feeditems-->
@@ -230,18 +229,13 @@
   <string name="download_error_details">Xehetasunak</string>
   <string name="download_error_details_message">%1$s \n\nartxibategiaren URL:\n%2$s</string>
   <string name="download_error_device_not_found">Ez da biltegiratze gailurik aurkitu</string>
-  <string name="download_error_insufficient_space">Ez dago nahiko tokirik</string>
   <string name="download_error_http_data_error">HTTP datuen errorea</string>
   <string name="download_error_error_unknown">Errore ezezaguna</string>
-  <string name="download_error_parser_exception">Analizatzailearen salbuespena</string>
   <string name="download_error_unsupported_type">Kanal mota ez onartua</string>
   <string name="download_error_connection_error">Konexio errorea</string>
-  <string name="download_error_unknown_host">Ostalari ezezaguna</string>
   <string name="download_error_unauthorized">Egiaztatze errorea</string>
   <string name="download_error_file_type_type">Artxibategi motaren errorea</string>
-  <string name="download_error_forbidden">Debekaturik</string>
   <string name="download_canceled_msg">Deskarga ezeztatua</string>
-  <string name="download_wrong_size">Zerbitzariaren konexioa galdu egin da deskarga amaitu aurretik</string>
   <string name="download_canceled_autodownload_enabled_msg">Deskarga ezeztatua\aktibatu da <i>Auto deskarga</i> elementu honetan</string>
   <string name="download_report_title">Deskarga(k) osatu d(ir)a errorea(k) d(it)uela</string>
   <string name="auto_download_report_title">Deskargatu automatikoak osatuta</string>
@@ -254,12 +248,7 @@
     <item quantity="one">%d deskarga zain</item>
     <item quantity="other">%d deskarga zain</item>
   </plurals>
-  <string name="downloads_processing">Deskargak prozesatzen</string>
   <string name="download_notification_title">Podcastaren datuak deskargatzen</string>
-  <plurals name="download_report_content">
-    <item quantity="one">Deskarga arrakastatsu %d , %d (e)k huts egin du(te)</item>
-    <item quantity="other">%d deskarga arrakastasuak, %d (e)k huts egin du(te)</item>
-  </plurals>
   <string name="download_log_title_unknown">Izenburu ezezaguna</string>
   <string name="download_type_feed">Kanala</string>
   <string name="download_type_media">Media artxibategia</string>

--- a/core/src/main/res/values-fa/strings.xml
+++ b/core/src/main/res/values-fa/strings.xml
@@ -144,7 +144,6 @@
   <string name="hide_not_queued_episodes_label">خارج از صف</string>
   <string name="hide_has_media_label">دارای رسانه</string>
   <string name="filtered_label">فیلتر شده</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} آخرین تازه‌سازی ناموفق بود</string>
   <string name="open_podcast">باز کردن پادکست</string>
   <string name="please_wait_for_data">لطفا تا زمان دریافت اطلاعات منتظر بمانید</string>
   <!--actions on feeditems-->
@@ -205,16 +204,12 @@
   <string name="download_error_details">جزئیات</string>
   <string name="download_error_details_message">%1$s\n\nنشانی پرونده:\n%2$s</string>
   <string name="download_error_device_not_found">حافظهٔ خارجی یافت نشد</string>
-  <string name="download_error_insufficient_space">فضای ناکافی</string>
   <string name="download_error_http_data_error">خطای HTTP Data </string>
   <string name="download_error_error_unknown">خطای ناشناخته</string>
-  <string name="download_error_parser_exception">خطای تجزیه</string>
   <string name="download_error_unsupported_type"> عدم  پشتیبانی از این نوع خوراک</string>
   <string name="download_error_connection_error">خطای اتصال</string>
-  <string name="download_error_unknown_host">میزبان ناشناس</string>
   <string name="download_error_unauthorized">خطای احراز هویت</string>
   <string name="download_error_file_type_type">خطای نوع پرونده</string>
-  <string name="download_error_forbidden">ممنوع</string>
   <string name="download_canceled_msg">بارگیری لغو شد</string>
   <string name="download_canceled_autodownload_enabled_msg">بارگیری لغو شد\nغیر فعال  کردن <i>بارگیری خودکار</i> برای این مورد </string>
   <string name="download_report_title">بارگیری‌ها با خطا(ها) کامل شد</string>
@@ -228,7 +223,6 @@
     <item quantity="one">%d بارگیری باقی مانده است</item>
     <item quantity="other">%d بارگیری باقی مانده است</item>
   </plurals>
-  <string name="downloads_processing">پردازش بارگیری‌ها</string>
   <string name="download_notification_title">بارگیری داده پادکست</string>
   <string name="download_log_title_unknown">عنوان ناشناخته</string>
   <string name="download_type_feed">خوراک</string>

--- a/core/src/main/res/values-fi/strings.xml
+++ b/core/src/main/res/values-fi/strings.xml
@@ -133,7 +133,6 @@
   <string name="hide_not_queued_episodes_label">Ei jonossa</string>
   <string name="hide_has_media_label">Sisältää mediaa</string>
   <string name="filtered_label">Suodatettu</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Viimeisin päivitys epäonnistui</string>
   <string name="open_podcast">Avaa podcast</string>
   <string name="please_wait_for_data">Odota kunnes tiedot ovat ladattu</string>
   <!--actions on feeditems-->
@@ -194,16 +193,12 @@
   <string name="download_error_details">Tiedot</string>
   <string name="download_error_details_message">%1$s \n\nTiedoston URL:\n%2$s</string>
   <string name="download_error_device_not_found">Tallennuslaitetta ei löytynyt</string>
-  <string name="download_error_insufficient_space">Ei tarpeeksi tilaa</string>
   <string name="download_error_http_data_error">HTTP Data virhe</string>
   <string name="download_error_error_unknown">Tuntematon virhe</string>
-  <string name="download_error_parser_exception">Jäsenninpoikkeus</string>
   <string name="download_error_unsupported_type">Ei tuettu syötetyyppi</string>
   <string name="download_error_connection_error">Yhteysvirhe</string>
-  <string name="download_error_unknown_host">Tuntematon isäntä</string>
   <string name="download_error_unauthorized">Todentamisvirhe</string>
   <string name="download_error_file_type_type">Tiedostotyyppivirhe</string>
-  <string name="download_error_forbidden">Ei sallittu</string>
   <string name="download_canceled_msg">Lataus peruutettu</string>
   <string name="download_canceled_autodownload_enabled_msg">Lataus peruutettu\nPoistettu <i>Automaattinen lataus</i> tälle tiedolle </string>
   <string name="download_report_title">Lataukset valmistuivat virhe(id)en kanssa</string>
@@ -217,7 +212,6 @@
     <item quantity="one">%d lataus jäljellä</item>
     <item quantity="other">%d latausta jäljellä</item>
   </plurals>
-  <string name="downloads_processing">Käsitellään latauksia</string>
   <string name="download_notification_title">Ladataan podcastin tietoja</string>
   <string name="download_log_title_unknown">Tuntematon otsikko</string>
   <string name="download_type_feed">Syöte</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -165,7 +165,6 @@
   <string name="hide_not_queued_episodes_label">Pas dans la liste de lecture</string>
   <string name="hide_has_media_label">Avec média</string>
   <string name="filtered_label">Filtré</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} La dernière mise à jour a échoué</string>
   <string name="open_podcast">Ouvrir le podcast</string>
   <string name="please_wait_for_data">Merci d\'attendre la fin du téléchargement des données</string>
   <!--actions on feeditems-->
@@ -230,18 +229,13 @@
   <string name="download_error_details">Détails</string>
   <string name="download_error_details_message">%1$s \n\nLien du fichier :\n%2$s</string>
   <string name="download_error_device_not_found">Volume de stockage non trouvé</string>
-  <string name="download_error_insufficient_space">Espace insuffisant</string>
   <string name="download_error_http_data_error">Erreur de données HTTP</string>
   <string name="download_error_error_unknown">Erreur inconnue</string>
-  <string name="download_error_parser_exception">Message d\'erreur</string>
   <string name="download_error_unsupported_type">Type de flux non géré</string>
   <string name="download_error_connection_error">Erreur de connexion</string>
-  <string name="download_error_unknown_host">Hôte inconnu</string>
   <string name="download_error_unauthorized">Erreur d\'authentification</string>
   <string name="download_error_file_type_type">Erreur format de fichier</string>
-  <string name="download_error_forbidden">Interdit</string>
   <string name="download_canceled_msg">Téléchargement annulé</string>
-  <string name="download_wrong_size">La connexion au serveur a été coupée avant la fin du téléchargement</string>
   <string name="download_canceled_autodownload_enabled_msg">Téléchargement annulé\n <i>Téléchargement Automatique</i> désactivé pour cet élément</string>
   <string name="download_report_title">Téléchargements terminés avec des erreurs</string>
   <string name="auto_download_report_title">Téléchargement automatique terminé</string>
@@ -254,12 +248,7 @@
     <item quantity="one">%d téléchargement restant</item>
     <item quantity="other">%d téléchargements restants</item>
   </plurals>
-  <string name="downloads_processing">Traitement des téléchargements</string>
   <string name="download_notification_title">Téléchargement des données du podcast</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%1$d téléchargement réussi, %2$d échoué</item>
-    <item quantity="other">%1$d téléchargements réussis, %2$d échoués</item>
-  </plurals>
   <string name="download_log_title_unknown">Titre inconnu</string>
   <string name="download_type_feed">Flux</string>
   <string name="download_type_media">Fichier média</string>

--- a/core/src/main/res/values-gl/strings.xml
+++ b/core/src/main/res/values-gl/strings.xml
@@ -165,7 +165,6 @@
   <string name="hide_not_queued_episodes_label">Fora da cola</string>
   <string name="hide_has_media_label">Ten multimedia</string>
   <string name="filtered_label">Filtrado</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Erro na última actualización</string>
   <string name="open_podcast">Abrir podcast</string>
   <string name="please_wait_for_data">Agarda ata que se carguen os datos</string>
   <!--actions on feeditems-->
@@ -230,18 +229,13 @@
   <string name="download_error_details">Detalles</string>
   <string name="download_error_details_message">%1$s\n\nURL do ficheiro:\n %2$s </string>
   <string name="download_error_device_not_found">Non se atopou dispositivo de almacenamento</string>
-  <string name="download_error_insufficient_space">Non hai suficiente espacio</string>
   <string name="download_error_http_data_error">Fallo de datos HTTP</string>
   <string name="download_error_error_unknown">Fallo descoñecido</string>
-  <string name="download_error_parser_exception">Excepción no procesador</string>
   <string name="download_error_unsupported_type">Tipo de fonte non admitida</string>
   <string name="download_error_connection_error">Fallo na conexión</string>
-  <string name="download_error_unknown_host">Servidor descoñecido</string>
   <string name="download_error_unauthorized">Fallo na autenticación</string>
   <string name="download_error_file_type_type">Fallo no tipo de ficheiro</string>
-  <string name="download_error_forbidden">Non admitido</string>
   <string name="download_canceled_msg">Descarga cancelada</string>
-  <string name="download_wrong_size">Perdeuse a conexión co servidor antes de completar a descarga</string>
   <string name="download_canceled_autodownload_enabled_msg">Descarga cancelada\nDesactivouse a <i>Descarga Automática</i> para este elemento</string>
   <string name="download_report_title">Descargas completadas con erro(s)</string>
   <string name="auto_download_report_title">Descarga automática completada</string>
@@ -254,12 +248,7 @@
     <item quantity="one">%d descarga restante</item>
     <item quantity="other">%d descargas restantes</item>
   </plurals>
-  <string name="downloads_processing">Procesando as descargas</string>
   <string name="download_notification_title">Descargando datos do podcast</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d descarga correcta, %d fallou</item>
-    <item quantity="other">%d descargas correctas, %d fallaron</item>
-  </plurals>
   <string name="download_log_title_unknown">Título descoñecido</string>
   <string name="download_type_feed">Fonte</string>
   <string name="download_type_media">Ficheiro de medios</string>

--- a/core/src/main/res/values-hu/strings.xml
+++ b/core/src/main/res/values-hu/strings.xml
@@ -144,7 +144,6 @@
   <string name="hide_not_queued_episodes_label">Nem sorbaállított</string>
   <string name="hide_has_media_label">Médiát tartalmaz</string>
   <string name="filtered_label">Szűrt</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} A legutóbbi frissítés sikertelen</string>
   <string name="open_podcast">Podcast megnyitása</string>
   <string name="please_wait_for_data">Várjon az adatok betöltésére</string>
   <!--actions on feeditems-->
@@ -205,18 +204,13 @@
   <string name="download_error_details">Részletek</string>
   <string name="download_error_details_message">%1$s \n\nFájl URL:\n%2$s</string>
   <string name="download_error_device_not_found">Tárolóeszköz nem található</string>
-  <string name="download_error_insufficient_space">Túl kevés tárhely</string>
   <string name="download_error_http_data_error">HTTP adathiba</string>
   <string name="download_error_error_unknown">Ismeretlen hiba</string>
-  <string name="download_error_parser_exception">Értelmező által dobott kivétel</string>
   <string name="download_error_unsupported_type">Nem támogatott csatornatípus</string>
   <string name="download_error_connection_error">Kapcsolódási hiba</string>
-  <string name="download_error_unknown_host">Ismeretlen kiszolgál</string>
   <string name="download_error_unauthorized">Hitelesítési hiba</string>
   <string name="download_error_file_type_type">Fájltípus-hiba</string>
-  <string name="download_error_forbidden">Megtiltva</string>
   <string name="download_canceled_msg">Letöltés megszakítva</string>
-  <string name="download_wrong_size">A kiszolgálókapcsolat elveszett a letöltés befejezése előtt</string>
   <string name="download_canceled_autodownload_enabled_msg">Letöltés megszakítva\n<i>Automatikus letöltése</i> letiltva az elemnél</string>
   <string name="download_report_title">A letöltések hibákkal fejeződtek be</string>
   <string name="auto_download_report_title">Elkészültek az automatikus letöltések</string>
@@ -229,12 +223,7 @@
     <item quantity="one">%d letöltés van hátra</item>
     <item quantity="other">%d letöltés van hátra</item>
   </plurals>
-  <string name="downloads_processing">Letöltések feldolgozása</string>
   <string name="download_notification_title">Podcast adatok letöltése</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d letöltés sikeres, %d sikertelen</item>
-    <item quantity="other">%d letöltés sikeres, %d sikertelen</item>
-  </plurals>
   <string name="download_log_title_unknown">Ismeretlen cím</string>
   <string name="download_type_feed">Csatorna</string>
   <string name="download_type_media">Médiafájl</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -165,7 +165,6 @@
   <string name="hide_not_queued_episodes_label">Non in coda</string>
   <string name="hide_has_media_label">Con media</string>
   <string name="filtered_label">Filtrati</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Ultimo aggiornamento fallito</string>
   <string name="open_podcast">Apri podcast</string>
   <string name="please_wait_for_data">Attendi il caricamento dei dati</string>
   <!--actions on feeditems-->
@@ -230,18 +229,13 @@
   <string name="download_error_details">Dettagli</string>
   <string name="download_error_details_message">%1$s \n\nURL file:\n%2$s</string>
   <string name="download_error_device_not_found">Spazio di archiviazione non trovato</string>
-  <string name="download_error_insufficient_space">Spazio insufficiente</string>
   <string name="download_error_http_data_error">Errore dei dati HTTP</string>
   <string name="download_error_error_unknown">Errore sconosciuto</string>
-  <string name="download_error_parser_exception">Eccezione del decodificatore</string>
   <string name="download_error_unsupported_type">Tipo di feed non supportato</string>
   <string name="download_error_connection_error">Errore di connessione</string>
-  <string name="download_error_unknown_host">Host sconosciuto</string>
   <string name="download_error_unauthorized">Errore di autenticazione</string>
   <string name="download_error_file_type_type">Errore del tipo di file</string>
-  <string name="download_error_forbidden">Proibito</string>
   <string name="download_canceled_msg">Download annullato</string>
-  <string name="download_wrong_size">Connessione con il server persa prima del completamento del download</string>
   <string name="download_canceled_autodownload_enabled_msg">Download annullato\n<i>Download automatico</i> disabilitato per questo elemento</string>
   <string name="download_report_title">Download completato con un errore (o errori)</string>
   <string name="auto_download_report_title">Download automatici completati</string>
@@ -254,12 +248,7 @@
     <item quantity="one">%d download rimanente</item>
     <item quantity="other">%d download rimanenti</item>
   </plurals>
-  <string name="downloads_processing">Elaborazione dei download in corso</string>
   <string name="download_notification_title">Scaricamento podcast in corso</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d scaricamento completato, %d non riuscito.</item>
-    <item quantity="other">%d scaricamenti completati, %d non riusciti.</item>
-  </plurals>
   <string name="download_log_title_unknown">Titolo sconosciuto</string>
   <string name="download_type_feed">Feed</string>
   <string name="download_type_media">File multimediali</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -177,7 +177,6 @@
   <string name="hide_not_queued_episodes_label">לא בתור</string>
   <string name="hide_has_media_label">יש מדיה</string>
   <string name="filtered_label">מסונן</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} הרענון האחרון נכשל</string>
   <string name="open_podcast">פתיחת פודקאסט</string>
   <string name="please_wait_for_data">נא להמתין לסיום טעינת הנתונים</string>
   <!--actions on feeditems-->
@@ -254,18 +253,13 @@
   <string name="download_error_details">פרטים</string>
   <string name="download_error_details_message">%1$s \n\nכתובת הקובץ:\n%2$s</string>
   <string name="download_error_device_not_found">התקן האחסון לא נמצא</string>
-  <string name="download_error_insufficient_space">אין די שטח אחסון</string>
   <string name="download_error_http_data_error">שגיאת נתוני HTTP</string>
   <string name="download_error_error_unknown">שגיאה לא ידועה</string>
-  <string name="download_error_parser_exception">שגיאת מפענח</string>
   <string name="download_error_unsupported_type">סוג ההזנה אינו נתמך</string>
   <string name="download_error_connection_error">שגיאת חיבור</string>
-  <string name="download_error_unknown_host">שרת לא ידוע</string>
   <string name="download_error_unauthorized">שגיאת אימות</string>
   <string name="download_error_file_type_type">שגיאת סוג קובץ</string>
-  <string name="download_error_forbidden">אסור</string>
   <string name="download_canceled_msg">הורדה בוטלה</string>
-  <string name="download_wrong_size">החיבור לשרת אבד בטרם השלמת ההורדה</string>
   <string name="download_canceled_autodownload_enabled_msg">ההורדה בוטלה\nה<i>הורדה האוטומטית</i> הושבתה עבור פריט זה</string>
   <string name="download_report_title">הורדות הושלמו עם שגיאה אחת או יותר</string>
   <string name="auto_download_report_title">ההורדות האוטומטיות הושלמו</string>
@@ -280,14 +274,7 @@
     <item quantity="many">נותרו %d הורדות</item>
     <item quantity="other">נותרו %d הורדות</item>
   </plurals>
-  <string name="downloads_processing">ההורדות בהליכי עיבוד</string>
   <string name="download_notification_title">נתוני הפודקאסט מתקבלים</string>
-  <plurals name="download_report_content">
-    <item quantity="one">הורדה %d הצליחה, %d נכשלו</item>
-    <item quantity="two">%d הורדות הצליחו, %d נכשלו</item>
-    <item quantity="many">%d הורדות הצליחו, %d נכשלו</item>
-    <item quantity="other">%d הורדות הצליחו, %d נכשלו</item>
-  </plurals>
   <string name="download_log_title_unknown">כותרת לא ידועה</string>
   <string name="download_type_feed">הזנה</string>
   <string name="download_type_media">קובץ מדיה</string>

--- a/core/src/main/res/values-ja/strings.xml
+++ b/core/src/main/res/values-ja/strings.xml
@@ -126,7 +126,6 @@
   <string name="hide_not_queued_episodes_label">キューに未追加</string>
   <string name="hide_has_media_label">メディアあり</string>
   <string name="filtered_label">フィルターしました</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} 前回更新に失敗しました</string>
   <string name="open_podcast">ポッドキャストを開く</string>
   <string name="please_wait_for_data">データが読み込まれるまでしばらくお待ちください</string>
   <!--actions on feeditems-->
@@ -181,16 +180,12 @@
   <string name="download_error_details">詳細</string>
   <string name="download_error_details_message">%1$s \n\nファイル URL:\n%2$s</string>
   <string name="download_error_device_not_found">ストレージ デバイスが見つかりません</string>
-  <string name="download_error_insufficient_space">スペースが不足しています</string>
   <string name="download_error_http_data_error">HTTPデータエラー</string>
   <string name="download_error_error_unknown">不明なエラー</string>
-  <string name="download_error_parser_exception">解析エラー</string>
   <string name="download_error_unsupported_type">サポートしないフィードタイプ</string>
   <string name="download_error_connection_error">接続エラー</string>
-  <string name="download_error_unknown_host">ホスト不明</string>
   <string name="download_error_unauthorized">認証エラー</string>
   <string name="download_error_file_type_type">ファイルタイプ エラー</string>
-  <string name="download_error_forbidden">禁止</string>
   <string name="download_canceled_msg">ダウンロードをキャンセルしました</string>
   <string name="download_canceled_autodownload_enabled_msg">ダウンロードをキャンセルしました\nこのアイテムの <i>自動ダウンロード</i> を無効にしました</string>
   <string name="download_report_title">ダウンロードがエラーで完了しました</string>
@@ -203,7 +198,6 @@
   <plurals name="downloads_left">
     <item quantity="other">%d ダウンロード残</item>
   </plurals>
-  <string name="downloads_processing">ダウンロード処理中</string>
   <string name="download_notification_title">ポッドキャストデータをダウンロード中</string>
   <string name="download_log_title_unknown">タイトル不明</string>
   <string name="download_type_feed">フィード</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -159,7 +159,6 @@
   <string name="hide_not_queued_episodes_label">대기열 추가 안 함</string>
   <string name="hide_has_media_label">미디어 있음</string>
   <string name="filtered_label">필터링함</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} 최근 새로 고침 실패</string>
   <string name="open_podcast">팟캐스트 열기</string>
   <string name="please_wait_for_data">데이터를 읽어 들일 때까지 기다리십시오</string>
   <!--actions on feeditems-->
@@ -218,18 +217,13 @@
   <string name="download_error_details">자세히</string>
   <string name="download_error_details_message">%1$s \n\n파일 URL:\n%2$s</string>
   <string name="download_error_device_not_found">저장 장치가 없습니다</string>
-  <string name="download_error_insufficient_space">저장 공간이 부족합니다</string>
   <string name="download_error_http_data_error">HTTP 데이터 오류</string>
   <string name="download_error_error_unknown">알 수 없는 오류</string>
-  <string name="download_error_parser_exception">파서 프로그램 예외</string>
   <string name="download_error_unsupported_type">지원하지 않는 피드 종류</string>
   <string name="download_error_connection_error">연결 오류</string>
-  <string name="download_error_unknown_host">알 수 없는 호스트</string>
   <string name="download_error_unauthorized">인증 오류</string>
   <string name="download_error_file_type_type">파일 종류 오류</string>
-  <string name="download_error_forbidden">금지됨</string>
   <string name="download_canceled_msg">다운로드 취소함</string>
-  <string name="download_wrong_size">다운로드를 마치기 전에 서버 연결이 끊어졌습니다.</string>
   <string name="download_canceled_autodownload_enabled_msg">다운로드 취소함\n이 항목에 <i>자동 다운로드</i>를 해제합니다</string>
   <string name="download_report_title">다운로드 마침 (오류 있음)</string>
   <string name="auto_download_report_title">자동 다운로드 마침</string>
@@ -241,11 +235,7 @@
   <plurals name="downloads_left">
     <item quantity="other">다운로드 %d개 남음</item>
   </plurals>
-  <string name="downloads_processing">다운로드 처리 중</string>
   <string name="download_notification_title">팟캐스트 데이터 다운로드 중</string>
-  <plurals name="download_report_content">
-    <item quantity="other">%d개 다운로드 성공. %d개 실패</item>
-  </plurals>
   <string name="download_log_title_unknown">알 수 없는 제목</string>
   <string name="download_type_feed">피드</string>
   <string name="download_type_media">미디어 파일</string>

--- a/core/src/main/res/values-lt/strings.xml
+++ b/core/src/main/res/values-lt/strings.xml
@@ -139,7 +139,6 @@
   <string name="hide_not_queued_episodes_label">Nesantys eilėje</string>
   <string name="hide_has_media_label">Turintys medijos failų</string>
   <string name="filtered_label">Filtruota</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Paskutinis atnaujinimas nepavyko</string>
   <string name="open_podcast">Atverti tinklalaidę</string>
   <string name="please_wait_for_data">Prašome luktelėti, kol duomenys bus įkelti</string>
   <!--actions on feeditems-->
@@ -210,16 +209,12 @@
   <string name="download_error_details">Išsami informacija</string>
   <string name="download_error_details_message">%1$s \n\nFailo URL:\n%2$s</string>
   <string name="download_error_device_not_found">Nerastas laikmenos įrenginys</string>
-  <string name="download_error_insufficient_space">Trūksta laisvos vietos</string>
   <string name="download_error_http_data_error">HTTP duomenų klaida</string>
   <string name="download_error_error_unknown">Nežinoma klaida</string>
-  <string name="download_error_parser_exception">Išimtinė situacija analizatoriuje</string>
   <string name="download_error_unsupported_type">Nepalaikomas sklaidos kanalo tipas</string>
   <string name="download_error_connection_error">Susijungimo klaida</string>
-  <string name="download_error_unknown_host">Nežinomas serveris</string>
   <string name="download_error_unauthorized">Tapatumo nustatymo klaida</string>
   <string name="download_error_file_type_type">Failo tipo klaida</string>
-  <string name="download_error_forbidden">Uždrausta</string>
   <string name="download_canceled_msg">Atsiuntimas atšauktas</string>
   <string name="download_canceled_autodownload_enabled_msg">Atsiuntimas atšauktas\n<i>Automatinis atsiuntimas</i> šiam elementui išjungtas</string>
   <string name="download_report_title">Atsiuntimai užbaigti su klaida (-omis)</string>
@@ -235,7 +230,6 @@
     <item quantity="many">Liko %d atsiuntimų</item>
     <item quantity="other">Liko %d atsiuntimų</item>
   </plurals>
-  <string name="downloads_processing">Apdorojami atsiuntimai</string>
   <string name="download_notification_title">Atsiunčiami tinklalaidės duomenys</string>
   <string name="download_log_title_unknown">Nežinomas pavadinimas</string>
   <string name="download_type_feed">Sklaidos kanalas</string>

--- a/core/src/main/res/values-nb/strings.xml
+++ b/core/src/main/res/values-nb/strings.xml
@@ -139,7 +139,6 @@
   <string name="hide_not_queued_episodes_label">Ikke i kø</string>
   <string name="hide_has_media_label">Har medier</string>
   <string name="filtered_label">Filtrert</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Siste oppdatering mislyktes</string>
   <string name="open_podcast">Åpne podkast</string>
   <string name="please_wait_for_data">Vent til dataene er lastet inn</string>
   <!--actions on feeditems-->
@@ -200,16 +199,12 @@
   <string name="download_error_details">Detaljer</string>
   <string name="download_error_details_message">%1$s \n\nFil-URL:\n%2$s</string>
   <string name="download_error_device_not_found">Lagringsenhet ikke funnet</string>
-  <string name="download_error_insufficient_space">Ikke nok plass</string>
   <string name="download_error_http_data_error">HTTP-datafeil</string>
   <string name="download_error_error_unknown">Ukjent feil</string>
-  <string name="download_error_parser_exception">Parser-unntak</string>
   <string name="download_error_unsupported_type">Strøm-typen er ikke støttet</string>
   <string name="download_error_connection_error">Tilkoblingsfeil</string>
-  <string name="download_error_unknown_host">Ukjent vert</string>
   <string name="download_error_unauthorized">Autentiseringsfeil</string>
   <string name="download_error_file_type_type">Filtype-feil</string>
-  <string name="download_error_forbidden">Ikke tillatt</string>
   <string name="download_canceled_msg">Nedlasting avbrutt</string>
   <string name="download_canceled_autodownload_enabled_msg">Nedlasting avbrutt\n<i>Automatisk nedlasting</i> for dette elementet er deaktivert</string>
   <string name="download_report_title">Nedlasting fullført med feilmeldinger</string>
@@ -223,12 +218,7 @@
     <item quantity="one">%d nedlasting gjenstår</item>
     <item quantity="other">%d nedlastinger gjenstår</item>
   </plurals>
-  <string name="downloads_processing">Behandler nedlastninger</string>
   <string name="download_notification_title">Laster ned data til podkast</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%1$d nedlastninger lyktes, %2$d mislyktes</item>
-    <item quantity="other">%d nedlastinger lyktes, %d mislyktes</item>
-  </plurals>
   <string name="download_log_title_unknown">Ukjent tittel</string>
   <string name="download_type_feed">Strøm</string>
   <string name="download_type_media">Mediafil</string>

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -165,7 +165,6 @@
   <string name="hide_not_queued_episodes_label">Niet in de wachtrij</string>
   <string name="hide_has_media_label">Bevat media</string>
   <string name="filtered_label">Gefilterd</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Vorige verversing mislukt</string>
   <string name="open_podcast">Podcast openen</string>
   <string name="please_wait_for_data">Wacht tot de gegevens geladen zijn</string>
   <!--actions on feeditems-->
@@ -230,18 +229,13 @@
   <string name="download_error_details">Details</string>
   <string name="download_error_details_message">%1$s \n\nURL van bestand:\n%2$s</string>
   <string name="download_error_device_not_found">Opslagmedium niet aangetroffen</string>
-  <string name="download_error_insufficient_space">Onvoldoende ruimte</string>
   <string name="download_error_http_data_error">HTTP-gegevensfout</string>
   <string name="download_error_error_unknown">Onbekende fout</string>
-  <string name="download_error_parser_exception">Verwerkingsuitzondering</string>
   <string name="download_error_unsupported_type">Niet-ondersteunde feedsoort</string>
   <string name="download_error_connection_error">Verbindingsfout</string>
-  <string name="download_error_unknown_host">Onbekende host</string>
   <string name="download_error_unauthorized">Authenticatiefout</string>
   <string name="download_error_file_type_type">Bestandssoortfout</string>
-  <string name="download_error_forbidden">Niet mogelijk</string>
   <string name="download_canceled_msg">Download afgebroken</string>
-  <string name="download_wrong_size">Het downloaden kan niet worden afgerond omdat de verbinding met de server verbroken is</string>
   <string name="download_canceled_autodownload_enabled_msg">Download afgebroken\n<i>Automatisch downloaden</i> uitgeschakeld voor deze aflevering</string>
   <string name="download_report_title">Downloads afgerond, maar met fout(en)</string>
   <string name="auto_download_report_title">Automatisch downloaden afgerond</string>
@@ -254,12 +248,7 @@
     <item quantity="one">Nog %d download</item>
     <item quantity="other">Nog %d downloads</item>
   </plurals>
-  <string name="downloads_processing">Bezig met verwerken van downloads</string>
   <string name="download_notification_title">Bezig met downloaden van podcastgegevens</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d download voltooid; %d mislukt</item>
-    <item quantity="other">%d downloads voltooid; %d mislukt</item>
-  </plurals>
   <string name="download_log_title_unknown">Onbekende titel</string>
   <string name="download_type_feed">Feed</string>
   <string name="download_type_media">Mediabestand</string>

--- a/core/src/main/res/values-pl/strings.xml
+++ b/core/src/main/res/values-pl/strings.xml
@@ -150,7 +150,6 @@
   <string name="hide_not_queued_episodes_label">Nie w kolejce</string>
   <string name="hide_has_media_label">Ma media</string>
   <string name="filtered_label">Przefiltrowany</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Ostatnie odświerzanie nie powiodło się</string>
   <string name="open_podcast">Otwórz Podcast</string>
   <string name="please_wait_for_data">Proszę czekać aż dane zostaną załadowane</string>
   <!--actions on feeditems-->
@@ -222,16 +221,12 @@
   <string name="download_error_details_message">%1$s \n\nAdres pliku:\n%2$s
 </string>
   <string name="download_error_device_not_found">Nie znaleziono urządzenia docelowego</string>
-  <string name="download_error_insufficient_space">Niewystarczająca ilość pamięci</string>
   <string name="download_error_http_data_error">Błąd danych HTTP</string>
   <string name="download_error_error_unknown">Nieznany błąd</string>
-  <string name="download_error_parser_exception">Wyjątek parsera</string>
   <string name="download_error_unsupported_type">Nieobsługiwany typ kanału</string>
   <string name="download_error_connection_error">Błąd połączenia</string>
-  <string name="download_error_unknown_host">Nieznany host</string>
   <string name="download_error_unauthorized">Błąd autoryzacji</string>
   <string name="download_error_file_type_type">Błąd rodzaju pliku</string>
-  <string name="download_error_forbidden">Zabronione</string>
   <string name="download_canceled_msg">Pobieranie anulowane</string>
   <string name="download_canceled_autodownload_enabled_msg">Pobieranie zatrzymane\nWyłączone <i>Automatyczne pobieranie</i> dla tego elementu</string>
   <string name="download_report_title">Pobieranie ukończone</string>
@@ -247,14 +242,7 @@
     <item quantity="many">%d elementów zostało do pobrania</item>
     <item quantity="other">%d elementów zostało do pobrania</item>
   </plurals>
-  <string name="downloads_processing">Przetwarzanie pobranych</string>
   <string name="download_notification_title">Pobieranie danych podcastu</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d pobranie udane, %d błędne</item>
-    <item quantity="few">%d pobrań udanych, %d błędnych</item>
-    <item quantity="many">%d pobrań udanych, %d błędnych</item>
-    <item quantity="other">%d pobrań udanych, %d błędnych</item>
-  </plurals>
   <string name="download_log_title_unknown">Nieznany tytuł</string>
   <string name="download_type_feed">Kanał</string>
   <string name="download_type_media">Plik multimedialny</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -146,7 +146,6 @@
   <string name="hide_not_queued_episodes_label">Não enfileirado</string>
   <string name="hide_has_media_label">Possui mídia</string>
   <string name="filtered_label">Filtrado</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Última Atualização falhou</string>
   <string name="open_podcast">Abrir Podcast</string>
   <string name="please_wait_for_data">Por favor, aguarde até que os dados sejam carregados</string>
   <!--actions on feeditems-->
@@ -207,16 +206,12 @@
   <string name="download_error_details">Detalhes</string>
   <string name="download_error_details_message">%1$s \n\nURL do arquivo:\n%2$s</string>
   <string name="download_error_device_not_found">Dispositivo de armazenamento não encontrado</string>
-  <string name="download_error_insufficient_space">Espaço insuficiente</string>
   <string name="download_error_http_data_error">Erro de HTTP Data</string>
   <string name="download_error_error_unknown">Erro desconhecido</string>
-  <string name="download_error_parser_exception">Parser Exception</string>
   <string name="download_error_unsupported_type">Tipo de feed não suportado</string>
   <string name="download_error_connection_error">Erro de conexão</string>
-  <string name="download_error_unknown_host">Host desconhecido</string>
   <string name="download_error_unauthorized">Erro de autenticação</string>
   <string name="download_error_file_type_type">Erro de Tipo de Arquivo</string>
-  <string name="download_error_forbidden">Proibido</string>
   <string name="download_canceled_msg">Download cancelado</string>
   <string name="download_canceled_autodownload_enabled_msg">Download cancelado\nDesabilitado <i>Download Automático</i> para este item</string>
   <string name="download_report_title">Downloads finalizados com erro(s)</string>
@@ -230,12 +225,7 @@
     <item quantity="one">%d download restante</item>
     <item quantity="other">%d downloads restantes</item>
   </plurals>
-  <string name="downloads_processing">Processando downloads</string>
   <string name="download_notification_title">Baixando dados do podcast</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%ddownload com sucesso, %dfalhou</item>
-    <item quantity="other">%ddownloads com sucesso, %dfalharam</item>
-  </plurals>
   <string name="download_log_title_unknown">Título desconhecido</string>
   <string name="download_type_feed">Feed</string>
   <string name="download_type_media">Arquivo de mídia</string>

--- a/core/src/main/res/values-pt/strings.xml
+++ b/core/src/main/res/values-pt/strings.xml
@@ -165,7 +165,6 @@
   <string name="hide_not_queued_episodes_label">Não na fila</string>
   <string name="hide_has_media_label">Tem ficheiro</string>
   <string name="filtered_label">Filtrados</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Última atualização falhada</string>
   <string name="open_podcast">Abrir podcast</string>
   <string name="please_wait_for_data">Aguarde pelo carregamento dos dados...</string>
   <!--actions on feeditems-->
@@ -230,18 +229,13 @@
   <string name="download_error_details">Detalhes</string>
   <string name="download_error_details_message">%1$s \n\Ficheiro URL:\n%2$s</string>
   <string name="download_error_device_not_found">Cartão SD não encontrado</string>
-  <string name="download_error_insufficient_space">Espaço insuficiente</string>
   <string name="download_error_http_data_error">Erro HTTP</string>
   <string name="download_error_error_unknown">Erro desconhecido</string>
-  <string name="download_error_parser_exception">Exceção do processador</string>
   <string name="download_error_unsupported_type">Fonte não suportada</string>
   <string name="download_error_connection_error">Erro de ligação</string>
-  <string name="download_error_unknown_host">Servidor desconhecido</string>
   <string name="download_error_unauthorized">Erro de autenticação</string>
   <string name="download_error_file_type_type">Erro do tipo de ficheiro</string>
-  <string name="download_error_forbidden">Proibido</string>
   <string name="download_canceled_msg">Descarga cancelada</string>
-  <string name="download_wrong_size">Perdemos a ligação ao servidor antes de terminar a descarga</string>
   <string name="download_canceled_autodownload_enabled_msg">Descarga cancelada\n<i>Descarga automática</i> desativada para este item</string>
   <string name="download_report_title">Descargas terminadas com erros</string>
   <string name="auto_download_report_title">Descargas automáticas terminadas</string>
@@ -254,12 +248,7 @@
     <item quantity="one">%d descarga em curso</item>
     <item quantity="other">%d descargas em curso</item>
   </plurals>
-  <string name="downloads_processing">Processamento de descargas</string>
   <string name="download_notification_title">A descarregar dados do podcast</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d descarga com sucesso, %d com falha</item>
-    <item quantity="other">%d descargas com sucesso, %d com falha</item>
-  </plurals>
   <string name="download_log_title_unknown">Título desconhecido</string>
   <string name="download_type_feed">Fonte</string>
   <string name="download_type_media">Ficheiro multimédia</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -177,7 +177,6 @@
   <string name="hide_not_queued_episodes_label">Не в очереди</string>
   <string name="hide_has_media_label">С файлами</string>
   <string name="filtered_label">Отфильтровано</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Последнее обновление не удалось</string>
   <string name="open_podcast">Открыть подкаст</string>
   <string name="please_wait_for_data">Подождите, пока загружаются данные</string>
   <!--actions on feeditems-->
@@ -254,18 +253,13 @@
   <string name="download_error_details">Подробнее</string>
   <string name="download_error_details_message">%1$s \n\nСсылка на файл:\n%2$s</string>
   <string name="download_error_device_not_found">Устройство хранения не найдено</string>
-  <string name="download_error_insufficient_space">Недостаточно места</string>
   <string name="download_error_http_data_error">Ошибка данных HTTP</string>
   <string name="download_error_error_unknown">Неизвестная ошибка</string>
-  <string name="download_error_parser_exception">Ошибка обработки</string>
   <string name="download_error_unsupported_type">Неподдерживаемый тип канала</string>
   <string name="download_error_connection_error">Ошибка соединения</string>
-  <string name="download_error_unknown_host">Неизвестный узел</string>
   <string name="download_error_unauthorized">Ошибка авторизации</string>
   <string name="download_error_file_type_type">Ошибка типа файла</string>
-  <string name="download_error_forbidden">Запрещено</string>
   <string name="download_canceled_msg">Загрузка отменена</string>
-  <string name="download_wrong_size">Соединение с сервером было утеряно до завершения загрузки</string>
   <string name="download_canceled_autodownload_enabled_msg">Загрузка отменена\n <i>Автозагрузка</i> отключена для этого выпуска</string>
   <string name="download_report_title">Загрузки завершились с ошибкой</string>
   <string name="auto_download_report_title">Автозагрузка завершена</string>
@@ -280,14 +274,7 @@
     <item quantity="many">Осталось %d загрузок</item>
     <item quantity="other">Осталось %d загрузок</item>
   </plurals>
-  <string name="downloads_processing">Производится загрузка</string>
   <string name="download_notification_title">Получение данных подкаста</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d загрузка завершена, %d не удалось</item>
-    <item quantity="few">%d загрузок завершено, %d не удалось</item>
-    <item quantity="many"> %d загрузок завершено, %d не удалось</item>
-    <item quantity="other">%d загрузок завершено,  %d не удалось</item>
-  </plurals>
   <string name="download_log_title_unknown">Неизвестное название</string>
   <string name="download_type_feed">Канал</string>
   <string name="download_type_media">Медиафайл</string>

--- a/core/src/main/res/values-sk/strings.xml
+++ b/core/src/main/res/values-sk/strings.xml
@@ -164,7 +164,6 @@
   <string name="hide_not_queued_episodes_label">Mimo poradia</string>
   <string name="hide_has_media_label">S médiami</string>
   <string name="filtered_label">Filtrované</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Posledná aktualizácia skončila s chybou</string>
   <string name="open_podcast">Otvoriť podcast</string>
   <string name="please_wait_for_data">Počkajte, kým sa dáta načítajú</string>
   <!--actions on feeditems-->
@@ -235,16 +234,12 @@
   <string name="download_error_details">Podrobnosti</string>
   <string name="download_error_details_message">%1$s \n\nURL adresa súboru:\n%2$s</string>
   <string name="download_error_device_not_found">Zariadenie úložiska nebolo nájdené</string>
-  <string name="download_error_insufficient_space">Nedostatok miesta</string>
   <string name="download_error_http_data_error">Chyba dát HTTP</string>
   <string name="download_error_error_unknown">Neznáma chyba</string>
-  <string name="download_error_parser_exception">Výnimka analyzátora</string>
   <string name="download_error_unsupported_type">Nepodporovaný typ zdroja</string>
   <string name="download_error_connection_error">Chyba pripojenia</string>
-  <string name="download_error_unknown_host">Neznámy hostiteľ</string>
   <string name="download_error_unauthorized">Chyba overenia</string>
   <string name="download_error_file_type_type">Chyba typu súboru</string>
-  <string name="download_error_forbidden">Zakázané</string>
   <string name="download_canceled_msg">Preberanie zrušené</string>
   <string name="download_report_title">Pri sťahovaní nastali chyby</string>
   <string name="download_report_content_title">Hlásenie o preberaniach</string>
@@ -258,14 +253,7 @@
     <item quantity="many">Zostáva %d súborov na stiahnutie</item>
     <item quantity="other">Zostáva %d súborov na stiahnutie</item>
   </plurals>
-  <string name="downloads_processing">Spracovanie prevzatých súborov</string>
   <string name="download_notification_title">Sťahujú sa údaje podcastu</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%dsťahovanie úspešné, %dzlyhalo</item>
-    <item quantity="few">%dsťahovania úspešné, %dzlyhali</item>
-    <item quantity="many">%dsťahovaní úspešných, %dzlyhalo</item>
-    <item quantity="other">%dsťahovaní úspešných, %dzlyhalo</item>
-  </plurals>
   <string name="download_log_title_unknown">Neznámy titul</string>
   <string name="download_type_feed">Zdroj</string>
   <string name="download_type_media">Mediálny súbor</string>

--- a/core/src/main/res/values-sv/strings.xml
+++ b/core/src/main/res/values-sv/strings.xml
@@ -164,7 +164,6 @@
   <string name="hide_not_queued_episodes_label">Inte köade</string>
   <string name="hide_has_media_label">Har media</string>
   <string name="filtered_label">Filtrerad</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Senaste uppdateringen misslyckades</string>
   <string name="open_podcast">Öppna podcast</string>
   <string name="please_wait_for_data">Vänta tills datan laddats</string>
   <!--actions on feeditems-->
@@ -229,18 +228,13 @@
   <string name="download_error_details">Detaljer</string>
   <string name="download_error_details_message">%1$s \n\nFil-URL:\n%2$s</string>
   <string name="download_error_device_not_found">Hittade ingen lagringsenhet</string>
-  <string name="download_error_insufficient_space">Otillräckligt utrymme</string>
   <string name="download_error_http_data_error">HTTP data fel</string>
   <string name="download_error_error_unknown">Okänt fel</string>
-  <string name="download_error_parser_exception">Tolkningsfel</string>
   <string name="download_error_unsupported_type">Flödestypen stöds inte</string>
   <string name="download_error_connection_error">Anslutningsfel</string>
-  <string name="download_error_unknown_host">Okänd värd</string>
   <string name="download_error_unauthorized">Autentiseringsfel</string>
   <string name="download_error_file_type_type">Filtypsfel</string>
-  <string name="download_error_forbidden">Förbjuden</string>
   <string name="download_canceled_msg">Nedladdning avbruten</string>
-  <string name="download_wrong_size">Serveranslutningen tappades innan nedladdningen var klar</string>
   <string name="download_canceled_autodownload_enabled_msg">Nedladdning avbruten\nStängde av <i>Automatisk nedladdning</i> för detta föremål</string>
   <string name="download_report_title">Nedladdningar avslutades med fel</string>
   <string name="auto_download_report_title">Automatiska nedladdningar klara</string>
@@ -253,12 +247,7 @@
     <item quantity="one">%d nedladdning kvar</item>
     <item quantity="other">%d nedladdningar kvar</item>
   </plurals>
-  <string name="downloads_processing">Bearbetar nedladdningar</string>
   <string name="download_notification_title">Laddar ner podcastdata</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d nedladdning lyckades, %d misslyckades</item>
-    <item quantity="other">%dnedladdningar lyckades, %d misslyckades</item>
-  </plurals>
   <string name="download_log_title_unknown">Okänd titel</string>
   <string name="download_type_feed">Flöde</string>
   <string name="download_type_media">Mediafil</string>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -144,7 +144,6 @@
   <string name="hide_not_queued_episodes_label">Kuyrukta değil</string>
   <string name="hide_has_media_label">Medya var</string>
   <string name="filtered_label">Filtrelendi</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Son yenileme başarısız oldu</string>
   <string name="open_podcast">Cep yayını aç</string>
   <string name="please_wait_for_data">Please wait until the data is loaded</string>
   <!--actions on feeditems-->
@@ -205,16 +204,12 @@
   <string name="download_error_details">Detaylar</string>
   <string name="download_error_details_message">%1$s \n\nFile URL:\n%2$s</string>
   <string name="download_error_device_not_found">Depolama aygıtı bulunamadı</string>
-  <string name="download_error_insufficient_space">Yetersiz alan</string>
   <string name="download_error_http_data_error">HTTP Veri Hatası</string>
   <string name="download_error_error_unknown">Bilinmeyen Hata</string>
-  <string name="download_error_parser_exception">Ayrıştırıcı İstisnası</string>
   <string name="download_error_unsupported_type">Desteklenmeyen Besleme türü</string>
   <string name="download_error_connection_error">Baplantı hatası</string>
-  <string name="download_error_unknown_host">Bilinmeyen sunucu</string>
   <string name="download_error_unauthorized">Yetkilendirme hatası</string>
   <string name="download_error_file_type_type">Dosya Tipi Hatası</string>
-  <string name="download_error_forbidden">Yasak</string>
   <string name="download_canceled_msg">İndirme iptal edildi</string>
   <string name="download_canceled_autodownload_enabled_msg">İndirme iptal edildi\nBu öğe için <i>Otomatik İndirme</i> devre dışı</string>
   <string name="download_report_title">İndirme hata(lar) ile tamamlandı</string>
@@ -228,12 +223,7 @@
     <item quantity="one">%d indirme kaldı</item>
     <item quantity="other">%d indirme kaldı</item>
   </plurals>
-  <string name="downloads_processing">İndirmeler işleniyor</string>
   <string name="download_notification_title">Cep yayını verileri indiriliyor</string>
-  <plurals name="download_report_content">
-    <item quantity="one">%d download succeeded, %d failed</item>
-    <item quantity="other">%d downloads succeeded, %d failed</item>
-  </plurals>
   <string name="download_log_title_unknown">bilinmeyen başlık</string>
   <string name="download_type_feed">Besleme</string>
   <string name="download_type_media">Medya dosyası</string>

--- a/core/src/main/res/values-uk/strings.xml
+++ b/core/src/main/res/values-uk/strings.xml
@@ -120,7 +120,6 @@
   <string name="hide_not_queued_episodes_label">Не в черзі</string>
   <string name="hide_has_media_label">Зі звуком або відео</string>
   <string name="filtered_label">Фільтровані</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} Останнє оновлення було невдалим</string>
   <string name="open_podcast">Відкрити подкаст</string>
   <!--actions on feeditems-->
   <string name="download_label">Завантажити</string>
@@ -183,16 +182,12 @@
   <string name="download_error_details">Докладно</string>
   <string name="download_error_details_message">%1$s \n\nПосилання на файл:\n%2$s</string>
   <string name="download_error_device_not_found">Пристрій зберігання даних не знайдено</string>
-  <string name="download_error_insufficient_space">Недостатній простір для зберігання</string>
   <string name="download_error_http_data_error">Помилка HTTP</string>
   <string name="download_error_error_unknown">Щось трапилось</string>
-  <string name="download_error_parser_exception">Помилка парсера</string>
   <string name="download_error_unsupported_type">Тип каналу не підтримується</string>
   <string name="download_error_connection_error">Помилка з\'єднання</string>
-  <string name="download_error_unknown_host">Невідомий хост</string>
   <string name="download_error_unauthorized">Помилка автентифікації</string>
   <string name="download_error_file_type_type">Помилка типу файлу</string>
-  <string name="download_error_forbidden">Заборонено</string>
   <string name="download_canceled_msg">Завантаження скасоване</string>
   <string name="download_canceled_autodownload_enabled_msg">Завантаження скасоване\n<i>Автозавантаження</i> для цього елементу вимкнуто</string>
   <string name="download_report_title">Завантаження завершені з помилками</string>
@@ -207,7 +202,6 @@
     <item quantity="many">%d завантажень залишилось</item>
     <item quantity="other">%d завантажень залишилось</item>
   </plurals>
-  <string name="downloads_processing">Обробка завантаженого</string>
   <string name="download_notification_title">Завантаження даних подкасту</string>
   <string name="download_log_title_unknown">Невідомий заголовок</string>
   <string name="download_type_feed">Канал</string>

--- a/core/src/main/res/values-zh-rCN/strings.xml
+++ b/core/src/main/res/values-zh-rCN/strings.xml
@@ -159,7 +159,6 @@
   <string name="hide_not_queued_episodes_label">不在播放列表中</string>
   <string name="hide_has_media_label">包含媒体文件</string>
   <string name="filtered_label">已过滤的</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} 上次刷新失败</string>
   <string name="open_podcast">打开播客</string>
   <string name="please_wait_for_data">请等待数据加载完成</string>
   <!--actions on feeditems-->
@@ -218,18 +217,13 @@
   <string name="download_error_details">详细信息</string>
   <string name="download_error_details_message">%1$s \n\nFile URL:\n%2$s</string>
   <string name="download_error_device_not_found">没有找到存储设备</string>
-  <string name="download_error_insufficient_space">空间不足</string>
   <string name="download_error_http_data_error">HTTP 数据错误</string>
   <string name="download_error_error_unknown">未知错误</string>
-  <string name="download_error_parser_exception">解析异常</string>
   <string name="download_error_unsupported_type">未提供的订阅类型</string>
   <string name="download_error_connection_error">链接错误</string>
-  <string name="download_error_unknown_host">未知主机</string>
   <string name="download_error_unauthorized">认证错误</string>
   <string name="download_error_file_type_type">文件类型错误</string>
-  <string name="download_error_forbidden">禁用的</string>
   <string name="download_canceled_msg">已取消下载</string>
-  <string name="download_wrong_size">完成下载前，服务器连接丢失</string>
   <string name="download_canceled_autodownload_enabled_msg">已取消下载\n对该曲目禁用<i>自动下载</i></string>
   <string name="download_report_title">下载完成</string>
   <string name="auto_download_report_title">自动下载完成</string>
@@ -241,11 +235,7 @@
   <plurals name="downloads_left">
     <item quantity="other">剩余%d个下载项</item>
   </plurals>
-  <string name="downloads_processing">正在处理下载</string>
   <string name="download_notification_title">下载播客数据</string>
-  <plurals name="download_report_content">
-    <item quantity="other">%d个下载成功，%d下载失败</item>
-  </plurals>
   <string name="download_log_title_unknown">未知标题</string>
   <string name="download_type_feed">订阅</string>
   <string name="download_type_media">媒体文件</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -141,7 +141,6 @@
   <string name="hide_not_queued_episodes_label">未列入待播清單</string>
   <string name="hide_has_media_label">包含媒體</string>
   <string name="filtered_label">已過濾</string>
-  <string name="refresh_failed_msg">{fa-exclamation-circle} 更新失敗</string>
   <string name="open_podcast">打開 Podcast</string>
   <string name="please_wait_for_data">資料載入中，請稍候</string>
   <!--actions on feeditems-->
@@ -197,16 +196,12 @@
   <string name="download_error_details">詳情</string>
   <string name="download_error_details_message">%1$s \n\n檔案網址：\n%2$s</string>
   <string name="download_error_device_not_found">沒找到儲存空間</string>
-  <string name="download_error_insufficient_space">儲存空間不足</string>
   <string name="download_error_http_data_error">HTTP 資料有誤</string>
   <string name="download_error_error_unknown">位置錯誤</string>
-  <string name="download_error_parser_exception">解析器異常</string>
   <string name="download_error_unsupported_type">不支援此來源類型</string>
   <string name="download_error_connection_error">連接錯誤</string>
-  <string name="download_error_unknown_host">不明主機</string>
   <string name="download_error_unauthorized">驗證失敗</string>
   <string name="download_error_file_type_type">文件格式錯誤</string>
-  <string name="download_error_forbidden">禁止存取</string>
   <string name="download_canceled_msg">下載已取消</string>
   <string name="download_canceled_autodownload_enabled_msg">下載已取消\n這一項的 <i>自動下載</i> 已停用</string>
   <string name="download_report_title">下載已完成，但可能有錯誤</string>
@@ -219,11 +214,7 @@
   <plurals name="downloads_left">
     <item quantity="other">剩餘%d 個下載</item>
   </plurals>
-  <string name="downloads_processing">正在下載</string>
   <string name="download_notification_title">Podcast 資料下載中</string>
-  <plurals name="download_report_content">
-    <item quantity="other">成功下載 %d 個單集，失敗 %d 個</item>
-  </plurals>
   <string name="download_log_title_unknown">標題不明</string>
   <string name="download_type_feed">資料來源</string>
   <string name="download_type_media">媒體檔案</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -262,7 +262,7 @@
     <string name="download_canceled_msg">Download canceled</string>
     <string name="download_error_wrong_size">The server connection was lost before completing the download</string>
     <string name="download_error_blocked">The download was blocked by another app on your device.</string>
-    <string name="download_error_certificate">Unable to establish a secure connection. This can mean that another app on your device blocks the download, or that something is wrong with the server certificates.</string>
+    <string name="download_error_certificate">Unable to establish a secure connection. This can mean that another app on your device blocked the download, or that something is wrong with the server certificates.</string>
     <string name="download_canceled_autodownload_enabled_msg">Download canceled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="auto_download_report_title">Auto-downloads completed</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -255,7 +255,7 @@
     <string name="download_error_unsupported_type_html">The podcast host\'s server sent a website, not a podcast.</string>
     <string name="download_error_not_found">The podcast host\'s server does not know where to find the file. It may have been deleted.</string>
     <string name="download_error_connection_error">Connection Error</string>
-    <string name="download_error_unknown_host">Unknown Host</string>
+    <string name="download_error_unknown_host">Cannot find the server. Check if the address is typed correctly and if you have a working network connection.</string>
     <string name="download_error_unauthorized">Authentication Error</string>
     <string name="download_error_file_type_type">File Type Error</string>
     <string name="download_error_forbidden">The podcast host\'s server refuses to respond.</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -276,10 +276,6 @@
     </plurals>
     <string name="service_shutting_down">Service shutting down</string>
     <string name="download_notification_title">Downloading podcast data</string>
-    <plurals name="download_report_content">
-        <item quantity="one">%d download succeeded, %d failed</item>
-        <item quantity="other">%d downloads succeeded, %d failed</item>
-    </plurals>
     <string name="download_log_title_unknown">Unknown Title</string>
     <string name="download_type_feed">Feed</string>
     <string name="download_type_media">Media file</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -258,6 +258,7 @@
     <string name="download_error_forbidden">Forbidden</string>
     <string name="download_canceled_msg">Download canceled</string>
     <string name="download_wrong_size">The server connection was lost before completing the download</string>
+    <string name="download_blocked">The download was blocked by another app on your device</string>
     <string name="download_canceled_autodownload_enabled_msg">Download canceled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="auto_download_report_title">Auto-downloads completed</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -262,6 +262,7 @@
     <string name="download_canceled_msg">Download canceled</string>
     <string name="download_error_wrong_size">The server connection was lost before completing the download</string>
     <string name="download_error_blocked">The download was blocked by another app on your device.</string>
+    <string name="download_error_certificate">Unable to establish a secure connection. This can mean that another app on your device blocks the download, or that something is wrong with the server certificates.</string>
     <string name="download_canceled_autodownload_enabled_msg">Download canceled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="auto_download_report_title">Auto-downloads completed</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -179,7 +179,7 @@
     <string name="hide_not_queued_episodes_label">Not queued</string>
     <string name="hide_has_media_label">Has media</string>
     <string name="filtered_label">Filtered</string>
-    <string name="refresh_failed_msg">{fa-exclamation-circle} Last Refresh failed</string>
+    <string name="refresh_failed_msg">{fa-exclamation-circle} Last Refresh failed. Tap to view details.</string>
     <string name="open_podcast">Open Podcast</string>
     <string name="please_wait_for_data">Please wait until the data is loaded</string>
 
@@ -245,20 +245,23 @@
     <string name="download_running">Download running</string>
     <string name="download_error_details">Details</string>
     <string name="download_error_details_message">%1$s \n\nFile URL:\n%2$s</string>
+    <string name="download_error_tap_for_details">Tap to view details.</string>
     <string name="download_error_device_not_found">Storage Device not found</string>
-    <string name="download_error_insufficient_space">Insufficient Space</string>
+    <string name="download_error_insufficient_space">There is not enough space left on your device.</string>
     <string name="download_error_http_data_error">HTTP Data Error</string>
     <string name="download_error_error_unknown">Unknown Error</string>
-    <string name="download_error_parser_exception">Parser Exception</string>
+    <string name="download_error_parser_exception">The podcast host\'s server sent a broken podcast feed.</string>
     <string name="download_error_unsupported_type">Unsupported Feed Type</string>
+    <string name="download_error_unsupported_type_html">The podcast host\'s server sent a website, not a podcast.</string>
+    <string name="download_error_not_found">The podcast host\'s server does not know where to find the file. It may have been deleted.</string>
     <string name="download_error_connection_error">Connection Error</string>
     <string name="download_error_unknown_host">Unknown Host</string>
     <string name="download_error_unauthorized">Authentication Error</string>
     <string name="download_error_file_type_type">File Type Error</string>
-    <string name="download_error_forbidden">Forbidden</string>
+    <string name="download_error_forbidden">The podcast host\'s server refuses to respond.</string>
     <string name="download_canceled_msg">Download canceled</string>
-    <string name="download_wrong_size">The server connection was lost before completing the download</string>
-    <string name="download_blocked">The download was blocked by another app on your device</string>
+    <string name="download_error_wrong_size">The server connection was lost before completing the download</string>
+    <string name="download_error_blocked">The download was blocked by another app on your device.</string>
     <string name="download_canceled_autodownload_enabled_msg">Download canceled\nDisabled <i>Auto Download</i> for this item</string>
     <string name="download_report_title">Downloads completed with error(s)</string>
     <string name="auto_download_report_title">Auto-downloads completed</string>


### PR DESCRIPTION
- Show dedicated error message when an app messes with the network (looking at you, Blockada)
- Describe download errors in a more human-readable way
- Hide the technical details unless the item is clicked (I hope that this makes it more likely that users actually read the text)
- Show the name of failing downloads in the notification (related: #4948)

I don't like changing strings during the beta but I think in this case, it's worth it. We get tons of reports caused by Blockada recently.