### PR TITLE
Fixed certain file types not being recognized in local feeds (Closes #4802)

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -77,10 +77,10 @@ public class LocalFeedUpdater {
             MediaType mediaType = MediaType.fromMimeType(mime);
             if (mediaType == MediaType.UNKNOWN) {
                 String path = file.getUri().toString();
-                int i = path.lastIndexOf('.');
-                if (i >= 0) {
-                    String suffixWithoutDot = path.substring(i + 1);
-                    mediaType = MediaType.fromSuffix(suffixWithoutDot);
+                int fileExtensionPosition = path.lastIndexOf('.');
+                if (fileExtensionPosition >= 0) {
+                    String extensionWithoutDot = path.substring(fileExtensionPosition + 1);
+                    mediaType = MediaType.fromFileExtension(extensionWithoutDot);
                 }
             }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -70,7 +70,21 @@ public class LocalFeedUpdater {
         Set<String> mediaFileNames = new HashSet<>();
         for (DocumentFile file : documentFolder.listFiles()) {
             String mime = file.getType();
-            if (mime != null && (mime.startsWith("audio/") || mime.startsWith("video/"))) {
+            if (mime == null) {
+                continue;
+            }
+
+            MediaType mediaType = MediaType.fromMimeType(mime);
+            if (mediaType == MediaType.UNKNOWN) {
+                String path = file.getUri().toString();
+                int i = path.lastIndexOf('.');
+                if (i >= 0) {
+                    String suffixWithoutDot = path.substring(i + 1);
+                    mediaType = MediaType.fromSuffix(suffixWithoutDot);
+                }
+            }
+
+            if (mediaType == MediaType.AUDIO || mediaType == MediaType.VIDEO) {
                 mediaFiles.add(file);
                 mediaFileNames.add(file.getName());
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/MediaType.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/MediaType.java
@@ -16,12 +16,12 @@ public enum MediaType {
     ));
 
     // based on https://developer.android.com/guide/topics/media/media-formats
-    static final Set<String> AUDIO_SUFFIXES = new HashSet<>(Arrays.asList(
+    static final Set<String> AUDIO_FILE_EXTENSIONS = new HashSet<>(Arrays.asList(
             "3gp", "aac", "amr", "flac", "imy", "m4a", "mid", "mkv", "mp3", "mp4", "mxmf", "oga",
             "ogg", "ogx", "opus", "ota", "rtttl", "rtx", "wav", "xmf"
     ));
 
-    static final Set<String> VIDEO_SUFFIXES = new HashSet<>(Arrays.asList(
+    static final Set<String> VIDEO_FILE_EXTENSIONS = new HashSet<>(Arrays.asList(
             "3gp", "mkv", "mp4", "ogg", "ogv", "ogx", "webm"
     ));
 
@@ -39,16 +39,16 @@ public enum MediaType {
     }
 
     /**
-     * @param suffixWithoutDot the file suffix (extension) without the dot
-     * @return the {@link MediaType} that likely corresponds to the suffix. However, since the
-     *         suffix is not always enough to determine whether a file is an audio or video (3gp
+     * @param extensionWithoutDot the file extension (suffix) without the dot
+     * @return the {@link MediaType} that likely corresponds to the extension. However, since the
+     *         extension is not always enough to determine whether a file is an audio or video (3gp
      *         can be both, for example), this may not be correct. As a result, where possible,
      *         {@link #fromMimeType(String) fromMimeType} should always be tried first.
      */
-    public static MediaType fromSuffix(String suffixWithoutDot) {
-        if (AUDIO_SUFFIXES.contains(suffixWithoutDot)) {
+    public static MediaType fromFileExtension(String extensionWithoutDot) {
+        if (AUDIO_FILE_EXTENSIONS.contains(extensionWithoutDot)) {
             return MediaType.AUDIO;
-        } else if (VIDEO_SUFFIXES.contains(suffixWithoutDot)) {
+        } else if (VIDEO_FILE_EXTENSIONS.contains(extensionWithoutDot)) {
             return MediaType.VIDEO;
         }
         return MediaType.UNKNOWN;

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/MediaType.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/MediaType.java
@@ -2,19 +2,55 @@ package de.danoeh.antennapod.core.feed;
 
 import android.text.TextUtils;
 
-public enum MediaType {
-	AUDIO, VIDEO, UNKNOWN;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
-	public static MediaType fromMimeType(String mime_type) {
-		if (TextUtils.isEmpty(mime_type)) {
-			return MediaType.UNKNOWN;
-		} else if (mime_type.startsWith("audio")) {
-			return MediaType.AUDIO;
-		} else if (mime_type.startsWith("video")) {
-			return MediaType.VIDEO;
-		} else if (mime_type.equals("application/ogg")) {
-			return MediaType.AUDIO;
-		}
-		return MediaType.UNKNOWN;
-	}
+public enum MediaType {
+    AUDIO, VIDEO, UNKNOWN;
+
+    private static final Set<String> AUDIO_APPLICATION_MIME_STRINGS = new HashSet<>(Arrays.asList(
+            "application/ogg",
+            "application/opus",
+            "application/x-flac"
+    ));
+
+    // based on https://developer.android.com/guide/topics/media/media-formats
+    static final Set<String> AUDIO_SUFFIXES = new HashSet<>(Arrays.asList(
+            "3gp", "aac", "amr", "flac", "imy", "m4a", "mid", "mkv", "mp3", "mp4", "mxmf", "oga",
+            "ogg", "ogx", "opus", "ota", "rtttl", "rtx", "wav", "xmf"
+    ));
+
+    static final Set<String> VIDEO_SUFFIXES = new HashSet<>(Arrays.asList(
+            "3gp", "mkv", "mp4", "ogg", "ogv", "ogx", "webm"
+    ));
+
+    public static MediaType fromMimeType(String mimeType) {
+        if (TextUtils.isEmpty(mimeType)) {
+            return MediaType.UNKNOWN;
+        } else if (mimeType.startsWith("audio")) {
+            return MediaType.AUDIO;
+        } else if (mimeType.startsWith("video")) {
+            return MediaType.VIDEO;
+        } else if (AUDIO_APPLICATION_MIME_STRINGS.contains(mimeType)) {
+            return MediaType.AUDIO;
+        }
+        return MediaType.UNKNOWN;
+    }
+
+    /**
+     * @param suffixWithoutDot the file suffix (extension) without the dot
+     * @return the {@link MediaType} that likely corresponds to the suffix. However, since the
+     *         suffix is not always enough to determine whether a file is an audio or video (3gp
+     *         can be both, for example), this may not be correct. As a result, where possible,
+     *         {@link #fromMimeType(String) fromMimeType} should always be tried first.
+     */
+    public static MediaType fromSuffix(String suffixWithoutDot) {
+        if (AUDIO_SUFFIXES.contains(suffixWithoutDot)) {
+            return MediaType.AUDIO;
+        } else if (VIDEO_SUFFIXES.contains(suffixWithoutDot)) {
+            return MediaType.VIDEO;
+        }
+        return MediaType.UNKNOWN;
+    }
 }


### PR DESCRIPTION
This fixes #4802 which, as was mentioned by @damoasda, is a result of incorrect mimetypes being returned for opus (and others) in Android 9 and before (maybe Android 10 too). For example, an opus file would return a mime type of `application/octet-stream`.

The PR provided here should also solve this problem for multiple other file types, by instead using the suffix (file extension) in cases where the mime type was of no help.

Screenshot:

![Screenshot](https://user-images.githubusercontent.com/3063858/111343081-5d56c880-867b-11eb-9849-0409f31cd2c1.png)