### PR TITLE
Remove old preDexLibs code in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,21 +19,6 @@ allprojects {
     }
 }
 
-// Disable predex if requested (we can"t predex in Circle CI
-// See http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance
-// and https://circleci.com/docs/android
-project.ext.preDexLibs = !project.hasProperty("disablePreDex")
-
-subprojects {
-    project.plugins.whenPluginAdded { plugin ->
-        if ("com.android.build.gradle.AppPlugin" == plugin.class.name) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-        } else if ("com.android.build.gradle.LibraryPlugin" == plugin.class.name) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-        }
-    }
-}
-
 project.ext {
     // AndroidX
     annotationVersion = "1.2.0"


### PR DESCRIPTION
Git blame tells me this is from 7 years ago, and seems to only be related to CircleCI. I think we can get rid of this.
