### PR TITLE
Fixed getting next page of feed

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedSyncTask.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedSyncTask.java
@@ -39,7 +39,7 @@ public class FeedSyncTask {
         if (loadAllPages && feed.getNextPageLink() != null) {
             try {
                 feed.setId(savedFeed.getId());
-                DBTasks.loadNextPageOfFeed(context, savedFeed, true);
+                DBTasks.loadNextPageOfFeed(context, feed, true);
             } catch (DownloadRequestException e) {
                 Log.e(TAG, "Error trying to load next page", e);
             }


### PR DESCRIPTION
Apparently, the feature was never actually working since it was introduced in 2014...