### PR TITLE
Update Checkstyle, use Temurin distribution

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Checkstyle
         run: |
-          curl -s -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-9.2.1/checkstyle-9.2.1-all.jar > checkstyle.jar
+          curl -s -L https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.3.1/checkstyle-10.3.1-all.jar > checkstyle.jar
           find . -name "*\.java" | xargs java -Dconfig_loc=config/checkstyle -jar checkstyle.jar -c config/checkstyle/checkstyle.xml
       - name: Find PR Base Commit
         id: vars
@@ -26,7 +26,7 @@ jobs:
           echo "::set-output name=branchBaseCommit::$(git merge-base origin/develop HEAD)"
       - name: Diff-Checkstyle
         run: |
-          curl -s -L https://github.com/yangziwen/diff-checkstyle/releases/download/0.0.4/diff-checkstyle.jar > diff-checkstyle.jar
+          curl -s -L https://github.com/yangziwen/diff-check/releases/download/0.0.7/diff-checkstyle.jar > diff-checkstyle.jar
           java -Dconfig_loc=config/checkstyle -jar diff-checkstyle.jar -c config/checkstyle/checkstyle-new-code.xml --git-dir . --base-rev ${{ steps.vars.outputs.branchBaseCommit }}
       - name: XML of changed files
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Build with Gradle
         run: ./gradlew assemblePlayDebugAndroidTest

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ project.ext {
 
 apply plugin: "checkstyle"
 checkstyle {
-    toolVersion '8.24'
+    toolVersion '10.3.1'
 }
 
 task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
- Updated Checkstyle to 10.3.1 ([changelog](https://checkstyle.org/releasenotes.html)) and ran the Checkstyle task
- Replace unmaintained [diff-checkstyle](https://github.com/yangziwen/diff-checkstyle/blob/master/README.md) with [diff-check](https://github.com/yangziwen/diff-check) (by the same person)
- AdoptJDK has moved to Temurin (also known as Adoptium)
