### PR TITLE
Fix stuck swipe refresh indicator

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -73,7 +73,6 @@ public class CompletedDownloadsFragment extends Fragment {
 
         recyclerView = root.findViewById(R.id.recyclerView);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
-        recyclerView.setVisibility(View.GONE);
         adapter = new CompletedDownloadsListAdapter((MainActivity) getActivity());
         recyclerView.setAdapter(adapter);
         progressBar = root.findViewById(R.id.progLoading);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -194,7 +194,6 @@ public abstract class EpisodesListFragment extends Fragment {
         txtvInformation = root.findViewById(R.id.txtvInformation);
 
         recyclerView = root.findViewById(android.R.id.list);
-        recyclerView.setVisibility(View.GONE);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         setupLoadMoreScrollListener();
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -156,7 +156,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
         recyclerView = root.findViewById(R.id.recyclerView);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
-        recyclerView.setVisibility(View.GONE);
 
         progressBar = root.findViewById(R.id.progLoading);
         txtvTitle = root.findViewById(R.id.txtvTitle);
@@ -436,7 +435,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             adapter = new FeedItemListAdapter((MainActivity) getActivity());
             recyclerView.setAdapter(adapter);
         }
-        recyclerView.setVisibility(View.VISIBLE);
         progressBar.setVisibility(View.GONE);
         if (feed != null) {
             adapter.updateItems(feed.getItems());

--- a/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/PlaybackHistoryFragment.java
@@ -75,7 +75,6 @@ public class PlaybackHistoryFragment extends Fragment implements Toolbar.OnMenuI
 
         recyclerView = root.findViewById(R.id.recyclerView);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
-        recyclerView.setVisibility(View.GONE);
         adapter = new PlaybackHistoryListAdapter((MainActivity) getActivity());
         recyclerView.setAdapter(adapter);
         progressBar = root.findViewById(R.id.progLoading);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -556,11 +556,9 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
                 emptyView.updateAdapter(recyclerAdapter);
             }
             recyclerAdapter.updateItems(queue);
-            recyclerView.setVisibility(View.VISIBLE);
         } else {
             recyclerAdapter = null;
-            recyclerView.setVisibility(View.GONE);
-            emptyView.updateAdapter(recyclerAdapter);
+            emptyView.updateAdapter(null);
         }
 
         if (restoreScrollPosition) {
@@ -602,7 +600,6 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
             disposable.dispose();
         }
         if (queue == null) {
-            recyclerView.setVisibility(View.GONE);
             emptyView.hide();
             progLoading.setVisibility(View.VISIBLE);
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -120,7 +120,6 @@ public class SearchFragment extends Fragment {
 
         recyclerView = layout.findViewById(R.id.recyclerView);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
-        recyclerView.setVisibility(View.GONE);
         adapter = new EpisodeItemListAdapter((MainActivity) getActivity());
         recyclerView.setAdapter(adapter);
 

--- a/app/src/main/java/de/danoeh/antennapod/view/EmptyViewHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/EmptyViewHandler.java
@@ -18,7 +18,6 @@ import de.danoeh.antennapod.R;
 
 public class EmptyViewHandler {
     private boolean layoutAdded = false;
-    private View list;
     private ListAdapter listAdapter;
     private RecyclerView.Adapter<?> recyclerAdapter;
 
@@ -61,7 +60,6 @@ public class EmptyViewHandler {
         }
         addToParentView(listView);
         layoutAdded = true;
-        this.list = listView;
         listView.setEmptyView(emptyView);
         updateAdapter(listView.getAdapter());
     }
@@ -72,7 +70,6 @@ public class EmptyViewHandler {
         }
         addToParentView(recyclerView);
         layoutAdded = true;
-        this.list = recyclerView;
         updateAdapter(recyclerView.getAdapter());
     }
 
@@ -142,7 +139,6 @@ public class EmptyViewHandler {
         } else {
             empty = true;
         }
-        list.setVisibility(empty ? View.GONE : View.VISIBLE);
         emptyView.setVisibility(empty ? View.VISIBLE : View.GONE);
     }
 }


### PR DESCRIPTION
ViewPager2 does not play nice with SwipeRefreshLayout if the wrapped
RecyclerView is hidden. This commit removes the show/hide logic from
EmptyViewHandler, so that the RecyclerView is always displayed, even
when empty. This prevents you from swiping left/right while pulling down
the swipe refresh indicator.


The RecyclerViews will now always remain visible. This did not cause any regressions in my tests, because empty RecyclerViews do not draw anything anyway and additional Views (such as the empty list message) are absolutely positioned inside Frame or RelativeLayouts and are added after the ReyclerView, so they are still shown on top. I hope I did not miss anything :)

Fixes #5132