### PR TITLE
Update RecyclerView and ViewPager2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,8 +126,8 @@ dependencies {
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation "androidx.media:media:$mediaVersion"
     implementation "androidx.preference:preference:$preferenceVersion"
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'androidx.viewpager2:viewpager2:1.1.0-alpha01'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.viewpager2:viewpager2:1.1.0-beta01'
     implementation "androidx.work:work-runtime:$workManagerVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"
 


### PR DESCRIPTION
- Bump RecyclerView 1.1.0 -> 1.2.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/recyclerview))
- Bump ViewPager2 1.1.0-alpha01 -> 1.1.0-beta01 ([changelog](https://developer.android.com/jetpack/androidx/releases/viewpager2))

The app already uses RecyclerView 1.2.1 from some transitive dependency, actually (otherwise, calling [these](https://github.com/AntennaPod/AntennaPod/search?q=getbindingadapterposition) would literally not be possible as they don't exist in 1.1.0). This only makes it official.