### PR TITLE
Update google-services-base library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,8 @@ project.ext {
     exoPlayerVersion = "2.14.2"
     audioPlayerVersion = "v2.0.0"
 
-    // Only used for free builds. This version should be updated regularly.
-    conscryptVersion = "2.5.2"
-
     // Google Play build
     wearableSupportVersion = "2.6.0"
-    playServicesVersion = "8.4.0"
 
     //Tests
     awaitilityVersion = "3.1.6"

--- a/net/ssl/build.gradle
+++ b/net/ssl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
 
-    playImplementation 'com.google.android.gms:play-services-base:8.4.0'
+    playImplementation 'com.google.android.gms:play-services-base:17.5.0'
     // This version should be updated regularly.
     freeImplementation 'org.conscrypt:conscrypt-android:2.5.2'
 }

--- a/net/ssl/build.gradle
+++ b/net/ssl/build.gradle
@@ -7,8 +7,10 @@ apply from: "../../playFlavor.gradle"
 dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
+
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
 
-    playImplementation "com.google.android.gms:play-services-base:$playServicesVersion"
-    freeImplementation "org.conscrypt:conscrypt-android:$conscryptVersion"
+    playImplementation 'com.google.android.gms:play-services-base:8.4.0'
+    // This version should be updated regularly.
+    freeImplementation 'org.conscrypt:conscrypt-android:2.5.2'
 }


### PR DESCRIPTION
If you decompile the latest version (2.5.2) and check the properties metadata for this library (play-services-base.properties), you will find that the app already uses version 17.5.0 (due to `play-services-base` being a transitive dependency of the cast-framework library used in `playback/cast`). Therefore, just like #5474, this is just making it "official."

Also, I removed it and Conscrypt from the global declarations because they are only used in `net/ssl`.