### PR TITLE
add property guid to episode action synchronization payload

### DIFF
--- a/net/sync/model/src/main/java/de/danoeh/antennapod/net/sync/model/EpisodeAction.java
+++ b/net/sync/model/src/main/java/de/danoeh/antennapod/net/sync/model/EpisodeAction.java
@@ -5,7 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.util.ObjectsCompat;
-import de.danoeh.antennapod.model.feed.FeedItem;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -14,6 +14,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+
+import de.danoeh.antennapod.model.feed.FeedItem;
 
 public class EpisodeAction {
     private static final String TAG = "EpisodeAction";
@@ -238,6 +240,7 @@ public class EpisodeAction {
 
         public Builder(FeedItem item, Action action) {
             this(item.getFeed().getDownload_url(), item.getMedia().getDownload_url(), action);
+            this.guid(item.getItemIdentifier());
         }
 
         public Builder(String podcast, String episode, Action action) {


### PR DESCRIPTION
add property guid to episode action synchronization payload.

I quick test with gpodder.net did succeed. Synchronization was OK. Gpodder.net does not seem to break when provided with unknown fields (like guid)