### PR TITLE
Use FragmentContainerView in settings

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -11,14 +11,13 @@ import androidx.preference.PreferenceFragmentCompat;
 import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.ViewGroup;
-import android.widget.FrameLayout;
 
 import com.bytehamster.lib.preferencesearch.SearchPreferenceResult;
 import com.bytehamster.lib.preferencesearch.SearchPreferenceResultListener;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.databinding.SettingsActivityBinding;
 import de.danoeh.antennapod.fragment.preferences.AutoDownloadPreferencesFragment;
 import de.danoeh.antennapod.fragment.preferences.GpodderPreferencesFragment;
 import de.danoeh.antennapod.fragment.preferences.ImportExportPreferencesFragment;
@@ -46,15 +45,12 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             ab.setDisplayHomeAsUpEnabled(true);
         }
 
-        FrameLayout root = new FrameLayout(this);
-        root.setId(R.id.content);
-        root.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT));
-        setContentView(root);
+        final SettingsActivityBinding binding = SettingsActivityBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
 
         if (getSupportFragmentManager().findFragmentByTag(FRAGMENT_TAG) == null) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.content, new MainPreferencesFragment(), FRAGMENT_TAG)
+                    .replace(R.id.settingsContainer, new MainPreferencesFragment(), FRAGMENT_TAG)
                     .commit();
         }
     }
@@ -115,7 +111,7 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
             startActivity(intent);
         } else {
-            getSupportFragmentManager().beginTransaction().replace(R.id.content, fragment)
+            getSupportFragmentManager().beginTransaction().replace(R.id.settingsContainer, fragment)
                     .addToBackStack(getString(getTitleOfPage(screen))).commit();
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/MainPreferencesFragment.java
@@ -87,14 +87,16 @@ public class MainPreferencesFragment extends PreferenceFragmentCompat {
         });
         findPreference(PREF_ABOUT).setOnPreferenceClickListener(
                 preference -> {
-                    getParentFragmentManager().beginTransaction().replace(R.id.content, new AboutFragment())
+                    getParentFragmentManager().beginTransaction()
+                            .replace(R.id.settingsContainer, new AboutFragment())
                             .addToBackStack(getString(R.string.about_pref)).commit();
                     return true;
                 }
         );
         findPreference(STATISTICS).setOnPreferenceClickListener(
                 preference -> {
-                    getParentFragmentManager().beginTransaction().replace(R.id.content, new StatisticsFragment())
+                    getParentFragmentManager().beginTransaction()
+                            .replace(R.id.settingsContainer, new StatisticsFragment())
                             .addToBackStack(getString(R.string.statistics_label)).commit();
                     return true;
                 }
@@ -117,7 +119,7 @@ public class MainPreferencesFragment extends PreferenceFragmentCompat {
         SearchPreference searchPreference = findPreference("searchPreference");
         SearchConfiguration config = searchPreference.getSearchConfiguration();
         config.setActivity((AppCompatActivity) getActivity());
-        config.setFragmentContainerViewId(R.id.content);
+        config.setFragmentContainerViewId(R.id.settingsContainer);
         config.setBreadcrumbsEnabled(true);
 
         config.index(R.xml.preferences_user_interface)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/about/AboutFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/about/AboutFragment.java
@@ -28,7 +28,8 @@ public class AboutFragment extends PreferenceFragmentCompat {
             return true;
         });
         findPreference("about_contributors").setOnPreferenceClickListener((preference) -> {
-            getParentFragmentManager().beginTransaction().replace(R.id.content, new ContributorsPagerFragment())
+            getParentFragmentManager().beginTransaction()
+                    .replace(R.id.settingsContainer, new ContributorsPagerFragment())
                     .addToBackStack(getString(R.string.contributors)).commit();
             return true;
         });
@@ -37,7 +38,8 @@ public class AboutFragment extends PreferenceFragmentCompat {
             return true;
         });
         findPreference("about_licenses").setOnPreferenceClickListener((preference) -> {
-            getParentFragmentManager().beginTransaction().replace(R.id.content, new LicensesFragment())
+            getParentFragmentManager().beginTransaction()
+                    .replace(R.id.settingsContainer, new LicensesFragment())
                     .addToBackStack(getString(R.string.translators)).commit();
             return true;
         });

--- a/app/src/main/res/layout/feedsettings.xml
+++ b/app/src/main/res/layout/feedsettings.xml
@@ -15,7 +15,7 @@
             android:elevation="4dp"
             android:id="@+id/toolbar"/>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/settingsContainer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->

See https://github.com/TeamNewPipe/NewPipe/pull/5882. As stated in that PR, you should read over the [reasons](https://developer.android.com/jetpack/androidx/releases/fragment#1.2.0-alpha02) for the class's creation to understand why this change was made.

This doesn't close any issues that I'm aware of.

However, you should update https://github.com/ByteHamster/SearchPreference's preference dependency to [1.1.1](https://developer.android.com/jetpack/androidx/releases/preference#1.1.1) so it can take advantage of the bugfixes between 1.1.0 and 1.2.4 that pertain to FragmentContainerView.