### PR TITLE
Show tags before subscriptions

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -900,7 +900,7 @@ public final class DBReader {
         }
         List<NavDrawerData.TagDrawerItem> foldersSorted = new ArrayList<>(folders.values());
         Collections.sort(foldersSorted, (o1, o2) -> o1.getTitle().compareToIgnoreCase(o2.getTitle()));
-        items.addAll(foldersSorted);
+        items.addAll(0, foldersSorted);
 
         NavDrawerData result = new NavDrawerData(items, queueSize, numNewItems, numDownloadedItems,
                 feedCounters, UserPreferences.getEpisodeCleanupAlgorithm().getReclaimableItems());


### PR DESCRIPTION
Solves #5318 and #5425
Simple adaptation to display tags before subscriptions in the drawer and in the subscription page.
Not sure if it's the way to go, or if this should integrated into a new feature or let the user choose how it should be displayed. If not needed, feel free to decline the PR.

