### PR TITLE
Use ServiceCompat.stopForeground

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -17,6 +17,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.app.ServiceCompat;
 
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.core.sync.SyncService;
@@ -645,7 +646,7 @@ public class DownloadService extends Service {
         }
         handler.post(() -> {
             cancelNotificationUpdater();
-            stopForeground(true);
+            ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
             stopSelf();
         });
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceStateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceStateManager.java
@@ -1,8 +1,8 @@
 package de.danoeh.antennapod.core.service.playback;
 
 import android.app.Notification;
-import android.app.Service;
-import android.os.Build;
+
+import androidx.core.app.ServiceCompat;
 
 class PlaybackServiceStateManager {
     private final PlaybackService playbackService;
@@ -27,12 +27,10 @@ class PlaybackServiceStateManager {
 
     void stopForeground(boolean removeNotification) {
         if (isInForeground) {
-            if (Build.VERSION.SDK_INT < 24) {
-                playbackService.stopForeground(removeNotification);
-            } else if (removeNotification) {
-                playbackService.stopForeground(Service.STOP_FOREGROUND_REMOVE);
+            if (removeNotification) {
+                ServiceCompat.stopForeground(playbackService, ServiceCompat.STOP_FOREGROUND_REMOVE);
             } else {
-                playbackService.stopForeground(Service.STOP_FOREGROUND_DETACH);
+                ServiceCompat.stopForeground(playbackService, ServiceCompat.STOP_FOREGROUND_DETACH);
             }
         }
         isInForeground = false;


### PR DESCRIPTION
See [here](https://developer.android.com/reference/androidx/core/app/ServiceCompat#stopForeground(android.app.Service,%20int)).

The internal code is this:
```
public static void stopForeground(@NonNull Service service, @StopForegroundFlags int flags) {
    if (Build.VERSION.SDK_INT >= 24) {
        service.stopForeground(flags);
    } else {
        service.stopForeground((flags & ServiceCompat.STOP_FOREGROUND_REMOVE) != 0);
    }
}
```
