### PR TITLE
Update Balloon library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
     implementation 'com.github.mfietz:fyydlin:v0.5.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
-    implementation 'com.github.skydoves:balloon:1.1.5'
+    implementation 'com.github.skydoves:balloon:1.4.0'
     implementation 'com.github.xabaras:RecyclerViewSwipeDecorator:1.3'
     implementation 'com.annimon:stream:1.2.2'
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -193,7 +193,6 @@ public class ItemFragment extends Fragment {
                 .setArrowOrientation(ArrowOrientation.TOP)
                 .setArrowPosition(0.25f + ((isLocaleRtl ^ offerStreaming) ? 0f : 0.5f))
                 .setWidthRatio(1.0f)
-                .isRtlSupport(true)
                 .setBackgroundColor(ThemeUtils.getColorFromAttr(getContext(), R.attr.colorSecondary))
                 .setBalloonAnimation(BalloonAnimation.OVERSHOOT)
                 .setLayout(R.layout.popup_bubble_view)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -193,6 +193,8 @@ public class ItemFragment extends Fragment {
                 .setArrowOrientation(ArrowOrientation.TOP)
                 .setArrowPosition(0.25f + ((isLocaleRtl ^ offerStreaming) ? 0f : 0.5f))
                 .setWidthRatio(1.0f)
+                .setMarginLeft(8)
+                .setMarginRight(8)
                 .setBackgroundColor(ThemeUtils.getColorFromAttr(getContext(), R.attr.colorSecondary))
                 .setBalloonAnimation(BalloonAnimation.OVERSHOOT)
                 .setLayout(R.layout.popup_bubble_view)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -22,6 +22,7 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.snackbar.Snackbar;
 import com.skydoves.balloon.ArrowOrientation;
+import com.skydoves.balloon.ArrowOrientationRules;
 import com.skydoves.balloon.Balloon;
 import com.skydoves.balloon.BalloonAnimation;
 import de.danoeh.antennapod.R;
@@ -191,6 +192,7 @@ public class ItemFragment extends Fragment {
                 == View.LAYOUT_DIRECTION_RTL;
         Balloon balloon = new Balloon.Builder(getContext())
                 .setArrowOrientation(ArrowOrientation.TOP)
+                .setArrowOrientationRules(ArrowOrientationRules.ALIGN_FIXED)
                 .setArrowPosition(0.25f + ((isLocaleRtl ^ offerStreaming) ? 0f : 0.5f))
                 .setWidthRatio(1.0f)
                 .setMarginLeft(8)

--- a/core/src/main/res/layout/popup_bubble_view.xml
+++ b/core/src/main/res/layout/popup_bubble_view.xml
@@ -17,14 +17,14 @@
             android:orientation="horizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="4dp"
             android:gravity="end">
 
         <Button
                 style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:textColor="?attr/colorOnSecondary"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="36dp"
                 android:text="@string/no"
                 android:id="@+id/balloon_button_negative"/>
 
@@ -32,7 +32,7 @@
                 style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:textColor="?attr/colorOnSecondary"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="36dp"
                 android:text="@string/yes"
                 android:id="@+id/balloon_button_positive"/>
 

--- a/core/src/main/res/layout/popup_bubble_view.xml
+++ b/core/src/main/res/layout/popup_bubble_view.xml
@@ -1,40 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="16dp">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
 
     <TextView
-            android:layout_width="match_parent"
-            android:textColor="?attr/colorOnSecondary"
-            android:layout_height="wrap_content"
-            android:lines="3"
-            android:id="@+id/balloon_message"/>
+        android:id="@+id/balloon_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/colorOnSecondary"
+        android:lines="3" />
 
     <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:gravity="end">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="4dp"
+        android:gravity="end">
 
         <Button
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:textColor="?attr/colorOnSecondary"
-                android:layout_width="wrap_content"
-                android:layout_height="36dp"
-                android:text="@string/no"
-                android:id="@+id/balloon_button_negative"/>
+            android:id="@+id/balloon_button_negative"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:textColor="?attr/colorOnSecondary"
+            android:text="@string/no"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
 
         <Button
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:textColor="?attr/colorOnSecondary"
-                android:layout_width="wrap_content"
-                android:layout_height="36dp"
-                android:text="@string/yes"
-                android:id="@+id/balloon_button_positive"/>
+            android:id="@+id/balloon_button_positive"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:textColor="?attr/colorOnSecondary"
+            android:text="@string/yes"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
 
     </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
### 1st commit
- Update Balloon 1.1.5 -> 1.4.0 ([changelog](https://github.com/skydoves/Balloon/releases))

### 2nd commit
- Context: https://github.com/skydoves/Balloon/releases/tag/1.2.2
- Let me know if you'd like the margins changed any (e.g. back to their margins in the "before" screenshot, etc.)

### 3rd commit
- Context: https://github.com/skydoves/Balloon/releases/tag/1.3.1
- I fixed the problem with the arrow being in the wrong place in newer versions that was mentioned [here](https://github.com/AntennaPod/AntennaPod/pull/5085).

I tested this hard. RTL also works just like before. Horizontally works fine too.

| Before | After |
| ------------- | ------------- |
| ![Screenshot_20211204-181802_AntennaPod Debug](https://user-images.githubusercontent.com/32376686/144727664-b7fc843a-048c-4ede-8776-1cbb65f7b9ff.png) | ![Screenshot_20211204-181900_AntennaPod Debug](https://user-images.githubusercontent.com/32376686/144727669-7bfca01e-855a-4e01-accc-352b40aa7c1e.png) |