### PR TITLE
Remove old redundant rules from proguard

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -41,15 +41,6 @@
 # for okhttp
 -dontwarn okhttp3.**
 -dontwarn okio.**
--dontwarn javax.annotation.**
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
--dontwarn org.codehaus.mojo.animal_sniffer.*
-
-# for RxJava:
--dontwarn sun.misc.Unsafe
-
-# for retrolambda
--dontwarn java.lang.invoke.*
 
 # greenrobot EventBus
 -keepattributes *Annotation*
@@ -70,12 +61,7 @@
 }
 -dontwarn com.bumptech.glide.load.resource.bitmap.VideoDecoder
 
-# for ViewPageIndicator problems (https://github.com/JakeWharton/ViewPagerIndicator/issues/366):
--dontwarn com.viewpagerindicator.LinePageIndicator
-
-# for some reason ProGuard removes this file. Why? Unsure.
--keep class de.danoeh.antennapod.core.cast.SwitchableMediaRouteActionProvider { *; }
-
+#### Proguard rules for fyyd client
 # Retrofit 2.0
 -dontwarn retrofit2.**
 -keep class retrofit2.** { *; }
@@ -89,7 +75,7 @@
 # Moshi
 -keep class com.squareup.moshi.** { *; }
 -keep interface com.squareup.moshi.** { *; }
--keep public class retrofit2.adapter.rxjava.RxJavaCallAdapterFactory { *; }
+####
 
 # awaitility
 -dontwarn java.beans.BeanInfo


### PR DESCRIPTION
I removed some old redundant rules from proguard. Explanations are below. No differences when decompiling APKs with APKTool.

---

The following OkHttp rules are consumed by the library itself internally as part of its own proguard file (as of [3.11.0](https://square.github.io/okhttp//changelogs/changelog_3x/#:~:text=New%3A%20Embed%20R8/ProGuard%20rules%20in%20the%20jar.%20These%20will%20be%20applied%20automatically%20by%20R8.)) (These rules were added [before](https://github.com/AntennaPod/AntennaPod/pull/2963/files) the [upgrade to that version](https://github.com/AntennaPod/AntennaPod/commit/e8be5cb8ec18d49c66abd6898a6a55d9f246c7e4).)
```
-dontwarn javax.annotation.**
-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
-dontwarn org.codehaus.mojo.animal_sniffer.*
```

This was an old RxJava rule from before the RxJava 2.x upgrade.
```
# for RxJava:
-dontwarn sun.misc.Unsafe
```

We no longer use retrolambda.
```
# for retrolambda
-dontwarn java.lang.invoke.*
```

Obviously this isn't used anywhere.
```
# for ViewPageIndicator problems (https://github.com/JakeWharton/ViewPagerIndicator/issues/366):
-dontwarn com.viewpagerindicator.LinePageIndicator
```

This was removed during the [chromecast rework](https://github.com/AntennaPod/AntennaPod/pull/5518).
```
# for some reason ProGuard removes this file. Why? Unsure.
-keep class de.danoeh.antennapod.core.cast.SwitchableMediaRouteActionProvider { *; }
```

I marked the place where rules for the Fyyd client were added a long time ago.

Even after upgrading the rule to the correct classpath, this one doesn't affect the outcome of the APK. Please advise whether we could get rid of this one.
```
-keep public class retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory { *; }
```