### PR TITLE
Refuse to show future dates

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSDublinCore.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSDublinCore.java
@@ -29,7 +29,7 @@ public class NSDublinCore extends Namespace {
             String second = state.getSecondTag().getName();
             if (DATE.equals(top) && ITEM.equals(second)) {
                 String content = state.getContentBuf().toString();
-                currentItem.setPubDate(DateUtils.parse(content));
+                currentItem.setPubDate(DateUtils.parseOrNullIfFuture(content));
             }
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSRSS20.java
@@ -124,7 +124,7 @@ public class NSRSS20 extends Namespace {
                     state.getCurrentItem().setLink(content);
                 }
             } else if (PUBDATE.equals(top) && ITEM.equals(second) && state.getCurrentItem() != null) {
-                state.getCurrentItem().setPubDate(DateUtils.parse(content));
+                state.getCurrentItem().setPubDate(DateUtils.parseOrNullIfFuture(content));
             } else if (URL.equals(top) && IMAGE.equals(second) && CHANNEL.equals(third)) {
                 // prefer itunes:image
                 if (state.getFeed() != null && state.getFeed().getImageUrl() == null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -205,9 +205,9 @@ public class NSAtom extends Namespace {
                 state.getCurrentItem().setDescriptionIfLonger(textElement.getProcessedContent());
             } else if (UPDATED.equals(top) && ENTRY.equals(second) && state.getCurrentItem() != null &&
                 state.getCurrentItem().getPubDate() == null) {
-                state.getCurrentItem().setPubDate(DateUtils.parse(content));
+                state.getCurrentItem().setPubDate(DateUtils.parseOrNullIfFuture(content));
             } else if (PUBLISHED.equals(top) && ENTRY.equals(second) && state.getCurrentItem() != null) {
-                state.getCurrentItem().setPubDate(DateUtils.parse(content));
+                state.getCurrentItem().setPubDate(DateUtils.parseOrNullIfFuture(content));
             } else if (IMAGE_LOGO.equals(top) && state.getFeed() != null && state.getFeed().getImageUrl() == null) {
                 state.getFeed().setImageUrl(content);
             } else if (IMAGE_ICON.equals(top) && state.getFeed() != null) {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/DateUtils.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.core.util;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 import java.text.DateFormat;
@@ -122,6 +123,21 @@ public class DateUtils {
         return null;
     }
 
+    /**
+     * Parses the date but if the date is in the future, returns null.
+     */
+    @Nullable
+    public static Date parseOrNullIfFuture(final String input) {
+        Date date = parse(input);
+        if (date == null) {
+            return null;
+        }
+        Date now = new Date();
+        if (date.after(now)) {
+            return null;
+        }
+        return date;
+    }
 
     /**
      * Takes a string of the form [HH:]MM:SS[.mmm] and converts it to


### PR DESCRIPTION
Some shows start to specify dates from the future to appear on top
of episode lists. If we find one of those episodes, just ignore that
it is there. We then use the date when we first found the item.

See https://forum.antennapod.org/t/filter-against-future-episodes/939
