### PR TITLE
Improve rendering of layout previews.

### DIFF
--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -2,6 +2,7 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -42,7 +43,8 @@
             android:layout_height="match_parent"
             android:layout_gravity="center_horizontal"
             android:paddingBottom="88dp"
-            android:clipToPadding="false" />
+            tools:itemCount="2"
+            tools:listitem="@layout/subscription_item" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/app/src/main/res/layout/quick_feed_discovery_item.xml
+++ b/app/src/main/res/layout/quick_feed_discovery_item.xml
@@ -2,6 +2,7 @@
 <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="4dp"
@@ -14,7 +15,8 @@
             android:elevation="4dp"
             android:outlineProvider="bounds"
             android:foreground="?android:attr/selectableItemBackground"
-            squareImageView:direction="width" />
+            squareImageView:direction="width"
+            tools:src="@android:drawable/sym_def_app_icon"/>
 
 </LinearLayout>
 


### PR DESCRIPTION
- I added `tools` attributes to enable a better preview rendering in Android Studio for the layouts.

# Before and after
- `fragment_subscriptions.xml`
![subscriptions_old](https://user-images.githubusercontent.com/144518/138590280-a78572aa-4ac0-4e3d-960b-ba546a84e53b.png) ![subscriptions_new](https://user-images.githubusercontent.com/144518/138590283-679ad8ee-0c2a-4420-b4eb-e078ccc8be7a.png)

- `quick_feed_discovery_item.xml`
![feed_old](https://user-images.githubusercontent.com/144518/138590289-e655e035-09a9-43ba-8598-e181a3820428.png) ![feed_new](https://user-images.githubusercontent.com/144518/138590291-f74efe78-439b-43d8-b6f3-2873828b5b56.png)

:purple_heart: Happy Hacktoberfest