### PR TITLE
Update Glide to 4.13.2

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -52,15 +52,6 @@
 # android-iconify
 -keep class com.joanzapata.** { *; }
 
-# Glide
--keep public class * implements com.bumptech.glide.module.GlideModule
--keep public class * extends com.bumptech.glide.module.AppGlideModule
--keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
-  **[] $VALUES;
-  public *;
-}
--dontwarn com.bumptech.glide.load.resource.bitmap.VideoDecoder
-
 #### Proguard rules for fyyd client
 # Retrofit 2.0
 -dontwarn retrofit2.**

--- a/app/src/main/java/de/danoeh/antennapod/activity/SelectSubscriptionActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/SelectSubscriptionActivity.java
@@ -118,7 +118,7 @@ public class SelectSubscriptionActivity extends AppCompatActivity {
         Glide.with(this)
                 .asBitmap()
                 .load(feed.getImageUrl())
-                .apply(new RequestOptions().override(iconSize, iconSize))
+                .apply(RequestOptions.overrideOf(iconSize, iconSize))
                 .listener(new RequestListener<Bitmap>() {
                     @Override
                     public boolean onLoadFailed(@Nullable GlideException e, Object model,

--- a/app/src/main/java/de/danoeh/antennapod/adapter/ChaptersListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/ChaptersListAdapter.java
@@ -108,7 +108,7 @@ public class ChaptersListAdapter extends RecyclerView.Adapter<ChaptersListAdapte
                         .apply(new RequestOptions()
                                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                                 .dontAnimate()
-                                .transforms(new FitCenter(), new RoundedCorners((int)
+                                .transform(new FitCenter(), new RoundedCorners((int)
                                         (4 * context.getResources().getDisplayMetrics().density))))
                         .into(holder.image);
             }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/itunes/ItunesAdapter.java
@@ -85,7 +85,7 @@ public class ItunesAdapter extends ArrayAdapter<PodcastSearchResult> {
                 .apply(new RequestOptions()
                     .placeholder(R.color.light_gray)
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .transforms(new FitCenter(),
+                    .transform(new FitCenter(),
                             new RoundedCorners((int) (4 * context.getResources().getDisplayMetrics().density)))
                     .dontAnimate())
                 .into(viewHolder.coverView);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CoverFragment.java
@@ -310,7 +310,7 @@ public class CoverFragment extends Fragment {
         RequestOptions options = new RequestOptions()
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
                 .dontAnimate()
-                .transforms(new FitCenter(),
+                .transform(new FitCenter(),
                         new RoundedCorners((int) (16 * getResources().getDisplayMetrics().density)));
 
             RequestBuilder<Drawable> cover = Glide.with(this)

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -293,7 +293,7 @@ public class ItemFragment extends Fragment {
         RequestOptions options = new RequestOptions()
                 .error(R.color.light_gray)
                 .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
-                .transforms(new FitCenter(),
+                .transform(new FitCenter(),
                         new RoundedCorners((int) (4 * getResources().getDisplayMetrics().density)))
                 .dontAnimate();
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ project.ext {
     commonslangVersion = "3.6"
     commonsioVersion = "2.5"
     jsoupVersion = "1.15.1"
-    glideVersion = "4.8.0"
+    glideVersion = "4.13.2"
     okhttpVersion = "3.12.10"
     okioVersion = "1.17.5"
     eventbusVersion = "3.2.0"

--- a/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/glide/ApGlideModule.java
@@ -31,7 +31,7 @@ public class ApGlideModule extends AppGlideModule {
 
     @Override
     public void applyOptions(@NonNull Context context, @NonNull GlideBuilder builder) {
-        builder.setDefaultRequestOptions(new RequestOptions().format(DecodeFormat.PREFER_ARGB_8888));
+        builder.setDefaultRequestOptions(RequestOptions.formatOf(DecodeFormat.PREFER_ARGB_8888));
         @SuppressLint("UsableSpace")
         long spaceAvailable = context.getCacheDir().getUsableSpace();
         long imageCacheSize = (spaceAvailable > 2 * GIGABYTES) ? (250 * MEGABYTES) : (50 * MEGABYTES);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/NewEpisodesNotification.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/NewEpisodesNotification.java
@@ -119,8 +119,9 @@ public class NewEpisodesNotification {
             return Glide.with(context)
                     .asBitmap()
                     .load(feed.getImageUrl())
-                    .apply(RequestOptions.diskCacheStrategyOf(ApGlideSettings.AP_DISK_CACHE_STRATEGY))
-                    .apply(new RequestOptions().centerCrop())
+                    .apply(new RequestOptions()
+                            .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
+                            .centerCrop())
                     .submit(iconSize, iconSize)
                     .get();
         } catch (Throwable tr) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
@@ -72,12 +72,14 @@ public class PlaybackServiceNotificationBuilder {
 
     public void loadIcon() {
         int iconSize = (int) (128 * context.getResources().getDisplayMetrics().density);
+        final RequestOptions options = new RequestOptions()
+                .diskCacheStrategy(ApGlideSettings.AP_DISK_CACHE_STRATEGY)
+                .centerCrop();
         try {
             icon = Glide.with(context)
                     .asBitmap()
                     .load(playable.getImageLocation())
-                    .apply(RequestOptions.diskCacheStrategyOf(ApGlideSettings.AP_DISK_CACHE_STRATEGY))
-                    .apply(new RequestOptions().centerCrop())
+                    .apply(options)
                     .submit(iconSize, iconSize)
                     .get();
         } catch (ExecutionException e) {
@@ -85,8 +87,7 @@ public class PlaybackServiceNotificationBuilder {
                 icon = Glide.with(context)
                         .asBitmap()
                         .load(ImageResourceUtils.getFallbackImageLocation(playable))
-                        .apply(RequestOptions.diskCacheStrategyOf(ApGlideSettings.AP_DISK_CACHE_STRATEGY))
-                        .apply(new RequestOptions().centerCrop())
+                        .apply(options)
                         .submit(iconSize, iconSize)
                         .get();
             } catch (InterruptedException ignore) {


### PR DESCRIPTION
Part of #5925.

Changelog: https://github.com/bumptech/glide/releases

The internal ProGuard rules are consumed automatically as of [4.9.0](https://github.com/bumptech/glide/releases#:~:text=Make%20proguard%20rules%20consumable%20by%20users%20of%20the%20library).

I also did a bit of cleaning.

Tested image loading throughout the app. Everything works as expected.
