### PR TITLE
Increase podcast title max lines to 6 in info fragment.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedInfoFragment.java
@@ -222,6 +222,7 @@ public class FeedInfoFragment extends Fragment implements Toolbar.OnMenuItemClic
                 .into(imgvBackground);
 
         txtvTitle.setText(feed.getTitle());
+        txtvTitle.setMaxLines(6);
 
         String description = HtmlToPlainText.getPlainText(feed.getDescription());
 


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
Fixes #4799 and PR #4856, display full podcast title on podcast info screen.