### PR TITLE
install diff-checkstyle as pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ libs
 gradle.properties
 *.keystore
 *.p12
+
+diff-checkstyle.jar

--- a/build.gradle
+++ b/build.gradle
@@ -87,3 +87,9 @@ task checkstyle(type: Checkstyle) {
     exclude("**/gen/**")
     exclude("**/generated/**")
 }
+
+copy {
+    from "githooks"
+    into ".git/hooks"
+    fileMode 0777
+}

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,8 @@
+git fetch origin develop
+branchBaseCommit=`git merge-base origin/develop HEAD`
+echo "Comparing to $branchBaseCommit"
+if  [ ! -f diff-checkstyle.jar ] 
+then
+	curl -s -L https://github.com/yangziwen/diff-checkstyle/releases/download/0.0.4/diff-checkstyle.jar > diff-checkstyle.jar
+fi
+java -Dconfig_loc=config/checkstyle -jar diff-checkstyle.jar -c config/checkstyle/checkstyle-new-code.xml --git-dir . --base-rev $branchBaseCommit


### PR DESCRIPTION
This installs the tool diff-checkstyle as pre-commit hook. Executing diff-checkstyle before anything gets commited prevents developers from the time (and energy) consuming cycle of waiting for CircleCI to find issues and then fix those and then wait again if all was fixed.

Reason:
* This saves developer time because issues are shown immediately and not by email notification minutes later
* This saves energy (think climate) because given no faulty code is being commited and pushed the CircleCI check is only executed successfully once per push.