### PR TITLE
Multi-Select on 'All episodes' screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
@@ -48,6 +48,7 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
     public void updateItems(List<FeedItem> items) {
         episodes = items;
         notifyDataSetChanged();
+        updateTitle();
     }
 
     @Override
@@ -195,6 +196,7 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
             return true;
         } else if (item.getItemId() == R.id.select_all_below) {
             setSelected(longPressedPosition + 1, getItemCount(), true);
+            shouldSelectLazyLoadedItems = true;
             return true;
         }
         return false;

--- a/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
@@ -195,8 +195,8 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
             setSelected(0, longPressedPosition, true);
             return true;
         } else if (item.getItemId() == R.id.select_all_below) {
-            setSelected(longPressedPosition + 1, getItemCount(), true);
             shouldSelectLazyLoadedItems = true;
+            setSelected(longPressedPosition + 1, getItemCount(), true);
             return true;
         }
         return false;

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SelectableAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SelectableAdapter.java
@@ -20,6 +20,7 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
     private final HashSet<Long> selectedIds = new HashSet<>();
     private final Activity activity;
     private OnSelectModeListener onSelectModeListener;
+    boolean shouldSelectLazyLoadedItems = false;
 
     public SelectableAdapter(Activity activity) {
         this.activity = activity;
@@ -34,6 +35,7 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
             onSelectModeListener.onStartSelectMode();
         }
 
+        shouldSelectLazyLoadedItems = false;
         selectedIds.clear();
         selectedIds.add(getItemId(pos));
         notifyDataSetChanged();
@@ -56,9 +58,10 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
             @Override
             public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
                 if (item.getItemId() == R.id.select_toggle) {
-                    boolean allSelected = selectedIds.size() == getItemCount();
-                    setSelected(0, getItemCount(), !allSelected);
-                    toggleSelectAllIcon(item, !allSelected);
+                    boolean selectAll = selectedIds.size() != getItemCount();
+                    shouldSelectLazyLoadedItems = selectAll;
+                    setSelected(0, getItemCount(), selectAll);
+                    toggleSelectAllIcon(item, selectAll);
                     updateTitle();
                     return true;
                 }
@@ -69,6 +72,7 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
             public void onDestroyActionMode(ActionMode mode) {
                 callOnEndSelectMode();
                 actionMode = null;
+                shouldSelectLazyLoadedItems = false;
                 selectedIds.clear();
                 notifyDataSetChanged();
             }
@@ -147,7 +151,7 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
         }
     }
 
-    private void updateTitle() {
+    void updateTitle() {
         if (actionMode == null) {
             return;
         }
@@ -164,6 +168,10 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
         if (onSelectModeListener != null) {
             onSelectModeListener.onEndSelectMode();
         }
+    }
+
+    public boolean shouldSelectLazyLoadedItems() {
+        return shouldSelectLazyLoadedItems;
     }
 
     public interface OnSelectModeListener {

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SelectableAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SelectableAdapter.java
@@ -15,12 +15,14 @@ import java.util.HashSet;
 /**
  * Used by Recyclerviews that need to provide ability to select items.
  */
-abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<T> {
+public abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<T> {
+    public static final int COUNT_AUTOMATICALLY = -1;
     private ActionMode actionMode;
     private final HashSet<Long> selectedIds = new HashSet<>();
     private final Activity activity;
     private OnSelectModeListener onSelectModeListener;
     boolean shouldSelectLazyLoadedItems = false;
+    private int totalNumberOfItems = COUNT_AUTOMATICALLY;
 
     public SelectableAdapter(Activity activity) {
         this.activity = activity;
@@ -155,9 +157,17 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
         if (actionMode == null) {
             return;
         }
+        int totalCount = getItemCount();
+        int selectedCount = selectedIds.size();
+        if (totalNumberOfItems != COUNT_AUTOMATICALLY) {
+            totalCount = totalNumberOfItems;
+            if (shouldSelectLazyLoadedItems) {
+                selectedCount += (totalNumberOfItems - getItemCount());
+            }
+        }
         actionMode.setTitle(activity.getResources()
                 .getQuantityString(R.plurals.num_selected_label, selectedIds.size(),
-                selectedIds.size(), getItemCount()));
+                selectedCount, totalCount));
     }
 
     public void setOnSelectModeListener(OnSelectModeListener onSelectModeListener) {
@@ -172,6 +182,14 @@ abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> extends Recy
 
     public boolean shouldSelectLazyLoadedItems() {
         return shouldSelectLazyLoadedItems;
+    }
+
+    /**
+     * Sets the total number of items that could be lazy-loaded.
+     * Can also be set to {@link #COUNT_AUTOMATICALLY} to simply use {@link #getItemCount}
+     */
+    public void setTotalNumberOfItems(int totalNumberOfItems) {
+        this.totalNumberOfItems = totalNumberOfItems;
     }
 
     public interface OnSelectModeListener {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -66,7 +66,6 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         menu.findItem(R.id.filter_items).setVisible(true);
-        menu.findItem(R.id.mark_all_read_item).setVisible(true);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -102,7 +102,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
 
     @NonNull
     @Override
-    protected List<FeedItem> loadMoreData() {
+    protected List<FeedItem> loadMoreData(int page) {
         return DBReader.getRecentlyPublishedEpisodes((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE, feedItemFilter);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -105,4 +105,9 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     protected List<FeedItem> loadMoreData() {
         return DBReader.getRecentlyPublishedEpisodes((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE, feedItemFilter);
     }
+
+    @Override
+    protected int loadTotalItemCount() {
+        return DBReader.getTotalEpisodeCount(feedItemFilter);
+    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -115,8 +115,8 @@ public class CompletedDownloadsFragment extends Fragment
             }
         });
         speedDialView.setOnActionSelectedListener(actionItem -> {
-            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), adapter.getSelectedItems())
-                    .handleAction(actionItem.getId());
+            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItem.getId())
+                    .handleAction(adapter.getSelectedItems());
             adapter.endSelectMode();
             return true;
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -137,21 +137,6 @@ public abstract class EpisodesListFragment extends Fragment implements EpisodeIt
         if (itemId == R.id.refresh_item) {
             AutoUpdateManager.runImmediate(requireContext());
             return true;
-        } else if (itemId == R.id.mark_all_read_item) {
-            ConfirmationDialog markAllReadConfirmationDialog = new ConfirmationDialog(getActivity(),
-                    R.string.mark_all_read_label,
-                    R.string.mark_all_read_confirmation_msg) {
-
-                @Override
-                public void onConfirmButtonPressed(DialogInterface dialog) {
-                    dialog.dismiss();
-                    DBWriter.markAllItemsRead();
-                    ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                            R.string.mark_all_read_msg, Toast.LENGTH_SHORT);
-                }
-            };
-            markAllReadConfirmationDialog.createNewDialog().show();
-            return true;
         } else if (itemId == R.id.remove_all_inbox_item) {
             ConfirmationDialog removeAllNewFlagsConfirmationDialog = new ConfirmationDialog(getActivity(),
                     R.string.remove_all_inbox_label,

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -283,6 +283,9 @@ public abstract class EpisodesListFragment extends Fragment implements EpisodeIt
                     }
                     episodes.addAll(data);
                     onFragmentLoaded(episodes);
+                    if (listAdapter.shouldSelectLazyLoadedItems()) {
+                        listAdapter.setSelected(episodes.size() - data.size(), episodes.size(), true);
+                    }
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)),
                     () -> {
                         recyclerView.post(() -> isLoadingMore = false); // Make sure to not always load 2 pages at once

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -246,8 +246,8 @@ public abstract class EpisodesListFragment extends Fragment implements EpisodeIt
             }
         });
         speedDialView.setOnActionSelectedListener(actionItem -> {
-            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), listAdapter.getSelectedItems())
-                    .handleAction(actionItem.getId());
+            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItem.getId())
+                    .handleAction(listAdapter.getSelectedItems());
             listAdapter.endSelectMode();
             return true;
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
@@ -48,7 +48,6 @@ public class FavoriteEpisodesFragment extends EpisodesListFragment {
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         menu.findItem(R.id.filter_items).setVisible(false);
-        menu.findItem(R.id.mark_all_read_item).setVisible(false);
     }
 
     @NonNull

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
@@ -99,7 +99,7 @@ public class FavoriteEpisodesFragment extends EpisodesListFragment {
 
     @NonNull
     @Override
-    protected List<FeedItem> loadMoreData() {
+    protected List<FeedItem> loadMoreData(int page) {
         return DBReader.getFavoriteItemsList((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FavoriteEpisodesFragment.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.view.viewholder.EpisodeItemViewHolder;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -100,5 +101,10 @@ public class FavoriteEpisodesFragment extends EpisodesListFragment {
     @Override
     protected List<FeedItem> loadMoreData() {
         return DBReader.getFavoriteItemsList((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE);
+    }
+
+    @Override
+    protected int loadTotalItemCount() {
+        return DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.IS_FAVORITE));
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -197,8 +197,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             }
         });
         speedDialBinding.fabSD.setOnActionSelectedListener(actionItem -> {
-            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), adapter.getSelectedItems())
-                    .handleAction(actionItem.getId());
+            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItem.getId())
+                    .handleAction(adapter.getSelectedItems());
             adapter.endSelectMode();
             return true;
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
@@ -116,7 +116,7 @@ public class InboxFragment extends EpisodesListFragment implements Toolbar.OnMen
 
     @NonNull
     @Override
-    protected List<FeedItem> loadMoreData() {
+    protected List<FeedItem> loadMoreData(int page) {
         return DBReader.getNewItemsList((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
@@ -67,6 +67,9 @@ public class InboxFragment extends EpisodesListFragment implements Toolbar.OnMen
         SwipeActions swipeActions = new SwipeActions(this, TAG).attachTo(recyclerView);
         swipeActions.setFilter(new FeedItemFilter(FeedItemFilter.NEW));
 
+        speedDialView.removeActionItemById(R.id.mark_unread_batch);
+        speedDialView.removeActionItemById(R.id.remove_from_queue_batch);
+        speedDialView.removeActionItemById(R.id.delete_batch);
         return inboxContainer;
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
@@ -119,4 +119,9 @@ public class InboxFragment extends EpisodesListFragment implements Toolbar.OnMen
     protected List<FeedItem> loadMoreData() {
         return DBReader.getNewItemsList((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE);
     }
+
+    @Override
+    protected int loadTotalItemCount() {
+        return DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW));
+    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -505,8 +505,8 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
             }
         });
         speedDialView.setOnActionSelectedListener(actionItem -> {
-            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), recyclerAdapter.getSelectedItems())
-                    .handleAction(actionItem.getId());
+            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItem.getId())
+                    .handleAction(recyclerAdapter.getSelectedItems());
             recyclerAdapter.endSelectMode();
             return true;
         });

--- a/app/src/main/java/de/danoeh/antennapod/fragment/actions/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/actions/EpisodeMultiSelectActionHandler.java
@@ -103,12 +103,15 @@ public class EpisodeMultiSelectActionHandler {
 
     private void showMessage(@PluralsRes int msgId, int numItems) {
         totalNumItems += numItems;
-        String text = activity.getResources().getQuantityString(msgId, totalNumItems, totalNumItems);
-        if (snackbar != null) {
-            snackbar.setText(text);
-        } else {
-            snackbar = activity.showSnackbarAbovePlayer(text, Snackbar.LENGTH_LONG);
-        }
+        activity.runOnUiThread(() -> {
+            String text = activity.getResources().getQuantityString(msgId, totalNumItems, totalNumItems);
+            if (snackbar != null) {
+                snackbar.setText(text);
+                snackbar.show(); // Resets the timeout
+            } else {
+                snackbar = activity.showSnackbarAbovePlayer(text, Snackbar.LENGTH_LONG);
+            }
+        });
     }
 
     private long[] getSelectedIds(List<FeedItem> items) {

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedMenuHandler.java
@@ -1,13 +1,11 @@
 package de.danoeh.antennapod.menuhandler;
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import androidx.annotation.NonNull;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.storage.DBTasks;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.core.util.IntentUtils;
@@ -56,19 +54,6 @@ public class FeedMenuHandler {
             DBTasks.forceRefreshCompleteFeed(context, selectedFeed);
         } else if (itemId == R.id.sort_items) {
             showSortDialog(context, selectedFeed);
-        } else if (itemId == R.id.mark_all_read_item) {
-            ConfirmationDialog conDialog = new ConfirmationDialog(context,
-                    R.string.mark_all_read_label,
-                    R.string.mark_all_read_feed_confirmation_msg) {
-
-                @Override
-                public void onConfirmButtonPressed(
-                        DialogInterface dialog) {
-                    dialog.dismiss();
-                    DBWriter.markFeedRead(selectedFeed.getId());
-                }
-            };
-            conDialog.createNewDialog().show();
         } else if (itemId == R.id.visit_website_item) {
             IntentUtils.openInBrowser(context, selectedFeed.getLink());
         } else if (itemId == R.id.share_item) {

--- a/app/src/main/res/layout/all_episodes_fragment.xml
+++ b/app/src/main/res/layout/all_episodes_fragment.xml
@@ -2,9 +2,9 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/txtvInformation"
@@ -23,17 +23,17 @@
         android:layout_below="@+id/txtvInformation"
         android:layout_above="@id/loadingMore">
 
-            <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
-                android:id="@android:id/list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="0dp"
-                android:layout_marginBottom="0dp"
-                android:paddingTop="@dimen/list_vertical_padding"
-                android:paddingBottom="@dimen/list_vertical_padding"
-                android:paddingHorizontal="@dimen/additional_horizontal_spacing"
-                tools:itemCount="13"
-                tools:listitem="@layout/feeditemlist_item" />
+        <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
+            android:id="@android:id/list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="0dp"
+            android:layout_marginBottom="0dp"
+            android:paddingTop="@dimen/list_vertical_padding"
+            android:paddingBottom="@dimen/list_vertical_padding"
+            android:paddingHorizontal="@dimen/additional_horizontal_spacing"
+            tools:itemCount="13"
+            tools:listitem="@layout/feeditemlist_item" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
@@ -45,7 +45,7 @@
         android:indeterminateOnly="true"
         android:visibility="gone"
         android:layout_centerInParent="true"
-        tools:background="@android:color/holo_red_light"/>
+        tools:background="@android:color/holo_red_light" />
 
     <LinearLayout
         android:id="@+id/loadingMore"
@@ -75,5 +75,8 @@
             android:text="@string/loading_more" />
 
     </LinearLayout>
+
+    <include
+        layout="@layout/multi_select_speed_dial" />
 
 </RelativeLayout>

--- a/app/src/main/res/menu/episodes.xml
+++ b/app/src/main/res/menu/episodes.xml
@@ -24,12 +24,4 @@
         android:visible="false"
         custom:showAsAction="ifRoom"/>
 
-    <item
-        android:id="@+id/mark_all_read_item"
-        android:title="@string/mark_all_read_label"
-        android:menuCategory="container"
-        custom:showAsAction="collapseActionView"
-        android:visible="false"
-        android:icon="@drawable/ic_check"/>
-
 </menu>

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -402,6 +402,19 @@ public final class DBReader {
         }
     }
 
+    public static int getTotalEpisodeCount(FeedItemFilter filter) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        try (Cursor cursor = adapter.getTotalEpisodeCountCursor(filter)) {
+            if (cursor.moveToFirst()) {
+                return cursor.getInt(0);
+            }
+            return -1;
+        } finally {
+            adapter.close();
+        }
+    }
+
     /**
      * Loads the playback history from the database. A FeedItem is in the playback history if playback of the correpsonding episode
      * has been completed at least once.

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -732,36 +732,6 @@ public class DBWriter {
     }
 
     /**
-     * Sets the 'read'-attribute of all FeedItems of a specific Feed to PLAYED.
-     *
-     * @param feedId ID of the Feed.
-     */
-    public static Future<?> markFeedRead(final long feedId) {
-        return dbExec.submit(() -> {
-            final PodDBAdapter adapter = PodDBAdapter.getInstance();
-            adapter.open();
-            adapter.setFeedItems(FeedItem.PLAYED, feedId);
-            adapter.close();
-
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-        });
-    }
-
-    /**
-     * Sets the 'read'-attribute of all FeedItems to PLAYED.
-     */
-    public static Future<?> markAllItemsRead() {
-        return dbExec.submit(() -> {
-            final PodDBAdapter adapter = PodDBAdapter.getInstance();
-            adapter.open();
-            adapter.setFeedItems(FeedItem.PLAYED);
-            adapter.close();
-
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-        });
-    }
-
-    /**
      * Sets the 'read'-attribute of all NEW FeedItems to UNPLAYED.
      */
     public static Future<?> removeAllNewFlags() {

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
@@ -752,34 +752,6 @@ public class DbWriterTest {
     }
 
     @Test
-    public void testMarkFeedRead() throws Exception {
-        final int numItems = 10;
-        Feed feed = new Feed("url", null, "title");
-        feed.setItems(new ArrayList<>());
-        for (int i = 0; i < numItems; i++) {
-            FeedItem item = new FeedItem(0, "title " + i, "id " + i, "link " + i,
-                    new Date(), FeedItem.UNPLAYED, feed);
-            feed.getItems().add(item);
-        }
-
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        adapter.setCompleteFeed(feed);
-        adapter.close();
-
-        assertTrue(feed.getId() != 0);
-        for (FeedItem item : feed.getItems()) {
-            assertTrue(item.getId() != 0);
-        }
-
-        DBWriter.markFeedRead(feed.getId()).get(TIMEOUT, TimeUnit.SECONDS);
-        List<FeedItem> loadedItems = DBReader.getFeedItemList(feed);
-        for (FeedItem item : loadedItems) {
-            assertTrue(item.isPlayed());
-        }
-    }
-
-    @Test
     public void testRemoveAllNewFlags() throws Exception {
         final int numItems = 10;
         Feed feed = new Feed("url", null, "title");
@@ -804,34 +776,6 @@ public class DbWriterTest {
         List<FeedItem> loadedItems = DBReader.getFeedItemList(feed);
         for (FeedItem item : loadedItems) {
             assertFalse(item.isNew());
-        }
-    }
-
-    @Test
-    public void testMarkAllItemsReadSameFeed() throws Exception {
-        final int numItems = 10;
-        Feed feed = new Feed("url", null, "title");
-        feed.setItems(new ArrayList<>());
-        for (int i = 0; i < numItems; i++) {
-            FeedItem item = new FeedItem(0, "title " + i, "id " + i, "link " + i,
-                    new Date(), FeedItem.UNPLAYED, feed);
-            feed.getItems().add(item);
-        }
-
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        adapter.setCompleteFeed(feed);
-        adapter.close();
-
-        assertTrue(feed.getId() != 0);
-        for (FeedItem item : feed.getItems()) {
-            assertTrue(item.getId() != 0);
-        }
-
-        DBWriter.markAllItemsRead().get(TIMEOUT, TimeUnit.SECONDS);
-        List<FeedItem> loadedItems = DBReader.getFeedItemList(feed);
-        for (FeedItem item : loadedItems) {
-            assertTrue(item.isPlayed());
         }
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1052,6 +1052,14 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
+    public final Cursor getTotalEpisodeCountCursor(FeedItemFilter filter) {
+        String filterQuery = FeedItemFilterQuery.generateFrom(filter);
+        String whereClause = "".equals(filterQuery) ? "" : " WHERE " + filterQuery;
+        final String query = "SELECT count(" + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + ") FROM " + TABLE_NAME_FEED_ITEMS
+                + JOIN_FEED_ITEM_AND_MEDIA + whereClause;
+        return db.rawQuery(query, null);
+    }
+
     public Cursor getDownloadedItemsCursor() {
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
                 + "WHERE " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOADED + " > 0";

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
@@ -34,6 +34,8 @@ public class FeedItemFilterQuery {
             statements.add(keyRead + " = 1 ");
         } else if (filter.showUnplayed) {
             statements.add(" NOT " + keyRead + " = 1 "); // Match "New" items (read = -1) as well
+        } else if (filter.showNew) {
+            statements.add(keyRead + " = -1 ");
         }
         if (filter.showPaused) {
             statements.add(" (" + keyPosition + " NOT NULL AND " + keyPosition + " > 0 " + ") ");

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -152,10 +152,6 @@
     <string name="new_episode_notification_group_text">Your subscriptions have new episodes.</string>
 
     <!-- Actions on feeds -->
-    <string name="mark_all_read_label">Mark all as played</string>
-    <string name="mark_all_read_msg">Marked all Episodes as played</string>
-    <string name="mark_all_read_confirmation_msg">Please confirm that you want to mark all episodes as being played.</string>
-    <string name="mark_all_read_feed_confirmation_msg">Please confirm that you want to mark all episodes in this podcast as being played.</string>
     <string name="remove_all_inbox_label">Remove all from inbox</string>
     <string name="removed_all_inbox_msg">Removed all from inbox</string>
     <string name="remove_all_inbox_confirmation_msg">Please confirm that you want to remove all from the inbox.</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -155,6 +155,8 @@
     <string name="remove_all_inbox_label">Remove all from inbox</string>
     <string name="removed_all_inbox_msg">Removed all from inbox</string>
     <string name="remove_all_inbox_confirmation_msg">Please confirm that you want to remove all from the inbox.</string>
+    <string name="multi_select_mark_played_confirmation">Please confirm that you want to mark all selected items as played.</string>
+    <string name="multi_select_mark_unplayed_confirmation">Please confirm that you want to mark all selected items as unplayed.</string>
     <string name="show_info_label">Show information</string>
     <string name="show_feed_settings_label">Show podcast settings</string>
     <string name="feed_settings_label">Podcast settings</string>


### PR DESCRIPTION
Closes #4971

Todo: Handle lazy loading

- [x] When having pressed "select all", newly loaded items should already be checked.
- [x] When having pressed "select all below", newly loaded items should already be checked.
- [x] When selecting an action, all items (even those not shown) should be changed according to the action when "select all" was used.
- [x] Total number of episodes in the title bar is wrong.