### PR TITLE
Feed drag drop

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -625,6 +625,9 @@ public class MainActivity extends CastEnabledActivity {
         AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
         Integer customKeyCode = null;
 
+        if (onKeyUpListener.onKeyUp(keyCode, event)) {
+            return true;
+        }
         switch (keyCode) {
             case KeyEvent.KEYCODE_P:
                 customKeyCode = KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
@@ -666,4 +669,15 @@ public class MainActivity extends CastEnabledActivity {
         }
         return super.onKeyUp(keyCode, event);
     }
+
+    private OnKeyUpListener onKeyUpListener;
+
+    public void setOnKeyUpListener(OnKeyUpListener onKeyUpListener) {
+        this.onKeyUpListener = onKeyUpListener;
+    }
+    public interface OnKeyUpListener {
+
+        boolean onKeyUp(int keyCode, KeyEvent event);
+    }
+
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedsItemMoveCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedsItemMoveCallback.java
@@ -1,0 +1,56 @@
+package de.danoeh.antennapod.adapter;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class FeedsItemMoveCallback extends ItemTouchHelper.Callback {
+    private final ItemTouchHelperContract adapter;
+
+    public FeedsItemMoveCallback(ItemTouchHelperContract adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public int getMovementFlags(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder) {
+        int dragFlags = ItemTouchHelper.UP | ItemTouchHelper.DOWN | ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT;
+        return makeMovementFlags(dragFlags, 0);
+    }
+
+    @Override
+    public boolean onMove(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder, @NonNull RecyclerView.ViewHolder target) {
+        adapter.onRowMoved(viewHolder.getAdapterPosition(),
+                target.getAdapterPosition());
+        return true;
+    }
+
+    @Override
+    public void onSelectedChanged(RecyclerView.ViewHolder viewHolder, int actionState) {
+        if (actionState != ItemTouchHelper.ACTION_STATE_IDLE) {
+            if (viewHolder instanceof SubscriptionsRecyclerAdapter.SubscriptionViewHolder) {
+                SubscriptionsRecyclerAdapter.SubscriptionViewHolder subscriptionViewHolder =
+                        (SubscriptionsRecyclerAdapter.SubscriptionViewHolder) viewHolder;
+                adapter.onRowSelected(viewHolder);
+            }
+        }
+    }
+    @Override
+    public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
+
+    }
+
+    @Override
+    public boolean isLongPressDragEnabled() {
+        return false;
+    }
+
+    public interface ItemTouchHelperContract {
+
+        void onRowMoved(int fromPosition, int toPosition);
+        void onRowSelected(RecyclerView.ViewHolder myViewHolder);
+        void onRowClear(RecyclerView.ViewHolder myViewHolder);
+
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.adapter;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -140,7 +139,10 @@ public class SubscriptionsRecyclerAdapter
             if (isFeed) {
                 if (inActionMode()) {
                     holder.selectCheckbox.setChecked(!isSelected(holder.getBindingAdapterPosition()));
-                } else {
+                } else if(!isDragNDropMode()) {
+                    Fragment fragment = FeedItemlistFragment.newInstance(((NavDrawerData.FeedDrawerItem) drawerItem).feed.getId());
+                            mainActivityRef.get().loadChildFragment(fragment);
+                }else  {
                     Fragment fragment = FeedItemlistFragment
                             .newInstance(((NavDrawerData.FeedDrawerItem) drawerItem).feed.getId());
                     mainActivityRef.get().loadChildFragment(fragment);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -93,6 +93,8 @@ public class SubscriptionFragment extends Fragment
     private EmptyViewHandler emptyView;
     private TextView feedsFilteredMsg;
     private Toolbar toolbar;
+    private SwipeRefreshLayout swipeRefreshLayout;
+
     private String displayedFolder = null;
     private boolean isUpdatingFeeds = false;
     private boolean displayUpArrow;
@@ -101,7 +103,6 @@ public class SubscriptionFragment extends Fragment
     private SharedPreferences prefs;
 
     private SpeedDialView speedDialView;
-    SwipeRefreshLayout swipeRefreshLayout;
     private List<NavDrawerData.DrawerItem> listItems;
 
     public static SubscriptionFragment newInstance(String folderTitle) {
@@ -171,7 +172,7 @@ public class SubscriptionFragment extends Fragment
         feedsFilteredMsg = root.findViewById(R.id.feeds_filtered_message);
         feedsFilteredMsg.setOnClickListener((l) -> SubscriptionsFilterDialog.showDialog(requireContext()));
 
-        SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
+        swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
         swipeRefreshLayout.setDistanceToTriggerSync(getResources().getInteger(R.integer.swipe_refresh_distance));
         swipeRefreshLayout.setOnRefreshListener(() -> {
             AutoUpdateManager.runImmediate(requireContext());
@@ -398,7 +399,8 @@ public class SubscriptionFragment extends Fragment
 
     private void endDragDropMode() {
         subscriptionAdapter.setDragNDropMode(false);
-        swipeRefreshLayout.setEnabled(true);
+        if (swipeRefreshLayout != null)
+            swipeRefreshLayout.setEnabled(true);
     }
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onFeedListChanged(FeedListUpdateEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/AutoDownloadPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/AutoDownloadPreferencesFragment.java
@@ -165,6 +165,7 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
         }
     }
 
+    // NOTE: should be moved to stoarge preferences
     private void buildEpisodeCleanupPreference() {
         final Resources res = getActivity().getResources();
 

--- a/app/src/main/res/layout/subscription_item.xml
+++ b/app/src/main/res/layout/subscription_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
     xmlns:tools="http://schemas.android.com/tools"
@@ -51,6 +50,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/ic_checkbox_background">
+
+        <ImageView
+            android:id="@+id/dragHandle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/accent_dark"
+            android:padding="8dp"
+            android:src="@drawable/ic_drag_lighttheme" />
 
         <CheckBox
             android:id="@+id/selectCheckBox"

--- a/app/src/main/res/layout/subscription_item.xml
+++ b/app/src/main/res/layout/subscription_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
     xmlns:tools="http://schemas.android.com/tools"
@@ -55,9 +56,12 @@
             android:id="@+id/dragHandle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/accent_dark"
-            android:padding="8dp"
-            android:src="@drawable/ic_drag_lighttheme" />
+            android:paddingLeft="10dp"
+            android:paddingRight="16dp"
+            android:backgroundTint="@color/white"
+            android:background="@drawable/ic_checkbox_background"
+            android:src="@drawable/ic_drag_lighttheme"
+            app:tint="?attr/colorSecondary"/>
 
         <CheckBox
             android:id="@+id/selectCheckBox"

--- a/app/src/main/res/layout/subscription_item.xml
+++ b/app/src/main/res/layout/subscription_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
     xmlns:tools="http://schemas.android.com/tools"
@@ -56,11 +55,11 @@
             android:id="@+id/dragHandle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingLeft="10dp"
-            android:paddingRight="16dp"
             android:backgroundTint="@color/white"
-            android:background="@drawable/ic_checkbox_background"
             android:src="@drawable/ic_drag_lighttheme"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:layout_margin="8dp"
             app:tint="?attr/colorSecondary"/>
 
         <CheckBox

--- a/app/src/main/res/menu/nav_feed_context.xml
+++ b/app/src/main/res/menu/nav_feed_context.xml
@@ -25,4 +25,8 @@
         android:id="@+id/multi_select"
         android:menuCategory="container"
         android:title="@string/multi_select" />
+    <item
+        android:id="@+id/reorder"
+        android:menuCategory="container"
+        android:title="Set Priority"/>
 </menu>


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
This is mock up to demonstrate drag and drop for feeds. It's intended to be used to implement setting priority of podcasts, a highly requested feature.

Currently, only the drag and drop is implemented. I want to get suggestions on how priority should be stored. I'm thinking maybe FeedPrefrences would be a good option. 

When merge this would provide option to set priority which refers to download priority (#2437)

Eventually other features I want to consider adding is sort option in queue to sort by priority.

Besides being used for download priority, it also acts as custom/mannual ordering, which has also been highly requested.