### PR TITLE
Ignore built APK directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ libs
 gradle.properties
 *.keystore
 *.p12
+app/free/
+app/play/


### PR DESCRIPTION
output.json files keep appearing as unversioned when an APK is built. This should fix that.
