### PR TITLE
Centralize library versions used in multiple modules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,12 +128,12 @@ dependencies {
     implementation "androidx.fragment:fragment:$fragmentVersion"
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation "androidx.media:media:$mediaVersion"
+    implementation "androidx.palette:palette:$paletteVersion"
     implementation "androidx.preference:preference:$preferenceVersion"
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.viewpager2:viewpager2:1.1.0-beta01'
+    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
+    implementation "androidx.viewpager2:viewpager2:$viewPager2Version"
     implementation "androidx.work:work-runtime:$workManagerVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation 'androidx.palette:palette:1.0.0'
 
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
     implementation "commons-io:commons-io:$commonsioVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,10 @@ project.ext {
     coreVersion = "1.5.0"
     fragmentVersion = "1.3.6"
     mediaVersion = "1.1.0"
+    paletteVersion = "1.0.0"
     preferenceVersion = "1.1.1"
+    recyclerViewVersion = "1.2.1"
+    viewPager2Version = "1.1.0-beta01"
     workManagerVersion = "2.3.4"
     googleMaterialVersion = "1.1.0"
 
@@ -71,6 +74,8 @@ project.ext {
 
     //Tests
     awaitilityVersion = "3.1.6"
+    junitVersion = "4.13"
+    robolectricVersion = "4.5-alpha-1"
     robotiumSoloVersion = "5.6.3"
     espressoVersion = "3.2.0"
     runnerVersion = "1.2.0"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,10 +39,10 @@ dependencies {
     implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation "androidx.fragment:fragment:$fragmentVersion"
     implementation "androidx.media:media:$mediaVersion"
+    implementation "androidx.palette:palette:$paletteVersion"
     implementation "androidx.preference:preference:$preferenceVersion"
     implementation "androidx.work:work-runtime:$workManagerVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation 'androidx.palette:palette:1.0.0'
 
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
     implementation "commons-io:commons-io:$commonsioVersion"
@@ -69,9 +69,9 @@ dependencies {
 
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    testImplementation 'junit:junit:4.13'
+    testImplementation "junit:junit:$junitVersion"
     testImplementation 'org.mockito:mockito-inline:3.5.13'
-    testImplementation 'org.robolectric:robolectric:4.5-alpha-1'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'javax.inject:javax.inject:1'
     androidTestImplementation "com.jayway.android.robotium:robotium-solo:$robotiumSoloVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"

--- a/net/sync/gpoddernet/build.gradle
+++ b/net/sync/gpoddernet/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation 'commons-io:commons-io:2.5'
+    implementation "commons-io:commons-io:$commonsioVersion"
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
 }

--- a/parser/feed/build.gradle
+++ b/parser/feed/build.gradle
@@ -18,6 +18,6 @@ dependencies {
     implementation "commons-io:commons-io:$commonsioVersion"
     implementation "org.jsoup:jsoup:$jsoupVersion"
 
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.robolectric:robolectric:4.5-alpha-1'
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/parser/media/build.gradle
+++ b/parser/media/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     implementation "commons-io:commons-io:$commonsioVersion"
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation "junit:junit:$junitVersion"
 }

--- a/playback/base/build.gradle
+++ b/playback/base/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation "junit:junit:$junitVersion"
 }


### PR DESCRIPTION
This is just for easier readability.
