### PR TITLE
load Media info from DB in order to grab last saved position

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1014,16 +1014,15 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 && UserPreferences.isFollowQueue() && !nextItem.getFeed().isLocalFeed()) {
             displayStreamingNotAllowedNotification(
                     new PlaybackServiceStarter(this, nextItem.getMedia())
-                    .prepareImmediately(true)
-                    .startWhenPrepared(true)
-                    .shouldStream(true)
-                    .getIntent());
+                            .prepareImmediately(true)
+                            .startWhenPrepared(true)
+                            .shouldStream(true)
+                            .getIntent());
             PlaybackPreferences.writeNoMediaPlaying();
             stateManager.stopService();
             return null;
         }
-        // After PlayableUtils::saveCurrentPosition saves position, load the position from the DB
-        return DBReader.getFeedMedia(nextItem.getMedia().getId());
+        return nextItem.getMedia();
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1029,8 +1029,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             stateManager.stopService();
             return null;
         }
-        return nextItem.getMedia();
-
+        // After PlayableUtils::saveCurrentPosition saves position, load the position from the DB
+        return DBReader.getFeedMedia(nextItem.getMedia().getId());
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -72,7 +72,6 @@ import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.receiver.MediaButtonReceiver;
 import de.danoeh.antennapod.core.storage.DBReader;
-import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.FeedSearcher;
 import de.danoeh.antennapod.core.sync.queue.SynchronizationQueueSink;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -997,13 +997,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             return null;
         }
         FeedItem nextItem;
-        try {
-            final List<FeedItem> queue = taskManager.getQueue();
-            nextItem = DBTasks.getQueueSuccessorOfItem(item.getId(), queue);
-        } catch (InterruptedException e) {
-            Log.e(TAG, "Error handling the queue in order to retrieve the next item", e);
-            return null;
-        }
+        nextItem = DBReader.getNextInQueue(item);
 
         if (nextItem == null || nextItem.getMedia() == null) {
             PlaybackPreferences.writeNoMediaPlaying();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -565,6 +565,34 @@ public final class DBReader {
     }
 
     /**
+     * Get next feed item in queue following a particular feeditem
+     *
+     * @param item The FeedItem
+     * @return The FeedItem next in queue or null if the FeedItem could not be found.
+     */
+    @Nullable
+    public static FeedItem getNextInQueue(FeedItem item) {
+        Log.d(TAG, "getNextInQueue() called with: " + "itemId = [" + item.getId() + "]");
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        try {
+            FeedItem nextItem = null;
+            try (Cursor cursor = adapter.getNextInQueue(item)) {
+                List<FeedItem> list = extractItemlistFromCursor(adapter, cursor);
+                if (!list.isEmpty()) {
+                    nextItem = list.get(0);
+                    loadAdditionalFeedItemListData(list);
+                }
+                return nextItem;
+            } catch (Exception e) {
+                return null;
+            }
+        } finally {
+            adapter.close();
+        }
+    }
+
+    /**
      * Loads a specific FeedItem from the database.
      *
      * @param guid feed item guid

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/PodDBAdapter.java
@@ -982,6 +982,18 @@ public class PodDBAdapter {
         return db.query(TABLE_NAME_QUEUE, new String[]{KEY_FEEDITEM}, null, null, null, null, KEY_ID + " ASC", null);
     }
 
+    public Cursor getNextInQueue(final FeedItem item) {
+        final String query = SELECT_FEED_ITEMS_AND_MEDIA
+                + "INNER JOIN " + TABLE_NAME_QUEUE
+                + " ON " + SELECT_KEY_ITEM_ID + " = " + TABLE_NAME_QUEUE + "." + KEY_FEEDITEM
+                + " WHERE Queue.ID > (SELECT Queue.ID FROM Queue WHERE Queue.FeedItem = "
+                +  item.getId()
+                + ")"
+                + " ORDER BY Queue.ID"
+                + " LIMIT 1";
+        return db.rawQuery(query, null);
+    }
+
     public final Cursor getFavoritesCursor(int offset, int limit) {
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
                 + " INNER JOIN " + TABLE_NAME_FAVORITES


### PR DESCRIPTION
fix #3892

Explaining the fix

- Add 2 episodes never played before into the queue
- Play the 2nd episode for 10+ seconds
- Don't hit pause, play the 1st episode
- Hit next
- Before this fix, the episode starts at 0:00.  This is because getting the next item from the queue does NOT load the saved position from the DB

Note for troubleshooting for future
- I first thought it was a bug in [LocalPSMP.java](https://github.com/AntennaPod/AntennaPod/blob/f0100e61ac633516082ea112363132c99f7c0b7a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java#L961) in `endPlayback()`
- I started the trace through the code in [PlaybackService.java](https://github.com/AntennaPod/AntennaPod/blob/31d76b5aaec95cba01a67e28f87b799bae67a41a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java#L983) and was reading through `getNextInQueue()` and was confused why the `position` was not saved
- When I found `saveCurrentPopsition()` in [PlayableUtils.java](https://github.com/AntennaPod/AntennaPod/blob/ba66ae76337133d92963fbf9c8ead27ee81ef148/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlayableUtils.java#L84), I was close to the problem.  The position is saved, but not loaded into memory