### PR TITLE
Remove Gradle plugins that are no longer needed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id('com.android.application')
-    id('com.getkeepsafe.dexcount')
     id('com.github.triplet.play') version '3.7.0-agp4.2' apply false
 }
 apply from: "../common.gradle"
@@ -37,27 +36,10 @@ android {
         releaseConfig {
             enableV1Signing true
             enableV2Signing true
-
-            if (project.hasProperty("releaseStoreFile")) {
-                storeFile file(releaseStoreFile)
-            } else {
-                storeFile file("keystore")
-            }
-            if (project.hasProperty("releaseStorePassword")) {
-                storePassword releaseStorePassword
-            } else {
-                storePassword "password"
-            }
-            if (project.hasProperty("releaseKeyAlias")) {
-                keyAlias releaseKeyAlias
-            } else {
-                keyAlias "alias"
-            }
-            if (project.hasProperty("releaseKeyPassword")) {
-                keyPassword releaseKeyPassword
-            } else {
-                keyPassword "password"
-            }
+            storeFile file(project.getProperties().getOrDefault("releaseStoreFile", "keystore"))
+            storePassword project.getProperties().getOrDefault("releaseStorePassword", "password")
+            keyAlias project.getProperties().getOrDefault("releaseKeyAlias", "alias")
+            keyPassword project.getProperties().getOrDefault("releaseKeyPassword", "password")
         }
     }
 
@@ -65,17 +47,11 @@ android {
         debug {
             applicationIdSuffix ".debug"
             resValue "string", "provider_authority", "de.danoeh.antennapod.debug.provider"
-
-            dexcount {
-                if (project.hasProperty("enableDexcountInDebug")) {
-                    runOnEachPackage = enableDexcountInDebug.toBoolean()
-                } else { // default to not running dexcount
-                    runOnEachPackage = false
-                }
-            }
+            resValue "string", "application_id", "de.danoeh.antennapod.debug"
         }
         release {
             resValue "string", "provider_authority", "de.danoeh.antennapod.provider"
+            resValue "string", "application_id", "de.danoeh.antennapod"
             minifyEnabled true
             shrinkResources true
             signingConfig signingConfigs.releaseConfig
@@ -187,8 +163,3 @@ task copyLicense(type: Copy) {
 }
 
 preBuild.dependsOn copyLicense
-
-apply plugin: 'de.timfreiheit.resourceplaceholders.plugin'
-resourcePlaceholders {
-    files = ['xml/shortcuts.xml']
-}

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="${applicationId}">
+            android:targetPackage="@string/application_id">
             <extra
                 android:name="fragment_tag"
                 android:value="QueueFragment" />
@@ -23,7 +23,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="${applicationId}">
+            android:targetPackage="@string/application_id">
             <extra
                 android:name="fragment_tag"
                 android:value="EpisodesFragment" />
@@ -38,7 +38,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="${applicationId}">
+            android:targetPackage="@string/application_id">
             <extra
                 android:name="fragment_tag"
                 android:value="SubscriptionFragment" />
@@ -53,7 +53,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="${applicationId}">
+            android:targetPackage="@string/application_id">
             <extra
                 android:name="refresh_on_start"
                 android:value="true" />

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:3.0.1'
-        classpath 'de.timfreiheit.resourceplaceholders:placeholders:0.4'
         classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.0"
         classpath 'org.codehaus.groovy:groovy-xml:3.0.9'
     }


### PR DESCRIPTION
- We use MultiDex now, so we no longer need dexcount
- We can use a resValue instead of a resourcePlaceholder
- Simplify getting default value of properties