### PR TITLE
Disable sleep timer vibration by default

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
@@ -57,7 +57,7 @@ public class SleepTimerPreferences {
     }
 
     public static boolean vibrate() {
-        return prefs.getBoolean(PREF_VIBRATE, true);
+        return prefs.getBoolean(PREF_VIBRATE, false);
     }
 
     public static void setShakeToReset(boolean shakeToReset) {


### PR DESCRIPTION
Requested on the forum (twice by the same person)
https://forum.antennapod.org/t/sleep-timer-vibrate-default-setting/2147
https://forum.antennapod.org/t/suggested-change-to-default-settings/1411

Opinions? In the last 7 years since #1072 was implemented, nobody else complained about the vibration being on by default. Still, I see that this could be a bit unexpected to have it vibrate.