### PR TITLE
Detect network changes with > Lollipop of Android

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -23,7 +23,6 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -38,7 +37,6 @@ import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.snackbar.Snackbar;
 
-import de.danoeh.antennapod.core.util.download.ConnectionStateMonitor;
 import de.danoeh.antennapod.playback.cast.CastEnabledActivity;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
@@ -146,21 +144,12 @@ public class MainActivity extends CastEnabledActivity {
 
         checkFirstLaunch();
         PreferenceUpgrader.checkUpgrades(this);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            this.registerLollipopNetworkListener();
-        }
 
         View bottomSheet = findViewById(R.id.audioplayerFragment);
         sheetBehavior = (LockableBottomSheetBehavior) BottomSheetBehavior.from(bottomSheet);
         sheetBehavior.setPeekHeight((int) getResources().getDimension(R.dimen.external_player_height));
         sheetBehavior.setHideable(false);
         sheetBehavior.setBottomSheetCallback(bottomSheetCallback);
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    void registerLollipopNetworkListener() {
-        ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
-        connectionMonitor.enable(getApplicationContext());
     }
 
     /**

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -37,6 +38,7 @@ import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.core.util.download.ConnectionStateMonitor;
 import de.danoeh.antennapod.playback.cast.CastEnabledActivity;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
@@ -144,13 +146,21 @@ public class MainActivity extends CastEnabledActivity {
 
         checkFirstLaunch();
         PreferenceUpgrader.checkUpgrades(this);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            this.registerLollipopNetworkListener();
+        }
+
         View bottomSheet = findViewById(R.id.audioplayerFragment);
         sheetBehavior = (LockableBottomSheetBehavior) BottomSheetBehavior.from(bottomSheet);
         sheetBehavior.setPeekHeight((int) getResources().getDimension(R.dimen.external_player_height));
         sheetBehavior.setHideable(false);
         sheetBehavior.setBottomSheetCallback(bottomSheetCallback);
     }
-
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    void registerLollipopNetworkListener() {
+        ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
+        connectionMonitor.enable(getApplicationContext());
+    }
     /**
      * View.generateViewId stores the current ID in a static variable.
      * When the process is killed, the variable gets reset.

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -156,11 +156,13 @@ public class MainActivity extends CastEnabledActivity {
         sheetBehavior.setHideable(false);
         sheetBehavior.setBottomSheetCallback(bottomSheetCallback);
     }
+
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     void registerLollipopNetworkListener() {
         ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
         connectionMonitor.enable(getApplicationContext());
     }
+
     /**
      * View.generateViewId stores the current ID in a static variable.
      * When the process is killed, the variable gets reset.

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -144,7 +144,6 @@ public class MainActivity extends CastEnabledActivity {
 
         checkFirstLaunch();
         PreferenceUpgrader.checkUpgrades(this);
-
         View bottomSheet = findViewById(R.id.audioplayerFragment);
         sheetBehavior = (LockableBottomSheetBehavior) BottomSheetBehavior.from(bottomSheet);
         sheetBehavior.setPeekHeight((int) getResources().getDimension(R.dimen.external_player_height));

--- a/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
@@ -20,7 +20,7 @@ public class ConnectivityActionReceiver extends BroadcastReceiver {
             Log.d(TAG, "Received intent");
 
             ClientConfig.initialize(context);
-            NetworkUtils.networkChangedDetected(context);
+            NetworkUtils.networkChangedDetected();
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
@@ -1,16 +1,14 @@
 package de.danoeh.antennapod.receiver;
-
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.text.TextUtils;
 import android.util.Log;
 
+
 import de.danoeh.antennapod.core.ClientConfig;
-import de.danoeh.antennapod.core.storage.DBTasks;
-import de.danoeh.antennapod.core.storage.DownloadRequester;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 
 public class ConnectivityActionReceiver extends BroadcastReceiver {
@@ -22,19 +20,7 @@ public class ConnectivityActionReceiver extends BroadcastReceiver {
 			Log.d(TAG, "Received intent");
 
             ClientConfig.initialize(context);
-            if (NetworkUtils.isAutoDownloadAllowed()) {
-				Log.d(TAG, "auto-dl network available, starting auto-download");
-					DBTasks.autodownloadUndownloadedItems(context);
-			} else { // if new network is Wi-Fi, finish ongoing downloads,
-						// otherwise cancel all downloads
-				ConnectivityManager cm = (ConnectivityManager) context
-						.getSystemService(Context.CONNECTIVITY_SERVICE);
-				NetworkInfo ni = cm.getActiveNetworkInfo();
-				if (ni == null || ni.getType() != ConnectivityManager.TYPE_WIFI) {
-					Log.i(TAG, "Device is no longer connected to Wi-Fi. Cancelling ongoing downloads");
-					DownloadRequester.getInstance().cancelAllDownloads(context);
-				}
-			}
+			NetworkUtils.networkChangedDetected(context);
 		}
 	}
 }

--- a/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
@@ -1,5 +1,4 @@
 package de.danoeh.antennapod.receiver;
-import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/ConnectivityActionReceiver.java
@@ -1,4 +1,5 @@
 package de.danoeh.antennapod.receiver;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -11,15 +12,15 @@ import de.danoeh.antennapod.core.ClientConfig;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 
 public class ConnectivityActionReceiver extends BroadcastReceiver {
-	private static final String TAG = "ConnectivityActionRecvr";
+    private static final String TAG = "ConnectivityActionRecvr";
 
-	@Override
-	public void onReceive(final Context context, Intent intent) {
-		if (TextUtils.equals(intent.getAction(), ConnectivityManager.CONNECTIVITY_ACTION)) {
-			Log.d(TAG, "Received intent");
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        if (TextUtils.equals(intent.getAction(), ConnectivityManager.CONNECTIVITY_ACTION)) {
+            Log.d(TAG, "Received intent");
 
             ClientConfig.initialize(context);
-			NetworkUtils.networkChangedDetected(context);
-		}
-	}
+            NetworkUtils.networkChangedDetected(context);
+        }
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -194,9 +194,7 @@ public class DownloadService extends Service {
         registerReceiver(cancelDownloadReceiver, cancelDownloadReceiverFilter);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (connectionMonitor == null) {
-                connectionMonitor = new ConnectionStateMonitor();
-            }
+            connectionMonitor = new ConnectionStateMonitor();
             connectionMonitor.enable(getApplicationContext());
         }
 
@@ -235,9 +233,7 @@ public class DownloadService extends Service {
         }
         unregisterReceiver(cancelDownloadReceiver);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (connectionMonitor != null) {
-                connectionMonitor.disable(getApplicationContext());
-            }
+            connectionMonitor.disable(getApplicationContext());
         }
 
         // start auto download in case anything new has shown up

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -123,7 +123,7 @@ public class DownloadService extends Service {
     private static final int SCHED_EX_POOL_SIZE = 1;
     private final ScheduledThreadPoolExecutor schedExecutor;
     private static DownloaderFactory downloaderFactory = new DefaultDownloaderFactory();
-
+    private ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
     private final IBinder mBinder = new LocalBinder();
 
     private class LocalBinder extends Binder {
@@ -202,15 +202,12 @@ public class DownloadService extends Service {
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     void registerLollipopNetworkListener() {
-        ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
         connectionMonitor.enable(getApplicationContext());
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     void unRegisterLollipopNetworkListener() {
-        ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
         connectionMonitor.disable(getApplicationContext());
-
     }
 
     @Override
@@ -244,6 +241,7 @@ public class DownloadService extends Service {
             downloadPostFuture.cancel(true);
         }
         unregisterReceiver(cancelDownloadReceiver);
+        unRegisterLollipopNetworkListener();
 
         // start auto download in case anything new has shown up
         DBTasks.autodownloadUndownloadedItems(getApplicationContext());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -123,7 +123,7 @@ public class DownloadService extends Service {
     private static final int SCHED_EX_POOL_SIZE = 1;
     private final ScheduledThreadPoolExecutor schedExecutor;
     private static DownloaderFactory downloaderFactory = new DefaultDownloaderFactory();
-    private ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
+    private ConnectionStateMonitor connectionMonitor;
     private final IBinder mBinder = new LocalBinder();
 
     private class LocalBinder extends Binder {
@@ -193,7 +193,11 @@ public class DownloadService extends Service {
         cancelDownloadReceiverFilter.addAction(ACTION_CANCEL_ALL_DOWNLOADS);
         cancelDownloadReceiverFilter.addAction(ACTION_CANCEL_DOWNLOAD);
         registerReceiver(cancelDownloadReceiver, cancelDownloadReceiverFilter);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (connectionMonitor == null) {
+                connectionMonitor = new ConnectionStateMonitor();
+            }
             connectionMonitor.enable(getApplicationContext());
         }
 
@@ -232,7 +236,9 @@ public class DownloadService extends Service {
         }
         unregisterReceiver(cancelDownloadReceiver);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            connectionMonitor.disable(getApplicationContext());
+            if (connectionMonitor != null) {
+                connectionMonitor.disable(getApplicationContext());
+            }
         }
 
         // start auto download in case anything new has shown up

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -17,7 +17,6 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ServiceCompat;
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
@@ -16,6 +17,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ServiceCompat;
 
@@ -39,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import de.danoeh.antennapod.core.event.DownloadEvent;
+import de.danoeh.antennapod.core.util.download.ConnectionStateMonitor;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
@@ -190,8 +193,24 @@ public class DownloadService extends Service {
         cancelDownloadReceiverFilter.addAction(ACTION_CANCEL_ALL_DOWNLOADS);
         cancelDownloadReceiverFilter.addAction(ACTION_CANCEL_DOWNLOAD);
         registerReceiver(cancelDownloadReceiver, cancelDownloadReceiverFilter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            this.registerLollipopNetworkListener();
+        }
 
         downloadCompletionThread.start();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    void registerLollipopNetworkListener() {
+        ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
+        connectionMonitor.enable(getApplicationContext());
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    void unRegisterLollipopNetworkListener() {
+        ConnectionStateMonitor connectionMonitor = new ConnectionStateMonitor();
+        connectionMonitor.disable(getApplicationContext());
+
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -194,20 +194,10 @@ public class DownloadService extends Service {
         cancelDownloadReceiverFilter.addAction(ACTION_CANCEL_DOWNLOAD);
         registerReceiver(cancelDownloadReceiver, cancelDownloadReceiverFilter);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            this.registerLollipopNetworkListener();
+            connectionMonitor.enable(getApplicationContext());
         }
 
         downloadCompletionThread.start();
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    void registerLollipopNetworkListener() {
-        connectionMonitor.enable(getApplicationContext());
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    void unRegisterLollipopNetworkListener() {
-        connectionMonitor.disable(getApplicationContext());
     }
 
     @Override
@@ -241,7 +231,9 @@ public class DownloadService extends Service {
             downloadPostFuture.cancel(true);
         }
         unregisterReceiver(cancelDownloadReceiver);
-        unRegisterLollipopNetworkListener();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            connectionMonitor.disable(getApplicationContext());
+        }
 
         // start auto download in case anything new has shown up
         DBTasks.autodownloadUndownloadedItems(getApplicationContext());

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -220,7 +220,7 @@ public class NetworkUtils {
                 .observeOn(AndroidSchedulers.mainThread());
     }
 
-    public static void networkChangedDetected(Context context) {
+    public static void networkChangedDetected() {
         if (NetworkUtils.isAutoDownloadAllowed()) {
             Log.d(TAG, "auto-dl network available, starting auto-download");
             DBTasks.autodownloadUndownloadedItems(context);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -116,7 +116,6 @@ public class NetworkUtils {
             if (capabilities == null) {
                 return true; // Better be safe than sorry
             }
-
             return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR);
         } else {
             // if the default network is a VPN,

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -117,10 +117,6 @@ public class NetworkUtils {
                 return true; // Better be safe than sorry
             }
 
-            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-                Log.d(TAG, "Network has WIFI");
-                return false;
-            }
             return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR);
         } else {
             // if the default network is a VPN,
@@ -230,9 +226,6 @@ public class NetworkUtils {
             DBTasks.autodownloadUndownloadedItems(context);
         } else { // if new network is Wi-Fi, finish ongoing downloads,
             // otherwise cancel all downloads
-            ConnectivityManager cm = (ConnectivityManager) context
-                    .getSystemService(Context.CONNECTIVITY_SERVICE);
-            NetworkInfo ni = cm.getActiveNetworkInfo();
             if (NetworkUtils.isNetworkRestricted()) {
                 Log.i(TAG, "Device is no longer connected to Wi-Fi. Cancelling ongoing downloads");
                 DownloadRequester.getInstance().cancelAllDownloads(context);

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -35,7 +35,6 @@ public class ConnectionStateMonitor
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.registerNetworkCallback(networkRequest, this);
         connectivityManager.addDefaultNetworkActiveListener(this);
-        Log.d(TAG, "enable " + connectivityManager.toString());
     }
 
     public void disable(Context context) {
@@ -43,6 +42,5 @@ public class ConnectionStateMonitor
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.unregisterNetworkCallback(this);
         connectivityManager.removeDefaultNetworkActiveListener(this);
-        Log.d(TAG, "disable" + connectivityManager.toString());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -16,14 +16,15 @@ public class ConnectionStateMonitor extends ConnectivityManager.NetworkCallback 
     final NetworkRequest networkRequest;
 
     public ConnectionStateMonitor() {
-            networkRequest = new NetworkRequest.Builder()
-                    .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
-                    .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-                    .build();
+        networkRequest = new NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .build();
     }
 
     public void enable(Context context) {
-        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager connectivityManager =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.registerNetworkCallback(networkRequest, this);
         connectivityManager.addDefaultNetworkActiveListener(() -> {
             Log.d(TAG, "ConnectionStateMonitor::onNetworkActive network connection changed");

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -11,7 +11,7 @@ import androidx.annotation.RequiresApi;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class ConnectionStateMonitor extends ConnectivityManager.NetworkCallback {
+public class ConnectionStateMonitor extends ConnectivityManager.NetworkCallback implements ConnectivityManager.OnNetworkActiveListener {
     private static final String TAG = "ConnectionStateMonitor";
     final NetworkRequest networkRequest;
 
@@ -22,14 +22,24 @@ public class ConnectionStateMonitor extends ConnectivityManager.NetworkCallback 
                 .build();
     }
 
+    public void onNetworkActive() {
+        Log.d(TAG, "ConnectionStateMonitor::onNetworkActive network connection changed");
+        NetworkUtils.networkChangedDetected();
+    }
+
     public void enable(Context context) {
         ConnectivityManager connectivityManager =
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.registerNetworkCallback(networkRequest, this);
-        connectivityManager.addDefaultNetworkActiveListener(() -> {
-            Log.d(TAG, "ConnectionStateMonitor::onNetworkActive network connection changed");
-            NetworkUtils.networkChangedDetected(context);
-        });
+        connectivityManager.addDefaultNetworkActiveListener(this);
+        Log.d(TAG, "ConnectionStateMonitor::enable " + connectivityManager.toString());
+    }
+
+    public void disable(Context context) {
+        ConnectivityManager connectivityManager =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        connectivityManager.unregisterNetworkCallback(this);
+        connectivityManager.removeDefaultNetworkActiveListener(this);
         Log.d(TAG, "ConnectionStateMonitor::enable " + connectivityManager.toString());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -35,7 +35,7 @@ public class ConnectionStateMonitor
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.registerNetworkCallback(networkRequest, this);
         connectivityManager.addDefaultNetworkActiveListener(this);
-        Log.d(TAG, "ConnectionStateMonitor::enable " + connectivityManager.toString());
+        Log.d(TAG, "enable " + connectivityManager.toString());
     }
 
     public void disable(Context context) {
@@ -43,6 +43,6 @@ public class ConnectionStateMonitor
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.unregisterNetworkCallback(this);
         connectivityManager.removeDefaultNetworkActiveListener(this);
-        Log.d(TAG, "ConnectionStateMonitor::enable " + connectivityManager.toString());
+        Log.d(TAG, "disable" + connectivityManager.toString());
     }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -24,6 +24,7 @@ public class ConnectionStateMonitor
                 .build();
     }
 
+    @Override
     public void onNetworkActive() {
         Log.d(TAG, "ConnectionStateMonitor::onNetworkActive network connection changed");
         NetworkUtils.networkChangedDetected();

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -1,0 +1,94 @@
+package de.danoeh.antennapod.core.util.download;
+
+public class ConnectionLiveData(context: Context) : LiveData<Boolean>() {
+
+private var connectivityManager: ConnectivityManager = context.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+
+private lateinit var connectivityManagerCallback: ConnectivityManager.NetworkCallback
+
+private val networkRequestBuilder: NetworkRequest.Builder = NetworkRequest.Builder()
+        .addTransportType(android.net.NetworkCapabilities.TRANSPORT_CELLULAR)
+        .addTransportType(android.net.NetworkCapabilities.TRANSPORT_WIFI)
+
+        override fun onActive() {
+        super.onActive()
+        updateConnection()
+        when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> connectivityManager.registerDefaultNetworkCallback(getConnectivityMarshmallowManagerCallback())
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> marshmallowNetworkAvailableRequest()
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> lollipopNetworkAvailableRequest()
+        else -> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        context.registerReceiver(networkReceiver, IntentFilter("android.net.conn.CONNECTIVITY_CHANGE")) // android.net.ConnectivityManager.CONNECTIVITY_ACTION
+        }
+        }
+        }
+        }
+
+        override fun onInactive() {
+        super.onInactive()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        connectivityManager.unregisterNetworkCallback(connectivityManagerCallback)
+        } else {
+        context.unregisterReceiver(networkReceiver)
+        }
+        }
+
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+private fun lollipopNetworkAvailableRequest() {
+        connectivityManager.registerNetworkCallback(networkRequestBuilder.build(), getConnectivityLollipopManagerCallback())
+        }
+
+@TargetApi(Build.VERSION_CODES.M)
+private fun marshmallowNetworkAvailableRequest() {
+        connectivityManager.registerNetworkCallback(networkRequestBuilder.build(), getConnectivityMarshmallowManagerCallback())
+        }
+
+private fun getConnectivityLollipopManagerCallback(): ConnectivityManager.NetworkCallback {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        connectivityManagerCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network?) {
+        postValue(true)
+        }
+
+        override fun onLost(network: Network?) {
+        postValue(false)
+        }
+        }
+        return connectivityManagerCallback
+        } else {
+        throw IllegalAccessError("Accessing wrong API version")
+        }
+        }
+
+private fun getConnectivityMarshmallowManagerCallback(): ConnectivityManager.NetworkCallback {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        connectivityManagerCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onCapabilitiesChanged(network: Network?, networkCapabilities: NetworkCapabilities?) {
+        networkCapabilities?.let { capabilities ->
+        if (capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
+        postValue(true)
+        }
+        }
+        }
+        override fun onLost(network: Network?) {
+        postValue(false)
+        }
+        }
+        return connectivityManagerCallback
+        } else {
+        throw IllegalAccessError("Accessing wrong API version")
+        }
+        }
+
+private val networkReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+        updateConnection()
+        }
+        }
+
+private fun updateConnection() {
+        val activeNetwork: NetworkInfo? = connectivityManager.activeNetworkInfo
+        postValue(activeNetwork?.isConnected == true)
+        }
+        }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/ConnectionStateMonitor.java
@@ -11,7 +11,9 @@ import androidx.annotation.RequiresApi;
 import de.danoeh.antennapod.core.util.NetworkUtils;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class ConnectionStateMonitor extends ConnectivityManager.NetworkCallback implements ConnectivityManager.OnNetworkActiveListener {
+public class ConnectionStateMonitor
+        extends ConnectivityManager.NetworkCallback
+        implements ConnectivityManager.OnNetworkActiveListener {
     private static final String TAG = "ConnectionStateMonitor";
     final NetworkRequest networkRequest;
 


### PR DESCRIPTION
fix #2220 

Alternatives ways to detect network changes.  This changes has 2 subtle fixes
1) For Lollipop, there is a new way to detect network changes
2) The suggestion [here](https://stackoverflow.com/questions/36421930/connectivitymanager-connectivity-action-deprecated) to use `onAvailable()` doesn't work because some wifi is available but not active, I had to put a Thread.wait(1000) in a `Runnable()` for it work work, so I ended up using this instead https://developer.android.com/reference/android/net/ConnectivityManager.OnNetworkActiveListener


To test this change

1) Enable mobile and wifi on Android 12
2) Turn off wifi, you should see this

```
1640302894.109 31595-31633/de.danoeh.antennapod.debug D/ConnectionStateMonitor: ConnectionStateMonitor::onNetworkActive network connection changed
1640302894.238 31595-31643/de.danoeh.antennapod.debug D/ConnectionStateMonitor: ConnectionStateMonitor::onAvailable network connection available but not active

1640302894.112 31595-31633/de.danoeh.antennapod.debug I/NetworkUtils: Device is no longer connected to Wi-Fi. Cancelling ongoing downloads
```

3) Enable wifi, you should see
```
1640302903.530 31595-31643/de.danoeh.antennapod.debug D/ConnectionStateMonitor: ConnectionStateMonitor::onAvailable network connection available but not active
1640302903.674 31595-31750/de.danoeh.antennapod.debug D/ConnectionStateMonitor: ConnectionStateMonitor::onNetworkActive network connection changed
1640302903.676 31595-31750/de.danoeh.antennapod.debug D/NetworkUtils: auto-dl network available, starting auto-download
```

4. With a VPN software enable, and with wifi enabled start a sequential download of 10 episodes with parallel downloads set to 1
5.  Turn off wifi, all downloads should stop