### PR TITLE
Fix bug  leading to cache miss in de.danoeh.antennapod.core.glide.FastBlurTransformation

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/glide/FastBlurTransformation.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/FastBlurTransformation.java
@@ -12,7 +12,7 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 
 public class FastBlurTransformation extends BitmapTransformation {
-    private static final String ID="de.danoeh.antennapod.core.glide.FastBlurTransformation";
+    private static final String ID = "de.danoeh.antennapod.core.glide.FastBlurTransformation";
 
     private static final String TAG = FastBlurTransformation.class.getSimpleName();
 
@@ -41,6 +41,11 @@ public class FastBlurTransformation extends BitmapTransformation {
     @Override
     public boolean equals(Object o) {
         return o instanceof FastBlurTransformation;
+    }
+
+    @Override
+    public int hashCode() {
+        return ID.hashCode();
     }
 
     @Override
@@ -285,10 +290,5 @@ public class FastBlurTransformation extends BitmapTransformation {
         }
         bitmap.setPixels(pix, 0, w, 0, 0, w, h);
         return bitmap;
-    }
-
-    @Override
-    public int hashCode() {
-        return ID.hashCode();
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/FastBlurTransformation.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/FastBlurTransformation.java
@@ -12,6 +12,7 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 
 public class FastBlurTransformation extends BitmapTransformation {
+    private static final String ID="de.danoeh.antennapod.core.glide.FastBlurTransformation";
 
     private static final String TAG = FastBlurTransformation.class.getSimpleName();
 
@@ -284,5 +285,10 @@ public class FastBlurTransformation extends BitmapTransformation {
         }
         bitmap.setPixels(pix, 0, w, 0, 0, w, h);
         return bitmap;
+    }
+
+    @Override
+    public int hashCode() {
+        return ID.hashCode();
     }
 }


### PR DESCRIPTION
I found the root cause of the second problem metioned in #5092, where a big image is repeatedly decoded multiple times.

The root cause of the problem lies in that the class `de.danoeh.antennapod.core.glide.FastBlurTransformation` fails to provided an implementation of the method hashcode().

The `com.bumptech.glide.load.engine.EnginKey` class, used by Glide as key for indexing cached image, calculates hashcode as this:
![image](https://user-images.githubusercontent.com/13826031/126340535-0db01272-df57-4fda-b5a4-86990985e4b0.png)
Here, `transformations `is a `SimpleArrayMap `whose hashcode is calculated by:
![image](https://user-images.githubusercontent.com/13826031/126341090-62a8b28f-d6c2-4fe1-811d-44ce73d1621d.png)

Each default `Transformation `provided by Glide provides a `hashcode()` method, which usually only depends on a static `String `to identify the class of the `Transformation`. For example, the `com.bumptech.glide.load.resource.bitmap.CenterCrop`:

![image](https://user-images.githubusercontent.com/13826031/126342400-3f9bed5a-b3b1-411d-8029-188b3c5a493c.png)

 
However, when the `transformations `array contains a `FastBlurTransformation `instance,  whose `hashcode() `is not provided, the default `hashcode() `method of `Object `would be invoked, and the returned hashcode varies from instance to instance.
As a result, each time the app tries to load an cached image (with `FastBlurTransformation`) would lead to a cache miss, and the cached image is repeatedly decoded.

The bug can be easily fixed by adding the `hashcode()` method to FastBlurTransformation that calculates the hashcode based on a static `String`, as changed in the PR.

I have tested the patch, and the repeated decoding problem is eliminated.

I hope this PR is helpful.
