### PR TITLE
limit to 100 episodes when browsing a podcast feed

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -174,6 +174,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     public static final int NOTIFICATION_TYPE_SLEEPTIMER_UPDATE = 4;
     public static final int NOTIFICATION_TYPE_BUFFER_START = 5;
     public static final int NOTIFICATION_TYPE_BUFFER_END = 6;
+
+    /**
+     * Set a max number of episodes to load for Android Auto, otherwise there could be performance issues
+     */
+    public static final int MAX_ANDROID_AUTO_EPISODES_PER_FEED = 100;
+
     /**
      * No more episodes are going to be played.
      */
@@ -460,9 +466,13 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         } else if (parentId.startsWith("FeedId:")) {
             long feedId = Long.parseLong(parentId.split(":")[1]);
             List<FeedItem> feedItems = DBReader.getFeedItemList(DBReader.getFeed(feedId));
+            int count = 0;
             for (FeedItem feedItem : feedItems) {
                 if (feedItem.getMedia() != null && feedItem.getMedia().getMediaItem() != null) {
                     mediaItems.add(feedItem.getMedia().getMediaItem());
+                    if (++count >= MAX_ANDROID_AUTO_EPISODES_PER_FEED) {
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
close #5247

Limit the number of browsable episodes in Android Auto for a podcast feed to 100.  The media browser hangs when the number of episodes gets too high (we saw 500 episodes would hang)

Future: we could choose to filter episodes in a feed to those the user have not listened to, only downloaded.. etc.  When you are in your car, you cannot browse safely anyways > 100 episodes.  We can also add search (another bad idea in a car unless it's voice controlled)