### PR TITLE
Remove iconify references in i18n

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/TagSettingsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/TagSettingsDialog.java
@@ -15,6 +15,7 @@ import androidx.fragment.app.DialogFragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.chip.Chip;
+import com.joanzapata.iconify.Iconify;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.storage.DBReader;
 import de.danoeh.antennapod.core.storage.NavDrawerData;
@@ -81,6 +82,9 @@ public class TagSettingsDialog extends DialogFragment {
             }
         });
 
+        viewBinding.commonTagsInfo.setText(
+                "{fa-info-circle} " + getString(R.string.multi_feed_common_tags_info));
+        Iconify.addIcons(viewBinding.commonTagsInfo);
         if (feedPreferencesList.size() > 1) {
             viewBinding.commonTagsInfo.setVisibility(View.VISIBLE);
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -503,6 +503,9 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         });
         viewBinding.header.butFilter.setOnClickListener(v ->
                 FeedItemFilterDialog.newInstance(feed).show(getChildFragmentManager(), null));
+        viewBinding.header.txtvFailure.setText(
+                "{fa-exclamation-circle} " + getString(R.string.refresh_failed_msg));
+        Iconify.addIcons(viewBinding.header.txtvFailure);
         viewBinding.header.txtvFailure.setOnClickListener(v -> showErrorDetails());
         headerCreated = true;
     }

--- a/app/src/main/res/layout/edit_tags_dialog.xml
+++ b/app/src/main/res/layout/edit_tags_dialog.xml
@@ -14,8 +14,7 @@
         android:gravity="center"
         android:visibility="gone"
         android:textSize="@dimen/text_size_micro"
-        android:paddingBottom="16dp"
-        android:text="@string/multi_feed_common_tags_info" />
+        android:paddingBottom="16dp" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tagsRecycler"

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -149,7 +149,6 @@
         android:gravity="center"
         android:textColor="@color/white"
         android:visibility="gone"
-        android:text="@string/refresh_failed_msg"
         tools:visibility="visible"
         tools:text="(!) Last refresh failed" />
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -173,7 +173,7 @@
     <string name="select_all_above">Select all above</string>
     <string name="select_all_below">Select all below</string>
     <string name="filtered_label">Filtered</string>
-    <string name="refresh_failed_msg">{fa-exclamation-circle} Last Refresh failed. Tap to view details.</string>
+    <string name="refresh_failed_msg">Last refresh failed. Tap to view details.</string>
     <string name="open_podcast">Open Podcast</string>
     <string name="please_wait_for_data">Please wait until the data is loaded</string>
     <string name="updates_disabled_label">Updates disabled</string>
@@ -682,7 +682,7 @@
     <string name="feed_tags_label">Tags</string>
     <string name="feed_tags_summary">Change the tags of this podcast to help organize your subscriptions</string>
     <string name="feed_folders_include_root">Show in main list</string>
-    <string name="multi_feed_common_tags_info">{fa-info-circle} Only common tags from all selected subscriptions are shown. Other tags stay unaffected.</string>
+    <string name="multi_feed_common_tags_info">Only common tags from all selected subscriptions are shown. Other tags stay unaffected.</string>
     <string name="auto_download_settings_label">Auto Download Settings</string>
     <string name="episode_filters_label">Episode Filter</string>
     <string name="episode_filters_description">List of terms used to decide if an episode should be included or excluded when auto downloading</string>


### PR DESCRIPTION
This will make it so that I don't get potential translation conflicts while working on removing this fully.

Also, this shouldn't be baked into the strings in the first place!

Should this be done through Transifex instead? I think it may be simpler to just sync it upstream to Transifex after merging (if that is possible).