### PR TITLE
Update EventBus library

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -42,13 +42,6 @@
 -dontwarn okhttp3.**
 -dontwarn okio.**
 
-# greenrobot EventBus
--keepattributes *Annotation*
--keepclassmembers class * {
-    @org.greenrobot.eventbus.Subscribe <methods>;
-}
--keep enum org.greenrobot.eventbus.ThreadMode { *; }
-
 # android-iconify
 -keep class com.joanzapata.** { *; }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ project.ext {
     glideVersion = "4.8.0"
     okhttpVersion = "3.12.10"
     okioVersion = "1.17.5"
-    eventbusVersion = "3.2.0"
+    eventbusVersion = "3.3.1"
     rxAndroidVersion = "2.1.1"
     rxJavaVersion = "2.2.2"
     iconifyVersion = "2.2.2"


### PR DESCRIPTION
I was doing some more research regarding #5903 for more ProGuard rules to clean up, and I found that the EventBus library also embeds the [ProGuard rules](https://github.com/greenrobot/EventBus/blob/master/eventbus-android/consumer-rules.pro) into itself as of 3.3.0.

See the releases: https://github.com/greenrobot/EventBus/releases

Of course, like last time, I decompiled the APKs with APKTool and diffed them with WinMerge. There was nothing missing.

I also tested it on my device and playback, navigation, etc. all worked normally.
