### PR TITLE
fix crash when not on network

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -103,7 +103,8 @@ public class NetworkUtils {
             NetworkCapabilities capabilities = connManager.getNetworkCapabilities(
                     connManager.getActiveNetwork());
 
-            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+            if (capabilities != null
+                    && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
                     && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
                 return false;
             }


### PR DESCRIPTION
Here is the crash log and a simple fix

```
## Environment
Android version: 12
OS version: 4.19.202-g319182f6dff7-ab7793572
AntennaPod version: 2.4.1
Model: Pixel 5a
Device: barbet
Product: barbet

## Crash info
Time: 02-01-2022 00:43:24
AntennaPod version: 2.4.1

## StackTrace

java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.net.NetworkCapabilities.hasTransport(int)' on a null object reference
	at de.danoeh.antennapod.core.util.NetworkUtils.isNetworkMetered(NetworkUtils.java:107)
	at de.danoeh.antennapod.core.util.NetworkUtils.isNetworkRestricted(NetworkUtils.java:96)
	at de.danoeh.antennapod.core.util.NetworkUtils.isEpisodeDownloadAllowed(NetworkUtils.java:74)
	at de.danoeh.antennapod.adapter.actionbutton.DownloadActionButton.onClick(DownloadActionButton.java:55)
	at de.danoeh.antennapod.adapter.actionbutton.ItemActionButton.lambda$configure$0$ItemActionButton(ItemActionButton.java:61)
	at de.danoeh.antennapod.adapter.actionbutton.-$$Lambda$ItemActionButton$u0Uxv5seUqroKPdpGgLkoN3Asqc.onClick(Unknown Source:4)
	at android.view.View.performClick(View.java:7441)
	at android.view.View.performClickInternal(View.java:7418)
	at android.view.View.access$3700(View.java:835)
	at android.view.View$PerformClick.run(View.java:28677)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7839)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```