### PR TITLE
Add CI check that enforces layout xml file formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,3 +96,15 @@ workflows:
             - run:
                 name: SpotBugs
                 command: ./gradlew spotbugsPlayDebug spotbugsDebug 2>&1 | grep -i "spotbugs"
+      - build:
+          name: XML
+          build-steps:
+            - run:
+                name: XML of changed files
+                command: |
+                  git fetch origin develop
+                  branchBaseCommit=`git merge-base origin/develop HEAD`
+                  echo "Comparing to $branchBaseCommit"
+                  curl -s -L https://github.com/ByteHamster/android-xml-formatter/releases/download/1.1.0/android-xml-formatter.jar > android-xml-formatter.jar
+                  git diff --name-only $branchBaseCommit | { grep "res/layout/" || true; } | xargs java -jar android-xml-formatter.jar
+                  test $(git diff | wc -l) -eq 0 || (echo -e "\n\n===== Found XML code style violations! See output below how to fix them. =====\n\n" && git --no-pager diff --color=always && false)


### PR DESCRIPTION
Contributors (including myself) will hate me for this one but it will finally avoid having xml whitespace changes in nearly every PR.