### PR TITLE
Highlighted seek bar while seeking on episode without chapters

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -166,7 +166,7 @@ public class AudioPlayerFragment extends Fragment implements
 
         float[] dividerPos = null;
 
-        if (media.getChapters() != null) {
+        if (media.getChapters() != null && !media.getChapters().isEmpty()) {
             List<Chapter> chapters = media.getChapters();
             dividerPos = new float[chapters.size()];
 


### PR DESCRIPTION
I'm not sure if this is intended, but for an episode without chapters, the bar gets highlighted while seeking (as with the chapters). This should fix it.
