### PR TITLE
Database optimizations

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/export/favorites/FavoritesWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/export/favorites/FavoritesWriter.java
@@ -3,13 +3,13 @@ package de.danoeh.antennapod.core.export.favorites;
 import android.content.Context;
 import android.util.Log;
 
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -22,9 +22,6 @@ import de.danoeh.antennapod.core.storage.DBReader;
 /** Writes saved favorites to file. */
 public class FavoritesWriter implements ExportWriter {
     private static final String TAG = "FavoritesWriter";
-
-    private static final int PAGE_LIMIT = 100;
-
     private static final String FAVORITE_TEMPLATE = "html-export-favorites-item-template.html";
     private static final String FEED_TEMPLATE = "html-export-feed-template.html";
     private static final String UTF_8 = "UTF-8";
@@ -45,7 +42,9 @@ public class FavoritesWriter implements ExportWriter {
         InputStream feedTemplateStream = context.getAssets().open(FEED_TEMPLATE);
         String feedTemplate = IOUtils.toString(feedTemplateStream, UTF_8);
 
-        Map<Long, List<FeedItem>> favoriteByFeed = getFeedMap(getFavorites());
+        List<FeedItem> allFavorites = DBReader.getRecentlyPublishedEpisodes(0, Integer.MAX_VALUE,
+                new FeedItemFilter(FeedItemFilter.IS_FAVORITE));
+        Map<Long, List<FeedItem>> favoriteByFeed = getFeedMap(allFavorites);
 
         writer.append(templateParts[0]);
 
@@ -64,23 +63,6 @@ public class FavoritesWriter implements ExportWriter {
         writer.append(templateParts[1]);
 
         Log.d(TAG, "Finished writing document");
-    }
-
-    private List<FeedItem> getFavorites() {
-        int page = 0;
-
-        List<FeedItem> favoritesList = new ArrayList<>();
-        List<FeedItem> favoritesPage;
-        do {
-            favoritesPage = DBReader.getFavoriteItemsList(page * PAGE_LIMIT, PAGE_LIMIT);
-            favoritesList.addAll(favoritesPage);
-            ++page;
-        } while (!favoritesPage.isEmpty() && favoritesPage.size() == PAGE_LIMIT);
-
-        // sort in descending order
-        Collections.sort(favoritesList, (lhs, rhs) -> rhs.getPubDate().compareTo(lhs.getPubDate()));
-
-        return favoritesList;
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -337,33 +337,12 @@ public final class DBReader {
         }
     }
 
-    /**
-     * Loads a list of favorite items.
-     *
-     * @param offset The first episode that should be loaded.
-     * @param limit The maximum number of episodes that should be loaded.
-     * @return A list of FeedItems that are marked as favorite.
-     */
-    public static List<FeedItem> getFavoriteItemsList(int offset, int limit) {
-        Log.d(TAG, "getFavoriteItemsList() called");
-
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        try (Cursor cursor = adapter.getFavoritesCursor(offset, limit)) {
-            List<FeedItem> items = extractItemlistFromCursor(adapter, cursor);
-            loadAdditionalFeedItemListData(items);
-            return items;
-        } finally {
-            adapter.close();
-        }
-    }
-
     private static LongList getFavoriteIDList() {
         Log.d(TAG, "getFavoriteIDList() called");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        try (Cursor cursor = adapter.getFavoritesCursor(0, Integer.MAX_VALUE)) {
+        try (Cursor cursor = adapter.getFavoritesIdsCursor(0, Integer.MAX_VALUE)) {
             LongList favoriteIDs = new LongList(cursor.getCount());
             while (cursor.moveToNext()) {
                 favoriteIDs.add(cursor.getLong(0));

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -971,9 +971,11 @@ public class PodDBAdapter {
      * cursor uses the FEEDITEM_SEL_FI_SMALL selection.
      */
     public final Cursor getQueueCursor() {
-        final String query = SELECT_FEED_ITEMS_AND_MEDIA
-                + " INNER JOIN " + TABLE_NAME_QUEUE
+        final String query = "SELECT " + KEYS_FEED_ITEM_WITHOUT_DESCRIPTION + ", " + KEYS_FEED_MEDIA
+                + " FROM " + TABLE_NAME_QUEUE
+                + " INNER JOIN " + TABLE_NAME_FEED_ITEMS
                 + " ON " + SELECT_KEY_ITEM_ID + " = " + TABLE_NAME_QUEUE + "." + KEY_FEEDITEM
+                +  JOIN_FEED_ITEM_AND_MEDIA
                 + " ORDER BY " + TABLE_NAME_QUEUE + "." + KEY_ID;
         return db.rawQuery(query, null);
     }
@@ -983,9 +985,11 @@ public class PodDBAdapter {
     }
 
     public Cursor getNextInQueue(final FeedItem item) {
-        final String query = SELECT_FEED_ITEMS_AND_MEDIA
-                + "INNER JOIN " + TABLE_NAME_QUEUE
+        final String query = "SELECT " + KEYS_FEED_ITEM_WITHOUT_DESCRIPTION + ", " + KEYS_FEED_MEDIA
+                + " FROM " + TABLE_NAME_QUEUE
+                + " INNER JOIN " + TABLE_NAME_FEED_ITEMS
                 + " ON " + SELECT_KEY_ITEM_ID + " = " + TABLE_NAME_QUEUE + "." + KEY_FEEDITEM
+                +  JOIN_FEED_ITEM_AND_MEDIA
                 + " WHERE Queue.ID > (SELECT Queue.ID FROM Queue WHERE Queue.FeedItem = "
                 +  item.getId()
                 + ")"
@@ -996,9 +1000,11 @@ public class PodDBAdapter {
 
     public final Cursor getPausedQueueCursor(int limit) {
         //playback position > 0 (paused), rank by last played, then rest of queue
-        final String query = SELECT_FEED_ITEMS_AND_MEDIA
-                + " INNER JOIN " + TABLE_NAME_QUEUE
+        final String query = "SELECT " + KEYS_FEED_ITEM_WITHOUT_DESCRIPTION + ", " + KEYS_FEED_MEDIA
+                + " FROM " + TABLE_NAME_QUEUE
+                + " INNER JOIN " + TABLE_NAME_FEED_ITEMS
                 + " ON " + SELECT_KEY_ITEM_ID + " = " + TABLE_NAME_QUEUE + "." + KEY_FEEDITEM
+                +  JOIN_FEED_ITEM_AND_MEDIA
                 + " ORDER BY " + TABLE_NAME_FEED_MEDIA + "."  + KEY_POSITION + ">0 DESC , "
                 + TABLE_NAME_FEED_MEDIA + "." + KEY_LAST_PLAYED_TIME + " DESC , " + TABLE_NAME_QUEUE + "." + KEY_ID
                 + " LIMIT " + limit;

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1005,25 +1005,19 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getFavoritesCursor(int offset, int limit) {
-        final String query = SELECT_FEED_ITEMS_AND_MEDIA
+    public final Cursor getFavoritesIdsCursor(int offset, int limit) {
+        // Way faster than selecting all columns
+        final String query = "SELECT " + TABLE_NAME_FEED_ITEMS + "." + KEY_ID
+                + " FROM " + TABLE_NAME_FEED_ITEMS
                 + " INNER JOIN " + TABLE_NAME_FAVORITES
-                + " ON " + SELECT_KEY_ITEM_ID + " = " + TABLE_NAME_FAVORITES + "." + KEY_FEEDITEM
+                + " ON " + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + " = " + TABLE_NAME_FAVORITES + "." + KEY_FEEDITEM
                 + " ORDER BY " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " DESC"
                 + " LIMIT " + offset + ", " + limit;
         return db.rawQuery(query, null);
     }
 
-    public void setFeedItems(int state) {
-        setFeedItems(Integer.MIN_VALUE, state, 0);
-    }
-
     public void setFeedItems(int oldState, int newState) {
         setFeedItems(oldState, newState, 0);
-    }
-
-    public void setFeedItems(int state, long feedId) {
-        setFeedItems(Integer.MIN_VALUE, state, feedId);
     }
 
     public void setFeedItems(int oldState, int newState, long feedId) {


### PR DESCRIPTION
I noticed that queue loading takes a long time when people have ridiculously long queues. This PR makes it a little faster.

### Before

<img width="600" src="https://user-images.githubusercontent.com/5811634/187507504-abcc2be2-1374-41a7-b5e6-afd12e399713.png" />

Note how getting the list of favorite episodes (to display the star icons) takes quite a significant percentage of the queue loading time. This is because instead of loading only the IDs of favorite episodes, we actually ask the database for all the items' information, and then only use the IDs. In the first commit, I change it to only load the IDs.

### Optimized favorite loading

<img width="600" src="https://user-images.githubusercontent.com/5811634/187508029-4fbfedf9-1180-4304-a7b4-295797025574.png" />

Notice how the favorites list (red arrow) is now only barely visible in the profiling result. The nice thing is that this favorite list is loaded for every single list, so this change makes *all* lists about 10% faster. The other thing that takes a lot of time is loading the queue itself (see the large orange block on the left). Apparently, SQLite's query optimizer is not completely smart here, so I rewrote the query slightly.

- Before: Take all episodes and look for their corresponding media. Then take only those that are in the queue.
- After: Take all episodes. Then filter out only those in the queue. Finally, look for the corresponding media.

That way, the join with `FeedMedia` only needs to be done for the items in the queue, not for all items.

### Optimized queue loading

<img width="600" src="https://user-images.githubusercontent.com/5811634/187509073-3b1879f6-38fb-4648-8174-3a1342e9b557.png" />

This PR has eliminated the two most important bottlenecks in queue loading. The two largest orange blocks in the profiler are gone now :) Queue loading should be about 2 times faster.