### PR TITLE
Remove more old rules from proguard

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -4,7 +4,6 @@
 -optimizations !code/allocation/variable
 -optimizationpasses 5
 
--dontpreverify
 -allowaccessmodification
 -dontskipnonpubliclibraryclassmembers
 
@@ -23,15 +22,6 @@
 }
 -keepclassmembers class org.apache.commons.io.IOUtils {
     public static void write(...);
-}
-
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-}
-
--keepclassmembers class * implements android.os.Parcelable {
-    static android.os.Parcelable$Creator CREATOR;
 }
 
 -keep public class org.jsoup.** {


### PR DESCRIPTION
A follow-up to #5903.

I looked at the default settings in `proguard-android.txt` provided by the SDK tools and found that these lines were duplicates. We use the `proguard-android.txt` file as the default in `common.gradle`. The file itself states:

```
# This file is no longer maintained and is not used by new (2.2+) versions of the
# Android plugin for Gradle. Instead, the Android plugin for Gradle generates the
# default rules at build time and stores them in the build directory.
```

The lines I removed in this PR were added around 2012-2013 according to the git blame. They may not have existed in the `proguard-android.txt` file at the time, and were likely meant to be a temporary bugfix until it was added upstream or something.

As with 5903, I decompiled the release APKs with APKTool and diffed them with WinMerge. There were NO differences.