### PR TITLE
Remove "inbox and unplayed" feed counter option

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -112,9 +112,9 @@ public class PreferenceUpgrader {
         if (oldVersion < 2080000) {
             // Migrate drawer feed counter setting to reflect removal of
             // "unplayed and in inbox" (0), by changing it to "unplayed" (2)
-            String feedCounterSetting = prefs.getString("prefDrawerFeedIndicator", "1");
+            String feedCounterSetting = prefs.getString(UserPreferences.PREF_DRAWER_FEED_COUNTER, "1");
             if (feedCounterSetting.equals("0")) {
-                prefs.edit().putString("prefDrawerFeedIndicator", "2").apply();
+                prefs.edit().putString(UserPreferences.PREF_DRAWER_FEED_COUNTER, "2").apply();
             }
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -109,5 +109,12 @@ public class PreferenceUpgrader {
         if (oldVersion < 2050000) {
             prefs.edit().putBoolean(UserPreferences.PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS, true).apply();
         }
+        if (oldVersion < 2070000) {
+            // Migrate drawer feed counter setting to reflect removal of
+            // "unplayed and in inbox" (0), by changing it to "unplayed" (2)
+            if (UserPreferences.getFeedCounterSetting().id == 0) {
+                UserPreferences.setFeedCounterSetting("2");
+            }
+        }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -109,11 +109,12 @@ public class PreferenceUpgrader {
         if (oldVersion < 2050000) {
             prefs.edit().putBoolean(UserPreferences.PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS, true).apply();
         }
-        if (oldVersion < 2070000) {
+        if (oldVersion < 2080000) {
             // Migrate drawer feed counter setting to reflect removal of
             // "unplayed and in inbox" (0), by changing it to "unplayed" (2)
-            if (UserPreferences.getFeedCounterSetting().id == 0) {
-                UserPreferences.setFeedCounterSetting("2");
+            String feedCounterSetting = prefs.getString("prefDrawerFeedIndicator", "1");
+            if (feedCounterSetting.equals("0")) {
+                prefs.edit().putString("prefDrawerFeedIndicator", "2").apply();
             }
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -52,7 +52,7 @@ public class UserPreferences {
     public static final String PREF_THEME = "prefTheme";
     public static final String PREF_HIDDEN_DRAWER_ITEMS = "prefHiddenDrawerItems";
     public static final String PREF_DRAWER_FEED_ORDER = "prefDrawerFeedOrder";
-    private static final String PREF_DRAWER_FEED_COUNTER = "prefDrawerFeedIndicator";
+    public static final String PREF_DRAWER_FEED_COUNTER = "prefDrawerFeedIndicator";
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_USE_EPISODE_COVER = "prefEpisodeCover";
     public static final String PREF_SHOW_TIME_LEFT = "showTimeLeft";

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -243,12 +243,6 @@ public class UserPreferences {
         return FeedCounter.fromOrdinal(Integer.parseInt(value));
     }
 
-    public static void setFeedCounterSetting(String selected) {
-        prefs.edit()
-                .putString(PREF_DRAWER_FEED_COUNTER, selected)
-                .apply();
-    }
-
     /**
      * @return {@code true} if episodes should use their own cover, {@code false}  otherwise
      */

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -243,6 +243,12 @@ public class UserPreferences {
         return FeedCounter.fromOrdinal(Integer.parseInt(value));
     }
 
+    public static void setFeedCounterSetting(String selected) {
+        prefs.edit()
+                .putString(PREF_DRAWER_FEED_COUNTER, selected)
+                .apply();
+    }
+
     /**
      * @return {@code true} if episodes should use their own cover, {@code false}  otherwise
      */

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -174,14 +174,12 @@
     </string-array>
 
     <string-array name="nav_drawer_feed_counter_options">
-        <item>@string/drawer_feed_counter_inbox_unplayed</item>
         <item>@string/drawer_feed_counter_inbox</item>
         <item>@string/drawer_feed_counter_unplayed</item>
         <item>@string/drawer_feed_counter_downloaded</item>
         <item>@string/drawer_feed_counter_none</item>
     </string-array>
     <string-array name="nav_drawer_feed_counter_values">
-        <item>0</item>
         <item>1</item>
         <item>2</item>
         <item>4</item>

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedCounter.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedCounter.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod.model.feed;
 
 public enum FeedCounter {
-    SHOW_NEW_UNPLAYED_SUM(0), // DEPRECATED
     SHOW_NEW(1),
     SHOW_UNPLAYED(2),
     SHOW_NONE(3),

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedCounter.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedCounter.java
@@ -1,7 +1,7 @@
 package de.danoeh.antennapod.model.feed;
 
 public enum FeedCounter {
-    SHOW_NEW_UNPLAYED_SUM(0),
+    SHOW_NEW_UNPLAYED_SUM(0), // DEPRECATED
     SHOW_NEW(1),
     SHOW_UNPLAYED(2),
     SHOW_NONE(3),

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1200,10 +1200,6 @@ public class PodDBAdapter {
     public final Map<Long, Integer> getFeedCounters(FeedCounter setting, long... feedIds) {
         String whereRead;
         switch (setting) {
-            case SHOW_NEW_UNPLAYED_SUM:
-                whereRead = "(" + KEY_READ + "=" + FeedItem.NEW +
-                        " OR " + KEY_READ + "=" + FeedItem.UNPLAYED + ")";
-                break;
             case SHOW_NEW:
                 whereRead = KEY_READ + "=" + FeedItem.NEW;
                 break;

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1204,7 +1204,8 @@ public class PodDBAdapter {
                 whereRead = KEY_READ + "=" + FeedItem.NEW;
                 break;
             case SHOW_UNPLAYED:
-                whereRead = KEY_READ + "=" + FeedItem.UNPLAYED;
+                whereRead = "(" + KEY_READ + "=" + FeedItem.NEW +
+                        " OR " + KEY_READ + "=" + FeedItem.UNPLAYED + ")";
                 break;
             case SHOW_DOWNLOADED:
                 whereRead = KEY_DOWNLOADED + "=1";

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1204,8 +1204,8 @@ public class PodDBAdapter {
                 whereRead = KEY_READ + "=" + FeedItem.NEW;
                 break;
             case SHOW_UNPLAYED:
-                whereRead = "(" + KEY_READ + "=" + FeedItem.NEW +
-                        " OR " + KEY_READ + "=" + FeedItem.UNPLAYED + ")";
+                whereRead = "(" + KEY_READ + "=" + FeedItem.NEW
+                        + " OR " + KEY_READ + "=" + FeedItem.UNPLAYED + ")";
                 break;
             case SHOW_DOWNLOADED:
                 whereRead = KEY_DOWNLOADED + "=1";

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -61,7 +61,6 @@
     <string name="drawer_feed_order_alphabetical">Sort alphabetically</string>
     <string name="drawer_feed_order_last_update">Sort by publication date</string>
     <string name="drawer_feed_order_most_played">Sort by number of played episodes</string>
-    <string name="drawer_feed_counter_inbox_unplayed">Number of unplayed episodes and episodes in the inbox</string>
     <string name="drawer_feed_counter_inbox">Number of episodes in the inbox</string>
     <string name="drawer_feed_counter_unplayed">Number of unplayed episodes</string>
     <string name="drawer_feed_counter_downloaded">Number of downloaded episodes</string>


### PR DESCRIPTION
Fixes #6011

Note that I had to leave the old value in the `FeedCounter` enum, because with that value removed, running `UserPreferences.getFeedCounterSetting()` when the pref is set to `"0"` will result in no match being found (`FeedCounter.fromOrdinal()` will find no item matching `0`).

I'm almost certain there is a better/more elegant way of doing this, so please let me know and I'll make the necessary changes.