### PR TITLE
EpisodeItem Cover to PodcastFeed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.view.viewholder;
 
+import android.content.Intent;
 import android.os.Build;
 import android.text.Layout;
 import android.text.format.Formatter;
@@ -132,6 +133,9 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
                     .withPlaceholderView(placeholder)
                     .withCoverView(cover)
                     .load();
+
+            Intent openFeed = MainActivity.getIntentToOpenFeed(activity, item.getFeedId());
+            cover.setOnClickListener(view -> activity.startActivity(openFeed));
         }
     }
 

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -85,6 +85,7 @@
                     android:id="@+id/imgvCover"
                     android:layout_width="@dimen/thumbnail_length_queue_item"
                     android:layout_height="@dimen/thumbnail_length_queue_item"
+                    android:foreground="?android:attr/selectableItemBackground"
                     android:layout_centerVertical="true"
                     android:importantForAccessibility="no"
                     tools:src="@tools:sample/avatars" />


### PR DESCRIPTION
Makes it easier to get from queue/inbox/episodes to the feed (without sidebar) if you are looking for more/older episodes
(I think this is expected behaviour, because all covers do something, either playpause in player or podcast description in the podcastfeed)