### PR TITLE
Fix name and location of chart box drawable

### DIFF
--- a/app/src/main/res/menu/subscriptions.xml
+++ b/app/src/main/res/menu/subscriptions.xml
@@ -8,7 +8,7 @@
             android:title="@string/search_label"/>
     <item
             android:id="@+id/action_statistics"
-            android:icon="@drawable/chart_box_outline"
+            android:icon="@drawable/ic_chart_box"
             android:title="@string/statistics_label"
             custom:showAsAction="always" />
     <item

--- a/core/src/main/res/drawable-xxxhdpi/chart_box_outline.xml
+++ b/core/src/main/res/drawable-xxxhdpi/chart_box_outline.xml
@@ -1,7 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="?attr/action_icon_color" android:pathData="M9 17H7V10H9V17M13 17H11V7H13V17M17 17H15V13H17V17M19 19H5V5H19V19.1M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3Z" />
-</vector>

--- a/core/src/main/res/drawable/ic_chart_box.xml
+++ b/core/src/main/res/drawable/ic_chart_box.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/action_icon_color"
+        android:pathData="M19,3L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM19,19L5,19L5,5h14v14zM7,10h2v7L7,17zM11,7h2v10h-2zM15,13h2v4h-2z" />
+</vector>


### PR DESCRIPTION
This came from https://github.com/AntennaPod/AntennaPod/pull/5706

I fixed the incorrect naming convention.

I also moved it from its weirdly chosen `drawable-xxxhdpi` subdirectory into the `drawable` subdirectory with all the other drawables (where it SHOULD be).
