### PR TITLE
Add human readable error messages for online feed search screen.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/OnlineSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/OnlineSearchFragment.java
@@ -23,7 +23,6 @@ import de.danoeh.antennapod.discovery.PodcastSearcher;
 import de.danoeh.antennapod.discovery.PodcastSearcherRegistry;
 import io.reactivex.disposables.Disposable;
 
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/OnlineSearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/OnlineSearchFragment.java
@@ -23,6 +23,7 @@ import de.danoeh.antennapod.discovery.PodcastSearcher;
 import de.danoeh.antennapod.discovery.PodcastSearcherRegistry;
 import io.reactivex.disposables.Disposable;
 
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -178,7 +179,7 @@ public class OnlineSearchFragment extends Fragment {
         }, error -> {
                 Log.e(TAG, Log.getStackTraceString(error));
                 progressBar.setVisibility(View.GONE);
-                txtvError.setText(error.toString());
+                txtvError.setText(R.string.network_error_msg);
                 txtvError.setVisibility(View.VISIBLE);
                 butRetry.setOnClickListener(v -> search(query));
                 butRetry.setVisibility(View.VISIBLE);

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -779,6 +779,7 @@
     <string name="discover_more">more »</string>
     <string name="discover_powered_by_itunes">Suggestions by iTunes</string>
     <string name="search_powered_by">Results by %1$s</string>
+    <string name="network_error_msg">Could not connect to network.</string>
 
     <!-- Local feeds -->
     <string name="add_local_folder">Add local folder</string>


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
Fixes  #4952: Display human-readable error message when gPodder cannot be browsed