### PR TITLE
Remove queue loading logic from PlaybackServiceTaskManager

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceTaskManagerTest.java
@@ -8,7 +8,6 @@ import androidx.test.filters.LargeTest;
 import de.danoeh.antennapod.event.playback.SleepTimerUpdatedEvent;
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.core.widget.WidgetUpdater;
-import org.awaitility.Awaitility;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.After;
@@ -21,20 +20,13 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import de.danoeh.antennapod.event.QueueEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
-import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.core.service.playback.PlaybackServiceTaskManager;
-import de.danoeh.antennapod.core.storage.DBReader;
-import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.storage.PodDBAdapter;
 import de.danoeh.antennapod.model.playback.Playable;
 
-import static de.test.antennapod.util.event.FeedItemEventListener.withFeedItemEventListener;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -86,80 +78,6 @@ public class PlaybackServiceTaskManagerTest {
             assertTrue(item.getId() != 0);
         }
         return f.getItems();
-    }
-
-    @Test
-    public void testGetQueueWriteBeforeCreation() throws InterruptedException {
-        final Context c = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        List<FeedItem> queue = writeTestQueue("a");
-        assertNotNull(queue);
-        PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
-        List<FeedItem> testQueue = pstm.getQueue();
-        assertNotNull(testQueue);
-        assertEquals(testQueue.size(), queue.size());
-        for (int i = 0; i < queue.size(); i++) {
-            assertEquals(testQueue.get(i).getId(), queue.get(i).getId());
-        }
-        pstm.shutdown();
-    }
-
-    @Test
-    public void testGetQueueWriteAfterCreation() throws InterruptedException {
-        final Context c = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
-        PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
-        List<FeedItem> testQueue = pstm.getQueue();
-        assertNotNull(testQueue);
-        assertTrue(testQueue.isEmpty());
-
-        List<FeedItem> queue = writeTestQueue("a");
-        EventBus.getDefault().post(QueueEvent.setQueue(queue));
-
-        assertNotNull(queue);
-        testQueue = pstm.getQueue();
-        assertNotNull(testQueue);
-        assertEquals(testQueue.size(), queue.size());
-        for (int i = 0; i < queue.size(); i++) {
-            assertEquals(testQueue.get(i).getId(), queue.get(i).getId());
-        }
-        pstm.shutdown();
-    }
-
-    @Test
-    public void testQueueUpdatedUponDownloadComplete() throws Exception {
-        final Context c = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        { // Setup test data
-            List<FeedItem> queue = writeTestQueue("a");
-            FeedItem item = DBReader.getFeedItem(queue.get(0).getId());
-            FeedMedia media = new FeedMedia(item, "http://example.com/episode.mp3", 12345, "audio/mp3");
-            item.setMedia(media);
-            DBWriter.setFeedMedia(media).get();
-            DBWriter.setFeedItem(item).get();
-        }
-
-        PlaybackServiceTaskManager pstm = new PlaybackServiceTaskManager(c, defaultPSTM);
-        final FeedItem testItem = pstm.getQueue().get(0);
-        assertFalse("The item should not yet be downloaded", testItem.getMedia().isDownloaded());
-
-        withFeedItemEventListener( feedItemEventListener -> {
-            // simulate download complete (in DownloadService.MediaHandlerThread)
-            FeedItem item = DBReader.getFeedItem(testItem.getId());
-            item.getMedia().setDownloaded(true);
-            item.getMedia().setFile_url("file://123");
-            item.disableAutoDownload();
-            DBWriter.setFeedMedia(item.getMedia()).get();
-            DBWriter.setFeedItem(item).get();
-
-            Awaitility.await()
-                    .atMost(1000, TimeUnit.MILLISECONDS)
-                    .until(() -> feedItemEventListener.getEvents().size() > 0);
-
-            final FeedItem itemUpdated = pstm.getQueue().get(0);
-            assertTrue("media.isDownloaded() should be true - The queue in PlaybackService should be updated after download is completed",
-                    itemUpdated.getMedia().isDownloaded());
-        });
-
-        pstm.shutdown();
     }
 
     @Test

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -367,7 +367,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     private void loadQueueForMediaSession() {
         Single.<List<MediaSessionCompat.QueueItem>>create(emitter -> {
             List<MediaSessionCompat.QueueItem> queueItems = new ArrayList<>();
-            for (FeedItem feedItem : taskManager.getQueue()) {
+            for (FeedItem feedItem : DBReader.getQueue()) {
                 if (feedItem.getMedia() != null) {
                     MediaDescriptionCompat mediaDescription = feedItem.getMedia().getMediaItem().getDescription();
                     queueItems.add(new MediaSessionCompat.QueueItem(mediaDescription, feedItem.getId()));
@@ -440,7 +440,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
         if (parentId.equals(getResources().getString(R.string.app_name))) {
             mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_black,
-                    taskManager.getQueue().size()));
+                    DBReader.getQueue().size()));
             mediaItems.add(createBrowsableMediaItem(R.string.downloads_label, R.drawable.ic_download_black,
                     DBReader.getDownloadedItems().size()));
             List<Feed> feeds = DBReader.getFeedList();
@@ -452,7 +452,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         List<FeedItem> feedItems;
         if (parentId.equals(getResources().getString(R.string.queue_label))) {
-            feedItems = taskManager.getQueue();
+            feedItems = DBReader.getQueue();
         } else if (parentId.equals(getResources().getString(R.string.downloads_label))) {
             feedItems = DBReader.getDownloadedItems();
         } else if (parentId.startsWith("FeedId:")) {
@@ -1427,10 +1427,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             i.putExtra("album", info.playable.getFeedTitle());
             i.putExtra("track", info.playable.getEpisodeTitle());
             i.putExtra("playing", isPlaying);
-            final List<FeedItem> queue = taskManager.getQueueIfLoaded();
-            if (queue != null) {
-                i.putExtra("ListSize", queue.size());
-            }
             i.putExtra("duration", (long) info.playable.getDuration());
             i.putExtra("position", (long) info.playable.getPosition());
             sendBroadcast(i);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -13,20 +13,11 @@ import de.danoeh.antennapod.core.util.ChapterUtils;
 import de.danoeh.antennapod.core.widget.WidgetUpdater;
 import io.reactivex.disposables.Disposable;
 import org.greenrobot.eventbus.EventBus;
-import org.greenrobot.eventbus.Subscribe;
 
-import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import de.danoeh.antennapod.event.FeedItemEvent;
-import de.danoeh.antennapod.event.QueueEvent;
-import de.danoeh.antennapod.model.feed.FeedItem;
-import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.model.playback.Playable;
 import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -59,7 +50,6 @@ public class PlaybackServiceTaskManager {
     private ScheduledFuture<?> positionSaverFuture;
     private ScheduledFuture<?> widgetUpdaterFuture;
     private ScheduledFuture<?> sleepTimerFuture;
-    private volatile Future<List<FeedItem>> queueFuture;
     private volatile Disposable chapterLoaderFuture;
 
     private SleepTimer sleepTimer;
@@ -82,88 +72,6 @@ public class PlaybackServiceTaskManager {
             t.setPriority(Thread.MIN_PRIORITY);
             return t;
         });
-        loadQueue();
-        EventBus.getDefault().register(this);
-    }
-
-    @Subscribe
-    public void onEvent(QueueEvent event) {
-        Log.d(TAG, "onEvent(QueueEvent " + event +")");
-        cancelQueueLoader();
-        loadQueue();
-    }
-
-    private synchronized boolean isQueueLoaderActive() {
-        return queueFuture != null && !queueFuture.isDone();
-    }
-
-    private synchronized void cancelQueueLoader() {
-        if (isQueueLoaderActive()) {
-            queueFuture.cancel(true);
-        }
-    }
-
-    private synchronized void loadQueue() {
-        if (!isQueueLoaderActive()) {
-            queueFuture = schedExecutor.submit(() -> DBReader.getQueue());
-        }
-    }
-
-    @Subscribe
-    public void onEvent(FeedItemEvent event) {
-        // Use case: when an item in the queue has been downloaded,
-        // listening to the event to ensure the downloaded item will be used.
-        Log.d(TAG, "onEvent(FeedItemEvent " + event + ")");
-
-        for (FeedItem item : event.items) {
-            if (isItemInQueue(item.getId())) {
-                Log.d(TAG, "onEvent(FeedItemEvent) - some item (" + item.getId() + ") in the queue has been updated (usually downloaded). Refresh the queue.");
-                cancelQueueLoader();
-                loadQueue();
-                return;
-            }
-        }
-    }
-
-    private boolean isItemInQueue(long itemId) {
-        List<FeedItem> queue = getQueueIfLoaded();
-        if (queue != null) {
-            for (FeedItem item : queue) {
-                if (item.getId() == itemId) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns the queue if it is already loaded or null if it hasn't been loaded yet.
-     * In order to wait until the queue has been loaded, use getQueue()
-     */
-    public synchronized List<FeedItem> getQueueIfLoaded() {
-        if (queueFuture.isDone()) {
-            try {
-                return queueFuture.get();
-            } catch (InterruptedException | ExecutionException | CancellationException e) {
-                e.printStackTrace();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns the queue or waits until the PSTM has loaded the queue from the database.
-     */
-    public List<FeedItem> getQueue() throws InterruptedException {
-        if (queueFuture == null) {
-            loadQueue();
-        }
-        try {
-            return queueFuture.get();
-        } catch (ExecutionException e) {
-            throw new IllegalArgumentException(e);
-        }
     }
 
     /**
@@ -289,7 +197,6 @@ public class PlaybackServiceTaskManager {
         }
     }
 
-
     /**
      * Returns true if the widget updater is currently running.
      */
@@ -338,7 +245,6 @@ public class PlaybackServiceTaskManager {
         cancelPositionSaver();
         cancelWidgetUpdater();
         disableSleepTimer();
-        cancelQueueLoader();
 
         if (chapterLoaderFuture != null) {
             chapterLoaderFuture.dispose();
@@ -351,7 +257,6 @@ public class PlaybackServiceTaskManager {
      * execution of this method.
      */
     public void shutdown() {
-        EventBus.getDefault().unregister(this);
         cancelAllTasks();
         schedExecutor.shutdownNow();
     }


### PR DESCRIPTION
This just causes problems with keeping the preloaded list up-to-date.
We only call the method from background threads anyway.

One more step towards removing that weird `PlaybackServiceTaskManager` class.