### PR TITLE
Fix crash when deleting feed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/RemoveFeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/RemoveFeedDialog.java
@@ -19,18 +19,18 @@ import io.reactivex.schedulers.Schedulers;
 public class RemoveFeedDialog {
     private static final String TAG = "RemoveFeedDialog";
 
-    public static void show(Context context, Feed feed, Runnable onSuccess) {
+    public static void show(Context context, Feed feed) {
         List<Feed> feeds = Collections.singletonList(feed);
         String message = getMessageId(context, feeds);
-        showDialog(context, feeds, message, onSuccess);
+        showDialog(context, feeds, message);
     }
 
-    public static void show(Context context, List<Feed> feeds, Runnable onSuccess) {
+    public static void show(Context context, List<Feed> feeds) {
         String message = getMessageId(context, feeds);
-        showDialog(context, feeds, message, onSuccess);
+        showDialog(context, feeds, message);
     }
 
-    private static void showDialog(Context context, List<Feed> feeds, String message, Runnable onSuccess) {
+    private static void showDialog(Context context, List<Feed> feeds, String message) {
         ConfirmationDialog dialog = new ConfirmationDialog(context, R.string.remove_feed_label, message) {
             @Override
             public void onConfirmButtonPressed(DialogInterface clickedDialog) {
@@ -42,20 +42,16 @@ public class RemoveFeedDialog {
                 progressDialog.setCancelable(false);
                 progressDialog.show();
 
-                Completable.fromCallable(() -> {
+                Completable.fromAction(() -> {
                     for (Feed feed : feeds) {
                         DBWriter.deleteFeed(context, feed.getId()).get();
                     }
-                    return null;
                 })
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(
                             () -> {
                                 Log.d(TAG, "Feed(s) deleted");
-                                if (onSuccess != null) {
-                                    onSuccess.run();
-                                }
                                 progressDialog.dismiss();
                             }, error -> {
                                 Log.e(TAG, Log.getStackTraceString(error));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -333,8 +333,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             new RenameFeedDialog(getActivity(), feed).show();
             return true;
         } else if (itemId == R.id.remove_item) {
-            RemoveFeedDialog.show(getContext(), feed, () ->
-                    ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null));
+            ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null);
+            RemoveFeedDialog.show(getContext(), feed);
             return true;
         } else if (itemId == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance(feed.getId(), feed.getTitle()));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/NavDrawerFragment.java
@@ -164,9 +164,8 @@ public class NavDrawerFragment extends Fragment implements SharedPreferences.OnS
             new RenameFeedDialog(getActivity(), feed).show();
             return true;
         } else if (itemId == R.id.remove_item) {
-            RemoveFeedDialog.show(getContext(), feed, () -> {
-                ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null);
-            });
+            ((MainActivity) getActivity()).loadFragment(EpisodesFragment.TAG, null);
+            RemoveFeedDialog.show(getContext(), feed);
             return true;
         }
         return super.onContextItemSelected(item);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -351,7 +351,7 @@ public class SubscriptionFragment extends Fragment
             new RenameFeedDialog(getActivity(), feed).show();
             return true;
         } else if (itemId == R.id.remove_item) {
-            RemoveFeedDialog.show(getContext(), feed, null);
+            RemoveFeedDialog.show(getContext(), feed);
             return true;
         } else if (itemId == R.id.multi_select) {
             speedDialView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/actions/FeedMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/actions/FeedMultiSelectActionHandler.java
@@ -35,7 +35,7 @@ public class FeedMultiSelectActionHandler {
 
     public void handleAction(int id) {
         if (id == R.id.remove_item) {
-            RemoveFeedDialog.show(activity, selectedItems, null);
+            RemoveFeedDialog.show(activity, selectedItems);
         } else if (id == R.id.keep_updated) {
             keepUpdatedPrefHandler();
         } else if (id == R.id.autodownload) {


### PR DESCRIPTION
When the database is huge, loading the subscription item list takes
a long time. Redirecting to the episodes screen after deleting
sometimes results in the item list starting to update before. If the
screen is then hidden before the Callable returns, the app crashes.

Closes #5319
