### PR TITLE
Decide whether or not to stream on demand

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/storage/AutoDownloadTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/storage/AutoDownloadTest.java
@@ -100,7 +100,6 @@ public class AutoDownloadTest {
         new PlaybackServiceStarter(context, media)
                 .callEvenIfRunning(true)
                 .startWhenPrepared(true)
-                .shouldStream(true)
                 .start();
         Awaitility.await("episode is playing")
                 .atMost(2000, MILLISECONDS)

--- a/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistDescriptionAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/FeedItemlistDescriptionAdapter.java
@@ -80,7 +80,6 @@ public class FeedItemlistDescriptionAdapter extends ArrayAdapter<FeedItem> {
             }
 
             new PlaybackServiceStarter(getContext(), playable)
-                    .shouldStream(true)
                     .startWhenPrepared(true)
                     .callEvenIfRunning(true)
                     .start();

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/PlayActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/PlayActionButton.java
@@ -42,7 +42,6 @@ public class PlayActionButton extends ItemActionButton {
         new PlaybackServiceStarter(context, media)
                 .callEvenIfRunning(true)
                 .startWhenPrepared(true)
-                .shouldStream(false)
                 .start();
 
         if (media.getMediaType() == MediaType.VIDEO) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/PlayLocalActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/PlayLocalActionButton.java
@@ -38,7 +38,6 @@ public class PlayLocalActionButton extends ItemActionButton {
         new PlaybackServiceStarter(context, media)
                 .callEvenIfRunning(true)
                 .startWhenPrepared(true)
-                .shouldStream(true)
                 .start();
 
         if (media.getMediaType() == MediaType.VIDEO) {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/StreamActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/StreamActionButton.java
@@ -48,7 +48,6 @@ public class StreamActionButton extends ItemActionButton {
         new PlaybackServiceStarter(context, media)
                 .callEvenIfRunning(true)
                 .startWhenPrepared(true)
-                .shouldStream(true)
                 .start();
 
         if (media.getMediaType() == MediaType.VIDEO) {

--- a/app/src/main/java/de/danoeh/antennapod/dialog/StreamingConfirmationDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/StreamingConfirmationDialog.java
@@ -33,7 +33,6 @@ public class StreamingConfirmationDialog {
         new PlaybackServiceStarter(context, playable)
                 .callEvenIfRunning(true)
                 .startWhenPrepared(true)
-                .shouldStream(true)
                 .shouldStreamThisTime(true)
                 .start();
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/PlaybackPreferences.java
@@ -45,11 +45,6 @@ public class PlaybackPreferences implements SharedPreferences.OnSharedPreference
             = "de.danoeh.antennapod.preferences.currentlyPlayingMedia";
 
     /**
-     * True if last played media was streamed.
-     */
-    private static final String PREF_CURRENT_EPISODE_IS_STREAM = "de.danoeh.antennapod.preferences.lastIsStream";
-
-    /**
      * True if last played media was a video.
      */
     private static final String PREF_CURRENT_EPISODE_IS_VIDEO = "de.danoeh.antennapod.preferences.lastIsVideo";
@@ -113,10 +108,6 @@ public class PlaybackPreferences implements SharedPreferences.OnSharedPreference
         return prefs.getLong(PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID, NO_MEDIA_PLAYING);
     }
 
-    public static boolean getCurrentEpisodeIsStream() {
-        return prefs.getBoolean(PREF_CURRENT_EPISODE_IS_STREAM, true);
-    }
-
     public static boolean getCurrentEpisodeIsVideo() {
         return prefs.getBoolean(PREF_CURRENT_EPISODE_IS_VIDEO, false);
     }
@@ -138,7 +129,7 @@ public class PlaybackPreferences implements SharedPreferences.OnSharedPreference
         editor.apply();
     }
 
-    public static void writeMediaPlaying(Playable playable, PlayerStatus playerStatus, boolean stream) {
+    public static void writeMediaPlaying(Playable playable, PlayerStatus playerStatus) {
         Log.d(TAG, "Writing playback preferences");
         SharedPreferences.Editor editor = prefs.edit();
 
@@ -146,7 +137,6 @@ public class PlaybackPreferences implements SharedPreferences.OnSharedPreference
             writeNoMediaPlaying();
         } else {
             editor.putLong(PREF_CURRENTLY_PLAYING_MEDIA_TYPE, playable.getPlayableType());
-            editor.putBoolean(PREF_CURRENT_EPISODE_IS_STREAM, stream);
             editor.putBoolean(PREF_CURRENT_EPISODE_IS_VIDEO, playable.getMediaType() == MediaType.VIDEO);
             if (playable instanceof FeedMedia) {
                 FeedMedia feedMedia = (FeedMedia) playable;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -868,7 +868,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                     pausedBecauseOfTransientAudiofocusLoss = false;
                     new PlaybackServiceStarter(context, getPlayable())
                             .startWhenPrepared(true)
-                            .streamIfLastWasStream()
                             .callEvenIfRunning(false)
                             .start();
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackController.java
@@ -331,7 +331,6 @@ public abstract class PlaybackController {
         if (playbackService == null) {
             new PlaybackServiceStarter(activity, media)
                     .startWhenPrepared(true)
-                    .streamIfLastWasStream()
                     .start();
             Log.w(TAG, "Play/Pause button was pressed, but playbackservice was null!");
             return;
@@ -354,7 +353,6 @@ public abstract class PlaybackController {
             default:
                 new PlaybackServiceStarter(activity, media)
                         .startWhenPrepared(true)
-                        .streamIfLastWasStream()
                         .callEvenIfRunning(true)
                         .start();
                 Log.w(TAG, "Play/Pause button was pressed and PlaybackService state was unknown");

--- a/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/playback/PlaybackServiceStarter.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.os.Parcelable;
 import androidx.core.content.ContextCompat;
 
-import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.model.playback.Playable;
 
@@ -13,7 +12,6 @@ public class PlaybackServiceStarter {
     private final Context context;
     private final Playable media;
     private boolean startWhenPrepared = false;
-    private boolean shouldStream = false;
     private boolean shouldStreamThisTime = false;
     private boolean callEvenIfRunning = false;
     private boolean prepareImmediately = true;
@@ -21,19 +19,6 @@ public class PlaybackServiceStarter {
     public PlaybackServiceStarter(Context context, Playable media) {
         this.context = context;
         this.media = media;
-    }
-
-    /**
-     * Default value: false
-     */
-    public PlaybackServiceStarter shouldStream(boolean shouldStream) {
-        this.shouldStream = shouldStream;
-        return this;
-    }
-
-    public PlaybackServiceStarter streamIfLastWasStream() {
-        boolean lastIsStream = PlaybackPreferences.getCurrentEpisodeIsStream();
-        return shouldStream(lastIsStream);
     }
 
     /**
@@ -69,7 +54,6 @@ public class PlaybackServiceStarter {
         Intent launchIntent = new Intent(context, PlaybackService.class);
         launchIntent.putExtra(PlaybackService.EXTRA_PLAYABLE, (Parcelable) media);
         launchIntent.putExtra(PlaybackService.EXTRA_START_WHEN_PREPARED, startWhenPrepared);
-        launchIntent.putExtra(PlaybackService.EXTRA_SHOULD_STREAM, shouldStream);
         launchIntent.putExtra(PlaybackService.EXTRA_PREPARE_IMMEDIATELY, prepareImmediately);
         launchIntent.putExtra(PlaybackService.EXTRA_ALLOW_STREAM_THIS_TIME, shouldStreamThisTime);
 

--- a/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdater.java
@@ -45,20 +45,17 @@ public abstract class WidgetUpdater {
         final int position;
         final int duration;
         final float playbackSpeed;
-        final boolean isCasting;
 
-        public WidgetState(Playable media, PlayerStatus status, int position, int duration,
-                           float playbackSpeed, boolean isCasting) {
+        public WidgetState(Playable media, PlayerStatus status, int position, int duration, float playbackSpeed) {
             this.media = media;
             this.status = status;
             this.position = position;
             this.duration = duration;
             this.playbackSpeed = playbackSpeed;
-            this.isCasting = isCasting;
         }
 
         public WidgetState(PlayerStatus status) {
-            this(null, status, Playable.INVALID_TIME, Playable.INVALID_TIME, 1.0f, false);
+            this(null, status, Playable.INVALID_TIME, Playable.INVALID_TIME, 1.0f);
         }
     }
 
@@ -71,8 +68,7 @@ public abstract class WidgetUpdater {
         }
 
         PendingIntent startMediaPlayer;
-        if (widgetState.media != null && widgetState.media.getMediaType() == MediaType.VIDEO
-                && !widgetState.isCasting) {
+        if (widgetState.media != null && widgetState.media.getMediaType() == MediaType.VIDEO) {
             startMediaPlayer = new VideoPlayerActivityStarter(context).getPendingIntent();
         } else {
             startMediaPlayer = new MainActivityStarter(context).withOpenPlayer().getPendingIntent();

--- a/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdaterJobService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdaterJobService.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.core.app.SafeJobIntentService;
 import de.danoeh.antennapod.core.feed.util.PlaybackSpeedUtils;
-import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.core.util.playback.PlayableUtils;
 import de.danoeh.antennapod.playback.base.PlayerStatus;
@@ -26,8 +25,7 @@ public class WidgetUpdaterJobService extends SafeJobIntentService {
         Playable media = PlayableUtils.createInstanceFromPreferences(getApplicationContext());
         if (media != null) {
             WidgetUpdater.updateWidget(this, new WidgetUpdater.WidgetState(media, PlayerStatus.STOPPED,
-                    media.getPosition(), media.getDuration(), PlaybackSpeedUtils.getCurrentPlaybackSpeed(media),
-                    PlaybackPreferences.getCurrentEpisodeIsStream()));
+                    media.getPosition(), media.getDuration(), PlaybackSpeedUtils.getCurrentPlaybackSpeed(media)));
         } else {
             WidgetUpdater.updateWidget(this, new WidgetUpdater.WidgetState(PlayerStatus.STOPPED));
         }


### PR DESCRIPTION
Fixes a bug where local folders sometimes did not start because AntennaPod
thought it needed to play locally. Also avoids situations in which it
streams even though a local file is available. Simplifies the
PlaybackService slightly.

Closes #5723
