### PR TITLE
Treat link without rel as rel=alternate

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/syndication/namespace/atom/NSAtom.java
@@ -81,7 +81,7 @@ public class NSAtom extends Namespace {
             String rel = attributes.getValue(LINK_REL);
             SyndElement parent = state.getTagstack().peek();
             if (parent.getName().matches(isFeedItem)) {
-                if (LINK_REL_ALTERNATE.equals(rel)) {
+                if (rel == null || LINK_REL_ALTERNATE.equals(rel)) {
                     state.getCurrentItem().setLink(href);
                 } else if (LINK_REL_ENCLOSURE.equals(rel)) {
                     String strSize = attributes.getValue(LINK_LENGTH);
@@ -107,7 +107,7 @@ public class NSAtom extends Namespace {
                     state.getCurrentItem().setPaymentLink(href);
                 }
             } else if (parent.getName().matches(isFeed)) {
-                if (LINK_REL_ALTERNATE.equals(rel)) {
+                if (rel == null || LINK_REL_ALTERNATE.equals(rel)) {
                     String type = attributes.getValue(LINK_TYPE);
                     /*
                      * Use as link if a) no type-attribute is given and

--- a/core/src/test/java/de/danoeh/antennapod/core/syndication/handler/AtomParserTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/syndication/handler/AtomParserTest.java
@@ -14,6 +14,7 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Tests for Atom feeds in FeedHandler.
@@ -52,6 +53,34 @@ public class AtomParserTest {
             // chapters
             assertNull(item.getChapters());
         }
+    }
+
+    @Test
+    public void testEmptyRelLinks() throws Exception {
+        File feedFile = FeedParserTestHelper.getFeedFile("feed-atom-testEmptyRelLinks.xml");
+        Feed feed = FeedParserTestHelper.runFeedParser(feedFile);
+        assertEquals(Feed.TYPE_ATOM1, feed.getType());
+        assertEquals("title", feed.getTitle());
+        assertEquals("http://example.com/feed", feed.getFeedIdentifier());
+        assertEquals("http://example.com", feed.getLink());
+        assertEquals("This is the description", feed.getDescription());
+        assertNull(feed.getPaymentLinks());
+        assertEquals("http://example.com/picture", feed.getImageUrl());
+        assertEquals(1, feed.getItems().size());
+
+        // feed entry
+        FeedItem item = feed.getItems().get(0);
+        assertEquals("http://example.com/item-0", item.getItemIdentifier());
+        assertEquals("item-0", item.getTitle());
+        assertNull(item.getDescription());
+        assertEquals("http://example.com/items/0", item.getLink());
+        assertEquals(new Date(0), item.getPubDate());
+        assertNull(item.getPaymentLink());
+        assertEquals("http://example.com/picture", item.getImageLocation());
+        // media
+        assertFalse(item.hasMedia());
+        // chapters
+        assertNull(item.getChapters());
     }
 
     @Test

--- a/core/src/test/resources/feed-atom-testEmptyRelLinks.xml
+++ b/core/src/test/resources/feed-atom-testEmptyRelLinks.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+   <id>http://example.com/feed</id>
+   <title>title</title>
+   <link href="http://example.com" />
+   <subtitle>This is the description</subtitle>
+   <logo>http://example.com/picture</logo>
+   <entry>
+      <id>http://example.com/item-0</id>
+      <title>item-0</title>
+      <link href="http://example.com/items/0" />
+      <published>1970-01-01T00:00:00Z</published>
+   </entry>
+</feed>


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
src: https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.7.2

If the "rel" attribute is not present, the link element MUST
be interpreted as if the link relation type is
"alternate".

Fixes: #5346 