### PR TITLE
Show on-demand configuration popup for stream vs download only once

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -205,7 +205,6 @@ public class ItemFragment extends Fragment {
                 .build();
         final Button positiveButton = balloon.getContentView().findViewById(R.id.balloon_button_positive);
         final Button negativeButton = balloon.getContentView().findViewById(R.id.balloon_button_negative);
-        final Button neverButton = balloon.getContentView().findViewById(R.id.balloon_button_never);
         final TextView message = balloon.getContentView().findViewById(R.id.balloon_message);
         message.setText(offerStreaming
                 ? R.string.on_demand_config_stream_text : R.string.on_demand_config_download_text);
@@ -218,10 +217,6 @@ public class ItemFragment extends Fragment {
             balloon.dismiss();
         });
         negativeButton.setOnClickListener(v1 -> {
-            UsageStatistics.askAgainLater(UsageStatistics.ACTION_STREAM); // Type does not matter. Both are silenced.
-            balloon.dismiss();
-        });
-        neverButton.setOnClickListener(v1 -> {
             UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM); // Type does not matter. Both are silenced.
             balloon.dismiss();
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -188,9 +188,9 @@ public class ItemFragment extends Fragment {
     }
 
     private void showOnDemandConfigBalloon(boolean offerStreaming) {
-        boolean isLocaleRtl = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault())
+        final boolean isLocaleRtl = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault())
                 == View.LAYOUT_DIRECTION_RTL;
-        Balloon balloon = new Balloon.Builder(getContext())
+        final Balloon balloon = new Balloon.Builder(getContext())
                 .setArrowOrientation(ArrowOrientation.TOP)
                 .setArrowOrientationRules(ArrowOrientationRules.ALIGN_FIXED)
                 .setArrowPosition(0.25f + ((isLocaleRtl ^ offerStreaming) ? 0f : 0.5f))
@@ -203,10 +203,10 @@ public class ItemFragment extends Fragment {
                 .setDismissWhenTouchOutside(true)
                 .setLifecycleOwner(this)
                 .build();
-        Button positiveButton = balloon.getContentView().findViewById(R.id.balloon_button_positive);
-        Button negativeButton = balloon.getContentView().findViewById(R.id.balloon_button_negative);
-        Button neverButton = balloon.getContentView().findViewById(R.id.balloon_button_never);
-        TextView message = balloon.getContentView().findViewById(R.id.balloon_message);
+        final Button positiveButton = balloon.getContentView().findViewById(R.id.balloon_button_positive);
+        final Button negativeButton = balloon.getContentView().findViewById(R.id.balloon_button_negative);
+        final Button neverButton = balloon.getContentView().findViewById(R.id.balloon_button_never);
+        final TextView message = balloon.getContentView().findViewById(R.id.balloon_message);
         message.setText(offerStreaming
                 ? R.string.on_demand_config_stream_text : R.string.on_demand_config_download_text);
         positiveButton.setOnClickListener(v1 -> {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -205,6 +205,7 @@ public class ItemFragment extends Fragment {
                 .build();
         Button positiveButton = balloon.getContentView().findViewById(R.id.balloon_button_positive);
         Button negativeButton = balloon.getContentView().findViewById(R.id.balloon_button_negative);
+        Button neverButton = balloon.getContentView().findViewById(R.id.balloon_button_never);
         TextView message = balloon.getContentView().findViewById(R.id.balloon_message);
         message.setText(offerStreaming
                 ? R.string.on_demand_config_stream_text : R.string.on_demand_config_download_text);
@@ -218,6 +219,10 @@ public class ItemFragment extends Fragment {
         });
         negativeButton.setOnClickListener(v1 -> {
             UsageStatistics.askAgainLater(UsageStatistics.ACTION_STREAM); // Type does not matter. Both are silenced.
+            balloon.dismiss();
+        });
+        neverButton.setOnClickListener(v1 -> {
+            UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM); // Type does not matter. Both are silenced.
             balloon.dismiss();
         });
         balloon.showAlignBottom(butAction1, 0, (int) (-12 * getResources().getDisplayMetrics().density));

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/PlaybackPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/PlaybackPreferencesFragment.java
@@ -56,7 +56,8 @@ public class PlaybackPreferencesFragment extends PreferenceFragmentCompat {
         findPreference(PREF_PLAYBACK_PREFER_STREAMING).setOnPreferenceChangeListener((preference, newValue) -> {
             // Update all visible lists to reflect new streaming action button
             EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-            UsageStatistics.askAgainLater(UsageStatistics.ACTION_STREAM);
+            // User consciously decided whether to prefer the streaming button, disable suggestion to change that
+            UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM);
             return true;
         });
 

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
@@ -24,6 +24,7 @@ public class UsageStatistics {
     private static final float MOVING_AVERAGE_BIAS_THRESHOLD = 0.1f;
     private static final long ASK_AGAIN_LATER_DELAY = 1000 * 3600 * 24 * 10; // 10 days
     private static final String SUFFIX_HIDDEN_UNTIL = "_hiddenUntil";
+    private static final String SUFFIX_HIDDEN_FOREVER = "_hiddenForever";
     private static SharedPreferences prefs;
 
     public static final StatsAction ACTION_STREAM = new StatsAction("downloadVsStream", 0);
@@ -51,7 +52,8 @@ public class UsageStatistics {
     public static boolean hasSignificantBiasTo(StatsAction action) {
         final float movingAverage = prefs.getFloat(action.type, 0.5f);
         final long askAfter = prefs.getLong(action.type + SUFFIX_HIDDEN_UNTIL, 0);
-        return Math.abs(action.value - movingAverage) < MOVING_AVERAGE_BIAS_THRESHOLD
+        final boolean dontAsk = prefs.getBoolean(action.type + SUFFIX_HIDDEN_FOREVER, false);
+        return !dontAsk && Math.abs(action.value - movingAverage) < MOVING_AVERAGE_BIAS_THRESHOLD
                 && Calendar.getInstance().getTimeInMillis() > askAfter;
     }
 
@@ -59,6 +61,10 @@ public class UsageStatistics {
         prefs.edit().putLong(action.type + SUFFIX_HIDDEN_UNTIL,
                 Calendar.getInstance().getTimeInMillis() + ASK_AGAIN_LATER_DELAY)
                 .apply();
+    }
+
+    public static void doNotAskAgain(StatsAction action) {
+        prefs.edit().putBoolean(action.type + SUFFIX_HIDDEN_FOREVER, true).apply();
     }
 
     public static final class StatsAction {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
@@ -50,11 +50,15 @@ public class UsageStatistics {
     }
 
     public static boolean hasSignificantBiasTo(StatsAction action) {
-        final float movingAverage = prefs.getFloat(action.type, 0.5f);
-        final long askAfter = prefs.getLong(action.type + SUFFIX_HIDDEN_UNTIL, 0);
         final boolean dontAsk = prefs.getBoolean(action.type + SUFFIX_HIDDEN_FOREVER, false);
-        return !dontAsk && Math.abs(action.value - movingAverage) < MOVING_AVERAGE_BIAS_THRESHOLD
-                && Calendar.getInstance().getTimeInMillis() > askAfter;
+        if (dontAsk) {
+            return false;
+        } else {
+            final float movingAverage = prefs.getFloat(action.type, 0.5f);
+            final long askAfter = prefs.getLong(action.type + SUFFIX_HIDDEN_UNTIL, 0);
+            return Math.abs(action.value - movingAverage) < MOVING_AVERAGE_BIAS_THRESHOLD
+                    && Calendar.getInstance().getTimeInMillis() > askAfter;
+        }
     }
 
     public static void askAgainLater(StatsAction action) {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
@@ -22,9 +22,7 @@ public class UsageStatistics {
     private static final String PREF_DB_NAME = "UsageStatistics";
     private static final float MOVING_AVERAGE_WEIGHT = 0.8f;
     private static final float MOVING_AVERAGE_BIAS_THRESHOLD = 0.1f;
-    private static final long ASK_AGAIN_LATER_DELAY = 1000 * 3600 * 24 * 10; // 10 days
-    private static final String SUFFIX_HIDDEN_UNTIL = "_hiddenUntil";
-    private static final String SUFFIX_HIDDEN_FOREVER = "_hiddenForever";
+    private static final String SUFFIX_HIDDEN = "_hidden";
     private static SharedPreferences prefs;
 
     public static final StatsAction ACTION_STREAM = new StatsAction("downloadVsStream", 0);
@@ -50,25 +48,16 @@ public class UsageStatistics {
     }
 
     public static boolean hasSignificantBiasTo(StatsAction action) {
-        final boolean dontAsk = prefs.getBoolean(action.type + SUFFIX_HIDDEN_FOREVER, false);
-        if (dontAsk) {
+        if (prefs.getBoolean(action.type + SUFFIX_HIDDEN, false)) {
             return false;
         } else {
             final float movingAverage = prefs.getFloat(action.type, 0.5f);
-            final long askAfter = prefs.getLong(action.type + SUFFIX_HIDDEN_UNTIL, 0);
-            return Math.abs(action.value - movingAverage) < MOVING_AVERAGE_BIAS_THRESHOLD
-                    && Calendar.getInstance().getTimeInMillis() > askAfter;
+            return Math.abs(action.value - movingAverage) < MOVING_AVERAGE_BIAS_THRESHOLD;
         }
     }
 
-    public static void askAgainLater(StatsAction action) {
-        prefs.edit().putLong(action.type + SUFFIX_HIDDEN_UNTIL,
-                Calendar.getInstance().getTimeInMillis() + ASK_AGAIN_LATER_DELAY)
-                .apply();
-    }
-
     public static void doNotAskAgain(StatsAction action) {
-        prefs.edit().putBoolean(action.type + SUFFIX_HIDDEN_FOREVER, true).apply();
+        prefs.edit().putBoolean(action.type + SUFFIX_HIDDEN, true).apply();
     }
 
     public static final class StatsAction {

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UsageStatistics.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 
-import java.util.Calendar;
-
 /**
  * Collects statistics about the app usage. The statistics are used to allow on-demand configuration:
  * "Looks like you stream a lot. Do you want to toggle the 'Prefer streaming' setting?".

--- a/core/src/main/res/layout/popup_bubble_view.xml
+++ b/core/src/main/res/layout/popup_bubble_view.xml
@@ -21,17 +21,9 @@
         android:gravity="end">
 
         <Button
-            android:id="@+id/balloon_button_never"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
-            android:textColor="?attr/colorOnSecondary"
-            android:text="@string/do_not_ask_again"
-            style="@style/Widget.MaterialComponents.Button.TextButton" />
-
-        <Button
             android:id="@+id/balloon_button_negative"
             android:layout_width="wrap_content"
-            android:layout_height="36dp"
+            android:layout_height="wrap_content"
             android:textColor="?attr/colorOnSecondary"
             android:text="@string/no"
             style="@style/Widget.MaterialComponents.Button.TextButton" />
@@ -39,7 +31,7 @@
         <Button
             android:id="@+id/balloon_button_positive"
             android:layout_width="wrap_content"
-            android:layout_height="36dp"
+            android:layout_height="wrap_content"
             android:textColor="?attr/colorOnSecondary"
             android:text="@string/yes"
             style="@style/Widget.MaterialComponents.Button.TextButton" />

--- a/core/src/main/res/layout/popup_bubble_view.xml
+++ b/core/src/main/res/layout/popup_bubble_view.xml
@@ -21,6 +21,14 @@
         android:gravity="end">
 
         <Button
+            android:id="@+id/balloon_button_never"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:textColor="?attr/colorOnSecondary"
+            android:text="@string/do_not_ask_again"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
+
+        <Button
             android:id="@+id/balloon_button_negative"
             android:layout_width="wrap_content"
             android:layout_height="36dp"

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -92,7 +92,6 @@
     <string name="cancel_label">Cancel</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
-    <string name="do_not_ask_again">Do not ask again</string>
     <string name="reset">Reset</string>
     <string name="url_label">URL</string>
     <string name="support_funding_label">Support</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="cancel_label">Cancel</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="do_not_ask_again">Do not ask again</string>
     <string name="reset">Reset</string>
     <string name="url_label">URL</string>
     <string name="support_funding_label">Support</string>


### PR DESCRIPTION
Although I mostly stream podcasts, I prefer the download button in episode lists, which allows me to quickly download multiple episodes, e.g., before traveling. This usage pattern, however, causes the on-demand configuration popup for stream vs download (added in #4121) to open infrequently. This PR adds a 'Do not ask again' button to this popup, honoring the decision of users who like to keep the Download button.

In the screenshot, the bottom of the letter __g__ is cut off. This cutoff seems unrelated to the proposed changes and also appears when only __No__ and __Yes__ are present (visible with a larger screen size).

![Screenshot](https://user-images.githubusercontent.com/48482306/160297468-0a68f072-4726-4016-81a5-12aecb04dca6.png)

Thank you for this great app! 