### PR TITLE
Fix line breaks in plain-text descriptions

### DIFF
--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Rss20.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Rss20.java
@@ -136,7 +136,7 @@ public class Rss20 extends Namespace {
                 if (CHANNEL.equals(second) && state.getFeed() != null) {
                     state.getFeed().setDescription(contentFromHtml);
                 } else if (ITEM.equals(second) && state.getCurrentItem() != null) {
-                    state.getCurrentItem().setDescriptionIfLonger(contentFromHtml);
+                    state.getCurrentItem().setDescriptionIfLonger(content); // fromHtml here breaks \n when not html
                 }
             } else if (LANGUAGE.equals(localName) && state.getFeed() != null) {
                 state.getFeed().setLanguage(content.toLowerCase(Locale.US));


### PR DESCRIPTION
Workaround was added for publishers misbehaving but the current
implementation breaks valid feeds