### PR TITLE
Truncate existing file when exporting OPML/HTML/Favorites

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/asynctask/DocumentFileExportWorker.java
+++ b/app/src/main/java/de/danoeh/antennapod/asynctask/DocumentFileExportWorker.java
@@ -36,7 +36,7 @@ public class DocumentFileExportWorker {
             OutputStreamWriter writer = null;
             try {
                 Uri uri = output.getUri();
-                outputStream = context.getContentResolver().openOutputStream(uri);
+                outputStream = context.getContentResolver().openOutputStream(uri, "wt");
                 if (outputStream == null) {
                     throw new IOException();
                 }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DatabaseExporter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DatabaseExporter.java
@@ -27,7 +27,7 @@ public class DatabaseExporter {
         ParcelFileDescriptor pfd = null;
         FileOutputStream fileOutputStream = null;
         try {
-            pfd = context.getContentResolver().openFileDescriptor(uri, "w");
+            pfd = context.getContentResolver().openFileDescriptor(uri, "wt");
             fileOutputStream = new FileOutputStream(pfd.getFileDescriptor());
             exportToStream(fileOutputStream, context);
         } catch (IOException e) {


### PR DESCRIPTION
Use "truncate mode" so there's no chance we end up with data from the old file when overwriting and existing file.

Fixes #5819