### PR TITLE
Check Lint recursively from the :app module

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,8 +57,8 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Lint
-        run: ./gradlew lintPlayRelease lintRelease
+      - name: Lint :app module recursively
+        run: ./gradlew :app:lintPlayRelease
       - name: SpotBugs
         run: ./gradlew spotbugsPlayDebug spotbugsDebug 2>&1 | grep -i "spotbugs"
 

--- a/net/discovery/build.gradle
+++ b/net/discovery/build.gradle
@@ -14,11 +14,6 @@ android {
             buildConfigField "String", "PODCASTINDEX_API_SECRET", '"XAaAhk4^2YBsTE33vdbwbZNj82ZRLABDDqFdKe7x"'
         }
     }
-
-    lintOptions {
-        disable 'InvalidPeriodicWorkRequestInterval', 'MissingPermission',
-                'GradleCompatible', 'AppCompatResource', 'QueryPermissionsNeeded'
-    }
 }
 
 dependencies {

--- a/parser/feed/build.gradle
+++ b/parser/feed/build.gradle
@@ -3,12 +3,6 @@ plugins {
 }
 apply from: "../../common.gradle"
 
-android {
-    lintOptions {
-        disable "TrustAllX509TrustManager"
-    }
-}
-
 dependencies {
     implementation project(':model')
 

--- a/ui/glide/build.gradle
+++ b/ui/glide/build.gradle
@@ -4,15 +4,6 @@ plugins {
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
 
-android {
-    lintOptions {
-        disable "InvalidPeriodicWorkRequestInterval", "ObsoleteLintCustomCheck", "DefaultLocale", "UnusedAttribute",
-                "ParcelClassLoader", "CheckResult", "TrustAllX509TrustManager",
-                "StaticFieldLeak", "IconDensities", "IconDuplicates", "MissingPermission", "AppCompatResource",
-                "GradleCompatible", "QueryPermissionsNeeded"
-    }
-}
-
 dependencies {
     implementation project(":model")
     implementation project(":core")

--- a/ui/statistics/build.gradle
+++ b/ui/statistics/build.gradle
@@ -4,13 +4,6 @@ plugins {
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
 
-android {
-    lintOptions {
-        disable "InvalidPeriodicWorkRequestInterval", "MissingPermission", "GradleCompatible",
-                "QueryPermissionsNeeded", "Overdraw", "SetTextI18n", "RtlHardcoded"
-    }
-}
-
 dependencies {
     implementation project(":core")
     implementation project(":event")


### PR DESCRIPTION
instead of checking every module individually. This avoids having to re-state all disabled Lint checks in all parent modules.