### PR TITLE
Safer remain time - default to zero when the media duration is wrong

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -433,7 +433,7 @@ public class AudioPlayerFragment extends Fragment implements
         TimeSpeedConverter converter = new TimeSpeedConverter(controller.getCurrentPlaybackSpeedMultiplier());
         int currentPosition = converter.convert(event.getPosition());
         int duration = converter.convert(event.getDuration());
-        int remainingTime = converter.convert(event.getDuration() - event.getPosition());
+        int remainingTime = converter.convert(Math.max(event.getDuration() - event.getPosition(), 0));
         Log.d(TAG, "currentPosition " + Converter.getDurationStringLong(currentPosition));
         if (currentPosition == PlaybackService.INVALID_TIME || duration == PlaybackService.INVALID_TIME) {
             Log.w(TAG, "Could not react to position observer update because of invalid time");
@@ -442,7 +442,7 @@ public class AudioPlayerFragment extends Fragment implements
         txtvPosition.setText(Converter.getDurationStringLong(currentPosition));
         showTimeLeft = UserPreferences.shouldShowRemainingTime();
         if (showTimeLeft) {
-            txtvLength.setText("-" + Converter.getDurationStringLong(remainingTime));
+            txtvLength.setText(((remainingTime > 0) ? "-" : "") + Converter.getDurationStringLong(remainingTime));
         } else {
             txtvLength.setText(Converter.getDurationStringLong(duration));
         }

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -154,6 +154,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
                 Converter.getDurationStringLocalized(activity, media.getDuration())));
         if (item.getState() == FeedItem.State.PLAYING || item.getState() == FeedItem.State.IN_PROGRESS) {
             int progress = (int) (100.0 * media.getPosition() / media.getDuration());
+            int remainingTime = Math.max(media.getDuration() - media.getPosition(), 0);
             progressBar.setProgress(progress);
             position.setText(Converter.getDurationStringLong(media.getPosition()));
             position.setContentDescription(activity.getString(R.string.position,
@@ -161,7 +162,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
             progressBar.setVisibility(View.VISIBLE);
             position.setVisibility(View.VISIBLE);
             if (UserPreferences.shouldShowRemainingTime()) {
-                duration.setText("-" + Converter.getDurationStringLong(media.getDuration() - media.getPosition()));
+                duration.setText(((remainingTime > 0) ? "-" : "") + Converter.getDurationStringLong(remainingTime));
                 duration.setContentDescription(activity.getString(R.string.chapter_duration,
                         Converter.getDurationStringLocalized(activity, (media.getDuration() - media.getPosition()))));
             }
@@ -194,14 +195,14 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
     private void updateDuration(PlaybackPositionEvent event) {
         int currentPosition = event.getPosition();
         int timeDuration = event.getDuration();
-        int remainingTime = event.getDuration() - event.getPosition();
+        int remainingTime = Math.max(timeDuration - currentPosition, 0);
         Log.d(TAG, "currentPosition " + Converter.getDurationStringLong(currentPosition));
         if (currentPosition == PlaybackService.INVALID_TIME || timeDuration == PlaybackService.INVALID_TIME) {
             Log.w(TAG, "Could not react to position observer update because of invalid time");
             return;
         }
         if (UserPreferences.shouldShowRemainingTime()) {
-            duration.setText("-" + Converter.getDurationStringLong(remainingTime));
+            duration.setText(((remainingTime > 0) ? "-" : "") + Converter.getDurationStringLong(remainingTime));
         } else {
             duration.setText(Converter.getDurationStringLong(timeDuration));
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -23,8 +23,12 @@ public final class Converter {
      * Converts milliseconds to a string containing hours, minutes and seconds.
      */
     public static String getDurationStringLong(int duration) {
-        int[] hms = millisecondsToHms(duration);
-        return String.format(Locale.getDefault(), "%02d:%02d:%02d", hms[0], hms[1], hms[2]);
+        if (duration <= 0) {
+            return "00:00:00";
+        } else {
+            int[] hms = millisecondsToHms(duration);
+            return String.format(Locale.getDefault(), "%02d:%02d:%02d", hms[0], hms[1], hms[2]);
+        }
     }
 
     private static int[] millisecondsToHms(long duration) {


### PR DESCRIPTION
rebased #5037 to master

Fixes this UI issue https://forum.antennapod.org/t/beta-version-2-2-0/751/10?u=tonytamsf
- don't show double negative remain time