### PR TITLE
Use dummy items instead of loading progress bar

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
@@ -52,6 +52,7 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
     private List<NavDrawerData.DrawerItem> listItems;
     private NavDrawerData.DrawerItem selectedItem = null;
     int longPressedPosition = 0; // used to init actionMode
+    private int dummyViews = 0;
 
     public SubscriptionsRecyclerAdapter(MainActivity mainActivity) {
         super(mainActivity);
@@ -95,6 +96,11 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
 
     @Override
     public void onBindViewHolder(@NonNull SubscriptionViewHolder holder, int position) {
+        if (position >= listItems.size()) {
+            holder.selectView.setVisibility(View.GONE);
+            holder.bindDummy();
+            return;
+        }
         NavDrawerData.DrawerItem drawerItem = listItems.get(position);
         boolean isFeed = drawerItem.type == NavDrawerData.DrawerItem.Type.FEED;
         holder.bind(drawerItem);
@@ -157,11 +163,14 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
 
     @Override
     public int getItemCount() {
-        return listItems.size();
+        return listItems.size() + dummyViews;
     }
 
     @Override
     public long getItemId(int position) {
+        if (position >= listItems.size()) {
+            return RecyclerView.NO_ID; // Dummy views
+        }
         return listItems.get(position).id;
     }
 
@@ -200,6 +209,10 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
             }
         }
         return items;
+    }
+
+    public void setDummyViews(int dummyViews) {
+        this.dummyViews = dummyViews;
     }
 
     public void setItems(List<NavDrawerData.DrawerItem> listItems) {
@@ -269,6 +282,17 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
                         .withCoverView(imageView)
                         .load();
             }
+        }
+
+        public void bindDummy() {
+            feedTitle.setText("███████");
+            feedTitle.setVisibility(View.VISIBLE);
+            count.setVisibility(View.GONE);
+            new CoverLoader(mainActivityRef.get())
+                    .withResource(android.R.color.transparent)
+                    .withPlaceholderView(feedTitle, false)
+                    .withCoverView(imageView)
+                    .load();
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QuickFeedDiscoveryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QuickFeedDiscoveryFragment.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.fragment;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import androidx.fragment.app.Fragment;
 
@@ -14,7 +15,6 @@ import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.GridView;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import de.danoeh.antennapod.net.discovery.ItunesTopListLoader;
@@ -41,7 +41,6 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
     private static final String TAG = "FeedDiscoveryFragment";
     private static final int NUM_SUGGESTIONS = 12;
 
-    private ProgressBar progressBar;
     private Disposable disposable;
     private FeedDiscoverAdapter adapter;
     private GridView discoverGridLayout;
@@ -59,7 +58,6 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
                 ((MainActivity) getActivity()).loadChildFragment(new DiscoveryFragment()));
 
         discoverGridLayout = root.findViewById(R.id.discover_grid);
-        progressBar = root.findViewById(R.id.discover_progress_bar);
         errorView = root.findViewById(R.id.discover_error);
         errorTextView = root.findViewById(R.id.discover_error_txtV);
         errorRetry = root.findViewById(R.id.discover_error_retry_btn);
@@ -108,8 +106,6 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
     }
 
     private void loadToplist() {
-        progressBar.setVisibility(View.VISIBLE);
-        discoverGridLayout.setVisibility(View.INVISIBLE);
         errorView.setVisibility(View.GONE);
         errorRetry.setVisibility(View.INVISIBLE);
         poweredByTextView.setVisibility(View.VISIBLE);
@@ -121,7 +117,6 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
         if (countryCode.equals(ItunesTopListLoader.DISCOVER_HIDE_FAKE_COUNTRY_CODE)) {
             errorTextView.setText(R.string.discover_is_hidden);
             errorView.setVisibility(View.VISIBLE);
-            progressBar.setVisibility(View.GONE);
             discoverGridLayout.setVisibility(View.GONE);
             errorRetry.setVisibility(View.GONE);
             poweredByTextView.setVisibility(View.GONE);
@@ -132,20 +127,18 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
                 .subscribe(
                         podcasts -> {
                             errorView.setVisibility(View.GONE);
-                            progressBar.setVisibility(View.GONE);
-                            discoverGridLayout.setVisibility(View.VISIBLE);
                             if (podcasts.size() == 0) {
                                 errorTextView.setText(getResources().getText(R.string.search_status_no_results));
                                 errorView.setVisibility(View.VISIBLE);
                                 discoverGridLayout.setVisibility(View.INVISIBLE);
                             } else {
+                                discoverGridLayout.setVisibility(View.VISIBLE);
                                 adapter.updateData(podcasts);
                             }
                         }, error -> {
                             Log.e(TAG, Log.getStackTraceString(error));
                             errorTextView.setText(error.getLocalizedMessage());
                             errorView.setVisibility(View.VISIBLE);
-                            progressBar.setVisibility(View.GONE);
                             discoverGridLayout.setVisibility(View.INVISIBLE);
                             errorRetry.setVisibility(View.VISIBLE);
                         });
@@ -154,7 +147,7 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
     @Override
     public void onItemClick(AdapterView<?> parent, final View view, int position, long id) {
         PodcastSearchResult podcast = adapter.getItem(position);
-        if (podcast.feedUrl == null) {
+        if (TextUtils.isEmpty(podcast.feedUrl)) {
             return;
         }
         Intent intent = new Intent(getActivity(), OnlineFeedViewActivity.class);

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -220,6 +220,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
                 .withPlaceholderView(placeholder)
                 .withCoverView(cover)
                 .load();
+        hideSeparatorIfNecessary();
     }
 
     private void updateDuration(PlaybackPositionEvent event) {

--- a/app/src/main/res/layout/episodes_list_fragment.xml
+++ b/app/src/main/res/layout/episodes_list_fragment.xml
@@ -32,8 +32,7 @@
         android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/txtvInformation"
-        android:layout_above="@id/loadingMore">
+        android:layout_below="@+id/txtvInformation">
 
         <de.danoeh.antennapod.view.EpisodeItemListRecyclerView
             android:id="@android:id/list"
@@ -48,45 +47,6 @@
             tools:listitem="@layout/feeditemlist_item" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-    <ProgressBar
-        android:id="@+id/progLoading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:indeterminateOnly="true"
-        android:visibility="gone"
-        android:layout_centerInParent="true"
-        tools:background="@android:color/holo_red_light" />
-
-    <LinearLayout
-        android:id="@+id/loadingMore"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:orientation="horizontal"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp"
-        android:visibility="gone"
-        android:gravity="center">
-
-        <ProgressBar
-            android:layout_width="16dp"
-            android:layout_height="16dp"
-            android:gravity="center_horizontal"
-            android:indeterminateOnly="true"
-            tools:background="@android:color/holo_red_light" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:layout_marginStart="4dp"
-            android:text="@string/loading_more" />
-
-    </LinearLayout>
 
     <include
         layout="@layout/multi_select_speed_dial" />

--- a/app/src/main/res/layout/feed_item_list_fragment.xml
+++ b/app/src/main/res/layout/feed_item_list_fragment.xml
@@ -61,14 +61,6 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <ProgressBar
-        android:id="@+id/progLoading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:indeterminateOnly="true"
-        android:visibility="gone" />
-
     <include
         android:id="@+id/more_content"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -49,14 +49,6 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <ProgressBar
-        android:id="@+id/progLoading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:indeterminateOnly="true"
-        android:visibility="visible" />
-
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/subscriptions_add"
         android:layout_width="56dp"

--- a/app/src/main/res/layout/queue_fragment.xml
+++ b/app/src/main/res/layout/queue_fragment.xml
@@ -49,14 +49,6 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <ProgressBar
-        android:id="@+id/progLoading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:indeterminateOnly="true"
-        android:visibility="gone" />
-
     <include
         layout="@layout/multi_select_speed_dial" />
 

--- a/app/src/main/res/layout/quick_feed_discovery.xml
+++ b/app/src/main/res/layout/quick_feed_discovery.xml
@@ -1,98 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:orientation="vertical">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
     <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
         <TextView
-                android:layout_width="0dip"
-                android:layout_height="wrap_content"
-                android:text="@string/discover"
-                android:textSize="18sp"
-                android:layout_marginBottom="8dp"
-                android:layout_weight="1"
-                android:textColor="?android:attr/textColorPrimary"/>
+            android:layout_width="0dip"
+            android:layout_height="wrap_content"
+            android:text="@string/discover"
+            android:textSize="18sp"
+            android:layout_marginBottom="8dp"
+            android:layout_weight="1"
+            android:textColor="?android:attr/textColorPrimary" />
 
         <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:text="@string/discover_more"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:id="@+id/discover_more"/>
+            android:id="@+id/discover_more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:minWidth="0dp"
+            android:text="@string/discover_more"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
+
     </LinearLayout>
 
     <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <de.danoeh.antennapod.ui.common.WrappingGridView
-                android:id="@+id/discover_grid"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:numColumns="4"
-                app:layout_columnWeight="1"
-                app:layout_rowWeight="1"
-                android:scrollbars="none"
-                android:layout_marginTop="8dp"
-                android:layout_centerInParent="true"
-                android:layout_gravity="center_horizontal"/>
-
-        <ProgressBar
-                android:id="@+id/discover_progress_bar"
-                style="?android:attr/progressBarStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_centerInParent="true"
-                android:layout_marginTop="30dp"/>
+            android:id="@+id/discover_grid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:numColumns="4"
+            android:scrollbars="none"
+            android:layout_marginTop="8dp"
+            android:layout_centerInParent="true"
+            android:layout_gravity="center_horizontal"
+            app:layout_columnWeight="1"
+            app:layout_rowWeight="1" />
 
         <LinearLayout
-                android:id="@+id/discover_error"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:gravity="center"
-                android:orientation="vertical">
+            android:id="@+id/discover_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:gravity="center"
+            android:orientation="vertical">
 
             <TextView
-                    android:id="@+id/discover_error_txtV"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:layout_margin="16dp"
-                    android:textSize="@dimen/text_size_small"
-                    tools:text="Error message"
-                    tools:background="@android:color/holo_red_light" />
+                android:id="@+id/discover_error_txtV"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:layout_margin="16dp"
+                android:textSize="@dimen/text_size_small"
+                tools:text="Error message"
+                tools:background="@android:color/holo_red_light" />
 
             <Button
-                    android:id="@+id/discover_error_retry_btn"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="16dp"
-                    android:text="@string/retry_label"
-                    tools:background="@android:color/holo_red_light" />
+                android:id="@+id/discover_error_retry_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@string/retry_label"
+                tools:background="@android:color/holo_red_light" />
+
         </LinearLayout>
 
     </RelativeLayout>
 
     <TextView
-            android:id="@+id/discover_powered_by_itunes"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textColor="?android:attr/textColorTertiary"
-            android:text="@string/discover_powered_by_itunes"
-            android:textSize="12sp"
-            android:layout_gravity="right|end"
-            android:paddingHorizontal="4dp"
-            android:textAlignment="textEnd"/>
+        android:id="@+id/discover_powered_by_itunes"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?android:attr/textColorTertiary"
+        android:text="@string/discover_powered_by_itunes"
+        android:textSize="12sp"
+        android:layout_gravity="right|end"
+        android:paddingHorizontal="4dp"
+        android:textAlignment="textEnd" />
 
 </LinearLayout>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -146,7 +146,6 @@
         <item quantity="one">%d episode</item>
         <item quantity="other">%d episodes</item>
     </plurals>
-    <string name="loading_more">Loading more…</string>
     <string name="episode_notification">Episode Notifications</string>
     <string name="episode_notification_summary">Show a notification when a new episode is released.</string>
     <plurals name="new_episode_notification_message">


### PR DESCRIPTION
Contributes to #5101, removing 2 of the 4 different spinners that we use

<img width="250" src="https://user-images.githubusercontent.com/5811634/187093843-f3c11b46-a0ac-43bb-b846-004edeafaaa4.png" /> <img width="250" src="https://user-images.githubusercontent.com/5811634/187093844-ee1ff798-0bbd-4a47-97f3-7e85ac7e8a71.png" />