### PR TITLE
Use data folder for initial subscriptions

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -50,7 +50,6 @@ import de.danoeh.antennapod.core.service.download.HttpDownloader;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.DBWriter;
-import de.danoeh.antennapod.core.util.FileNameGenerator;
 import de.danoeh.antennapod.parser.feed.FeedHandler;
 import de.danoeh.antennapod.parser.feed.FeedHandlerResult;
 import de.danoeh.antennapod.core.util.DownloadError;
@@ -291,12 +290,11 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         Log.d(TAG, "Starting feed download");
         url = URLChecker.prepareURL(url);
         feed = new Feed(url, null);
-        String fileUrl = new File(getExternalCacheDir(),
-                FileNameGenerator.generateFileName(feed.getDownload_url())).toString();
-        feed.setFile_url(fileUrl);
-        final DownloadRequest request = new DownloadRequest(feed.getFile_url(),
-                feed.getDownload_url(), "OnlineFeed", 0, Feed.FEEDFILETYPE_FEED, username, password,
-                true, null, true);
+        DownloadRequest request = DownloadRequestCreator.create(feed)
+                .withAuthentication(username, password)
+                .withInitiatedByUser(true)
+                .build();
+        feed.setFile_url(request.getDestination());
 
         download = Observable.fromCallable(() -> {
             feeds = DBReader.getFeedList();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadRequest.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadRequest.java
@@ -290,8 +290,9 @@ public class DownloadRequest implements Parcelable {
             this.feedfileType = feed.getTypeAsInt();
         }
 
-        public void setInitiatedByUser(boolean initiatedByUser) {
+        public Builder withInitiatedByUser(boolean initiatedByUser) {
             this.initiatedByUser = initiatedByUser;
+            return this;
         }
 
         public void setForce(boolean force) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -500,7 +500,7 @@ public class DownloadService extends Service {
         for (Feed feed : feeds) {
             if (feed.getPreferences().getKeepUpdated()) {
                 DownloadRequest.Builder builder = DownloadRequestCreator.create(feed);
-                builder.setInitiatedByUser(initiatedByUser);
+                builder.withInitiatedByUser(initiatedByUser);
                 addNewRequest(builder.build());
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/AutomaticDownloadAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/AutomaticDownloadAlgorithm.java
@@ -96,7 +96,7 @@ public class AutomaticDownloadAlgorithm {
                     List<DownloadRequest> requests = new ArrayList<>();
                     for (FeedItem episode : itemsToDownload) {
                         DownloadRequest.Builder request = DownloadRequestCreator.create(episode.getMedia());
-                        request.setInitiatedByUser(false);
+                        request.withInitiatedByUser(false);
                         requests.add(request.build());
                     }
                     DownloadService.download(context, false, requests.toArray(new DownloadRequest[0]));

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -161,7 +161,7 @@ public final class DBTasks {
 
     private static void forceRefreshFeed(Context context, Feed feed, boolean loadAllPages, boolean initiatedByUser) {
         DownloadRequest.Builder builder = DownloadRequestCreator.create(feed);
-        builder.setInitiatedByUser(initiatedByUser);
+        builder.withInitiatedByUser(initiatedByUser);
         builder.setForce(true);
         builder.loadAllPages(loadAllPages);
         DownloadService.download(context, false, builder.build());


### PR DESCRIPTION
This was already implemented in 31c0f90d0720518705da6a86b2541c2b38b054b8
but apparently got overwritten by a merge conflict with the download
service rewrite.

Closes #5763