### PR TITLE
Update plugins and Gradle (4.2.2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id('com.android.application')
     id('com.getkeepsafe.dexcount')
-    id('com.github.triplet.play') version '3.4.0' apply false
+    id('com.github.triplet.play') version '3.6.0-agp4.2' apply false
 }
 apply from: "../common.gradle"
 apply from: "../playFlavor.gradle"
@@ -76,9 +76,9 @@ android {
 
             dexcount {
                 if (project.hasProperty("enableDexcountInDebug")) {
-                    runOnEachPackage enableDexcountInDebug.toBoolean()
+                    runOnEachPackage = enableDexcountInDebug.toBoolean()
                 } else { // default to not running dexcount
-                    runOnEachPackage false
+                    runOnEachPackage = false
                 }
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/WidgetConfigActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/WidgetConfigActivity.java
@@ -1,21 +1,14 @@
 package de.danoeh.antennapod.activity;
 
-import android.Manifest;
-import android.app.WallpaperManager;
 import android.appwidget.AppWidgetManager;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
-import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.CheckBox;
-import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.receiver.PlayerWidget;
@@ -51,7 +44,6 @@ public class WidgetConfigActivity extends AppCompatActivity {
             finish();
         }
 
-        displayDeviceBackground();
         opacityTextView = findViewById(R.id.widget_opacity_textView);
         opacitySeekBar = findViewById(R.id.widget_opacity_seekBar);
         widgetPreview = findViewById(R.id.widgetLayout);
@@ -100,16 +92,6 @@ public class WidgetConfigActivity extends AppCompatActivity {
                 .setVisibility(ckFastForward.isChecked() ? View.VISIBLE : View.GONE);
         widgetPreview.findViewById(R.id.butSkip).setVisibility(ckSkip.isChecked() ? View.VISIBLE : View.GONE);
         widgetPreview.findViewById(R.id.butRew).setVisibility(ckRewind.isChecked() ? View.VISIBLE : View.GONE);
-    }
-
-    private void displayDeviceBackground() {
-        int permission = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
-        if (Build.VERSION.SDK_INT < 27 || permission == PackageManager.PERMISSION_GRANTED) {
-            final WallpaperManager wallpaperManager = WallpaperManager.getInstance(this);
-            final Drawable wallpaperDrawable = wallpaperManager.getDrawable();
-            ImageView background = findViewById(R.id.widget_config_background);
-            background.setImageDrawable(wallpaperDrawable);
-        }
     }
 
     private void confirmCreateWidget(View v) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.4'
-        classpath 'de.timfreiheit.resourceplaceholders:placeholders:0.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:3.0.0'
+        classpath 'de.timfreiheit.resourceplaceholders:placeholders:0.4'
         classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.0"
     }
 }

--- a/core/lint.xml
+++ b/core/lint.xml
@@ -8,4 +8,8 @@
     <issue id="MissingDefaultResource">
         <ignore path="**/values-**/strings.xml" />
     </issue>
+
+    <issue id="UnusedResources" severity="error">
+        <ignore path="**/values-**/strings.xml" />
+    </issue>
 </lint>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -530,7 +530,8 @@ public class UserPreferences {
     private static void setAllowMobileFor(String type, boolean allow) {
         HashSet<String> defaultValue = new HashSet<>();
         defaultValue.add("images");
-        Set<String> allowed = prefs.getStringSet(PREF_MOBILE_UPDATE, defaultValue);
+        final Set<String> getValueStringSet = prefs.getStringSet(PREF_MOBILE_UPDATE, defaultValue);
+        final Set<String> allowed = new HashSet<>(getValueStringSet);
         if (allow) {
             allowed.add(type);
         } else {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/mapper/FeedMediaCursorMapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/mapper/FeedMediaCursorMapper.java
@@ -36,7 +36,7 @@ public abstract class FeedMediaCursorMapper {
         }
 
         Boolean hasEmbeddedPicture;
-        switch (cursor.getInt(cursor.getColumnIndex(PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE))) {
+        switch (cursor.getInt(cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE))) {
             case 1:
                 hasEmbeddedPicture = Boolean.TRUE;
                 break;


### PR DESCRIPTION
IntelliJ's IDEA 2021.2 has been released, which [adds support for AGP 4.2.x](https://www.jetbrains.com/idea/whatsnew/#:~:text=The%20Android%20plugin%20was%20upgraded%20to%20v4.2.0.).

### 1st commit
- Update gradle wrapper to 7.2 using git bash

### 2nd commit
- Update Triplet 3.4.0 -> 3.6.0-agp4.2 ([changelog](https://github.com/Triple-T/gradle-play-publisher/releases))
- Update Android Studio 4.1.3 -> 4.2.2 ([changelog](https://developer.android.com/studio/releases/gradle-plugin#4-2-0))
- Update dexcount-gradle-plugin 1.0.4 -> 3.0.0 ([changelog](https://github.com/KeepSafe/dexcount-gradle-plugin/releases))
- Update resourceplaceholders 0.3 -> 0.4 ([changelog](https://github.com/timfreiheit/ResourcePlaceholdersPlugin/releases))

### 3rd commit
- Fix
```
...\AntennaPod\core\src\main\java\de\danoeh\antennapod\core\preferences\UserPreferences.java:535: Error: Do not modify the set returned by SharedPreferences.getStringSet(
)` [MutatingSharedPrefs]
              allowed.add(type);
              ~~~~~~~~~~~~~~~~~
...\AntennaPod\core\src\main\java\de\danoeh\antennapod\core\preferences\UserPreferences.java:537: Error: Do not modify the set returned by SharedPreferences.getStringSet(
)` [MutatingSharedPrefs]
              allowed.remove(type);
              ~~~~~~~~~~~~~~~~~~~~

```
See [this](https://stackoverflow.com/questions/14034803/misbehavior-when-trying-to-store-a-string-set-using-sharedpreferences/14034804) for context.

### 4th commit
- Fix
```
...\AntennaPod\app\src\main\java\de\danoeh\antennapod\activity\WidgetConfigActivity.java:109: Error: Missing permissions required by WallpaperManager.getDrawable: android
.permission.READ_EXTERNAL_STORAGE [MissingPermission]
              final Drawable wallpaperDrawable = wallpaperManager.getDrawable();
```

### 5th commit
- Suppress UnusedResources lint