### PR TITLE
detect pause/unpause when user disconnect/reconnect headset

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -174,22 +174,22 @@ public class PreferencesTest {
     @Test
     public void testHeadPhonesDisconnect() {
         clickPreference(R.string.playback_pref);
-        final boolean pauseOnHeadsetDisconnect = UserPreferences.isPauseOnHeadsetDisconnect();
+        final boolean pauseOnHeadsetDisconnect = UserPreferences.isPauseOnHeadsetBluetoothDisconnect();
         onView(withText(R.string.pref_pauseOnHeadsetDisconnect_title)).perform(click());
         Awaitility.await().atMost(1000, MILLISECONDS)
-                .until(() -> pauseOnHeadsetDisconnect != UserPreferences.isPauseOnHeadsetDisconnect());
+                .until(() -> pauseOnHeadsetDisconnect != UserPreferences.isPauseOnHeadsetBluetoothDisconnect());
         onView(withText(R.string.pref_pauseOnHeadsetDisconnect_title)).perform(click());
         Awaitility.await().atMost(1000, MILLISECONDS)
-                .until(() -> pauseOnHeadsetDisconnect == UserPreferences.isPauseOnHeadsetDisconnect());
+                .until(() -> pauseOnHeadsetDisconnect == UserPreferences.isPauseOnHeadsetBluetoothDisconnect());
     }
 
     @Test
     public void testHeadPhonesReconnect() {
         clickPreference(R.string.playback_pref);
-        if (!UserPreferences.isPauseOnHeadsetDisconnect()) {
+        if (!UserPreferences.isPauseOnHeadsetBluetoothDisconnect()) {
             onView(withText(R.string.pref_pauseOnHeadsetDisconnect_title)).perform(click());
             Awaitility.await().atMost(1000, MILLISECONDS)
-                    .until(UserPreferences::isPauseOnHeadsetDisconnect);
+                    .until(UserPreferences::isPauseOnHeadsetBluetoothDisconnect);
         }
         final boolean unpauseOnHeadsetReconnect = UserPreferences.isUnpauseOnHeadsetReconnect();
         onView(withText(R.string.pref_unpauseOnHeadsetReconnect_title)).perform(click());
@@ -203,10 +203,10 @@ public class PreferencesTest {
     @Test
     public void testBluetoothReconnect() {
         clickPreference(R.string.playback_pref);
-        if (!UserPreferences.isPauseOnHeadsetDisconnect()) {
+        if (!UserPreferences.isPauseOnHeadsetBluetoothDisconnect()) {
             onView(withText(R.string.pref_pauseOnHeadsetDisconnect_title)).perform(click());
             Awaitility.await().atMost(1000, MILLISECONDS)
-                    .until(UserPreferences::isPauseOnHeadsetDisconnect);
+                    .until(UserPreferences::isPauseOnHeadsetBluetoothDisconnect);
         }
         final boolean unpauseOnBluetoothReconnect = UserPreferences.isUnpauseOnBluetoothReconnect();
         onView(withText(R.string.pref_unpauseOnBluetoothReconnect_title)).perform(click());

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -75,7 +75,7 @@ public class UserPreferences {
     public static final String PREF_QUEUE_KEEP_SORTED_ORDER = "prefQueueKeepSortedOrder";
 
     // Playback
-    public static final String PREF_PAUSE_ON_HEADSET_DISCONNECT = "prefPauseOnHeadsetDisconnect";
+    public static final String PREF_PAUSE_ON_HEADSET_BLUETOOTH_DISCONNECT = "prefPauseOnHeadsetDisconnect";
     public static final String PREF_UNPAUSE_ON_HEADSET_RECONNECT = "prefUnpauseOnHeadsetReconnect";
     private static final String PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT = "prefUnpauseOnBluetoothReconnect";
     public static final String PREF_HARDWARE_FORWARD_BUTTON = "prefHardwareForwardButton";
@@ -378,8 +378,8 @@ public class UserPreferences {
                 .apply();
     }
 
-    public static boolean isPauseOnHeadsetDisconnect() {
-        return prefs.getBoolean(PREF_PAUSE_ON_HEADSET_DISCONNECT, true);
+    public static boolean isPauseOnHeadsetBluetoothDisconnect() {
+        return prefs.getBoolean(PREF_PAUSE_ON_HEADSET_BLUETOOTH_DISCONNECT, true);
     }
 
     public static boolean isUnpauseOnHeadsetReconnect() {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1525,12 +1525,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     };
 
     /**
-     * Pauses playback if PREF_PAUSE_ON_HEADSET_DISCONNECT was set to true.
+     * Pauses playback if PREF_PAUSE_ON_HEADSET_BLUETOOTH_DISCONNECT was set to true.
      */
     private void pauseIfPauseOnDisconnect() {
         Log.d(TAG, "pauseIfPauseOnDisconnect()");
-        if (UserPreferences.isPauseOnHeadsetDisconnect() && !isCasting()) {
-            transientPause = true;
+        transientPause = (mediaPlayer.getPlayerStatus() == PlayerStatus.PLAYING);
+        if (UserPreferences.isPauseOnHeadsetBluetoothDisconnect() && !isCasting()) {
             mediaPlayer.pause(!UserPreferences.isPersistNotify(), false);
         }
     }


### PR DESCRIPTION
fix #5559

## Problem

A user playing an episode pauses it.  disconnect headset (wired and bluetooth) and reconnect again.  The episode should *NOT* be playing, but it currently starts playing incorrectly.

## Fix

Looks like we are currently not detecting whether a user unplug when an episode was playing.  This broke Bluetooth and a wired headset.