### PR TITLE
Improve accessibility of back button.

### DIFF
--- a/app/src/main/res/layout/audioplayer_fragment.xml
+++ b/app/src/main/res/layout/audioplayer_fragment.xml
@@ -12,6 +12,7 @@
             android:minHeight="?attr/actionBarSize"
             android:theme="?attr/actionBarTheme"
             android:layout_alignParentTop="true"
+            app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="?homeAsUpIndicator"
             android:id="@+id/toolbar"/>
 

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -45,6 +45,7 @@
                     android:minHeight="?attr/actionBarSize"
                     android:theme="?attr/actionBarTheme"
                     app:layout_collapseMode="pin"
+                    app:navigationContentDescription="@string/toolbar_back_button_content_description"
                     app:navigationIcon="?homeAsUpIndicator" />
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>

--- a/app/src/main/res/layout/feeditem_pager_fragment.xml
+++ b/app/src/main/res/layout/feeditem_pager_fragment.xml
@@ -11,6 +11,7 @@
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
             android:theme="?attr/actionBarTheme"
+            app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="?homeAsUpIndicator"
             android:id="@+id/toolbar"/>
 

--- a/app/src/main/res/layout/feedsettings.xml
+++ b/app/src/main/res/layout/feedsettings.xml
@@ -11,6 +11,7 @@
             android:minHeight="?attr/actionBarSize"
             android:theme="?attr/actionBarTheme"
             app:title="@string/feed_settings_label"
+            app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="?homeAsUpIndicator"
             android:elevation="4dp"
             android:id="@+id/toolbar"/>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -676,6 +676,7 @@
     <string name="stop_preview">Stop preview</string>
 
     <!-- Content descriptions for image buttons -->
+    <string name="toolbar_back_button_content_description">Back</string>
     <string name="rewind_label">Rewind</string>
     <string name="fast_forward_label">Fast forward</string>
     <string name="increase_speed">Increase speed</string>


### PR DESCRIPTION
+ Let [TalkBack](https://support.google.com/accessibility/android/answer/6283677) read out "back" when tapping the arrow left button.
+ Tested on Pixel 2, Android 11

# Screenshot of TalkBack read-out
![new1](https://user-images.githubusercontent.com/144518/138588561-3a86af8a-23b9-4020-9134-c648a94fa036.png)



:orange_heart: Happy Hacktoberfest