### PR TITLE
Fixed bug that causes "skip" button to be unresponsive

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -949,7 +949,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 }
 
                 if (nextMedia != null) {
-                    callback.onPlaybackEnded(nextMedia.getMediaType(), !playNextEpisode);
+                    callback.onPlaybackEnded(nextMedia.getMediaType(), false);
                     // setting media to null signals to playMediaObject() that we're taking care of post-playback processing
                     media = null;
                     playMediaObject(nextMedia, false, !nextMedia.localFileAvailable(), playNextEpisode, playNextEpisode);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -939,20 +939,12 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 // is an episode in the queue left.
                 // Start playback immediately if continuous playback is enabled
                 nextMedia = callback.getNextInQueue(currentMedia);
-                boolean playNextEpisode = isPlaying && nextMedia != null;
-                if (playNextEpisode) {
-                    Log.d(TAG, "Playback of next episode will start immediately.");
-                } else if (nextMedia == null) {
-                    Log.d(TAG, "No more episodes available to play");
-                } else {
-                    Log.d(TAG, "Loading next episode, but not playing automatically.");
-                }
-
                 if (nextMedia != null) {
                     callback.onPlaybackEnded(nextMedia.getMediaType(), false);
-                    // setting media to null signals to playMediaObject() that we're taking care of post-playback processing
+                    // setting media to null signals to playMediaObject() that
+                    // we're taking care of post-playback processing
                     media = null;
-                    playMediaObject(nextMedia, false, !nextMedia.localFileAvailable(), playNextEpisode, playNextEpisode);
+                    playMediaObject(nextMedia, false, !nextMedia.localFileAvailable(), isPlaying, isPlaying);
                 }
             }
             if (shouldContinue || toStoppedState) {


### PR DESCRIPTION
This PR is an attempt to fix a bug (#5863) that causes the "skip" button to be unresponsive if the player is paused. Previously, the player would be **stopped** (in `PlaybackService`) if the podcast was previously paused, thus not responding to subsequent "skip" operations. I could be wrong, but I think that "stopping" the player is only necessary if the current podcast is the last podcast in your queue.
Unfortunately, the tests in `PlaybackTest `are 'flaky', so adding new tests is not really possible on my machine.

This is my first contribution to AntennaPod. So if there is anything I can improve, just let me know.
