### PR TITLE
Removed highlighting of episode title

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -161,7 +161,9 @@ public class CoverFragment extends Fragment {
             int animUnit = 1500;
             if (lines > txtvEpisodeTitle.getMaxLines()) {
                 ObjectAnimator verticalMarquee = ObjectAnimator.ofInt(
-                        txtvEpisodeTitle, "scrollY", 0, txtvEpisodeTitle.getHeight())
+                        txtvEpisodeTitle, "scrollY", 0, (lines - txtvEpisodeTitle.getMaxLines()) * (
+                                (txtvEpisodeTitle.getHeight() - txtvEpisodeTitle.getPaddingTop()
+                                        - txtvEpisodeTitle.getPaddingBottom()) / txtvEpisodeTitle.getMaxLines()))
                         .setDuration(lines * animUnit);
                 ObjectAnimator fadeOut = ObjectAnimator.ofFloat(
                         txtvEpisodeTitle, "alpha", 0);

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -4,10 +4,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/cover_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal"
-    android:id="@+id/cover_fragment"
     android:padding="8dp"
     android:gravity="center">
 
@@ -57,7 +57,6 @@
             android:id="@+id/txtvEpisodeTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackground"
             android:ellipsize="none"
             android:gravity="center_horizontal"
             android:maxLines="2"
@@ -125,6 +124,7 @@
                 android:text="@string/shownotes_label"
                 android:textColor="?android:attr/textColorSecondary"
                 android:textSize="16sp" />
+
         </LinearLayout>
 
         <LinearLayout
@@ -168,6 +168,7 @@
                 android:contentDescription="@string/next_chapter"
                 android:scaleType="fitCenter"
                 app:srcCompat="@drawable/ic_chapter_next" />
+
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
I did a user test yesterday and it was the second person who wondered what clicking the title does. This is not clear if the titles have a normal length. To avoid confusion, I just removed the ripple effect.

(also, fixed scrolling too far for 3-line titles)