### PR TITLE
Fix Permission Denial when sharing files

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import com.google.android.material.snackbar.Snackbar;
@@ -103,22 +102,21 @@ public class BugReportActivity extends AppCompatActivity {
             Runtime.getRuntime().exec(cmd);
             //share file
             try {
-                Intent i = new Intent(Intent.ACTION_SEND);
-                i.setType("text/*");
+                Intent intent = new Intent(Intent.ACTION_SEND);
+                intent.setType("text/*");
                 String authString = getString(de.danoeh.antennapod.core.R.string.provider_authority);
                 Uri fileUri = FileProvider.getUriForFile(this, authString, filename);
-                i.putExtra(Intent.EXTRA_STREAM, fileUri);
-                i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-                    PackageManager pm = getPackageManager();
-                    List<ResolveInfo> resInfos = pm.queryIntentActivities(i, PackageManager.MATCH_DEFAULT_ONLY);
-                    for (ResolveInfo resolveInfo : resInfos) {
-                        String packageName = resolveInfo.activityInfo.packageName;
-                        grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    }
-                }
+                intent.putExtra(Intent.EXTRA_STREAM, fileUri);
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 String chooserTitle = getString(de.danoeh.antennapod.core.R.string.share_file_label);
-                startActivity(Intent.createChooser(i, chooserTitle));
+                Intent chooser = Intent.createChooser(intent, chooserTitle);
+                List<ResolveInfo> resInfos = getPackageManager()
+                        .queryIntentActivities(chooser, PackageManager.MATCH_DEFAULT_ONLY);
+                for (ResolveInfo resolveInfo : resInfos) {
+                    String packageName = resolveInfo.activityInfo.packageName;
+                    grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                }
+                startActivity(chooser);
             } catch (Exception e) {
                 e.printStackTrace();
                 int strResId = R.string.log_file_share_exception;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -232,15 +232,14 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
             sendIntent.putExtra(Intent.EXTRA_STREAM, streamUri);
             sendIntent.setType("text/plain");
             sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-                List<ResolveInfo> resInfoList = getContext().getPackageManager()
-                        .queryIntentActivities(sendIntent, PackageManager.MATCH_DEFAULT_ONLY);
-                for (ResolveInfo resolveInfo : resInfoList) {
-                    String packageName = resolveInfo.activityInfo.packageName;
-                    getContext().grantUriPermission(packageName, streamUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                }
+            Intent chooserIntent = Intent.createChooser(sendIntent, getString(R.string.send_label));
+            List<ResolveInfo> resInfoList = getContext().getPackageManager()
+                    .queryIntentActivities(sendIntent, PackageManager.MATCH_DEFAULT_ONLY);
+            for (ResolveInfo resolveInfo : resInfoList) {
+                String packageName = resolveInfo.activityInfo.packageName;
+                getContext().grantUriPermission(packageName, streamUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
             }
-            getContext().startActivity(Intent.createChooser(sendIntent, getString(R.string.send_label)));
+            getContext().startActivity(chooserIntent);
         });
         alert.create().show();
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.os.Build;
 import androidx.core.content.FileProvider;
 import android.util.Log;
 
@@ -75,21 +74,20 @@ public class ShareUtils {
     }
 
     public static void shareFeedItemFile(Context context, FeedMedia media) {
-        Intent i = new Intent(Intent.ACTION_SEND);
-        i.setType(media.getMime_type());
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType(media.getMime_type());
         Uri fileUri = FileProvider.getUriForFile(context, context.getString(R.string.provider_authority),
                 new File(media.getLocalMediaUrl()));
-        i.putExtra(Intent.EXTRA_STREAM,  fileUri);
-        i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            List<ResolveInfo> resInfoList = context.getPackageManager()
-                    .queryIntentActivities(i, PackageManager.MATCH_DEFAULT_ONLY);
-            for (ResolveInfo resolveInfo : resInfoList) {
-                String packageName = resolveInfo.activityInfo.packageName;
-                context.grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            }
+        intent.putExtra(Intent.EXTRA_STREAM,  fileUri);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        Intent chooserIntent = Intent.createChooser(intent, context.getString(R.string.share_file_label));
+        List<ResolveInfo> resInfoList = context.getPackageManager()
+                .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+        for (ResolveInfo resolveInfo : resInfoList) {
+            String packageName = resolveInfo.activityInfo.packageName;
+            context.grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
-        context.startActivity(Intent.createChooser(i, context.getString(R.string.share_file_label)));
+        context.startActivity(chooserIntent);
         Log.e(TAG, "shareFeedItemFile called");
     }
 }


### PR DESCRIPTION
Fixes the following lines appearing in exported logs:

```
11-13 11:37:30.293  1088  3430 E DatabaseUtils: java.lang.SecurityException: Permission Denial: reading androidx.core.content.FileProvider uri content://de.danoeh.antennapod.provider/external_storage/Android/data/de.danoeh.antennapod/files/full-logs.txt from pid=4587, uid=1000 requires the provider be exported, or grantUriPermission()
11-13 11:37:30.293  1088  3430 E DatabaseUtils: 	at android.content.ContentProvider.enforceReadPermissionInner(ContentProvider.java:820)
11-13 11:37:30.293  1088  3430 E DatabaseUtils: 	at android.content.ContentProvider$Transport.enforceReadPermission(ContentProvider.java:684)
11-13 11:37:30.293  1088  3430 E DatabaseUtils: 	at android.content.ContentProvider$Transport.query(ContentProvider.java:239)
11-13 11:37:30.293  1088  3430 E DatabaseUtils: 	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:106)
11-13 11:37:30.293  1088  3430 E DatabaseUtils: 	at android.os.Binder.execTransactInternal(Binder.java:1154)
11-13 11:37:30.293  1088  3430 E DatabaseUtils: 	at android.os.Binder.execTransact(Binder.java:1123)
```