### PR TITLE
Update Material Components library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ project.ext {
     recyclerViewVersion = "1.2.1"
     viewPager2Version = "1.1.0-beta01"
     workManagerVersion = "2.3.4"
-    googleMaterialVersion = "1.1.0"
+    googleMaterialVersion = "1.4.0"
 
     // Third-party
     commonslangVersion = "3.6"


### PR DESCRIPTION
Update Material Components 1.1.0 -> 1.4.0 ([changelog](https://github.com/material-components/material-components-android/releases))

Discussion about the size increase was [here](https://github.com/AntennaPod/AntennaPod/pull/5201) and was found to be very minimal. My own APK analyzation comparisons showed only tiny increases.

Tested APK worked fine.

By the way, what do you think about migrating the currently used Material design over to Material 3? Support will be official in 1.5.0. I think it'd make AntennaPod look pretty good.
