### PR TITLE
Speed up loading media info

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/view/ChapterSeekBar.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/ChapterSeekBar.java
@@ -62,6 +62,7 @@ public class ChapterSeekBar extends androidx.appcompat.widget.AppCompatSeekBar {
         } else {
             this.dividerPos = null;
         }
+        invalidate();
     }
 
     public void highlightCurrentChapter() {


### PR DESCRIPTION
Loading chapters can take around 5-10 seconds, depending on the media
type. During that time, the player screen shows nothing or the old media
file. Instead, load the chapters afterwards.

In my case, a podcast uses a 400kb image that takes ages for the parser to skip. Not sure why it takes so long - 400kb is not insanely big.