### PR TITLE
add nextcloud single sign on: cannot get result for AccountChooser acitivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,6 +150,8 @@ dependencies {
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
     implementation 'com.github.skydoves:balloon:1.1.5'
 
+    implementation "com.github.nextcloud:Android-SingleSignOn:0.5.1"
+
     // Non-free dependencies:
     playImplementation 'com.google.android.play:core:1.8.0'
     compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderPreferencesFragment.java
@@ -133,7 +133,7 @@ public class GpodderPreferencesFragment extends PreferenceFragmentCompat {
 
     private void openAccountChooser() {
         try {
-            AccountImporter.pickNewAccount(this);
+            AccountImporter.pickNewAccount(getActivity());
         } catch (NextcloudFilesAppNotInstalledException | AndroidGetAccountsPermissionNotGranted e) {
             UiExceptionManager.showDialogForException(getContext(), e);
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/GpodderPreferencesFragment.java
@@ -8,6 +8,11 @@ import androidx.preference.PreferenceFragmentCompat;
 import android.text.Spanned;
 import android.text.format.DateUtils;
 import com.google.android.material.snackbar.Snackbar;
+import com.nextcloud.android.sso.AccountImporter;
+import com.nextcloud.android.sso.exceptions.AndroidGetAccountsPermissionNotGranted;
+import com.nextcloud.android.sso.exceptions.NextcloudFilesAppNotInstalledException;
+import com.nextcloud.android.sso.ui.UiExceptionManager;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.PreferenceActivity;
 import de.danoeh.antennapod.core.event.SyncServiceEvent;
@@ -65,7 +70,7 @@ public class GpodderPreferencesFragment extends PreferenceFragmentCompat {
         final Activity activity = getActivity();
 
         findPreference(PREF_GPODNET_LOGIN).setOnPreferenceClickListener(preference -> {
-            new GpodderAuthenticationFragment().show(getChildFragmentManager(), GpodderAuthenticationFragment.TAG);
+            openAccountChooser();
             return true;
         });
         findPreference(PREF_GPODNET_SETLOGIN_INFORMATION)
@@ -125,4 +130,15 @@ public class GpodderPreferencesFragment extends PreferenceFragmentCompat {
                         lastTime, DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, DateUtils.FORMAT_SHOW_TIME));
         ((PreferenceActivity) getActivity()).getSupportActionBar().setSubtitle(status);
     }
+
+    private void openAccountChooser() {
+        try {
+            AccountImporter.pickNewAccount(this);
+        } catch (NextcloudFilesAppNotInstalledException | AndroidGetAccountsPermissionNotGranted e) {
+            UiExceptionManager.showDialogForException(getContext(), e);
+        }
+    }
+
+
+
 }

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -10,6 +10,11 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <queries>
+        <package android:name="com.nextcloud.client" />
+        <package android:name="com.nextcloud.android.beta" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
I want to add nextcloud single-sign-on (https://github.com/nextcloud/Android-SingleSignOn) to enable synchronization through an nextloud app in the future.
I can trigger the account chooser but the requestCode i get back in the preference activity is a random one and not 4242 from the AccountChooser activity. I am new to android development. 

Can anybody point out to me why i dont get the result for my activity?