### PR TITLE
follow 301 for authorization headers during download

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
@@ -4,8 +4,6 @@ import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
 
-import org.apache.commons.lang3.StringUtils;
-
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.storage.DBReader;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
@@ -3,6 +3,9 @@ package de.danoeh.antennapod.core.service;
 import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
+
+import org.apache.commons.lang3.StringUtils;
+
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.storage.DBReader;
@@ -50,6 +53,12 @@ public class BasicAuthorizationInterceptor implements Interceptor {
         }
 
         Request.Builder newRequest = request.newBuilder();
+        if (0 != StringUtils.compare(
+                response.request().url().toString(),
+                request.url().toString())) {
+            newRequest.url(response.request().url());
+        }
+
         Log.d(TAG, "Authorization failed, re-trying with ISO-8859-1 encoded credentials");
         String credentials = HttpDownloader.encodeCredentials(parts[0], parts[1], "ISO-8859-1");
         newRequest.header("Authorization", credentials);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.core.service;
 import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
-
 import de.danoeh.antennapod.core.service.download.DownloadRequest;
 import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.storage.DBReader;
@@ -51,8 +50,7 @@ public class BasicAuthorizationInterceptor implements Interceptor {
         }
 
         Request.Builder newRequest = request.newBuilder();
-        if (! TextUtils.equals(response.request().url().toString(),
-                request.url().toString())) {
+        if (!TextUtils.equals(response.request().url().toString(), request.url().toString())) {
             newRequest.url(response.request().url());
         }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
@@ -53,8 +53,7 @@ public class BasicAuthorizationInterceptor implements Interceptor {
         }
 
         Request.Builder newRequest = request.newBuilder();
-        if (0 != StringUtils.compare(
-                response.request().url().toString(),
+        if (! TextUtils.equals(response.request().url().toString(),
                 request.url().toString())) {
             newRequest.url(response.request().url());
         }


### PR DESCRIPTION
fix #5214

This code works while testing this [feed](https://tools.bytehamster.com/podcast/passwordProtectedMedia.xml) (1st item), I'm not sure if this is the right place to fix it.  

Another way to fix this would be in the redirect interceptor but that didn't work, any ideas @ByteHamster ?
I would have rather have this fixed in [AntennapodHttpClient.java](https://github.com/AntennaPod/AntennaPod/blob/32ac7f7f7140e5d837fbe9090c4f934ee0dba1c4/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java#L95)
```
response = response.newBuilder().request(request.newBuilder().url(location).build()).build();
```