### PR TITLE
Fewer default speed values

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -244,8 +244,8 @@ public class PreferencesTest {
     public void testPlaybackSpeeds() {
         clickPreference(R.string.playback_pref);
         clickPreference(R.string.playback_speed);
-        onView(isRoot()).perform(waitForView(withText("0.75"), 1000));
-        onView(withText("0.75")).check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitForView(withText("1.25"), 1000));
+        onView(withText("1.25")).check(matches(isDisplayed()));
     }
 
     @Test

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -812,7 +812,7 @@ public class UserPreferences {
             }
         }
         // If this preference hasn't been set yet, return the default options
-        return Arrays.asList(0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f);
+        return Arrays.asList(1.0f, 1.25f, 1.5f);
     }
 
     public static String getMediaPlayer() {


### PR DESCRIPTION
Now that the speed selector is a dialog that also shows the slider, we no longer need to have 6 presets by default. 3 are enough and make the dialog look more slim. Also, it's quicker because the most used ones (1.0-1.5) are closer to the bottom of the screen.

Previously, the values were needed because users didn't realize that they can set the speed freely in addition to the presets.