### PR TITLE
Clean up some existing viewbinding stuff

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
@@ -51,7 +51,7 @@ import java.util.List;
 public class OpmlImportActivity extends AppCompatActivity {
     private static final String TAG = "OpmlImportBaseActivity";
     @Nullable private Uri uri;
-    OpmlSelectionBinding viewBinding;
+    private OpmlSelectionBinding viewBinding;
     private ArrayAdapter<String> listAdapter;
     private MenuItem selectAll;
     private MenuItem deselectAll;

--- a/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PreferenceActivity.java
@@ -38,6 +38,7 @@ import de.danoeh.antennapod.fragment.preferences.UserInterfacePreferencesFragmen
 public class PreferenceActivity extends AppCompatActivity implements SearchPreferenceResultListener {
     private static final String FRAGMENT_TAG = "tag_preferences";
     public static final String OPEN_AUTO_DOWNLOAD_SETTINGS = "OpenAutoDownloadSettings";
+    private SettingsActivityBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,12 +50,12 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             ab.setDisplayHomeAsUpEnabled(true);
         }
 
-        final SettingsActivityBinding binding = SettingsActivityBinding.inflate(getLayoutInflater());
+        binding = SettingsActivityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
         if (getSupportFragmentManager().findFragmentByTag(FRAGMENT_TAG) == null) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.settingsContainer, new MainPreferencesFragment(), FRAGMENT_TAG)
+                    .replace(binding.settingsContainer.getId(), new MainPreferencesFragment(), FRAGMENT_TAG)
                     .commit();
         }
         Intent intent = getIntent();
@@ -121,7 +122,8 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
             startActivity(intent);
         } else {
-            getSupportFragmentManager().beginTransaction().replace(R.id.settingsContainer, fragment)
+            getSupportFragmentManager().beginTransaction()
+                    .replace(binding.settingsContainer.getId(), fragment)
                     .addToBackStack(getString(getTitleOfPage(screen))).commit();
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/dialog/RenameItemDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/RenameItemDialog.java
@@ -6,7 +6,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
-import android.view.View;
+import android.view.LayoutInflater;
 import androidx.appcompat.app.AlertDialog;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.storage.NavDrawerData;
@@ -37,16 +37,15 @@ public class RenameItemDialog {
             return;
         }
 
-        View content = View.inflate(activity, R.layout.edit_text_dialog, null);
-        EditTextDialogBinding alertViewBinding = EditTextDialogBinding.bind(content);
+        final EditTextDialogBinding binding = EditTextDialogBinding.inflate(LayoutInflater.from(activity));
         String title = feed != null ? feed.getTitle() : drawerItem.getTitle();
 
-        alertViewBinding.urlEditText.setText(title);
+        binding.urlEditText.setText(title);
         AlertDialog dialog = new AlertDialog.Builder(activity)
-                .setView(content)
+                .setView(binding.getRoot())
                 .setTitle(feed != null ? R.string.rename_feed_label : R.string.rename_tag_label)
                 .setPositiveButton(android.R.string.ok, (d, input) -> {
-                    String newTitle = alertViewBinding.urlEditText.getText().toString();
+                    String newTitle = binding.urlEditText.getText().toString();
                     if (feed != null) {
                         feed.setCustomTitle(newTitle);
                         DBWriter.setFeedCustomTitle(feed);
@@ -60,7 +59,7 @@ public class RenameItemDialog {
 
         // To prevent cancelling the dialog on button click
         dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(
-                (view) -> alertViewBinding.urlEditText.setText(title));
+                (view) -> binding.urlEditText.setText(title));
     }
 
     private void renameTag(String title) {

--- a/app/src/main/java/de/danoeh/antennapod/dialog/ShareDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/ShareDialog.java
@@ -23,7 +23,7 @@ public class ShareDialog extends BottomSheetDialogFragment {
     private FeedItem item;
     private SharedPreferences prefs;
 
-    ShareEpisodeDialogBinding viewBinding;
+    private ShareEpisodeDialogBinding viewBinding;
 
     public ShareDialog() {
         // Empty constructor required for DialogFragment

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AddFeedFragment.java
@@ -21,7 +21,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.Toolbar;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.Fragment;
 import com.google.android.material.snackbar.Snackbar;
@@ -69,15 +68,14 @@ public class AddFeedFragment extends Fragment {
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
-        viewBinding = AddfeedBinding.inflate(getLayoutInflater());
+        viewBinding = AddfeedBinding.inflate(inflater);
         activity = (MainActivity) getActivity();
 
-        Toolbar toolbar = viewBinding.toolbar;
         displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
         if (savedInstanceState != null) {
             displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
         }
-        ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
+        ((MainActivity) getActivity()).setupToolbarToggle(viewBinding.toolbar, displayUpArrow);
 
         viewBinding.searchItunesButton.setOnClickListener(v
                 -> activity.loadChildFragment(OnlineSearchFragment.newInstance(ItunesPodcastSearcher.class)));
@@ -136,21 +134,20 @@ public class AddFeedFragment extends Fragment {
     private void showAddViaUrlDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
         builder.setTitle(R.string.add_podcast_by_url);
-        View content = View.inflate(getContext(), R.layout.edit_text_dialog, null);
-        EditTextDialogBinding alertViewBinding = EditTextDialogBinding.bind(content);
-        alertViewBinding.urlEditText.setHint(R.string.add_podcast_by_url_hint);
+        final EditTextDialogBinding dialogBinding = EditTextDialogBinding.inflate(getLayoutInflater());
+        dialogBinding.urlEditText.setHint(R.string.add_podcast_by_url_hint);
 
         ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
         final ClipData clipData = clipboard.getPrimaryClip();
         if (clipData != null && clipData.getItemCount() > 0 && clipData.getItemAt(0).getText() != null) {
             final String clipboardContent = clipData.getItemAt(0).getText().toString();
             if (clipboardContent.trim().startsWith("http")) {
-                alertViewBinding.urlEditText.setText(clipboardContent.trim());
+                dialogBinding.urlEditText.setText(clipboardContent.trim());
             }
         }
-        builder.setView(alertViewBinding.getRoot());
+        builder.setView(dialogBinding.getRoot());
         builder.setPositiveButton(R.string.confirm_label,
-                (dialog, which) -> addUrl(alertViewBinding.urlEditText.getText().toString()));
+                (dialog, which) -> addUrl(dialogBinding.urlEditText.getText().toString()));
         builder.setNegativeButton(R.string.cancel_label, null);
         builder.show();
     }


### PR DESCRIPTION
I thought I would clean up some things first before I start working on migrating the rest of the codebase over.

[Here](https://developer.android.com/topic/libraries/view-binding#fragments:~:text=Make%20sure%20you%20clean%20up%20any%20references)'s the context for declaring binding as null in `onDestroyView`.

Built and tested on my device, everything works fine.
