### PR TITLE
Fixes #4927 - Adds a visual cue to the podcast header view whenever updates are disabled

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -100,6 +100,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     private ImageView imgvCover;
     private TextView txtvInformation;
     private TextView txtvAuthor;
+    private TextView txtvUpdatesDisabled;
     private ImageButton butShowInfo;
     private ImageButton butShowSettings;
     private View header;
@@ -166,6 +167,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         butShowSettings = root.findViewById(R.id.butShowSettings);
         txtvInformation = root.findViewById(R.id.txtvInformation);
         txtvFailure = root.findViewById(R.id.txtvFailure);
+        txtvUpdatesDisabled = root.findViewById(R.id.txtvUpdatesDisabled);
         header = root.findViewById(R.id.headerContainer);
         AppBarLayout appBar = root.findViewById(R.id.appBar);
         CollapsingToolbarLayout collapsingToolbar = root.findViewById(R.id.collapsing_toolbar);
@@ -455,6 +457,13 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             txtvFailure.setVisibility(View.VISIBLE);
         } else {
             txtvFailure.setVisibility(View.GONE);
+        }
+        if(!feed.getPreferences().getKeepUpdated()) {
+            txtvUpdatesDisabled.setText("{md-pause-circle-outline} " + this.getString(R.string.updates_disabled_label));
+            Iconify.addIcons(txtvUpdatesDisabled);
+            txtvUpdatesDisabled.setVisibility(View.VISIBLE);
+        } else {
+            txtvUpdatesDisabled.setVisibility(View.GONE);
         }
         txtvTitle.setText(feed.getTitle());
         txtvAuthor.setText(feed.getAuthor());

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -117,4 +117,15 @@
             android:gravity="center"
             tools:visibility="visible"
             tools:text="(i) Information"/>
+
+    <TextView
+        android:id="@+id/txtvUpdatesDisabled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="2dp"
+        android:background="?android:attr/windowBackground"
+        android:visibility="gone"
+        android:gravity="center"
+        tools:visibility="visible"
+        tools:text="Updates disabled"/>
 </LinearLayout>

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -119,13 +119,13 @@
             tools:text="(i) Information"/>
 
     <TextView
-        android:id="@+id/txtvUpdatesDisabled"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="2dp"
-        android:background="?android:attr/windowBackground"
-        android:visibility="gone"
-        android:gravity="center"
-        tools:visibility="visible"
-        tools:text="Updates disabled"/>
+            android:id="@+id/txtvUpdatesDisabled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="2dp"
+            android:background="?android:attr/windowBackground"
+            android:visibility="gone"
+            android:gravity="center"
+            tools:visibility="visible"
+            tools:text="Updates disabled"/>
 </LinearLayout>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="refresh_failed_msg">{fa-exclamation-circle} Last Refresh failed. Tap to view details.</string>
     <string name="open_podcast">Open Podcast</string>
     <string name="please_wait_for_data">Please wait until the data is loaded</string>
+    <string name="updates_disabled_label">Updates disabled</string>
 
     <!-- actions on feeditems -->
     <string name="download_label">Download</string>


### PR DESCRIPTION
Fixes #4927 

Added the message "Updates disabled" to the header view as discussed in the issue. 

**Changes made**: Added an condition in `refreshHeaderView()` method of `FeedItemlistFragment` class which fetches the feed preferences from the feed object and checks the value of keepUpdated attribute, if it returns false the newly added message gets displayed to the user. Additionally, a TextView was made to accommodate the newly added label in `feedlist_header.xml` file, along with the message string in `strings.xml`.

Refer screenshots below:

Keep Updated option turned off:
![image](https://user-images.githubusercontent.com/44409076/110541473-cc00c700-814d-11eb-9f27-38b24b4713e2.png)

With filtered label:
![image](https://user-images.githubusercontent.com/44409076/110541352-9eb41900-814d-11eb-8565-0762a4f271a1.png)

Without filtered label:
![image](https://user-images.githubusercontent.com/44409076/110541403-b4c1d980-814d-11eb-8c36-1d05d79ffbf9.png)

Please review and let me know if anything needs to be changed further.