### PR TITLE
Make checkstyle CI faster

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,15 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache Gradle
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
       - name: Checkstyle
-        run: ./gradlew checkstyle
+        run: |
+          curl -s -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-9.2.1/checkstyle-9.2.1-all.jar > checkstyle.jar
+          find . -name "*\.java" | xargs java -Dconfig_loc=config/checkstyle -jar checkstyle.jar -c config/checkstyle/checkstyle.xml
       - name: Find PR Base Commit
         id: vars
         run: |

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,5 +8,6 @@
     
     <suppress checks="." files="[\\/]generated-sources[\\/]"/>
     <suppress checks="." files="[\\/]build[\\/]"/>
+    <suppress checks="." files="[\\/]gen[\\/]"/>
     <suppress checks="." files="[\\/].idea[\\/]"/>
 </suppressions>


### PR DESCRIPTION
Using the checkstyle binary instead of executing it with Gradle. This makes the check significantly faster and also no longer requires restoring the gradle cache on each run.

Before: ~40-50 seconds
After: ~20-25 seconds