### PR TITLE
Only declare used ExoPlayer submodules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ project.ext {
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"
+    exoPlayerVersion = "2.11.8"
     audioPlayerVersion = "v2.0.0"
 
     // Only used for free builds. This version should be updated regularly.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,7 +50,8 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.8'
+    implementation "com.google.android.exoplayer:exoplayer-core:$exoPlayerVersion"
+    implementation "com.google.android.exoplayer:exoplayer-ui:$exoPlayerVersion"
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
 
     // Non-free dependencies:


### PR DESCRIPTION
This reduces the size of debug APKs with no side effect.

| Left-aligned | Before | After |
| :---         |     :---:      |          ---: |
| Size   | 13,222 KB     | 13,086 KB    |
| Method count (according to dexCount plugin)    | 105817       | 104733      |
