### PR TITLE
Fix typo

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -578,7 +578,7 @@
     <string name="opml_import_summary">Import your subscriptions from another podcast app</string>
     <string name="database_export_summary">Transfer subscriptions, listened episodes and queue to AntennaPod on another device</string>
     <string name="database_import_summary">Import AntennaPod database from another device</string>
-    <string name="opml_import_label">OPML Import</string>
+    <string name="opml_import_label">OPML import</string>
     <string name="opml_add_podcast_label">Import podcast list (OPML)</string>
     <string name="opml_reader_error">An error has occurred while reading the OPML document:</string>
     <string name="opml_import_error_no_file">No file selected!</string>


### PR DESCRIPTION
As "export" and "import" is lowercase everywhere else in the settings as well