### PR TITLE
Fix FAB overlay sometimes not showing

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -84,6 +84,7 @@ public class CompletedDownloadsFragment extends Fragment implements
         progressBar = root.findViewById(R.id.progLoading);
 
         speedDialView = root.findViewById(R.id.fabSD);
+        speedDialView.setOverlayLayout(root.findViewById(R.id.fabSDOverlay));
         speedDialView.inflate(R.menu.episodes_apply_action_speeddial);
         speedDialView.removeActionItemById(R.id.download_batch);
         speedDialView.removeActionItemById(R.id.mark_read_batch);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -238,6 +238,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
         // Init action UI (via a FAB Speed Dial)
         speedDialView = root.findViewById(R.id.fabSD);
+        speedDialView.setOverlayLayout(root.findViewById(R.id.fabSDOverlay));
         speedDialView.inflate(R.menu.episodes_apply_action_speeddial);
         speedDialView.setOnChangeListener(new SpeedDialView.OnChangeListener() {
             @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -465,6 +465,7 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
         progLoading.setVisibility(View.VISIBLE);
 
         speedDialView = root.findViewById(R.id.fabSD);
+        speedDialView.setOverlayLayout(root.findViewById(R.id.fabSDOverlay));
         speedDialView.inflate(R.menu.episodes_apply_action_speeddial);
         speedDialView.removeActionItemById(R.id.mark_read_batch);
         speedDialView.removeActionItemById(R.id.mark_unread_batch);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -167,6 +167,7 @@ public class SubscriptionFragment extends Fragment
         });
 
         speedDialView = root.findViewById(R.id.fabSD);
+        speedDialView.setOverlayLayout(root.findViewById(R.id.fabSDOverlay));
         speedDialView.inflate(R.menu.nav_feed_action_speeddial);
         speedDialView.setOnChangeListener(new SpeedDialView.OnChangeListener() {
             @Override


### PR DESCRIPTION
We use the same ID for each overlay layout. The speed dial searches
everywhere, even in invisible fragments, so it sometimes shows/hides the
wrong overlay layout.

Fixes #5421