### PR TITLE
Move queue lock feature to the overflow menu

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/QueueFragmentTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/QueueFragmentTest.java
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
-import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static de.test.antennapod.NthMatcher.first;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -40,9 +39,11 @@ public class QueueFragmentTest {
 
     @Test
     public void testLockEmptyQueue() {
-        onView(withContentDescription(R.string.lock_queue)).perform(click());
+        onView(first(EspressoTestUtils.actionBarOverflow())).perform(click());
+        onView(withText(R.string.lock_queue)).perform(click());
         onView(allOf(withClassName(endsWith("Button")), withText(R.string.lock_queue))).perform(click());
-        onView(withContentDescription(R.string.unlock_queue)).perform(click());
+        onView(first(EspressoTestUtils.actionBarOverflow())).perform(click());
+        onView(withText(R.string.lock_queue)).perform(click());
     }
 
     @Test

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -247,16 +247,8 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
             () -> DownloadService.isRunning && DownloadRequester.getInstance().isDownloadingFeeds();
 
     private void refreshToolbarState() {
-        final MenuItem queueLock = toolbar.getMenu().findItem(R.id.queue_lock);
-        if (UserPreferences.isQueueLocked()) {
-            queueLock.setTitle(de.danoeh.antennapod.R.string.unlock_queue);
-            queueLock.setIcon(R.drawable.ic_lock_open);
-        } else {
-            queueLock.setTitle(de.danoeh.antennapod.R.string.lock_queue);
-            queueLock.setIcon(R.drawable.ic_lock_closed);
-        }
+        toolbar.getMenu().findItem(R.id.queue_lock).setChecked(UserPreferences.isQueueLocked());
         boolean keepSorted = UserPreferences.isQueueKeepSorted();
-
         toolbar.getMenu().findItem(R.id.queue_sort_random).setVisible(!keepSorted);
         toolbar.getMenu().findItem(R.id.queue_keep_sorted).setChecked(keepSorted);
         isUpdatingFeeds = MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(),

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:custom="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/queue_lock"
-        android:title=""
-        android:menuCategory="container"
-        custom:showAsAction="always" />
+        android:id="@+id/action_search"
+        android:icon="@drawable/ic_search"
+        custom:showAsAction="ifRoom"
+        android:title="@string/search_label"/>
 
     <item
         android:id="@+id/refresh_item"
@@ -17,10 +16,10 @@
         android:icon="@drawable/ic_refresh"/>
 
     <item
-        android:id="@+id/action_search"
-        android:icon="@drawable/ic_search"
-        custom:showAsAction="ifRoom"
-        android:title="@string/search_label"/>
+        android:id="@+id/queue_lock"
+        android:title="@string/lock_queue"
+        android:menuCategory="container"
+        android:checkable="true" />
 
     <item
         android:id="@+id/queue_sort"

--- a/core/src/main/res/drawable/ic_lock_closed.xml
+++ b/core/src/main/res/drawable/ic_lock_closed.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?attr/action_icon_color" android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1s3.1,1.39 3.1,3.1v2L8.9,8L8.9,6zM18,20L6,20L6,10h12v10z"/>
-</vector>

--- a/core/src/main/res/drawable/ic_lock_open.xml
+++ b/core/src/main/res/drawable/ic_lock_open.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?attr/action_icon_color" android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
-</vector>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -304,7 +304,6 @@
 
     <!-- Queue operations -->
     <string name="lock_queue">Lock Queue</string>
-    <string name="unlock_queue">Unlock Queue</string>
     <string name="queue_locked">Queue locked</string>
     <string name="queue_unlocked">Queue unlocked</string>
     <string name="queue_lock_warning">If you lock the queue, you can no longer swipe or reorder episodes.</string>


### PR DESCRIPTION
Even though this option now has a warning dialog, it still seems to confuse users. I think there are now quite a few reasons to no longer display that option as prominently.

- Users can see the title text (and a checkbox), so they do not have to guess what the icon means
- The queue screen is more consistent with other screens (search+refresh icon)
- Swiping (which was a use-case for the lock feature) can now be disabled (and will be made slightly harder in #4844)
- By selecting "keep sorted", even reordering can be disabled
- It is an extremely specific option that is likely only used by very few users

The option is still available in the overflow menu for now but I actually would like to remove it completely in the future.

Any opinions about this change? Pinging some users who have indicated that they use queue locking: @keunes @Matth7878 @jhenninger @egvimo @olivoto @szukai (sorrry for the noise).