### PR TITLE
Exclude non-functional notification settings screen from settings search for android versions 26+

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -109,11 +109,11 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
 
     public PreferenceFragmentCompat openScreen(int screen) {
         PreferenceFragmentCompat fragment = getPreferenceScreen(screen);
-        if(screen == R.xml.preferences_notifications && Build.VERSION.SDK_INT >= 26) {
-                Intent intent = new Intent();
-                intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-                intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
-                startActivity(intent);
+        if (screen == R.xml.preferences_notifications && Build.VERSION.SDK_INT >= 26) {
+            Intent intent = new Intent();
+            intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
+            startActivity(intent);
         } else {
             getSupportFragmentManager().beginTransaction().replace(R.id.content, fragment)
                     .addToBackStack(getString(getTitleOfPage(screen))).commit();
@@ -151,7 +151,7 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             builder.setMessage(R.string.pref_feed_settings_dialog_msg);
             builder.setPositiveButton(android.R.string.ok, null);
             builder.show();
-        } else if(screen == R.xml.preferences_notifications) {
+        } else if (screen == R.xml.preferences_notifications) {
             openScreen(screen);
         } else {
             PreferenceFragmentCompat fragment = openScreen(result.getResourceFile());

--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -1,10 +1,14 @@
 package de.danoeh.antennapod.activity;
 
+import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceFragmentCompat;
+
+import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.ViewGroup;
@@ -105,8 +109,17 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
 
     public PreferenceFragmentCompat openScreen(int screen) {
         PreferenceFragmentCompat fragment = getPreferenceScreen(screen);
-        getSupportFragmentManager().beginTransaction().replace(R.id.content, fragment)
-                .addToBackStack(getString(getTitleOfPage(screen))).commit();
+        if(screen == R.xml.preferences_notifications && Build.VERSION.SDK_INT >= 26) {
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+                intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
+                startActivity(intent);
+        } else {
+            getSupportFragmentManager().beginTransaction().replace(R.id.content, fragment)
+                    .addToBackStack(getString(getTitleOfPage(screen))).commit();
+        }
+
+
         return fragment;
     }
 
@@ -138,6 +151,8 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             builder.setMessage(R.string.pref_feed_settings_dialog_msg);
             builder.setPositiveButton(android.R.string.ok, null);
             builder.show();
+        } else if(screen == R.xml.preferences_notifications) {
+            openScreen(screen);
         } else {
             PreferenceFragmentCompat fragment = openScreen(result.getResourceFile());
             result.highlight(fragment);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
@@ -81,14 +81,7 @@ public class MainPreferencesFragment extends PreferenceFragmentCompat {
             return true;
         });
         findPreference(PREF_NOTIFICATION).setOnPreferenceClickListener(preference -> {
-            if (Build.VERSION.SDK_INT >= 26) {
-                Intent intent = new Intent();
-                intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-                intent.putExtra(Settings.EXTRA_APP_PACKAGE, getActivity().getPackageName());
-                startActivity(intent);
-            } else {
-                ((PreferenceActivity) getActivity()).openScreen(R.xml.preferences_notifications);
-            }
+            ((PreferenceActivity) getActivity()).openScreen(R.xml.preferences_notifications);
             return true;
         });
         findPreference(PREF_ABOUT).setOnPreferenceClickListener(

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
@@ -1,14 +1,15 @@
 package de.danoeh.antennapod.fragment.preferences;
 
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
-import android.provider.Settings;
+
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
 import com.bytehamster.lib.preferencesearch.SearchConfiguration;
 import com.bytehamster.lib.preferencesearch.SearchPreference;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.BugReportActivity;
 import de.danoeh.antennapod.activity.PreferenceActivity;


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
I've tested it and it works great. I've refactored to eliminate code duplication. Hope it's fine with you.

Fixes #4918