### PR TITLE
Only remove new swipe action when showing only new episodes

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/RemoveFromInboxSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/RemoveFromInboxSwipeAction.java
@@ -40,6 +40,6 @@ public class RemoveFromInboxSwipeAction implements SwipeAction {
 
     @Override
     public boolean willRemove(FeedItemFilter filter) {
-        return filter.showUnplayed;
+        return filter.showNew;
     }
 }


### PR DESCRIPTION
Otherwise, setting the filter to "unplayed" wrongly removes the episode. Review request: @ueen 