### PR TITLE
Update SpeedDial library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,7 @@ dependencies {
     implementation "com.joanzapata.iconify:android-iconify-fontawesome:$iconifyVersion"
     implementation "com.joanzapata.iconify:android-iconify-material:$iconifyVersion"
     implementation 'com.github.shts:TriangleLabelView:1.1.2'
-    implementation 'com.github.leinardi:FloatingActionButtonSpeedDial:3.1.1'
+    implementation 'com.leinardi.android:speed-dial:3.2.0'
     implementation "com.github.AntennaPod:AntennaPod-AudioPlayer:$audioPlayerVersion"
     implementation 'com.github.mfietz:fyydlin:v0.5.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'


### PR DESCRIPTION
Updates FloatingActionButtonSpeedDial 3.1.1 -> 3.2.0 ([changelog](https://github.com/leinardi/FloatingActionButtonSpeedDial/releases))

This brings accessibility improvements that I think could benefit some AntennaPod users.
The library now uses Maven Central as well.
Linked issues are in the changelog.

Tested APK worked fine.
