### PR TITLE
Use new method of getting screen width for R+

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -17,6 +17,7 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowMetrics;
 import android.widget.EditText;
 import android.widget.Toast;
 
@@ -390,9 +391,14 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     private int getScreenWidth() {
-        DisplayMetrics displayMetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-        return displayMetrics.widthPixels;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            final WindowMetrics windowMetrics = getWindowManager().getCurrentWindowMetrics();
+            return windowMetrics.getBounds().width();
+        } else {
+            final DisplayMetrics displayMetrics = new DisplayMetrics();
+            getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+            return displayMetrics.widthPixels;
+        }
     }
 
     @Override


### PR DESCRIPTION
The original way with using `getDefaultDisplay` is now deprecated but we can't remove it because the new version is only supported on APIs 30 and up (which sucks but what can we do).

Due to some interesting circumstances, I now have access to a physical Android 12 device (Galaxy S10), so testing changes for APIs 30 and 31 will be super easy now that I won't have to use an emulator. I of course still have my Android 10 device (which is my main one).

Anyway, I tested this change on my Android 12 device and compared before-and-after APKs. There was no difference in the drawer width.