### PR TITLE
Added "always" mode for shake to reset sleep

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -31,6 +32,7 @@ public class SleepTimerDialog extends DialogFragment {
     private PlaybackController controller;
     private EditText etxtTime;
     private Spinner spTimeUnit;
+    private Spinner spShakeToResetMode;
     private LinearLayout timeSetup;
     private LinearLayout timeDisplay;
     private TextView time;
@@ -71,6 +73,7 @@ public class SleepTimerDialog extends DialogFragment {
 
         etxtTime = content.findViewById(R.id.etxtTime);
         spTimeUnit = content.findViewById(R.id.spTimeUnit);
+        spShakeToResetMode = content.findViewById(R.id.spShakeToResetMode);
         timeSetup = content.findViewById(R.id.timeSetup);
         timeDisplay = content.findViewById(R.id.timeDisplay);
         timeDisplay.setVisibility(View.GONE);
@@ -103,15 +106,33 @@ public class SleepTimerDialog extends DialogFragment {
             imm.showSoftInput(etxtTime, InputMethodManager.SHOW_IMPLICIT);
         }, 100);
 
-        String[] spinnerContent = new String[] {
+        String[] spTimeUnitContent = new String[] {
                 getString(R.string.time_seconds),
                 getString(R.string.time_minutes),
                 getString(R.string.time_hours) };
-        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(getContext(),
-                android.R.layout.simple_spinner_item, spinnerContent);
-        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spTimeUnit.setAdapter(spinnerAdapter);
+        ArrayAdapter<String> spTimeUnitAdapter = new ArrayAdapter<>(getContext(),
+                android.R.layout.simple_spinner_item, spTimeUnitContent);
+        spTimeUnitAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spTimeUnit.setAdapter(spTimeUnitAdapter);
         spTimeUnit.setSelection(SleepTimerPreferences.lastTimerTimeUnit());
+
+        String[] spShakeToResetModeContent = new String[] {
+                getString(R.string.sleep_timer_shake_to_reset_mode_end),
+                getString(R.string.sleep_timer_shake_to_reset_mode_always) };
+        ArrayAdapter<String> spShakeToResetModeAdapter = new ArrayAdapter<>(getContext(),
+                android.R.layout.simple_spinner_item, spShakeToResetModeContent);
+        spShakeToResetModeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spShakeToResetMode.setAdapter(spShakeToResetModeAdapter);
+        spShakeToResetMode.setSelection(SleepTimerPreferences.shakeToResetMode());
+        spShakeToResetMode.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                SleepTimerPreferences.setShakeToResetMode(position);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) { };
+        });
 
         CheckBox cbShakeToReset = content.findViewById(R.id.cbShakeToReset);
         CheckBox cbVibrate = content.findViewById(R.id.cbVibrate);

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -123,11 +123,24 @@
         android:orientation="vertical"
         android:layout_marginTop="8dp">
 
-        <CheckBox
-            android:id="@+id/cbShakeToReset"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/shake_to_reset_label" />
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/cbShakeToReset"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/shake_to_reset_label" />
+
+            <Spinner
+                android:id="@+id/spShakeToResetMode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
 
         <CheckBox
             android:id="@+id/cbVibrate"

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/SleepTimerPreferences.java
@@ -16,12 +16,14 @@ public class SleepTimerPreferences {
     private static final String PREF_TIME_UNIT = "LastTimeUnit";
     private static final String PREF_VIBRATE = "Vibrate";
     private static final String PREF_SHAKE_TO_RESET = "ShakeToReset";
+    private static final String PREF_SHAKE_TO_RESET_MODE = "ShakeToResetMode";
     private static final String PREF_AUTO_ENABLE = "AutoEnable";
 
     private static final TimeUnit[] UNITS = { TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS };
 
     private static final String DEFAULT_VALUE = "15";
     private static final int DEFAULT_TIME_UNIT = 1;
+    private static final int DEFAULT_SHAKE_TO_RESET_MODE = 0;
 
     private static SharedPreferences prefs;
 
@@ -66,6 +68,14 @@ public class SleepTimerPreferences {
 
     public static boolean shakeToReset() {
         return prefs.getBoolean(PREF_SHAKE_TO_RESET, true);
+    }
+
+    public static void setShakeToResetMode(int value) {
+        prefs.edit().putInt(PREF_SHAKE_TO_RESET_MODE, value).apply();
+    }
+
+    public static int shakeToResetMode()  {
+        return prefs.getInt(PREF_SHAKE_TO_RESET_MODE, DEFAULT_SHAKE_TO_RESET_MODE);
     }
 
     public static void setAutoEnable(boolean autoEnable) {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -626,6 +626,8 @@
     </plurals>
     <string name="auto_enable_label">Auto-enable</string>
     <string name="sleep_timer_enabled_label">Sleep timer enabled</string>
+    <string name="sleep_timer_shake_to_reset_mode_end">At end</string>
+    <string name="sleep_timer_shake_to_reset_mode_always">Always</string>
 
     <!-- gpodder.net -->
     <string name="gpodnetauth_login_butLabel">Login</string>


### PR DESCRIPTION
Shaking to reset the sleep timer only at the end of the timer is not always helpful. A mayor use case is to allow shaking all the time. Several podcast and audio book players having the feature available like this, which makes it a lot more handy.
To fulfill this I've added a spinner to allow selection of the reset mode:
![Screenshot_20221027-223437_AntennaPod Debug](https://user-images.githubusercontent.com/29866610/198393163-c79c8f69-4963-4754-8ed9-9c74e2bcc473.jpg)
![Screenshot_20221027-223455_AntennaPod Debug](https://user-images.githubusercontent.com/29866610/198393167-f2019b61-220e-46c1-b4cc-1ff2b284db8a.jpg)
This allows the user to select if shaking should be always detected or only at the end.
