### PR TITLE
Add Feature Request template link to Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ How to submit a feature request
 - To make it easier for us to keep track of requests, please only make one feature request per issue.
 - Give a brief explanation about the problem that may currently exist and how your requested feature solves this problem.
 - Try to be as specific as possible. Please not only explain what the feature does, but also how. If your request is about (or includes) changing or extending the UI, describe what the UI would look like and how the user would interact with it.
+- - Please use the following **[template](.github/ISSUE_TEMPLATE/feature_request.md)**. 
 
 
 Translating AntennaPod

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ How to submit a feature request
 - To make it easier for us to keep track of requests, please only make one feature request per issue.
 - Give a brief explanation about the problem that may currently exist and how your requested feature solves this problem.
 - Try to be as specific as possible. Please not only explain what the feature does, but also how. If your request is about (or includes) changing or extending the UI, describe what the UI would look like and how the user would interact with it.
-- - Please use the following **[template](.github/ISSUE_TEMPLATE/feature_request.md)**. 
+- Please use the following **[template](.github/ISSUE_TEMPLATE/feature_request.md)**. 
 
 
 Translating AntennaPod


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->

Added a link directly to the Feature Request template, just like there is for the Bug Report template, so that new contributors can more easily find it. Previously, even contributors who had read through the contributing guidelines were unaware that a specific template existed for Feature Requests and would submit poorly formatted requests as a result, which then would get flagged by antennapod-bot and need to be edited.
