### PR TITLE
Make navigation bar color match theming

### DIFF
--- a/core/src/main/res/values-v21/styles.xml
+++ b/core/src/main/res/values-v21/styles.xml
@@ -4,14 +4,17 @@
         <item name="android:windowContentTransitions">true</item>
         <!-- To make icons visible -->
         <item name="android:statusBarColor">@color/grey600</item>
+        <item name="android:navigationBarColor">@color/grey600</item>
     </style>
 
     <style name="Theme.AntennaPod.Dark" parent="Theme.Base.AntennaPod.Dark">
         <item name="android:windowContentTransitions">true</item>
         <item name="android:statusBarColor">@color/background_darktheme</item>
+        <item name="android:navigationBarColor">@color/background_darktheme</item>
     </style>
 
     <style name="Theme.AntennaPod.TrueBlack" parent="Theme.Base.AntennaPod.TrueBlack">
         <item name="android:statusBarColor">@color/black</item>
+        <item name="android:navigationBarColor">@color/black</item>
     </style>
 </resources>

--- a/core/src/main/res/values-v23/styles.xml
+++ b/core/src/main/res/values-v23/styles.xml
@@ -4,15 +4,18 @@
         <item name="android:windowContentTransitions">true</item>
         <item name="android:statusBarColor">@color/background_light</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@color/background_light</item>
     </style>
 
     <style name="Theme.AntennaPod.Dark" parent="Theme.Base.AntennaPod.Dark">
         <item name="android:windowContentTransitions">true</item>
         <item name="android:statusBarColor">@color/background_darktheme</item>
         <item name="android:windowLightStatusBar">false</item>
+        <item name="android:navigationBarColor">@color/background_darktheme</item>
     </style>
 
     <style name="Theme.AntennaPod.TrueBlack" parent="Theme.Base.AntennaPod.TrueBlack">
         <item name="android:statusBarColor">@color/black</item>
+        <item name="android:navigationBarColor">@color/black</item>
     </style>
 </resources>

--- a/core/src/main/res/values-v27/styles.xml
+++ b/core/src/main/res/values-v27/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.AntennaPod.Light" parent="Theme.Base.AntennaPod.Light">
+        <item name="android:windowContentTransitions">true</item>
+        <item name="android:statusBarColor">@color/background_light</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@color/background_light</item>
+        <item name="android:navigationBarDividerColor">@color/navigation_bar_divider_light</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -25,6 +25,7 @@
     <color name="non_square_icon_background">#22777777</color>
     <color name="seek_background_light">#90000000</color>
     <color name="seek_background_dark">#905B5B5B</color>
+    <color name="navigation_bar_divider_light">#1F000000</color>
 
     <color name="accent_light">#0078C2</color>
     <color name="accent_dark">#3D8BFF</color>


### PR DESCRIPTION
Because I am more than tired of seeing that horrid bright white navbar on my otherwise completely dark screen.

During the switching process from AppCompat (1.x.x) to MaterialComponents (2.x.x) for theming, that navbar tinting for the dark modes was removed for some reason. Here's to adding it back ~~at least for API 27+ devices for now. I might add API 21-26 support in another PR~~.

This closes https://github.com/AntennaPod/AntennaPod/issues/4559 / https://github.com/AntennaPod/AntennaPod/issues/4570 (paging @hmilgraum and @xylo, cause you guys opened those two issues).

Tested on my Android 10 device.

OUTDATED SCREENSHOTS, SEE NEW ONES [HERE](https://github.com/AntennaPod/AntennaPod/pull/5422#issuecomment-950400644).

| UI changes | Before | After |
| ------------- | ------------- | ------------- |
| Dark | ![image](https://user-images.githubusercontent.com/32376686/134579161-310e1585-c3a8-48b2-a66d-570ced71513b.png) | ![image](https://user-images.githubusercontent.com/32376686/134579242-deaa0a74-40a5-4f46-b9f0-35cdb51eb00f.png) |
| True Black | ![image](https://user-images.githubusercontent.com/32376686/134578999-6cbd21f9-ee21-4b26-aa09-cb54e1e5da98.png) | ![image](https://user-images.githubusercontent.com/32376686/134579085-aa554839-ad70-4bf8-bc9f-7d7188cd2121.png) |