### PR TITLE
Clear cover target when setting folder image in CoverLoader

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/CoverLoader.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/CoverLoader.java
@@ -72,7 +72,10 @@ public class CoverLoader {
     }
 
     public void load() {
+        CoverTarget coverTarget = new CoverTarget(txtvPlaceholder, imgvCover, textAndImageCombined);
+
         if (resource != 0) {
+            Glide.with(activity).clear(coverTarget);
             imgvCover.setImageResource(resource);
             CoverTarget.setPlaceholderVisibility(txtvPlaceholder, textAndImageCombined);
             return;
@@ -93,7 +96,7 @@ public class CoverLoader {
                     .apply(options));
         }
 
-        builder.into(new CoverTarget(txtvPlaceholder, imgvCover, textAndImageCombined));
+        builder.into(coverTarget);
     }
 
     static class CoverTarget extends CustomViewTarget<ImageView, Drawable> {


### PR DESCRIPTION
I noticed a bug where the wrong cover-art would be show in some cases. It seems to be related to a race condition where the load of the folder-image is almost instant and could then be replaced by an earlier triggered cover-art load by Glide. Probably also related to how GridView is recycling views when scrolling!

By explicitly calling the clear, we can remove any resources that are waiting to be loaded into the specific view/ViewTarget. 

Steps to reproduce:
1. Have at least one podcast with a folder/tag.
2. Navigate to the subscription page
3. Press the FAB/+ to add a new subscription
4. Search and add a new subscription
5. Use the android back button to navigate back all the way to the subscription page (3 steps back)
6. See that the last folder now has the cover art for the first subscription in the GridView.

Actual/Before:
<img src="https://user-images.githubusercontent.com/2098329/128945100-0c55d7d0-ac13-4d35-9255-eea8ada9a60c.jpg" width="400">

Expected/After:
<img src="https://user-images.githubusercontent.com/2098329/128945104-f6c6de75-0282-4c75-af8a-54c9ccf499eb.jpg" width="400">

Was not sure if there is some good way to unit test the Glide functionality, could not find any tests covering the CoverLoader. But happy to add some if anyone have any guidance on how to do it in a good way! :)

Let me know if there some better way to solve this! I tried out to load the resource with Glide as well (and get the cancellation out of the box), but that did not really work. No image was loaded or set, not sure why. Maybe that is something to discover in the future to get a unified async image loading experience :)
