### PR TITLE
Remove auto-enable setting from sleep timer

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -115,18 +115,14 @@ public class SleepTimerDialog extends DialogFragment {
 
         CheckBox cbShakeToReset = content.findViewById(R.id.cbShakeToReset);
         CheckBox cbVibrate = content.findViewById(R.id.cbVibrate);
-        CheckBox chAutoEnable = content.findViewById(R.id.chAutoEnable);
 
         cbShakeToReset.setChecked(SleepTimerPreferences.shakeToReset());
         cbVibrate.setChecked(SleepTimerPreferences.vibrate());
-        chAutoEnable.setChecked(SleepTimerPreferences.autoEnable());
 
         cbShakeToReset.setOnCheckedChangeListener((buttonView, isChecked)
                 -> SleepTimerPreferences.setShakeToReset(isChecked));
         cbVibrate.setOnCheckedChangeListener((buttonView, isChecked)
                 -> SleepTimerPreferences.setVibrate(isChecked));
-        chAutoEnable.setOnCheckedChangeListener((compoundButton, isChecked)
-                -> SleepTimerPreferences.setAutoEnable(isChecked));
 
         Button disableButton = content.findViewById(R.id.disableSleeptimerButton);
         disableButton.setOnClickListener(v -> {

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -134,12 +134,6 @@
             android:layout_height="wrap_content"
             android:text="@string/timer_vibration_label" />
 
-        <CheckBox
-            android:id="@+id/chAutoEnable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/auto_enable_label" />
-
     </LinearLayout>
 
 </LinearLayout>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
@@ -16,7 +16,6 @@ public class SleepTimerPreferences {
     private static final String PREF_TIME_UNIT = "LastTimeUnit";
     private static final String PREF_VIBRATE = "Vibrate";
     private static final String PREF_SHAKE_TO_RESET = "ShakeToReset";
-    private static final String PREF_AUTO_ENABLE = "AutoEnable";
 
     private static final TimeUnit[] UNITS = { TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS };
 
@@ -67,13 +66,4 @@ public class SleepTimerPreferences {
     public static boolean shakeToReset() {
         return prefs.getBoolean(PREF_SHAKE_TO_RESET, true);
     }
-
-    public static void setAutoEnable(boolean autoEnable) {
-        prefs.edit().putBoolean(PREF_AUTO_ENABLE, autoEnable).apply();
-    }
-
-    public static boolean autoEnable() {
-        return prefs.getBoolean(PREF_AUTO_ENABLE, false);
-    }
-
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -62,13 +62,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.core.R;
-import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.event.settings.SkipIntroEndingChangedEvent;
 import de.danoeh.antennapod.event.settings.SpeedPresetChangedEvent;
 import de.danoeh.antennapod.event.settings.VolumeAdaptionChangedEvent;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
-import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.receiver.MediaButtonReceiver;
 import de.danoeh.antennapod.core.storage.DBReader;
@@ -822,13 +820,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     updateNotificationAndMediaSession(newInfo.playable);
                     setupPositionObserver();
                     stateManager.validStartCommandWasReceived();
-                    // set sleep timer if auto-enabled
-                    if (newInfo.oldPlayerStatus != null && newInfo.oldPlayerStatus != PlayerStatus.SEEKING
-                            && SleepTimerPreferences.autoEnable() && !sleepTimerActive()) {
-                        setSleepTimer(SleepTimerPreferences.timerMillis());
-                        EventBus.getDefault().post(new MessageEvent(getString(R.string.sleep_timer_enabled_label),
-                                PlaybackService.this::disableSleepTimer));
-                    }
                     loadQueueForMediaSession();
                     break;
                 case ERROR:

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -623,8 +623,6 @@
         <item quantity="one">1 hour</item>
         <item quantity="other">%d hours</item>
     </plurals>
-    <string name="auto_enable_label">Auto-enable</string>
-    <string name="sleep_timer_enabled_label">Sleep timer enabled</string>
 
     <!-- gpodder.net -->
     <string name="gpodnet_taglist_header">CATEGORIES</string>


### PR DESCRIPTION
The feature was introduced to work around an issue that has a much easier solution: Turning off the "follow queue" setting. The feature only confuses people who want to use the sleep timer.

Closes #5226