### PR TITLE
Fix png icons on Android 4.4

### DIFF
--- a/ui/png-icons/build.gradle
+++ b/ui/png-icons/build.gradle
@@ -4,7 +4,7 @@ apply from: "../../common.gradle"
 android {
     defaultConfig {
         vectorDrawables.useSupportLibrary false
-        vectorDrawables.generatedDensities = null
+        vectorDrawables.generatedDensities = ["xhdpi"]
     }
 }
 


### PR DESCRIPTION
Subscribing otherwise crashes on Android 4.4, see https://forum.antennapod.org/t/android-4-4-2-support/1168