### PR TITLE
Add external-files-path to share provider

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path name="external_storage" path="."/>
+    <external-path name="external_storage" path="." />
+    <external-files-path name="external_file_storage" path="." />
     <files-path name="name" path="." />
 </paths>


### PR DESCRIPTION
Sharing crashes on some devices with
"Failed to find configured root that contains
/storage/XXXX-XXXX/Android/data/de.danoeh.antennapod/files/media/x/y.mp3"

Might fix #6106