### PR TITLE
Use new material playlist drawables

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/NavListAdapter.java
@@ -114,7 +114,7 @@ public class NavListAdapter extends RecyclerView.Adapter<NavListAdapter.Holder>
     private @DrawableRes int getDrawable(String tag) {
         switch (tag) {
             case QueueFragment.TAG:
-                return R.drawable.ic_playlist;
+                return R.drawable.ic_playlist_play;
             case InboxFragment.TAG:
                 return R.drawable.ic_inbox;
             case EpisodesFragment.TAG:

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -476,7 +476,7 @@ public class QueueFragment extends Fragment implements Toolbar.OnMenuItemClickLi
 
         emptyView = new EmptyViewHandler(getContext());
         emptyView.attachToRecyclerView(recyclerView);
-        emptyView.setIcon(R.drawable.ic_playlist);
+        emptyView.setIcon(R.drawable.ic_playlist_play);
         emptyView.setTitle(R.string.no_items_header_label);
         emptyView.setMessage(R.string.no_items_label);
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/AddToQueueSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/AddToQueueSwipeAction.java
@@ -18,7 +18,7 @@ public class AddToQueueSwipeAction implements SwipeAction {
 
     @Override
     public int getActionIcon() {
-        return R.drawable.ic_playlist;
+        return R.drawable.ic_playlist_play;
     }
 
     @Override

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -140,7 +140,7 @@
                     android:layout_width="14sp"
                     android:layout_height="14sp"
                     android:contentDescription="@string/in_queue_label"
-                    app:srcCompat="@drawable/ic_playlist" />
+                    app:srcCompat="@drawable/ic_playlist_play" />
 
                 <TextView
                     android:id="@+id/separatorIcons"

--- a/app/src/main/res/menu/episodes_apply_action_speeddial.xml
+++ b/app/src/main/res/menu/episodes_apply_action_speeddial.xml
@@ -28,7 +28,7 @@
         />
     <item
         android:id="@+id/add_to_queue_batch"
-        android:icon="@drawable/ic_playlist"
+        android:icon="@drawable/ic_playlist_play"
         android:title="@string/add_to_queue_label"
         />
 </menu>

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -435,7 +435,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             throws InterruptedException {
         List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
         if (parentId.equals(getResources().getString(R.string.app_name))) {
-            mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_black,
+            mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_play_black,
                     DBReader.getQueue().size()));
             mediaItems.add(createBrowsableMediaItem(R.string.downloads_label, R.drawable.ic_download_black,
                     DBReader.getDownloadedItems().size()));

--- a/core/src/main/res/drawable-anydpi-v26/ic_playlist_shortcut.xml
+++ b/core/src/main/res/drawable-anydpi-v26/ic_playlist_shortcut.xml
@@ -3,7 +3,7 @@
     <background android:drawable="@color/grey100" />
     <foreground>
         <inset
-            android:drawable="@drawable/ic_playlist_black"
+            android:drawable="@drawable/ic_playlist_play_black"
             android:inset="33.3%" />
     </foreground>
 </adaptive-icon>

--- a/core/src/main/res/drawable/ic_playlist.xml
+++ b/core/src/main/res/drawable/ic_playlist.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?attr/action_icon_color" android:pathData="M19,9L2,9v2h17L19,9zM19,5L2,5v2h17L19,5zM2,15h13v-2L2,13v2zM17,13v6l5,-3 -5,-3z"/>
-</vector>

--- a/core/src/main/res/drawable/ic_playlist_black.xml
+++ b/core/src/main/res/drawable/ic_playlist_black.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M19,9L2,9v2h17L19,9zM19,5L2,5v2h17L19,5zM2,15h13v-2L2,13v2zM17,13v6l5,-3 -5,-3z"/>
-</vector>

--- a/core/src/main/res/drawable/ic_playlist_play.xml
+++ b/core/src/main/res/drawable/ic_playlist_play.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/action_icon_color"
+        android:pathData="M3,10h11v2h-11z" />
+    <path
+        android:fillColor="?attr/action_icon_color"
+        android:pathData="M3,6h11v2h-11z" />
+    <path
+        android:fillColor="?attr/action_icon_color"
+        android:pathData="M3,14h7v2h-7z" />
+    <path
+        android:fillColor="?attr/action_icon_color"
+        android:pathData="M16,13l0,8l6,-4z" />
+</vector>

--- a/core/src/main/res/drawable/ic_playlist_play_black.xml
+++ b/core/src/main/res/drawable/ic_playlist_play_black.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3,10h11v2h-11z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3,6h11v2h-11z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3,14h7v2h-7z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M16,13l0,8l6,-4z" />
+</vector>

--- a/core/src/main/res/drawable/ic_playlist_remove.xml
+++ b/core/src/main/res/drawable/ic_playlist_remove.xml
@@ -1,8 +1,9 @@
-<!-- drawable/playlist_remove.xml -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
     android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <path android:fillColor="?attr/action_icon_color" android:pathData="M2,6V8H14V6H2M2,10V12H11V10H2M14.17,10.76L12.76,12.17L15.59,15L12.76,17.83L14.17,19.24L17,16.41L19.83,19.24L21.24,17.83L18.41,15L21.24,12.17L19.83,10.76L17,13.59L14.17,10.76M2,14V16H11V14H2Z" />
+    <path
+        android:fillColor="?attr/action_icon_color"
+        android:pathData="M14,10H3v2h11V10zM14,6H3v2h11V6zM3,16h7v-2H3V16zM14.41,22L17,19.41L19.59,22L21,20.59L18.41,18L21,15.41L19.59,14L17,16.59L14.41,14L13,15.41L15.59,18L13,20.59L14.41,22z" />
 </vector>

--- a/core/src/main/res/drawable/ic_playlist_shortcut.xml
+++ b/core/src/main/res/drawable/ic_playlist_shortcut.xml
@@ -2,6 +2,6 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@drawable/ic_shortcut_background" />
     <item
-        android:drawable="@drawable/ic_playlist_black"
+        android:drawable="@drawable/ic_playlist_play_black"
         android:gravity="center" />
 </layer-list>


### PR DESCRIPTION
I noticed that the spacing of the old drawables were inconsistent with each other. The old `playlist_play` bars are much longer and the top two are full-length. Meanwhile, the old `playlist_remove` bars were shorter and only the first top bar was full length.

The newer Material icons by Google no longer have these discrepancies.

The `playlist_play` drawable currently used is a design from 2015 (gotten from [materialdesignicons.com](https://materialdesignicons.com/icon/playlist-play), whose Google icons are pretty outdated). This drawable has had several redesigns since then, but has not been updated in AntennaPod.

There originally wasn't a `playlist_remove` drawable by Google, so we had to get a custom-made one from [materialdesignicons.com](https://materialdesignicons.com/icon/playlist-remove). However, Google now officially has their own as of [Nov 2021](https://github.com/google/material-design-icons/blob/master/android/av/playlist_remove/materialicons/black/res/drawable-xxxhdpi/baseline_playlist_remove_black_48.png).

Top is before, bottom is after.

![image](https://user-images.githubusercontent.com/32376686/173252946-c0bba424-6506-4e79-8a28-6e1290d58497.png)

![image](https://user-images.githubusercontent.com/32376686/173253699-293c9100-5c0e-422d-b8d7-693e171688ba.png)
