### PR TITLE
Update AndroidX Fragment to 1.3.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,6 +122,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
     implementation "androidx.core:core:$coreVersion"
+    implementation "androidx.fragment:fragment:$fragmentVersion"
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation "androidx.media:media:$mediaVersion"
     implementation "androidx.preference:preference:$preferenceVersion"

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.activity;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -15,7 +16,9 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
-import androidx.annotation.NonNull;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -35,7 +38,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
-import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -48,7 +50,6 @@ import java.util.List;
  * */
 public class OpmlImportActivity extends AppCompatActivity {
     private static final String TAG = "OpmlImportBaseActivity";
-    private static final int PERMISSION_REQUEST_READ_EXTERNAL_STORAGE = 5;
     @Nullable private Uri uri;
     OpmlSelectionBinding viewBinding;
     private ArrayAdapter<String> listAdapter;
@@ -198,27 +199,23 @@ public class OpmlImportActivity extends AppCompatActivity {
     }
 
     private void requestPermission() {
-        String[] permissions = { android.Manifest.permission.READ_EXTERNAL_STORAGE };
-        ActivityCompat.requestPermissions(this, permissions, PERMISSION_REQUEST_READ_EXTERNAL_STORAGE);
+        requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE);
     }
 
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode != PERMISSION_REQUEST_READ_EXTERNAL_STORAGE) {
-            return;
-        }
-        if (grantResults.length > 0 && ArrayUtils.contains(grantResults, PackageManager.PERMISSION_GRANTED)) {
-            startImport();
-        } else {
-            new AlertDialog.Builder(this)
-                    .setMessage(R.string.opml_import_ask_read_permission)
-                    .setPositiveButton(android.R.string.ok, (dialog, which) -> requestPermission())
-                    .setNegativeButton(R.string.cancel_label, (dialog, which) -> finish())
-                    .show();
-        }
-    }
+    private final ActivityResultLauncher<String> requestPermissionLauncher =
+            registerForActivityResult(new RequestPermission(), isGranted -> {
+                if (isGranted) {
+                    startImport();
+                } else {
+                    new AlertDialog.Builder(this)
+                            .setMessage(R.string.opml_import_ask_read_permission)
+                            .setPositiveButton(android.R.string.ok, (dialog, which) ->
+                                    requestPermission())
+                            .setNegativeButton(R.string.cancel_label, (dialog, which) ->
+                                    finish())
+                            .show();
+                }
+            });
 
     /** Starts the import process. */
     private void startImport() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ExternalPlayerFragment.java
@@ -9,6 +9,8 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
@@ -77,8 +79,8 @@ public class ExternalPlayerFragment extends Fragment {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         butPlay.setOnClickListener(v -> {
             if (controller == null) {
                 return;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedInfoFragment.java
@@ -10,6 +10,10 @@ import android.graphics.LightingColorFilter;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -74,7 +78,8 @@ public class FeedInfoFragment extends Fragment implements Toolbar.OnMenuItemClic
 
     private static final String EXTRA_FEED_ID = "de.danoeh.antennapod.extra.feedId";
     private static final String TAG = "FeedInfoActivity";
-    private static final int REQUEST_CODE_ADD_LOCAL_FOLDER = 2;
+    private final ActivityResultLauncher<Intent> addLocalFolderLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::addLocalFolderResult);
 
     private Feed feed;
     private Disposable disposable;
@@ -353,7 +358,7 @@ public class FeedInfoFragment extends Fragment implements Toolbar.OnMenuItemClic
                 try {
                     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
                     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    startActivityForResult(intent, REQUEST_CODE_ADD_LOCAL_FOLDER);
+                    addLocalFolderLauncher.launch(intent);
                 } catch (ActivityNotFoundException e) {
                     Log.e(TAG, "No activity found. Should never happen...");
                 }
@@ -366,16 +371,12 @@ public class FeedInfoFragment extends Fragment implements Toolbar.OnMenuItemClic
         return handled;
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode != Activity.RESULT_OK || data == null) {
+    private void addLocalFolderResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
             return;
         }
-        Uri uri = data.getData();
-
-        if (requestCode == REQUEST_CODE_ADD_LOCAL_FOLDER) {
-            reconnectLocalFolder(uri);
-        }
+        final Uri uri = result.getData().getData();
+        reconnectLocalFolder(uri);
     }
 
     private void reconnectLocalFolder(Uri uri) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -230,11 +230,6 @@ public class ItemFragment extends Fragment {
     }
 
     @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-    }
-
-    @Override
     public void onStart() {
         super.onStart();
         EventBus.getDefault().register(this);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -249,8 +249,8 @@ public class SubscriptionFragment extends Fragment
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View v, Bundle savedInstanceState) {
+        super.onViewCreated(v, savedInstanceState);
         subscriptionAdapter = new SubscriptionsRecyclerAdapter((MainActivity) getActivity());
         subscriptionAdapter.setOnSelectModeListener(this);
         subscriptionRecycler.setAdapter(subscriptionAdapter);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -12,6 +12,10 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.Log;
+
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.FileProvider;
 import androidx.preference.PreferenceFragmentCompat;
@@ -54,13 +58,19 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
     private static final String DEFAULT_HTML_OUTPUT_NAME = "antennapod-feeds-%s.html";
     private static final String CONTENT_TYPE_HTML = "text/html";
     private static final String DEFAULT_FAVORITES_OUTPUT_NAME = "antennapod-favorites-%s.html";
-    private static final int REQUEST_CODE_CHOOSE_OPML_EXPORT_PATH = 1;
-    private static final int REQUEST_CODE_CHOOSE_OPML_IMPORT_PATH = 2;
-    private static final int REQUEST_CODE_CHOOSE_HTML_EXPORT_PATH = 3;
-    private static final int REQUEST_CODE_RESTORE_DATABASE = 4;
-    private static final int REQUEST_CODE_BACKUP_DATABASE = 5;
-    private static final int REQUEST_CODE_CHOOSE_FAVORITES_EXPORT_PATH = 6;
     private static final String DATABASE_EXPORT_FILENAME = "AntennaPodBackup-%s.db";
+    private final ActivityResultLauncher<Intent> chooseOpmlExportPathLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::chooseOpmlExportPathResult);
+    private final ActivityResultLauncher<Intent> chooseHtmlExportPathLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::chooseHtmlExportPathResult);
+    private final ActivityResultLauncher<Intent> chooseFavoritesExportPathLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::chooseFavoritesExportPathResult);
+    private final ActivityResultLauncher<Intent> restoreDatabaseLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::restoreDatabaseResult);
+    private final ActivityResultLauncher<Intent> backupDatabaseLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::backupDatabaseResult);
+    private final ActivityResultLauncher<Intent> chooseOpmlImportPathLauncher =
+            registerForActivityResult(new StartActivityForResult(), this::chooseOpmlImportPathResult);
     private Disposable disposable;
     private ProgressDialog progressDialog;
 
@@ -95,14 +105,14 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
         findPreference(PREF_OPML_EXPORT).setOnPreferenceClickListener(
                 preference -> {
                     openExportPathPicker(CONTENT_TYPE_OPML, dateStampFilename(DEFAULT_OPML_OUTPUT_NAME),
-                            REQUEST_CODE_CHOOSE_OPML_EXPORT_PATH, new OpmlWriter());
+                            chooseOpmlExportPathLauncher, new OpmlWriter());
                     return true;
                 }
         );
         findPreference(PREF_HTML_EXPORT).setOnPreferenceClickListener(
                 preference -> {
                     openExportPathPicker(CONTENT_TYPE_HTML, dateStampFilename(DEFAULT_HTML_OUTPUT_NAME),
-                            REQUEST_CODE_CHOOSE_HTML_EXPORT_PATH, new HtmlWriter());
+                            chooseHtmlExportPathLauncher, new HtmlWriter());
                     return true;
                 });
         findPreference(PREF_OPML_IMPORT).setOnPreferenceClickListener(
@@ -111,7 +121,7 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
                         Intent intentGetContentAction = new Intent(Intent.ACTION_GET_CONTENT);
                         intentGetContentAction.addCategory(Intent.CATEGORY_OPENABLE);
                         intentGetContentAction.setType("*/*");
-                        startActivityForResult(intentGetContentAction, REQUEST_CODE_CHOOSE_OPML_IMPORT_PATH);
+                        chooseOpmlImportPathLauncher.launch(intentGetContentAction);
                     } catch (ActivityNotFoundException e) {
                         Log.e(TAG, "No activity found. Should never happen...");
                     }
@@ -130,7 +140,7 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
         findPreference(PREF_FAVORITE_EXPORT).setOnPreferenceClickListener(
                 preference -> {
                     openExportPathPicker(CONTENT_TYPE_HTML, dateStampFilename(DEFAULT_FAVORITES_OUTPUT_NAME),
-                            REQUEST_CODE_CHOOSE_FAVORITES_EXPORT_PATH, new FavoritesWriter());
+                            chooseFavoritesExportPathLauncher, new FavoritesWriter());
                     return true;
                 });
     }
@@ -165,7 +175,7 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
                     .setType("application/x-sqlite3")
                     .putExtra(Intent.EXTRA_TITLE, dateStampFilename(DATABASE_EXPORT_FILENAME));
 
-            startActivityForResult(intent, REQUEST_CODE_BACKUP_DATABASE);
+            backupDatabaseLauncher.launch(intent);
         } else {
             File sd = Environment.getExternalStorageDirectory();
             File backupDB = new File(sd, dateStampFilename(DATABASE_EXPORT_FILENAME));
@@ -193,12 +203,12 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
                     if (Build.VERSION.SDK_INT >= 19) {
                         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
                         intent.setType("*/*");
-                        startActivityForResult(intent, REQUEST_CODE_RESTORE_DATABASE);
+                        restoreDatabaseLauncher.launch(intent);
                     } else {
                         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
                         intent.setType("*/*");
-                        startActivityForResult(Intent.createChooser(intent,
-                                getString(R.string.import_select_file)), REQUEST_CODE_RESTORE_DATABASE);
+                        restoreDatabaseLauncher.launch(Intent.createChooser(intent,
+                                getString(R.string.import_select_file)));
                     }
                 }
         );
@@ -249,46 +259,73 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
         alert.show();
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode != Activity.RESULT_OK || data == null) {
+    private void chooseOpmlExportPathResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
             return;
         }
-        Uri uri = data.getData();
-
-        if (requestCode == REQUEST_CODE_CHOOSE_OPML_EXPORT_PATH) {
-            exportWithWriter(new OpmlWriter(), uri);
-        } else if (requestCode == REQUEST_CODE_CHOOSE_HTML_EXPORT_PATH) {
-            exportWithWriter(new HtmlWriter(), uri);
-        } else if (requestCode == REQUEST_CODE_CHOOSE_FAVORITES_EXPORT_PATH) {
-            exportWithWriter(new FavoritesWriter(), uri);
-        } else if (requestCode == REQUEST_CODE_RESTORE_DATABASE) {
-            progressDialog.show();
-            disposable = Completable.fromAction(() -> DatabaseExporter.importBackup(uri, getContext()))
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(() -> {
-                        showDatabaseImportSuccessDialog();
-                        UserPreferences.unsetUsageCountingDate();
-                        progressDialog.dismiss();
-                    }, this::showExportErrorDialog);
-        } else if (requestCode == REQUEST_CODE_BACKUP_DATABASE) {
-            progressDialog.show();
-            disposable = Completable.fromAction(() -> DatabaseExporter.exportToDocument(uri, getContext()))
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(() -> {
-                        Snackbar.make(getView(), R.string.export_success_title, Snackbar.LENGTH_LONG).show();
-                        progressDialog.dismiss();
-                    }, this::showExportErrorDialog);
-        } else if (requestCode == REQUEST_CODE_CHOOSE_OPML_IMPORT_PATH) {
-            Intent intent = new Intent(getContext(), OpmlImportActivity.class);
-            intent.setData(uri);
-            startActivity(intent);
-        }
+        final Uri uri = result.getData().getData();
+        exportWithWriter(new OpmlWriter(), uri);
     }
 
-    private void openExportPathPicker(String contentType, String title, int requestCode, ExportWriter writer) {
+    private void chooseHtmlExportPathResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            return;
+        }
+        final Uri uri = result.getData().getData();
+        exportWithWriter(new HtmlWriter(), uri);
+    }
+
+    private void chooseFavoritesExportPathResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            return;
+        }
+        final Uri uri = result.getData().getData();
+        exportWithWriter(new FavoritesWriter(), uri);
+    }
+
+    private void restoreDatabaseResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            return;
+        }
+        final Uri uri = result.getData().getData();
+        progressDialog.show();
+        disposable = Completable.fromAction(() -> DatabaseExporter.importBackup(uri, getContext()))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(() -> {
+                    showDatabaseImportSuccessDialog();
+                    UserPreferences.unsetUsageCountingDate();
+                    progressDialog.dismiss();
+                }, this::showExportErrorDialog);
+    }
+
+    private void backupDatabaseResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            return;
+        }
+        final Uri uri = result.getData().getData();
+        progressDialog.show();
+        disposable = Completable.fromAction(() -> DatabaseExporter.exportToDocument(uri, getContext()))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(() -> {
+                    Snackbar.make(getView(), R.string.export_success_title, Snackbar.LENGTH_LONG).show();
+                    progressDialog.dismiss();
+                }, this::showExportErrorDialog);
+    }
+
+    private void chooseOpmlImportPathResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            return;
+        }
+        final Uri uri = result.getData().getData();
+        final Intent intent = new Intent(getContext(), OpmlImportActivity.class);
+        intent.setData(uri);
+        startActivity(intent);
+    }
+
+    private void openExportPathPicker(String contentType, String title,
+                                      final ActivityResultLauncher<Intent> result, ExportWriter writer) {
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2) {
             Intent intentPickAction = new Intent(Intent.ACTION_CREATE_DOCUMENT)
                     .addCategory(Intent.CATEGORY_OPENABLE)
@@ -298,7 +335,7 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
             // Creates an implicit intent to launch a file manager which lets
             // the user choose a specific directory to export to.
             try {
-                startActivityForResult(intentPickAction, requestCode);
+                result.launch(intentPickAction);
                 return;
             } catch (ActivityNotFoundException e) {
                 Log.e(TAG, "No activity found. Should never happen...");

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ project.ext {
     annotationVersion = "1.2.0"
     appcompatVersion = "1.3.1"
     coreVersion = "1.5.0"
+    fragmentVersion = "1.3.6"
     mediaVersion = "1.1.0"
     preferenceVersion = "1.1.1"
     workManagerVersion = "2.3.4"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "androidx.core:core:$coreVersion"
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation "androidx.fragment:fragment:$fragmentVersion"
     implementation "androidx.media:media:$mediaVersion"
     implementation "androidx.preference:preference:$preferenceVersion"
     implementation "androidx.work:work-runtime:$workManagerVersion"


### PR DESCRIPTION
This fixes many internal issues with Fragments that can manifest in app behavior (this includes some FragmentContainerView bugfixes as well).

Be sure to read every [version changelog](https://developer.android.com/jetpack/androidx/releases/fragment#version_135_3) from 1.2.4 (a transitive version that was used) to 1.3.6.

As onActivityResult and onRequestPermissionsResult were deprecated with Fragment [1.3.0](https://developer.android.com/jetpack/androidx/releases/fragment#version_130_3), I have replaced them with the new Activity Result APIs.

The only other deprecations that came with this update is the deprecation of setRetainInstance(boolean), and fixing that would entail a rather significant rewrite of AntennaPod to use ViewModel objects and AndroidX Lifecycle. This deprecation doesn't bring any behavior changes so it should be fine for now.

I built an APK and thoroughly tested these changes on my device.

~~Edit: AppCompat 1.2.0 is using a transitive Fragment version of 1.1.0, which is causing the CIs to fail because they're using that transitive version instead of 1.3.5 like I declared. AppCompat has a newer version of [1.3.0](https://developer.android.com/jetpack/androidx/releases/appcompat#version_130_3), which solves this issue (transitive is 1.3.4)... I could also use the `configurations.all.resolutionStrategy.force` block to force them to use that version, but IDK if it will work... and even then, it's not an ideal solution. An update to the AppCompat library is something you're obviously going to test extremely thoroughly, so I don't think this will be merged. The thing is, this error shouldn't be happening in the first place, so I'm rather confused. AppCompat 1.2.0 should have no problem with this Fragment version, so it's another library that's using Fragment 1.1.0 that's causing this issue. Are there any solutions other than updating the culprit library?~~

Above fixed with https://github.com/AntennaPod/AntennaPod/pull/5368
