### PR TITLE
Bump RecyclerViewSwipeDecorator to 1.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,7 +150,7 @@ dependencies {
     implementation 'com.github.mfietz:fyydlin:v0.5.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
     implementation 'com.github.skydoves:balloon:1.1.5'
-    implementation 'it.xabaras.android:recyclerview-swipedecorator:1.2.3'
+    implementation 'com.github.xabaras:RecyclerViewSwipeDecorator:1.3'
     implementation 'com.annimon:stream:1.2.2'
 
     // Non-free dependencies:


### PR DESCRIPTION
This contributes to https://github.com/AntennaPod/AntennaPod/issues/4930 and checks off one of the checkboxes. Version 1.2.3 does not exist on JitPack, so we must upgrade to the new release that does away with jcenter.

See https://github.com/xabaras/RecyclerViewSwipeDecorator and https://github.com/xabaras/RecyclerViewSwipeDecorator/releases.
