### PR TITLE
Fix Inbox not default screen when set as such

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
@@ -23,7 +23,7 @@ import java.util.List;
  * supports swiping to mark as read.
  */
 public class InboxFragment extends EpisodesListFragment {
-    public static final String TAG = "InboxFragment";
+    public static final String TAG = "NewEpisodesFragment";
     private static final String PREF_NAME = "PrefNewEpisodesFragment";
 
     @NonNull

--- a/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/InboxFragment.java
@@ -23,7 +23,7 @@ import java.util.List;
  * supports swiping to mark as read.
  */
 public class InboxFragment extends EpisodesListFragment {
-    public static final String TAG = "NewEpisodesFragment";
+    public static final String TAG = "InboxFragment";
     private static final String PREF_NAME = "PrefNewEpisodesFragment";
 
     @NonNull

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -268,7 +268,7 @@
     <string-array name="default_page_values">
         <item>HomeFragment</item>
         <item>QueueFragment</item>
-        <item>InboxFragment</item>
+        <item>NewEpisodesFragment</item>
         <item>EpisodesFragment</item>
         <item>SubscriptionFragment</item>
         <item>remember</item>


### PR DESCRIPTION
This PR closes #6167.

# Fixes
* Fixed the tag name of InboxFragment in accordance with its name in ListPreference so that InboxFragment could be named matched with its Preference Name and loaded in `MainActivity::onCreate()`