### PR TITLE
resume playing only if the user unplugs via wired headset or bluetooth while episode in progress

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1532,8 +1532,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      */
     private void pauseIfPauseOnDisconnect() {
         Log.d(TAG, "pauseIfPauseOnDisconnect()");
+        transientPause = (mediaPlayer.getPlayerStatus() == PlayerStatus.PLAYING);
         if (UserPreferences.isPauseOnHeadsetDisconnect() && !isCasting()) {
-            transientPause = true;
             mediaPlayer.pause(!UserPreferences.isPersistNotify(), false);
         }
     }


### PR DESCRIPTION
fix #5559

retarget to `master`, same as https://github.com/AntennaPod/AntennaPod/pull/5609](https://github.com/AntennaPod/AntennaPod/pull/5610)

## Problem

A user playing an episode pauses it.  disconnect headset (wired and bluetooth) and reconnect again.  The episode should *NOT* be playing, but it currently starts playing incorrectly.

## Fix

Looks like we are currently not detecting whether a user unplug when an episode was playing.  This broke Bluetooth and a wired headset.

