### PR TITLE
Add persian valid characters in file name

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/FileNameGenerator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FileNameGenerator.java
@@ -16,10 +16,14 @@ public class FileNameGenerator {
     public static final int MAX_FILENAME_LENGTH = 242; // limited by CircleCI
     private static final int MD5_HEX_LENGTH = 32;
 
-    private static final char[] validChars =
-            ("abcdefghijklmnopqrstuvwxyz"
+    private static final String englishValidChars = "abcdefghijklmnopqrstuvwxyz"
             + "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            + "0123456789"
+            + "0123456789";
+    private static final String persianValidChars = "ئءاآبپتثجچحخدذرزژسشصضطظعغفقکگلمنوهیي"
+            + "۰۱۲۳۴۵۶۷۸۹";
+    private static final char[] validChars =
+            (englishValidChars
+            + persianValidChars
             + " _-").toCharArray();
 
     private FileNameGenerator() {

--- a/core/src/test/java/de/danoeh/antennapod/core/util/FilenameGeneratorTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/util/FilenameGeneratorTest.java
@@ -44,6 +44,13 @@ public class FilenameGeneratorTest {
     }
 
     @Test
+    public void testGenerateFileName3() throws Exception {
+        String result = FileNameGenerator.generateFileName("این یک نام معتبر است");
+        assertEquals(result, "این یک نام معتبر است");
+        createFiles(result);
+    }
+
+    @Test
     public void testFeedTitleContainsApostrophe() {
         String result = FileNameGenerator.generateFileName("Feed's Title ...");
         assertEquals("Feeds Title", result);
@@ -59,6 +66,18 @@ public class FilenameGeneratorTest {
     public void testFeedTitleContainsAccents() {
         String result = FileNameGenerator.generateFileName("Äàáâãå");
         assertEquals("Aaaaaa", result);
+    }
+
+    @Test
+    public void testFeedTitleContainsPersianComma() throws Exception {
+        String result = FileNameGenerator.generateFileName("سلام، سلام");
+        assertEquals(result, "سلام سلام");
+    }
+
+    @Test
+    public void testFeedTitleContainsPersianNumbers() throws Exception {
+        String result = FileNameGenerator.generateFileName("پادکست قسمت ۱۲۳");
+        assertEquals(result, "پادکست قسمت ۱۲۳");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
There was a problem that downloaded podcasts with Persian names were stored in a random generated string name. So, I decided to add valid Persian characters to file name generator class and now the files are stored in their real names.<br>
I assume that this issue still exists for other languages and it would be great to add other language valid characters to the list too.