### PR TITLE
Upgraded dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,7 +189,7 @@ dependencies {
     implementation 'com.github.leinardi:FloatingActionButtonSpeedDial:3.1.1'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
     implementation 'com.github.mfietz:fyydlin:v0.5.0'
-    implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
+    implementation 'com.github.ByteHamster:SearchPreference:v2.1.0'
     implementation 'com.github.skydoves:balloon:1.1.5'
 
     // Non-free dependencies:
@@ -197,7 +197,7 @@ dependencies {
     compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
 
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    androidTestImplementation 'com.nanohttpd:nanohttpd:2.1.1'
+    androidTestImplementation 'com.nanohttpd:nanohttpd:2.2.0'
     androidTestImplementation "com.jayway.android.robotium:robotium-solo:$robotiumSoloVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"

--- a/app/src/androidTest/java/de/test/antennapod/util/service/download/HTTPBin.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/service/download/HTTPBin.java
@@ -101,7 +101,7 @@ public class HTTPBin extends NanoHTTPD {
         if (func.equalsIgnoreCase("status")) {
             try {
                 int code = Integer.parseInt(param);
-                return new Response(getStatus(code), MIME_HTML, "");
+                return newChunkedResponse(getStatus(code), MIME_HTML, null);
             } catch (NumberFormatException e) {
                 e.printStackTrace();
                 return getInternalError();
@@ -255,7 +255,8 @@ public class HTTPBin extends NanoHTTPD {
             }
         }
 
-        Response response = new Response(status, URLConnection.guessContentTypeFromName(file.getAbsolutePath()), inputStream);
+        Response response = newChunkedResponse(status,
+                URLConnection.guessContentTypeFromName(file.getAbsolutePath()), inputStream);
 
         response.addHeader("Accept-Ranges", "bytes");
         if (contentRange != null) {
@@ -281,7 +282,7 @@ public class HTTPBin extends NanoHTTPD {
         gzipOutputStream.close();
 
         InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        Response response = new Response(Response.Status.OK, MIME_PLAIN, inputStream);
+        Response response = newChunkedResponse(Response.Status.OK, MIME_PLAIN, inputStream);
         response.addHeader("Content-Encoding", "gzip");
         response.addHeader("Content-Length", String.valueOf(compressed.size()));
         return response;
@@ -330,7 +331,8 @@ public class HTTPBin extends NanoHTTPD {
 
     private Response getRedirectResponse(int times) {
         if (times > 0) {
-            Response response = new Response(Response.Status.REDIRECT, MIME_HTML, "This resource has been moved permanently");
+            Response response = newFixedLengthResponse(Response.Status.REDIRECT, MIME_HTML,
+                    "This resource has been moved permanently");
             response.addHeader("Location", "/redirect/" + times);
             return response;
         } else if (times == 0) {
@@ -341,24 +343,26 @@ public class HTTPBin extends NanoHTTPD {
     }
 
     private Response getUnauthorizedResponse() {
-        Response response = new Response(Response.Status.UNAUTHORIZED, MIME_HTML, "");
+        Response response = newFixedLengthResponse(Response.Status.UNAUTHORIZED, MIME_HTML, "");
         response.addHeader("WWW-Authenticate", "Basic realm=\"Test Realm\"");
         return response;
     }
 
     private Response getOKResponse() {
-        return new Response(Response.Status.OK, MIME_HTML, "");
+        return newFixedLengthResponse(Response.Status.OK, MIME_HTML, "");
     }
 
     private Response getInternalError() {
-        return new Response(Response.Status.INTERNAL_ERROR, MIME_HTML, "The server encountered an internal error");
+        return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_HTML,
+                "The server encountered an internal error");
     }
 
     private Response getRangeNotSatisfiable() {
-        return new Response(Response.Status.RANGE_NOT_SATISFIABLE, MIME_PLAIN, "");
+        return newFixedLengthResponse(Response.Status.RANGE_NOT_SATISFIABLE, MIME_PLAIN, "");
     }
 
     private Response get404Error() {
-        return new Response(Response.Status.NOT_FOUND, MIME_HTML, "The requested URL was not found on this server");
+        return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_HTML,
+                "The requested URL was not found on this server");
     }
 }

--- a/app/src/play/java/de/danoeh/antennapod/dialog/CustomMRControllerDialog.java
+++ b/app/src/play/java/de/danoeh/antennapod/dialog/CustomMRControllerDialog.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.RemoteException;
 import androidx.annotation.NonNull;
 import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
@@ -74,12 +73,8 @@ public class CustomMRControllerDialog extends MediaRouteControllerDialog {
         super(context, theme);
         mediaRouter = MediaRouter.getInstance(getContext());
         token = mediaRouter.getMediaSessionToken();
-        try {
-            if (token != null) {
-                mediaController = new MediaControllerCompat(getContext(), token);
-            }
-        } catch (RemoteException e) {
-            Log.e(TAG, "Error creating media controller", e);
+        if (token != null) {
+            mediaController = new MediaControllerCompat(getContext(), token);
         }
 
         if (mediaController != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.2'
         classpath 'de.timfreiheit.resourceplaceholders:placeholders:0.3'
         classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.0"
@@ -81,18 +81,18 @@ project.ext {
     targetSdkVersion = 30
 
     // AndroidX
-    annotationVersion = "1.1.0"
+    annotationVersion = "1.2.0"
     appcompatVersion = "1.2.0"
-    mediaVersion = "1.1.0"
+    mediaVersion = "1.2.1"
     preferenceVersion = "1.1.1"
-    workManagerVersion = "2.3.4"
-    googleMaterialVersion = "1.1.0"
+    workManagerVersion = "2.5.0"
+    googleMaterialVersion = "1.3.0"
 
     // Third-party
     commonslangVersion = "3.6"
     commonsioVersion = "2.5"
-    jsoupVersion = "1.11.2"
-    glideVersion = "4.8.0"
+    jsoupVersion = "1.13.1"
+    glideVersion = "4.12.0"
     okhttpVersion = "3.12.10"
     okioVersion = "1.17.5"
     eventbusVersion = "3.2.0"
@@ -102,7 +102,7 @@ project.ext {
     audioPlayerVersion = "v2.0.0"
 
     // Only used for free builds. This version should be updated regularly.
-    conscryptVersion = "2.4.0"
+    conscryptVersion = "2.5.2"
 
     // Google Play build
     wearableSupportVersion = "2.6.0"
@@ -111,9 +111,9 @@ project.ext {
     //Tests
     awaitilityVersion = "3.1.6"
     robotiumSoloVersion = "5.6.3"
-    espressoVersion = "3.2.0"
-    runnerVersion = "1.2.0"
-    rulesVersion = "1.2.0"
+    espressoVersion = "3.3.0"
+    runnerVersion = "1.3.0"
+    rulesVersion = "1.3.0"
 }
 
 wrapper {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.8'
+    implementation 'com.google.android.exoplayer:exoplayer:2.13.2'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     // Non-free dependencies:
@@ -108,9 +108,9 @@ dependencies {
     compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
 
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-inline:3.5.13'
-    testImplementation 'org.robolectric:robolectric:4.5-alpha-1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-inline:3.8.0'
+    testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation 'javax.inject:javax.inject:1'
     androidTestImplementation "com.jayway.android.robotium:robotium-solo:$robotiumSoloVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1921,11 +1921,16 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             }
         }
 
-
         @Override
         public void onSeekTo(long pos) {
             Log.d(TAG, "onSeekTo()");
             seekTo((int) pos);
+        }
+
+        @Override
+        public void onSetPlaybackSpeed(float speed) {
+            Log.d(TAG, "onSetPlaybackSpeed()");
+            setSpeed(speed);
         }
 
         @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/util/syndication/HtmlToPlainText.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/syndication/HtmlToPlainText.java
@@ -4,7 +4,7 @@ import android.text.TextUtils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
-import org.jsoup.helper.StringUtil;
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;


### PR DESCRIPTION
Not upgraded:
- `com.github.skydoves:balloon` shows the triangle in the wrong place
- `io.reactivex.rxjava3:rxjava` is more complex and will be done in its own PR: #5086 requires Java 8 support (API 21+)
- `commons-io:commons-io` requires Java 7 support (API 19+)
- `org.apache.commons:commons-lang3` requires Java 7 support (API 19+)
- `com.squareup.okhttp3:okhttp` requires Java 8 support (API 21+)