### PR TITLE
Recode images to save cache space

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApOkHttpUrlLoader.java
@@ -4,7 +4,6 @@ import android.content.ContentResolver;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.bumptech.glide.integration.okhttp3.OkHttpStreamFetcher;
 import com.bumptech.glide.load.Options;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.ModelLoader;
@@ -77,7 +76,7 @@ class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
     @Nullable
     @Override
     public LoadData<InputStream> buildLoadData(@NonNull String model, int width, int height, @NonNull Options options) {
-        return new LoadData<>(new ObjectKey(model), new OkHttpStreamFetcher(client, new GlideUrl(model)));
+        return new LoadData<>(new ObjectKey(model), new ResizingOkHttpStreamFetcher(client, new GlideUrl(model)));
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ResizingOkHttpStreamFetcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ResizingOkHttpStreamFetcher.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -103,7 +102,7 @@ public class ResizingOkHttpStreamFetcher extends OkHttpStreamFetcher {
                     callback.onDataReady(stream);
                     Log.d(TAG, "Compressed image from " + tempIn.length() / 1024
                             + " to " + tempOut.length() / 1024 + " kB (quality: " + quality + "%)");
-                } catch (IOException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
 
                     try {

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ResizingOkHttpStreamFetcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ResizingOkHttpStreamFetcher.java
@@ -1,0 +1,133 @@
+package de.danoeh.antennapod.core.glide;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.bumptech.glide.Priority;
+import com.bumptech.glide.integration.okhttp3.OkHttpStreamFetcher;
+import com.bumptech.glide.load.model.GlideUrl;
+import com.google.android.exoplayer2.util.Log;
+import okhttp3.Call;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ResizingOkHttpStreamFetcher extends OkHttpStreamFetcher {
+    private static final String TAG = "ResizingOkHttpStreamFetcher";
+    private static final int MAX_DIMENSIONS = 2000;
+    private static final int MAX_FILE_SIZE = 1024 * 1024; // 1 MB
+
+    private FileInputStream stream;
+    private File tempIn;
+    private File tempOut;
+
+    public ResizingOkHttpStreamFetcher(Call.Factory client, GlideUrl url) {
+        super(client, url);
+    }
+
+    @Override
+    public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super InputStream> callback) {
+        super.loadData(priority, new DataCallback<InputStream>() {
+            @Override
+            public void onDataReady(@Nullable InputStream data) {
+                if (data == null) {
+                    callback.onDataReady(null);
+                    return;
+                }
+                try {
+                    tempIn = File.createTempFile("resize_", null);
+                    tempOut = File.createTempFile("resize_", null);
+                    OutputStream outputStream = new FileOutputStream(tempIn);
+                    IOUtils.copy(data, outputStream);
+                    outputStream.close();
+                    IOUtils.closeQuietly(data);
+
+                    if (tempIn.length() <= MAX_FILE_SIZE) {
+                        try {
+                            stream = new FileInputStream(tempIn);
+                            callback.onDataReady(stream); // Just deliver the original, non-scaled image
+                        } catch (FileNotFoundException fileNotFoundException) {
+                            callback.onLoadFailed(fileNotFoundException);
+                        }
+                        return;
+                    }
+
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inJustDecodeBounds = true;
+                    FileInputStream in = new FileInputStream(tempIn);
+                    BitmapFactory.decodeStream(in, null, options);
+                    IOUtils.closeQuietly(in);
+
+                    if (Math.max(options.outHeight, options.outWidth) >= MAX_DIMENSIONS) {
+                        double sampleSize = (double) Math.max(options.outHeight, options.outWidth) / MAX_DIMENSIONS;
+                        options.inSampleSize = (int) Math.pow(2d, Math.floor(Math.log(sampleSize) / Math.log(2d)));
+                    }
+
+                    options.inJustDecodeBounds = false;
+                    in = new FileInputStream(tempIn);
+                    Bitmap bitmap = BitmapFactory.decodeStream(in, null, options);
+                    IOUtils.closeQuietly(in);
+
+                    Bitmap.CompressFormat format = Build.VERSION.SDK_INT < 30
+                            ? Bitmap.CompressFormat.WEBP : Bitmap.CompressFormat.WEBP_LOSSY;
+
+                    int quality = 100;
+                    while (true) {
+                        FileOutputStream out = new FileOutputStream(tempOut);
+                        bitmap.compress(format, quality, out);
+                        IOUtils.closeQuietly(out);
+
+                        if (tempOut.length() > 3 * MAX_FILE_SIZE && quality >= 45) {
+                            quality -= 40;
+                        } else if (tempOut.length() > 2 * MAX_FILE_SIZE && quality >= 25) {
+                            quality -= 20;
+                        } else if (tempOut.length() > MAX_FILE_SIZE && quality >= 15) {
+                            quality -= 10;
+                        } else if (tempOut.length() > MAX_FILE_SIZE && quality >= 10) {
+                            quality -= 5;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    stream = new FileInputStream(tempOut);
+                    callback.onDataReady(stream);
+                    Log.d(TAG, "Compressed image from " + tempIn.length() / 1024
+                            + " to " + tempOut.length() / 1024 + " kB (quality: " + quality + "%)");
+                } catch (IOException e) {
+                    e.printStackTrace();
+
+                    try {
+                        stream = new FileInputStream(tempIn);
+                        callback.onDataReady(stream); // Just deliver the original, non-scaled image
+                    } catch (FileNotFoundException fileNotFoundException) {
+                        e.printStackTrace();
+                        callback.onLoadFailed(fileNotFoundException);
+                    }
+                }
+            }
+
+            @Override
+            public void onLoadFailed(@NonNull Exception e) {
+                callback.onLoadFailed(e);
+            }
+        });
+    }
+
+    @Override
+    public void cleanup() {
+        IOUtils.closeQuietly(stream);
+        FileUtils.deleteQuietly(tempIn);
+        FileUtils.deleteQuietly(tempOut);
+        super.cleanup();
+    }
+}

--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/NSMedia.java
@@ -47,8 +47,8 @@ public class NSMedia extends Namespace {
             String medium = attributes.getValue(MEDIUM);
             boolean validTypeMedia = false;
             boolean validTypeImage = false;
-
             boolean isDefault = "true".equals(defaultStr);
+            String guessedType = SyndTypeUtils.getMimeTypeFromUrl(url);
 
             if (MEDIUM_AUDIO.equals(medium)) {
                 validTypeMedia = true;
@@ -56,12 +56,14 @@ public class NSMedia extends Namespace {
             } else if (MEDIUM_VIDEO.equals(medium)) {
                 validTypeMedia = true;
                 type = "video/*";
-            } else if (MEDIUM_IMAGE.equals(medium)) {
+            } else if (MEDIUM_IMAGE.equals(medium) && (guessedType == null
+                    || (!guessedType.startsWith("audio/") && !guessedType.startsWith("video/")))) {
+                // Apparently, some publishers explicitly specify the audio file as an image
                 validTypeImage = true;
                 type = "image/*";
             } else {
                 if (type == null) {
-                    type = SyndTypeUtils.getMimeTypeFromUrl(url);
+                    type = guessedType;
                 }
 
                 if (SyndTypeUtils.enclosureTypeValid(type)) {


### PR DESCRIPTION
All images <= 1 MB are not touched at all. All images > 1 MB are scaled down to at most 2000 px and converted to webp format. Then we iteratively decrease the quality until we are below 1 MB. Only the scaled version is saved as the "original" image in Glide. Glide might then also store possible transformations for different sizes but these are small.

If you want to try, you can use this feed: https://tools.bytehamster.com/podcast/rss.xml. It has an episode (called "Huge image") with a huge (20 MB) image. Here, the image is so large that even 5% quality produces more than 1 MB, so we just stop there and use the 1.6 MB file. I don't think an image can get much larger than RGB noise, so this should be the absolute minimum an image will ever have.

Review request @pc-bert
Related: #5057