### PR TITLE
Don't mark episodes as played when removing from queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -490,19 +490,13 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
                     final int position = viewHolder.getAdapterPosition();
                     Log.d(TAG, "remove(" + position + ")");
                     final FeedItem item = queue.get(position);
-                    final boolean isRead = item.isPlayed();
-                    DBWriter.markItemPlayed(FeedItem.PLAYED, false, item.getId());
                     DBWriter.removeQueueItem(getActivity(), true, item);
 
                     ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                            item.hasMedia() ? R.string.marked_as_read_label : R.string.marked_as_read_no_media_label,
+                            getResources().getQuantityString(R.plurals.removed_from_queue_batch_label, 1, 1),
                             Snackbar.LENGTH_LONG)
-                            .setAction(getString(R.string.undo), v -> {
-                                DBWriter.addQueueItemAt(getActivity(), item.getId(), position, false);
-                                if (!isRead) {
-                                    DBWriter.markItemPlayed(FeedItem.UNPLAYED, item.getId());
-                                }
-                            });
+                            .setAction(getString(R.string.undo), v ->
+                                    DBWriter.addQueueItemAt(getActivity(), item.getId(), position, false));
                 }
 
                 @Override

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -197,9 +197,7 @@
     <string name="remove_new_flag_label">Remove \"new\" flag</string>
     <string name="removed_new_flag_label">Removed \"new\" flag</string>
     <string name="mark_read_label">Mark as played</string>
-    <string name="marked_as_read_label">Marked as played</string>
     <string name="mark_read_no_media_label">Mark as read</string>
-    <string name="marked_as_read_no_media_label">Marked as read</string>
     <string name="play_this_to_seek_position">To jump to positions, you need to play the episode</string>
     <plurals name="marked_read_batch_label">
         <item quantity="one">%d episode marked as played.</item>


### PR DESCRIPTION
Was introduced in 67d2287323260e0bcbfcd644a33da5402c29b383 but I
am not sure why. It is not really logical to do - removing from the
queue just means that one is no longer interested in the episode - not
that it was actually played.

<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
