### PR TITLE
Delay loading queue until media is loaded

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -155,7 +155,10 @@ public class PlaybackServiceTaskManager {
     /**
      * Returns the queue or waits until the PSTM has loaded the queue from the database.
      */
-    public synchronized List<FeedItem> getQueue() throws InterruptedException {
+    public List<FeedItem> getQueue() throws InterruptedException {
+        if (queueFuture == null) {
+            loadQueue();
+        }
         try {
             return queueFuture.get();
         } catch (ExecutionException e) {


### PR DESCRIPTION
When the queue is extremely long, it blocked loading the playable and therefore made playback slow to start. Closes #5024.