### PR TITLE
Simplify updating refresh menu

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -93,7 +93,6 @@ public class SubscriptionFragment extends Fragment
     private TextView feedsFilteredMsg;
     private Toolbar toolbar;
     private String displayedFolder = null;
-    private boolean isUpdatingFeeds = false;
     private boolean displayUpArrow;
 
     private Disposable disposable;
@@ -200,8 +199,8 @@ public class SubscriptionFragment extends Fragment
         int columns = prefs.getInt(PREF_NUM_COLUMNS, getDefaultNumOfColumns());
         toolbar.getMenu().findItem(COLUMN_CHECKBOX_IDS[columns - MIN_NUM_COLUMNS]).setChecked(true);
 
-        isUpdatingFeeds = MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(),
-                R.id.refresh_item, updateRefreshMenuItemChecker);
+        MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item,
+                DownloadService.isRunning && DownloadService.isDownloadingFeeds());
     }
 
     @Override
@@ -407,13 +406,8 @@ public class SubscriptionFragment extends Fragment
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(DownloadEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
-        if (event.hasChangedFeedUpdateStatus(isUpdatingFeeds)) {
-            refreshToolbarState();
-        }
+        refreshToolbarState();
     }
-
-    private final MenuItemUtils.UpdateRefreshMenuItemChecker updateRefreshMenuItemChecker =
-            () -> DownloadService.isRunning && DownloadService.isDownloadingFeeds();
 
     @Override
     public void onEndSelectMode() {

--- a/core/src/main/java/de/danoeh/antennapod/core/menuhandler/MenuItemUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/menuhandler/MenuItemUtils.java
@@ -11,29 +11,19 @@ import de.danoeh.antennapod.core.R;
 public class MenuItemUtils {
 
     /**
-     * Changes the appearance of a MenuItem depending on whether the given UpdateRefreshMenuItemChecker
-     * is refreshing or not. If it returns true, the menu item will be replaced by an indeterminate progress
-     * bar, otherwise the progress bar will be hidden.
-     *
      * @param menu    The menu that the MenuItem belongs to
      * @param resId   The id of the MenuItem
-     * @param checker Is used for checking whether to show the progress indicator or not.
-     * @return The returned value of the UpdateRefreshMenuItemChecker's isRefreshing() method.
      */
-    public static boolean updateRefreshMenuItem(Menu menu, int resId, UpdateRefreshMenuItemChecker checker) {
+    public static void updateRefreshMenuItem(Menu menu, int resId, boolean isRefreshing) {
         // expand actionview if feeds are being downloaded, collapse otherwise
         MenuItem refreshItem = menu.findItem(resId);
-        if (checker.isRefreshing()) {
-            refreshItem.setActionView(R.layout.refresh_action_view);
-            return true;
+        if (isRefreshing) {
+            if (refreshItem.getActionView() == null) {
+                refreshItem.setActionView(R.layout.refresh_action_view);
+            }
         } else {
             refreshItem.setActionView(null);
-            return false;
         }
-    }
-
-    public interface UpdateRefreshMenuItemChecker {
-        boolean isRefreshing();
     }
 
     /**


### PR DESCRIPTION
With the migration in #6001, flickering of the refresh menu got more. This PR reworks the menu, so that the flicker can simply no longer happen because the spinner is not set when it is already there.

Closes #3842