### PR TITLE
Restore volumes slider on playback controls dialog

### DIFF
--- a/app/src/main/res/layout/audio_controls.xml
+++ b/app/src/main/res/layout/audio_controls.xml
@@ -47,6 +47,59 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="4dp"
+            style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
+            android:text="@string/volume" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:orientation="horizontal"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/txtvLeft"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/left_short" />
+
+            <SeekBar
+                android:id="@+id/volume_left"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="100" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:orientation="horizontal"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/txtvRight"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/right_short" />
+
+            <SeekBar
+                android:id="@+id/volume_right"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="100" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:text="@string/audio_effects"
             style="@style/AntennaPod.TextView.ListItemPrimaryTitle" />

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -8,6 +8,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.KeyEvent;
 
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
@@ -39,6 +40,7 @@ import de.danoeh.antennapod.core.storage.ExceptFavoriteCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APNullCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.APQueueCleanupAlgorithm;
 import de.danoeh.antennapod.core.storage.EpisodeCleanupAlgorithm;
+import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.core.util.download.AutoUpdateManager;
 
@@ -467,6 +469,24 @@ public class UserPreferences {
         return readPlaybackSpeedArray(prefs.getString(PREF_PLAYBACK_SPEED_ARRAY, null));
     }
 
+    public static float getLeftVolume() {
+        int volume = prefs.getInt(PREF_LEFT_VOLUME, 100);
+        return Converter.getVolumeFromPercentage(volume);
+    }
+
+    public static float getRightVolume() {
+        int volume = prefs.getInt(PREF_RIGHT_VOLUME, 100);
+        return Converter.getVolumeFromPercentage(volume);
+    }
+
+    public static int getLeftVolumePercentage() {
+        return prefs.getInt(PREF_LEFT_VOLUME, 100);
+    }
+
+    public static int getRightVolumePercentage() {
+        return prefs.getInt(PREF_RIGHT_VOLUME, 100);
+    }
+
     public static boolean shouldPauseForFocusLoss() {
         return prefs.getBoolean(PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS, true);
     }
@@ -696,6 +716,14 @@ public class UserPreferences {
         }
         prefs.edit()
              .putString(PREF_PLAYBACK_SPEED_ARRAY, jsonArray.toString())
+             .apply();
+    }
+
+    public static void setVolume(@IntRange(from = 0, to = 100) int leftVolume,
+                                 @IntRange(from = 0, to = 100) int rightVolume) {
+        prefs.edit()
+             .putInt(PREF_LEFT_VOLUME, leftVolume)
+             .putInt(PREF_RIGHT_VOLUME, rightVolume)
              .apply();
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -328,7 +328,10 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 acquireWifiLockIfNecessary();
 
                 setPlaybackParams(PlaybackSpeedUtils.getCurrentPlaybackSpeed(media), UserPreferences.isSkipSilence());
-                setVolume(1.0f, 1.0f);
+
+                float leftVolume = UserPreferences.getLeftVolume();
+                float rightVolume = UserPreferences.getRightVolume();
+                setVolume(leftVolume, rightVolume);
 
                 if (playerStatus == PlayerStatus.PREPARED && media.getPosition() > 0) {
                     int newPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
@@ -889,13 +892,16 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                     if (pausedBecauseOfTransientAudiofocusLoss) { // we paused => play now
                         resume();
                     } else { // we ducked => raise audio level back
-                        setVolumeSync(1.0f, 1.0f);
+                        setVolumeSync(UserPreferences.getLeftVolume(),
+                                UserPreferences.getRightVolume());
                     }
                 } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
                     if (playerStatus == PlayerStatus.PLAYING) {
                         if (!UserPreferences.shouldPauseForFocusLoss()) {
                             Log.d(TAG, "Lost audio focus temporarily. Ducking...");
-                            setVolumeSync(0.25f, 0.25f);
+                            final float DUCK_FACTOR = 0.25f;
+                            setVolumeSync(DUCK_FACTOR * UserPreferences.getLeftVolume(),
+                                    DUCK_FACTOR * UserPreferences.getRightVolume());
                             pausedBecauseOfTransientAudiofocusLoss = false;
                         } else {
                             Log.d(TAG, "Lost audio focus temporarily. Could duck, but won't, pausing...");

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -966,16 +966,19 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     @Subscribe(threadMode = ThreadMode.MAIN)
     @SuppressWarnings("unused")
     public void sleepTimerUpdate(SleepTimerUpdatedEvent event) {
+        float leftVolume = UserPreferences.getLeftVolume();
+        float rightVolume = UserPreferences.getRightVolume();
+
         if (event.isOver()) {
             mediaPlayer.pause(true, true);
-            mediaPlayer.setVolume(1.0f, 1.0f);
+            mediaPlayer.setVolume(leftVolume, rightVolume);
         } else if (event.getTimeLeft() < PlaybackServiceTaskManager.SleepTimer.NOTIFICATION_THRESHOLD) {
             final float[] multiplicators = {0.1f, 0.2f, 0.3f, 0.3f, 0.3f, 0.4f, 0.4f, 0.4f, 0.6f, 0.8f};
             float multiplicator = multiplicators[Math.max(0, (int) event.getTimeLeft() / 1000)];
             Log.d(TAG, "onSleepTimerAlmostExpired: " + multiplicator);
-            mediaPlayer.setVolume(multiplicator, multiplicator);
+            mediaPlayer.setVolume(leftVolume * multiplicator, rightVolume * multiplicator);
         } else if (event.isCancelled()) {
-            mediaPlayer.setVolume(1.0f, 1.0f);
+            mediaPlayer.setVolume(leftVolume, rightVolume);
         }
     }
 
@@ -1671,6 +1674,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
     public void skipSilence(boolean skipSilence) {
         mediaPlayer.setPlaybackParams(getCurrentPlaybackSpeed(), skipSilence);
+    }
+
+    public void setVolume(float leftVolume, float rightVolume) {
+        mediaPlayer.setVolume(leftVolume, rightVolume);
     }
 
     public float getCurrentPlaybackSpeed() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/Converter.java
@@ -105,4 +105,17 @@ public final class Converter {
         float hours = (float) time / 3600f;
         return String.format(Locale.getDefault(), "%.1f ", hours) + context.getString(R.string.time_hours);
     }
+
+    /**
+     * Converts the volume as read as the progress from a SeekBar scaled to 100 and as saved in
+     * UserPreferences to the format taken by setVolume methods.
+     * @param progress integer between 0 to 100 taken from the SeekBar progress
+     * @return the appropriate volume as float taken by setVolume methods
+     */
+    public static float getVolumeFromPercentage(int progress) {
+        if (progress == 100) {
+            return 1f;
+        }
+        return (float) (1 - (Math.log(101 - progress) / Math.log(101)));
+    }
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -462,6 +462,12 @@ public abstract class PlaybackController {
         }
     }
 
+    public void setVolume(float leftVolume, float rightVolume) {
+        if (playbackService != null) {
+            playbackService.setVolume(leftVolume, rightVolume);
+        }
+    }
+
     public float getCurrentPlaybackSpeedMultiplier() {
         if (playbackService != null) {
             return playbackService.getCurrentPlaybackSpeed();

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -786,6 +786,9 @@
     <!-- Audio controls -->
     <string name="audio_controls">Audio controls</string>
     <string name="playback_speed">Playback Speed</string>
+    <string name="volume">Volume</string>
+    <string name="left_short">L</string>
+    <string name="right_short">R</string>
     <string name="audio_effects">Audio Effects</string>
     <string name="stereo_to_mono">Downmix: Stereo to mono</string>
     <string name="sonic_only">Sonic only</string>


### PR DESCRIPTION
Resolves #5596.

The volume slider on on the playback controls dialog is a feature I use very often.

Doesn't just reverse 4e185f2895d773ae3a966597ab8cc65e4d1c576d, but now when the left and right can't be controlled separate only one slider will be shown. 

![screenshot 2](https://user-images.githubusercontent.com/33923948/147669614-327f41e1-e28a-4642-ba26-0363dc5b43fe.png)
