### PR TITLE
Fix streaming password protected media with http redirect

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/BasicAuthorizationInterceptor.java
@@ -9,12 +9,15 @@ import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.util.URIUtil;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.List;
+
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
 public class BasicAuthorizationInterceptor implements Interceptor {
     private static final String TAG = "BasicAuthInterceptor";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
 
     @Override
     @NonNull
@@ -25,6 +28,19 @@ public class BasicAuthorizationInterceptor implements Interceptor {
 
         if (response.code() != HttpURLConnection.HTTP_UNAUTHORIZED) {
             return response;
+        }
+
+        Request.Builder newRequest = request.newBuilder();
+        if (!TextUtils.equals(response.request().url().toString(), request.url().toString())) {
+            // Redirect detected. OkHTTP does not re-add the headers on redirect, so calling the new location directly.
+            newRequest.url(response.request().url());
+
+            List<String> authorizationHeaders = request.headers().values(HEADER_AUTHORIZATION);
+            if (!authorizationHeaders.isEmpty() && !TextUtils.isEmpty(authorizationHeaders.get(0))) {
+                // Call already had authorization headers. Try again with the same credentials.
+                newRequest.header(HEADER_AUTHORIZATION, authorizationHeaders.get(0));
+                return chain.proceed(newRequest.build());
+            }
         }
 
         String userInfo;
@@ -49,14 +65,9 @@ public class BasicAuthorizationInterceptor implements Interceptor {
             return response;
         }
 
-        Request.Builder newRequest = request.newBuilder();
-        if (!TextUtils.equals(response.request().url().toString(), request.url().toString())) {
-            newRequest.url(response.request().url());
-        }
-
         Log.d(TAG, "Authorization failed, re-trying with ISO-8859-1 encoded credentials");
         String credentials = HttpDownloader.encodeCredentials(parts[0], parts[1], "ISO-8859-1");
-        newRequest.header("Authorization", credentials);
+        newRequest.header(HEADER_AUTHORIZATION, credentials);
         response = chain.proceed(newRequest.build());
 
         if (response.code() != HttpURLConnection.HTTP_UNAUTHORIZED) {
@@ -65,7 +76,7 @@ public class BasicAuthorizationInterceptor implements Interceptor {
 
         Log.d(TAG, "Authorization failed, re-trying with UTF-8 encoded credentials");
         credentials = HttpDownloader.encodeCredentials(parts[0], parts[1], "UTF-8");
-        newRequest.header("Authorization", credentials);
+        newRequest.header(HEADER_AUTHORIZATION, credentials);
         return chain.proceed(newRequest.build());
     }
 }


### PR DESCRIPTION
@tonytamsf found a fix for downloads with password+redirect not working in #5612. While streaming actually worked when that issue got created, it got broken when we switched to the OkHTTP backend for ExoPlayer in #5510. This PR fixes streaming again.