### PR TITLE
Limit maximum number of subscriptions

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
@@ -91,6 +91,11 @@ public class OpmlImportActivity extends AppCompatActivity {
             Completable.fromAction(() -> {
                 DownloadRequester requester = DownloadRequester.getInstance();
                 SparseBooleanArray checked = viewBinding.feedlist.getCheckedItemPositions();
+                if (checked.size() > 200) {
+                    // People try to import lists with hundreds of subscriptions that they downloaded somewhere.
+                    // AntennaPod is made for manual subscription management, so this makes the app impossible to use.
+                    throw new IllegalStateException("Too many subscriptions");
+                }
                 for (int i = 0; i < checked.size(); i++) {
                     if (!checked.valueAt(i)) {
                         continue;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -132,6 +132,16 @@ public final class DBTasks {
                 iterator.remove();
             }
         }
+        if (feeds.size() > 200) { // Refreshing so many feeds is impractical
+            int startIndex = (int) (Math.random() * feeds.size());
+            if (startIndex + 200 <= feeds.size()) {
+                feeds = feeds.subList(startIndex, startIndex + 200);
+            } else {
+                List<Feed> first = feeds.subList(0, (startIndex + 200) % feeds.size());
+                feeds = feeds.subList(startIndex, feeds.size());
+                feeds.addAll(first);
+            }
+        }
         try {
             refreshFeeds(context, feeds, false, false, false);
         } catch (DownloadRequestException e) {


### PR DESCRIPTION
- Refuse to import more than 200 subscriptions. (People apparently import collection lists with hundreds of subscriptions, not just manually managed ones that they exported in other apps.) Manually pressing the subscribe button is not affected and can go above 200.
- When refreshing subscriptions, only refresh a random 200 of them. (If you have 200+ subscriptions, you probably don't have an overview over individual releases anyway. This makes the refresh faster, reduces your data volume and makes the app more responsive. 200 already is insanely high, that's about 400 MB of feed data being downloaded each day, excluding media)

Opinions @keunes?

See #5476, #5272