### PR TITLE
Rewrite feed redirect handling

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/AntennapodHttpClient.java
@@ -6,20 +6,14 @@ import androidx.annotation.NonNull;
 import de.danoeh.antennapod.core.preferences.UserPreferences;
 import de.danoeh.antennapod.core.service.BasicAuthorizationInterceptor;
 import de.danoeh.antennapod.core.service.UserAgentInterceptor;
-import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.net.ssl.SslClientSetup;
 import okhttp3.Cache;
 import okhttp3.Credentials;
-import okhttp3.HttpUrl;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.internal.http.StatusLine;
 import java.io.File;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
-import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.SocketAddress;
@@ -69,36 +63,6 @@ public class AntennapodHttpClient {
         System.setProperty("http.maxConnections", String.valueOf(MAX_CONNECTIONS));
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
-
-        // detect 301 Moved permanently and 308 Permanent Redirect
-        builder.networkInterceptors().add(chain -> {
-            Request request = chain.request();
-            Response response = chain.proceed(request);
-            if (response.code() == HttpURLConnection.HTTP_MOVED_PERM
-                    || response.code() == StatusLine.HTTP_PERM_REDIRECT) {
-                String location = response.header("Location");
-                if (location == null) {
-                    return response;
-                }
-                if (location.startsWith("/")) { // URL is not absolute, but relative
-                    HttpUrl url = request.url();
-                    location = url.scheme() + "://" + url.host() + location;
-                } else if (!location.toLowerCase().startsWith("http://")
-                        && !location.toLowerCase().startsWith("https://")) {
-                    // Reference is relative to current path
-                    HttpUrl url = request.url();
-                    String path = url.encodedPath();
-                    String newPath = path.substring(0, path.lastIndexOf("/") + 1) + location;
-                    location = url.scheme() + "://" + url.host() + newPath;
-                }
-                try {
-                    DBWriter.updateFeedDownloadURL(request.url().toString(), location).get();
-                } catch (Exception e) {
-                    Log.e(TAG, Log.getStackTraceString(e));
-                }
-            }
-            return response;
-        });
         builder.interceptors().add(new BasicAuthorizationInterceptor());
         builder.networkInterceptors().add(new UserAgentInterceptor());
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -335,6 +335,9 @@ public class DownloadService extends Service {
                     // Was stored in the database before and not initiated manually
                     newEpisodesNotification.showIfNeeded(DownloadService.this, task.getSavedFeed());
                 }
+                if (downloader.permanentRedirectUrl != null) {
+                    DBWriter.updateFeedDownloadURL(request.getSource(), downloader.permanentRedirectUrl);
+                }
             } else {
                 DBWriter.setFeedLastUpdateFailed(request.getFeedfileId(), true);
                 saveDownloadStatus(task.getDownloadStatus());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/Downloader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/Downloader.java
@@ -18,8 +18,8 @@ public abstract class Downloader implements Callable<Downloader> {
     private static final String TAG = "Downloader";
 
     private volatile boolean finished;
-
     public volatile boolean cancelled;
+    public String permanentRedirectUrl = null;
 
     @NonNull
     final DownloadRequest request;


### PR DESCRIPTION
- Only redirects when feed was parsed successfully (for misbehaving captive portals, closes #5324)
- Decouple http client from database (contributes to #4661)