### PR TITLE
Update AndroidX Media and ExoPlayer

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -2,6 +2,7 @@ package de.test.antennapod.service.playback;
 
 import android.content.Context;
 
+import androidx.test.annotation.UiThreadTest;
 import androidx.test.filters.MediumTest;
 
 import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
@@ -56,12 +57,14 @@ public class PlaybackServiceMediaPlayerTest {
     private volatile AssertionFailedError assertionError;
 
     @After
+    @UiThreadTest
     public void tearDown() throws Exception {
         PodDBAdapter.deleteDatabase();
         httpServer.stop();
     }
 
     @Before
+    @UiThreadTest
     public void setUp() throws Exception {
         assertionError = null;
         EspressoTestUtils.clearPreferences();
@@ -117,6 +120,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testInit() {
         final Context c = getInstrumentation().getTargetContext();
         PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, new DefaultPSMPCallback());
@@ -141,6 +145,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectStreamNoStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
@@ -181,6 +186,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectStreamStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
@@ -222,6 +228,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectStreamNoStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(4);
@@ -264,6 +271,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectStreamStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(5);
@@ -308,6 +316,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectLocalNoStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
@@ -347,6 +356,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectLocalStartNoPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
@@ -386,6 +396,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectLocalNoStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(4);
@@ -427,6 +438,7 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPlayMediaObjectLocalStartPrepare() throws InterruptedException {
         final Context c = getInstrumentation().getTargetContext();
         final CountDownLatch countDownLatch = new CountDownLatch(5);
@@ -530,46 +542,55 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPauseDefaultState() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.STOPPED, false, false, false, 1);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateNoAbandonNoReinitNoStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, false, false, false, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateNoAbandonNoReinitStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, true, false, false, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateAbandonNoReinitNoStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, false, true, false, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateAbandonNoReinitStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, true, true, false, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateNoAbandonReinitNoStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, false, false, true, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateNoAbandonReinitStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, true, false, true, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateAbandonReinitNoStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, false, true, true, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPausePlayingStateAbandonReinitStream() throws InterruptedException {
         pauseTestSkeleton(PlayerStatus.PLAYING, true, true, true, LATCH_TIMEOUT_SECONDS);
     }
@@ -616,16 +637,19 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testResumePausedState() throws InterruptedException {
         resumeTestSkeleton(PlayerStatus.PAUSED, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testResumePreparedState() throws InterruptedException {
         resumeTestSkeleton(PlayerStatus.PREPARED, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testResumePlayingState() throws InterruptedException {
         resumeTestSkeleton(PlayerStatus.PLAYING, 1);
     }
@@ -678,21 +702,25 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testPrepareInitializedState() throws InterruptedException {
         prepareTestSkeleton(PlayerStatus.INITIALIZED, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPreparePlayingState() throws InterruptedException {
         prepareTestSkeleton(PlayerStatus.PLAYING, 1);
     }
 
     @Test
+    @UiThreadTest
     public void testPreparePausedState() throws InterruptedException {
         prepareTestSkeleton(PlayerStatus.PAUSED, 1);
     }
 
     @Test
+    @UiThreadTest
     public void testPreparePreparedState() throws InterruptedException {
         prepareTestSkeleton(PlayerStatus.PREPARED, 1);
     }
@@ -735,21 +763,25 @@ public class PlaybackServiceMediaPlayerTest {
     }
 
     @Test
+    @UiThreadTest
     public void testReinitPlayingState() throws InterruptedException {
         reinitTestSkeleton(PlayerStatus.PLAYING, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testReinitPausedState() throws InterruptedException {
         reinitTestSkeleton(PlayerStatus.PAUSED, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testPreparedPlayingState() throws InterruptedException {
         reinitTestSkeleton(PlayerStatus.PREPARED, LATCH_TIMEOUT_SECONDS);
     }
 
     @Test
+    @UiThreadTest
     public void testReinitInitializedState() throws InterruptedException {
         reinitTestSkeleton(PlayerStatus.INITIALIZED, LATCH_TIMEOUT_SECONDS);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ project.ext {
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"
-    exoPlayerVersion = "2.11.8"
+    exoPlayerVersion = "2.12.3"
     audioPlayerVersion = "v2.0.0"
 
     // Only used for free builds. This version should be updated regularly.

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ project.ext {
     appcompatVersion = "1.3.1"
     coreVersion = "1.5.0"
     fragmentVersion = "1.3.6"
-    mediaVersion = "1.1.0"
+    mediaVersion = "1.4.3"
     preferenceVersion = "1.1.1"
     workManagerVersion = "2.3.4"
     googleMaterialVersion = "1.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ project.ext {
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"
-    exoPlayerVersion = "2.12.3"
+    exoPlayerVersion = "2.13.3"
     audioPlayerVersion = "v2.0.0"
 
     // Only used for free builds. This version should be updated regularly.

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ project.ext {
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"
-    exoPlayerVersion = "2.13.3"
+    exoPlayerVersion = "2.14.2"
     audioPlayerVersion = "v2.0.0"
 
     // Only used for free builds. This version should be updated regularly.

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ResizingOkHttpStreamFetcher.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ResizingOkHttpStreamFetcher.java
@@ -3,12 +3,13 @@ package de.danoeh.antennapod.core.glide;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Build;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.integration.okhttp3.OkHttpStreamFetcher;
 import com.bumptech.glide.load.model.GlideUrl;
-import com.google.android.exoplayer2.util.Log;
 import okhttp3.Call;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -22,7 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class ResizingOkHttpStreamFetcher extends OkHttpStreamFetcher {
-    private static final String TAG = "ResizingOkHttpStreamFetcher";
+    private static final String TAG = "ResizingOkHttpStreamFet";
     private static final int MAX_DIMENSIONS = 1500;
     private static final int MAX_FILE_SIZE = 1024 * 1024; // 1 MB
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -93,7 +93,7 @@ public class ExoPlayerWrapper implements IPlayer {
                 .setLoadControl(loadControl.build())
                 .build();
         exoPlayer.setSeekParameters(SeekParameters.EXACT);
-        exoPlayer.addListener(new Player.EventListener() {
+        exoPlayer.addListener(new Player.Listener() {
             @Override
             public void onPlaybackStateChanged(@Player.State int playbackState) {
                 if (audioCompletionListener != null && playbackState == Player.STATE_ENDED) {
@@ -121,7 +121,9 @@ public class ExoPlayerWrapper implements IPlayer {
             }
 
             @Override
-            public void onPositionDiscontinuity(@Player.DiscontinuityReason int reason) {
+            public void onPositionDiscontinuity(@NonNull Player.PositionInfo oldPosition,
+                                                @NonNull Player.PositionInfo newPosition,
+                                                @Player.DiscontinuityReason int reason) {
                 if (audioSeekCompleteListener != null && reason == Player.DISCONTINUITY_REASON_SEEK) {
                     audioSeekCompleteListener.onSeekComplete(null);
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1231,7 +1231,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 | PlaybackStateCompat.ACTION_PAUSE
                 | PlaybackStateCompat.ACTION_FAST_FORWARD
                 | PlaybackStateCompat.ACTION_SKIP_TO_NEXT
-                | PlaybackStateCompat.ACTION_SEEK_TO;
+                | PlaybackStateCompat.ACTION_SEEK_TO
+                | PlaybackStateCompat.ACTION_SET_PLAYBACK_SPEED;
 
         if (useSkipToPreviousForRewindInLockscreen()) {
             // Workaround to fool Android so that Lockscreen will expose a skip-to-previous button,
@@ -1885,6 +1886,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         public void onSeekTo(long pos) {
             Log.d(TAG, "onSeekTo()");
             seekTo((int) pos);
+        }
+
+        @Override
+        public void onSetPlaybackSpeed(float speed) {
+            Log.d(TAG, "onSetPlaybackSpeed()");
+            setSpeed(speed);
         }
 
         @Override


### PR DESCRIPTION
This will have to be done sooner or later due to https://github.com/AntennaPod/AntennaPod/issues/4930. February 2022 is coming, whether we like it or not, and the ExoPlayer team only seems to want to host versions 2.13.3 and up on the new Maven repo. We want to do this now so that we are prepared and have ample time to fix any potential bugs. Due to Jcenter's sunsetting, it isn't just a "bigger version number somewhere in the code," it's actually integral to the continued maintenance of AntennaPod as an app.

I've merged together the ExoPlayer changes from https://github.com/AntennaPod/AntennaPod/pull/5085 and https://github.com/AntennaPod/AntennaPod/pull/4752.

I am willing to debug the hell out of this and do any testing necessary to get this merged. Feel free to ask questions regarding any changes I've made.

- Updated ExoPlayer 2.11.8 -> 2.14.2 ([changelog](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md)) (I'm willing to downgrade this to 2.13.3 if you wish)
- Updated AndroidX Media 1.1.0 -> 1.4.3 ([changelog](https://developer.android.com/jetpack/androidx/releases/media))

Benefits of upgrading ExoPlayer:
- First and foremost: We're able to mark one more library off the Jcenter migration list. 
- Whatever internal improvements the ExoPlayer team made, though that's not as important.

Benefits of upgrading AndroidX Media:
- We actually don't have a choice. ExoPlayer uses a few things from AndroidX Media internally, and its transitive version for versions 2.13 and up is 1.2.1, which makes AntennaPod use 1.2.1 as well. We might as well take advantage of the newest version, because there's important bugfixes and features that AntennaPod can take advantage of.
- A [bugfix](https://developer.android.com/jetpack/androidx/releases/media#:~:text=Fixed%20an%20issue%20with%20AudioAttributesCompat.Builder%23setContentType) in 1.2.0 that most definitely [affects AntennaPod](https://github.com/AntennaPod/AntennaPod/blob/develop/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java#L163).
- A new constant in 1.3.0: [PlaybackStateCompat.ACTION_SET_PLAYBACK_SPEED](https://developer.android.com/jetpack/androidx/releases/media#:~:text=Added%20a%20new%20constant%20PlaybackStateCompat.ACTION_SET_PLAYBACK_SPEED).
- A potential [bugfix](https://developer.android.com/jetpack/androidx/releases/media#:~:text=Fix%20ClassVerificationFailure%20for%20NotificationCompat.MediaStyle) in 1.4.1.

By the way, have you heard of my app called [Scoop](https://github.com/TacoTheDank/Scoop)? You might find it useful to debug crashes.