### PR TITLE
Show queue lock button even if "keep sorted" is active

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -242,7 +242,6 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
     private void refreshToolbarState() {
         MenuItemUtils.refreshLockItem(getActivity(), toolbar.getMenu());
         boolean keepSorted = UserPreferences.isQueueKeepSorted();
-        toolbar.getMenu().findItem(R.id.queue_lock).setVisible(!keepSorted);
 
         toolbar.getMenu().findItem(R.id.queue_sort_random).setVisible(!keepSorted);
         toolbar.getMenu().findItem(R.id.queue_keep_sorted).setChecked(keepSorted);


### PR DESCRIPTION
The lock button controls whether tracks in the queue can be reordered and swiped. Since swipe works regardless of the "keep sorted" setting, the button to disable swipe should always be available.

Without this change, you have to disable "keep sorted", lock/unlock the queue and then activate "keep sorted" again if you want to enable/disable the swipe feature. I didn't even know that the lock function existed because I always have keep sorted active.

Slightly related to #4844