### PR TITLE
Don't show 'Set SleepTimer' and 'Disable SleepTimer' at the same time

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -73,6 +73,7 @@ public class SleepTimerDialog extends DialogFragment {
         spTimeUnit = content.findViewById(R.id.spTimeUnit);
         timeSetup = content.findViewById(R.id.timeSetup);
         timeDisplay = content.findViewById(R.id.timeDisplay);
+        timeDisplay.setVisibility(View.GONE);
         time = content.findViewById(R.id.time);
         Button extendSleepFiveMinutesButton = content.findViewById(R.id.extendSleepFiveMinutesButton);
         extendSleepFiveMinutesButton.setText(getString(R.string.extend_sleep_timer_label, 5));


### PR DESCRIPTION
Fixes a bug not yet mentioned in the issues that the sleep timer dialog in the current develop branch (3656ddc) shows too many buttons and labels (see screenshot below).

Bug occurs due to the switching to the event bus. By default, everything is shown and only if the bus reports a change, some buttons will be hidden. This change fixes this behaviour by hiding the 'disable SleepTimer' buttons by default and only enabling them if necessary.

This does not fix the problem that after opening the sleep timer dialog, it can take up to 1 second (next sleep timer tick) to load whether the sleep timer is active or not. Fixing this could be possible by using sticky events for the sleep timer - because then the sleep timer dialog would get the latest state of the sleep timer at setup and not after the first tick. I didn't implement this because I wasn't sure if this would be a good solution, but I could implement it if wanted.

![bug that too many buttons are shown in sleep tiemr dialog](https://user-images.githubusercontent.com/11487762/147880909-3075894f-c4dc-4f1e-b4e1-27fd820923ff.png)
