### PR TITLE
Fix miniplayer sometimes showing old media file

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -59,6 +59,7 @@ public abstract class PlaybackController {
     private boolean released = false;
     private boolean initialized = false;
     private boolean eventsRegistered = false;
+    private long loadedFeedMedia = -1;
 
     private Disposable mediaLoader;
 
@@ -380,7 +381,8 @@ public abstract class PlaybackController {
     }
 
     private void checkMediaInfoLoaded() {
-        if (!mediaInfoLoaded) {
+        if (!mediaInfoLoaded || loadedFeedMedia != PlaybackPreferences.getCurrentlyPlayingFeedMediaId()) {
+            loadedFeedMedia = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
             loadMediaInfo();
         }
         mediaInfoLoaded = true;


### PR DESCRIPTION
Happens when pressing play on another episode without pausing the previous one.

<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
