### PR TITLE
Fix shortcuts showing 'app not installed'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,11 +47,9 @@ android {
         debug {
             applicationIdSuffix ".debug"
             resValue "string", "provider_authority", "de.danoeh.antennapod.debug.provider"
-            resValue "string", "application_id", "de.danoeh.antennapod.debug"
         }
         release {
             resValue "string", "provider_authority", "de.danoeh.antennapod.provider"
-            resValue "string", "application_id", "de.danoeh.antennapod"
             minifyEnabled true
             shrinkResources true
             signingConfig signingConfigs.releaseConfig

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="@string/application_id">
+            android:targetPackage="de.danoeh.antennapod">
             <extra
                 android:name="fragment_tag"
                 android:value="QueueFragment" />
@@ -23,7 +23,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="@string/application_id">
+            android:targetPackage="de.danoeh.antennapod">
             <extra
                 android:name="fragment_tag"
                 android:value="EpisodesFragment" />
@@ -38,7 +38,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="@string/application_id">
+            android:targetPackage="de.danoeh.antennapod">
             <extra
                 android:name="fragment_tag"
                 android:value="SubscriptionFragment" />
@@ -53,7 +53,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="@string/application_id">
+            android:targetPackage="de.danoeh.antennapod">
             <extra
                 android:name="refresh_on_start"
                 android:value="true" />


### PR DESCRIPTION
New AGP versions no longer use resValues in the shortcuts file. We also cannot use the previous resourceplaceholders plugin (see bfb811d29e611146855f77df5dd97b9fb664cf25) because that plugin does not support recent AGP versions either.

Side-effect:
The shortcuts of the debug version now start the release version.

Fixes #6093
