### PR TITLE
Fix filter dialog crashing if someone has a non-supported filter value set

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/FilterDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/FilterDialog.java
@@ -52,7 +52,10 @@ public abstract class FilterDialog {
 
         for (String filterId : filterValues) {
             if (!TextUtils.isEmpty(filterId)) {
-                ((RadioButton) layout.findViewWithTag(filterId)).setChecked(true);
+                RadioButton button = layout.findViewWithTag(filterId);
+                if (button != null) {
+                    button.setChecked(true);
+                }
             }
         }
 


### PR DESCRIPTION
No idea how someone could end up with that invalid value but it was reported by a user.

https://forum.antennapod.org/t/filter-option-causes-app-to-crash-on-one-podcast-broken-database/1229