### PR TITLE
Remove playing notification when deleting currently playing episode

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -130,8 +130,8 @@ public class DBWriter {
                 PlaybackPreferences.writeNoMediaPlaying();
                 IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
 
-                NotificationManagerCompat mNotificationManager = NotificationManagerCompat.from(context);
-                mNotificationManager.cancel(R.id.notification_playing);
+                NotificationManagerCompat nm = NotificationManagerCompat.from(context);
+                nm.cancel(R.id.notification_playing);
             }
 
             // Gpodder: queue delete action for synchronization

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 
 import org.greenrobot.eventbus.EventBus;
 
@@ -128,6 +129,9 @@ public class DBWriter {
             if (media.getId() == PlaybackPreferences.getCurrentlyPlayingFeedMediaId()) {
                 PlaybackPreferences.writeNoMediaPlaying();
                 IntentUtils.sendLocalBroadcast(context, PlaybackService.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
+
+                NotificationManagerCompat mNotificationManager = NotificationManagerCompat.from(context);
+                mNotificationManager.cancel(R.id.notification_playing);
             }
 
             // Gpodder: queue delete action for synchronization


### PR DESCRIPTION
Fixes the issue that the playing notification doesn't disappear when deleting the currently playing episode. This closes #3704.
