### PR TITLE
Use ShareCompat.IntentBuilder for all share actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -366,11 +366,4 @@
             android:resource="@xml/actions" />
     </application>
 
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.SEND" />
-            <data android:mimeType="text/*" />
-        </intent>
-    </queries>
-
 </manifest>

--- a/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
@@ -99,13 +99,13 @@ public class BugReportActivity extends AppCompatActivity {
             Runtime.getRuntime().exec(cmd);
             //share file
             try {
-                String authority = getString(de.danoeh.antennapod.core.R.string.provider_authority);
+                String authority = getString(R.string.provider_authority);
                 Uri fileUri = FileProvider.getUriForFile(this, authority, filename);
 
                 new ShareCompat.IntentBuilder(this)
                         .setType("text/*")
                         .addStream(fileUri)
-                        .setChooserTitle(de.danoeh.antennapod.core.R.string.share_file_label)
+                        .setChooserTitle(R.string.share_file_label)
                         .startChooser();
             } catch (Exception e) {
                 e.printStackTrace();

--- a/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/BugReportActivity.java
@@ -3,9 +3,6 @@ package de.danoeh.antennapod.activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -14,6 +11,7 @@ import com.google.android.material.snackbar.Snackbar;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ShareCompat;
 import androidx.core.content.FileProvider;
 
 
@@ -32,7 +30,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.List;
 
 /**
  * Displays the 'crash report' screen
@@ -102,21 +99,14 @@ public class BugReportActivity extends AppCompatActivity {
             Runtime.getRuntime().exec(cmd);
             //share file
             try {
-                Intent intent = new Intent(Intent.ACTION_SEND);
-                intent.setType("text/*");
-                String authString = getString(de.danoeh.antennapod.core.R.string.provider_authority);
-                Uri fileUri = FileProvider.getUriForFile(this, authString, filename);
-                intent.putExtra(Intent.EXTRA_STREAM, fileUri);
-                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                String chooserTitle = getString(de.danoeh.antennapod.core.R.string.share_file_label);
-                Intent chooser = Intent.createChooser(intent, chooserTitle);
-                List<ResolveInfo> resInfos = getPackageManager()
-                        .queryIntentActivities(chooser, PackageManager.MATCH_DEFAULT_ONLY);
-                for (ResolveInfo resolveInfo : resInfos) {
-                    String packageName = resolveInfo.activityInfo.packageName;
-                    grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                }
-                startActivity(chooser);
+                String authority = getString(de.danoeh.antennapod.core.R.string.provider_authority);
+                Uri fileUri = FileProvider.getUriForFile(this, authority, filename);
+
+                new ShareCompat.IntentBuilder(this)
+                        .setType("text/*")
+                        .addStream(fileUri)
+                        .setChooserTitle(de.danoeh.antennapod.core.R.string.share_file_label)
+                        .startChooser();
             } catch (Exception e) {
                 e.printStackTrace();
                 int strResId = R.string.log_file_share_exception;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -5,8 +5,6 @@ import android.app.ProgressDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -18,6 +16,7 @@ import androidx.activity.result.contract.ActivityResultContracts.GetContent;
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.ShareCompat;
 import androidx.core.content.FileProvider;
 import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.snackbar.Snackbar;
@@ -41,7 +40,6 @@ import io.reactivex.schedulers.Schedulers;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 
 public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
@@ -201,19 +199,12 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
         alert.setTitle(R.string.export_success_title);
         alert.setMessage(getContext().getString(R.string.export_success_sum, path));
         alert.setPositiveButton(R.string.send_label, (dialog, which) -> {
-            Intent sendIntent = new Intent(Intent.ACTION_SEND);
-            sendIntent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.opml_export_label));
-            sendIntent.putExtra(Intent.EXTRA_STREAM, streamUri);
-            sendIntent.setType("text/plain");
-            sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            Intent chooserIntent = Intent.createChooser(sendIntent, getString(R.string.send_label));
-            List<ResolveInfo> resInfoList = getContext().getPackageManager()
-                    .queryIntentActivities(sendIntent, PackageManager.MATCH_DEFAULT_ONLY);
-            for (ResolveInfo resolveInfo : resInfoList) {
-                String packageName = resolveInfo.activityInfo.packageName;
-                getContext().grantUriPermission(packageName, streamUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            }
-            getContext().startActivity(chooserIntent);
+            new ShareCompat.IntentBuilder(getContext())
+                    .setType("text/*")
+                    .setSubject(getString(R.string.opml_export_label))
+                    .addStream(streamUri)
+                    .setChooserTitle(R.string.send_label)
+                    .startChooser();
         });
         alert.create().show();
     }

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -50,11 +50,6 @@
 
     <queries>
         <intent>
-            <action android:name="android.intent.action.SEND" />
-            <data android:mimeType="*/*" />
-        </intent>
-
-        <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https" />
         </intent>

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -2,8 +2,6 @@ package de.danoeh.antennapod.core.util;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.util.Log;
 
@@ -12,7 +10,6 @@ import androidx.core.app.ShareCompat;
 import androidx.core.content.FileProvider;
 
 import java.io.File;
-import java.util.List;
 
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -76,20 +73,15 @@ public class ShareUtils {
     }
 
     public static void shareFeedItemFile(Context context, FeedMedia media) {
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType(media.getMime_type());
         Uri fileUri = FileProvider.getUriForFile(context, context.getString(R.string.provider_authority),
                 new File(media.getLocalMediaUrl()));
-        intent.putExtra(Intent.EXTRA_STREAM,  fileUri);
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        Intent chooserIntent = Intent.createChooser(intent, context.getString(R.string.share_file_label));
-        List<ResolveInfo> resInfoList = context.getPackageManager()
-                .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-        for (ResolveInfo resolveInfo : resInfoList) {
-            String packageName = resolveInfo.activityInfo.packageName;
-            context.grantUriPermission(packageName, fileUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        }
-        context.startActivity(chooserIntent);
+
+        new ShareCompat.IntentBuilder(context)
+                .setType(media.getMime_type())
+                .addStream(fileUri)
+                .setChooserTitle(R.string.share_file_label)
+                .startChooser();
+
         Log.e(TAG, "shareFeedItemFile called");
     }
 }


### PR DESCRIPTION
Using `ShareCompat.IntentBuilder` takes care of all the subtleties associated with Android's share mechanism.

The `PackageManager.queryIntentActivities()` code is unnecessary. See https://issuetracker.google.com/issues/173137936