### PR TITLE
Update AppCompat to 1.3.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+    implementation "androidx.core:core:$coreVersion"
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation "androidx.media:media:$mediaVersion"
     implementation "androidx.preference:preference:$preferenceVersion"

--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
@@ -205,6 +205,7 @@ public class OpmlImportActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode != PERMISSION_REQUEST_READ_EXTERNAL_STORAGE) {
             return;
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/UserInterfacePreferencesFragment.java
@@ -5,6 +5,7 @@ import android.os.Build;
 import android.os.Bundle;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.ActivityCompat;
 import androidx.preference.PreferenceFragmentCompat;
 import android.widget.ListView;
 import de.danoeh.antennapod.R;
@@ -39,7 +40,7 @@ public class UserInterfacePreferencesFragment extends PreferenceFragmentCompat {
         findPreference(UserPreferences.PREF_THEME)
                 .setOnPreferenceChangeListener(
                         (preference, newValue) -> {
-                            getActivity().recreate();
+                            ActivityCompat.recreate(getActivity());
                             return true;
                         });
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,9 @@ subprojects {
 
 project.ext {
     // AndroidX
-    annotationVersion = "1.1.0"
-    appcompatVersion = "1.2.0"
+    annotationVersion = "1.2.0"
+    appcompatVersion = "1.3.1"
+    coreVersion = "1.5.0"
     mediaVersion = "1.1.0"
     preferenceVersion = "1.1.1"
     workManagerVersion = "2.3.4"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation "androidx.core:core:$coreVersion"
     implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation "androidx.media:media:$mediaVersion"
     implementation "androidx.preference:preference:$preferenceVersion"

--- a/core/src/main/java/de/danoeh/antennapod/core/util/gui/NotificationUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/gui/NotificationUtils.java
@@ -1,12 +1,13 @@
 package de.danoeh.antennapod.core.util.gui;
 
-
-import android.app.NotificationChannel;
-import android.app.NotificationChannelGroup;
-import android.app.NotificationManager;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.RequiresApi;
+
+import androidx.core.app.NotificationChannelCompat;
+import androidx.core.app.NotificationChannelGroupCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import java.util.Arrays;
+import java.util.List;
 
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
@@ -23,113 +24,112 @@ public class NotificationUtils {
     public static final String GROUP_ID_ERRORS = "group_errors";
     public static final String GROUP_ID_NEWS = "group_news";
 
-    public static void createChannels(Context context) {
-        if (Build.VERSION.SDK_INT < 26) {
-            return;
-        }
-        NotificationManager mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    public static void createChannels(final Context context) {
+        final NotificationManagerCompat mNotificationManager = NotificationManagerCompat.from(context);
 
-        if (mNotificationManager != null) {
-            mNotificationManager.createNotificationChannelGroup(createGroupErrors(context));
-            mNotificationManager.createNotificationChannelGroup(createGroupNews(context));
+        final List<NotificationChannelGroupCompat> channelGroups = Arrays.asList(
+                createGroupErrors(context),
+                createGroupNews(context));
+        mNotificationManager.createNotificationChannelGroupsCompat(channelGroups);
 
-            mNotificationManager.createNotificationChannel(createChannelUserAction(context));
-            mNotificationManager.createNotificationChannel(createChannelDownloading(context));
-            mNotificationManager.createNotificationChannel(createChannelPlaying(context));
-            mNotificationManager.createNotificationChannel(createChannelError(context));
-            mNotificationManager.createNotificationChannel(createChannelSyncError(context));
-            mNotificationManager.createNotificationChannel(createChannelAutoDownload(context));
-            mNotificationManager.createNotificationChannel(createChannelEpisodeNotification(context));
-        }
+        final List<NotificationChannelCompat> channels = Arrays.asList(
+                createChannelUserAction(context),
+                createChannelDownloading(context),
+                createChannelPlaying(context),
+                createChannelError(context),
+                createChannelSyncError(context),
+                createChannelAutoDownload(context),
+                createChannelEpisodeNotification(context));
+        mNotificationManager.createNotificationChannelsCompat(channels);
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelUserAction(Context c) {
-        NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID_USER_ACTION,
-                c.getString(R.string.notification_channel_user_action), NotificationManager.IMPORTANCE_HIGH);
-        notificationChannel.setDescription(c.getString(R.string.notification_channel_user_action_description));
-        notificationChannel.setGroup(GROUP_ID_ERRORS);
-        return notificationChannel;
+    private static NotificationChannelCompat createChannelUserAction(final Context c) {
+        return new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_USER_ACTION, NotificationManagerCompat.IMPORTANCE_HIGH)
+                .setName(c.getString(R.string.notification_channel_user_action))
+                .setDescription(c.getString(R.string.notification_channel_user_action_description))
+                .setGroup(GROUP_ID_ERRORS)
+                .build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelDownloading(Context c) {
-        NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID_DOWNLOADING,
-                c.getString(R.string.notification_channel_downloading), NotificationManager.IMPORTANCE_LOW);
-        notificationChannel.setDescription(c.getString(R.string.notification_channel_downloading_description));
-        notificationChannel.setShowBadge(false);
-        return notificationChannel;
+    private static NotificationChannelCompat createChannelDownloading(final Context c) {
+        return new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_DOWNLOADING, NotificationManagerCompat.IMPORTANCE_LOW)
+                .setName(c.getString(R.string.notification_channel_downloading))
+                .setDescription(c.getString(R.string.notification_channel_downloading_description))
+                .setShowBadge(false)
+                .build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelPlaying(Context c) {
-        NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID_PLAYING,
-                c.getString(R.string.notification_channel_playing), NotificationManager.IMPORTANCE_LOW);
-        notificationChannel.setDescription(c.getString(R.string.notification_channel_playing_description));
-        notificationChannel.setShowBadge(false);
-        return notificationChannel;
+    private static NotificationChannelCompat createChannelPlaying(final Context c) {
+        return new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_PLAYING, NotificationManagerCompat.IMPORTANCE_LOW)
+                .setName(c.getString(R.string.notification_channel_playing))
+                .setDescription(c.getString(R.string.notification_channel_playing_description))
+                .setShowBadge(false)
+                .build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelError(Context c) {
-        NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID_DOWNLOAD_ERROR,
-                c.getString(R.string.notification_channel_download_error), NotificationManager.IMPORTANCE_HIGH);
-        notificationChannel.setDescription(c.getString(R.string.notification_channel_download_error_description));
-        notificationChannel.setGroup(GROUP_ID_ERRORS);
+    private static NotificationChannelCompat createChannelError(final Context c) {
+        final NotificationChannelCompat.Builder notificationChannel = new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_DOWNLOAD_ERROR, NotificationManagerCompat.IMPORTANCE_HIGH)
+                .setName(c.getString(R.string.notification_channel_download_error))
+                .setDescription(c.getString(R.string.notification_channel_download_error_description))
+                .setGroup(GROUP_ID_ERRORS);
 
         if (!UserPreferences.getShowDownloadReportRaw()) {
             // Migration from app managed setting: disable notification
-            notificationChannel.setImportance(NotificationManager.IMPORTANCE_NONE);
+            notificationChannel.setImportance(NotificationManagerCompat.IMPORTANCE_NONE);
         }
-        return notificationChannel;
+        return notificationChannel.build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelSyncError(Context c) {
-        NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID_SYNC_ERROR,
-                c.getString(R.string.notification_channel_sync_error), NotificationManager.IMPORTANCE_HIGH);
-        notificationChannel.setDescription(c.getString(R.string.notification_channel_sync_error_description));
-        notificationChannel.setGroup(GROUP_ID_ERRORS);
+    private static NotificationChannelCompat createChannelSyncError(final Context c) {
+        final NotificationChannelCompat.Builder notificationChannel = new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_SYNC_ERROR, NotificationManagerCompat.IMPORTANCE_HIGH)
+                .setName(c.getString(R.string.notification_channel_sync_error))
+                .setDescription(c.getString(R.string.notification_channel_sync_error_description))
+                .setGroup(GROUP_ID_ERRORS);
 
         if (!UserPreferences.getGpodnetNotificationsEnabledRaw()) {
             // Migration from app managed setting: disable notification
-            notificationChannel.setImportance(NotificationManager.IMPORTANCE_NONE);
+            notificationChannel.setImportance(NotificationManagerCompat.IMPORTANCE_NONE);
         }
-        return notificationChannel;
+        return notificationChannel.build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelAutoDownload(Context c) {
-        NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID_AUTO_DOWNLOAD,
-                c.getString(R.string.notification_channel_auto_download), NotificationManager.IMPORTANCE_NONE);
-        notificationChannel.setDescription(c.getString(R.string.notification_channel_episode_auto_download));
-        notificationChannel.setGroup(GROUP_ID_NEWS);
+    private static NotificationChannelCompat createChannelAutoDownload(final Context c) {
+        final NotificationChannelCompat.Builder notificationChannel = new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_AUTO_DOWNLOAD, NotificationManagerCompat.IMPORTANCE_NONE)
+                .setName(c.getString(R.string.notification_channel_auto_download))
+                .setDescription(c.getString(R.string.notification_channel_episode_auto_download))
+                .setGroup(GROUP_ID_NEWS);
 
         if (UserPreferences.getShowAutoDownloadReportRaw()) {
             // Migration from app managed setting: enable notification
-            notificationChannel.setImportance(NotificationManager.IMPORTANCE_DEFAULT);
+            notificationChannel.setImportance(NotificationManagerCompat.IMPORTANCE_DEFAULT);
         }
-        return notificationChannel;
+        return notificationChannel.build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannel createChannelEpisodeNotification(Context c) {
-        NotificationChannel channel = new NotificationChannel(CHANNEL_ID_EPISODE_NOTIFICATIONS,
-                c.getString(R.string.notification_channel_new_episode), NotificationManager.IMPORTANCE_DEFAULT);
-        channel.setDescription(c.getString(R.string.notification_channel_new_episode_description));
-        channel.setGroup(GROUP_ID_NEWS);
-        return channel;
+    private static NotificationChannelCompat createChannelEpisodeNotification(final Context c) {
+        return new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_EPISODE_NOTIFICATIONS, NotificationManagerCompat.IMPORTANCE_DEFAULT)
+                .setName(c.getString(R.string.notification_channel_new_episode))
+                .setDescription(c.getString(R.string.notification_channel_new_episode_description))
+                .setGroup(GROUP_ID_NEWS)
+                .build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannelGroup createGroupErrors(Context c) {
-        return new NotificationChannelGroup(GROUP_ID_ERRORS,
-                c.getString(R.string.notification_group_errors));
+    private static NotificationChannelGroupCompat createGroupErrors(final Context c) {
+        return new NotificationChannelGroupCompat.Builder(GROUP_ID_ERRORS)
+                .setName(c.getString(R.string.notification_group_errors))
+                .build();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static NotificationChannelGroup createGroupNews(Context c) {
-        return new NotificationChannelGroup(GROUP_ID_NEWS,
-                c.getString(R.string.notification_group_news));
+    private static NotificationChannelGroupCompat createGroupNews(final Context c) {
+        return new NotificationChannelGroupCompat.Builder(GROUP_ID_NEWS)
+                .setName(c.getString(R.string.notification_group_news))
+                .build();
     }
 }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,7 +3,6 @@ apply from: "../common.gradle"
 
 dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "androidx.media:media:$mediaVersion"
 
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"

--- a/parser/feed/build.gradle
+++ b/parser/feed/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
 
-    implementation "androidx.core:core:$appcompatVersion"
+    implementation "androidx.core:core:$coreVersion"
 
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
     implementation "commons-io:commons-io:$commonsioVersion"

--- a/ui/app-start-intent/build.gradle
+++ b/ui/app-start-intent/build.gradle
@@ -3,5 +3,4 @@ apply from: "../../common.gradle"
 
 dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
 }

--- a/ui/png-icons/build.gradle
+++ b/ui/png-icons/build.gradle
@@ -10,5 +10,4 @@ android {
 
 dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
 }


### PR DESCRIPTION
Reference: https://github.com/AntennaPod/AntennaPod/pull/5201#issuecomment-907605489

I even included a few compatibility improvements to, y'know, sweeten the pot a little ;)

### 1st commit
- Remove AndroidX libraries from modules where they aren't used.

### 2nd commit
- Update AppCompat 1.2.0 -> 1.3.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/appcompat)) (Be sure to read the changelogs in AppCompat's internally updated dependencies as well. They'll be listed in the AppCompat changelog.)
  - This includes Fragment 1.3.6, which is dealt with in the original PR I made.
  - This also includes Annotation 1.2.0 and Core 1.5.0.

### 3rd commit
- Fix missing super call (this is rendered obsolete by my Fragment PR, but this must be done for now for lint to pass).

### 4th commit
- Use an AndroidX Core feature: [ActivityCompat.recreate](https://developer.android.com/jetpack/androidx/releases/core#1.5.0-alpha04)
  - Use Ctrl + F and input `ActivityCompat.recreate()` to see the reason for its creation. There's four instances in the docs to read.

### 5th commit
- Use an AndroidX Core 1.5.0 feature: [NotificationChannelCompat utilities](https://developer.android.com/jetpack/androidx/releases/core#:~:text=Added%20NotificationChannelCompat%20and%20NotificationChannelGroupCompat)