### PR TITLE
Target API 31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,10 @@ project.ext {
     awaitilityVersion = "3.1.6"
     junitVersion = "4.13"
     robolectricVersion = "4.5-alpha-1"
-    espressoVersion = "3.2.0"
-    runnerVersion = "1.2.0"
-    rulesVersion = "1.2.0"
+    espressoVersion = "3.5.0"
+    runnerVersion = "1.5.0"
+    rulesVersion = "1.5.0"
+    testCoreVersion = "1.5.0"
 }
 
 apply plugin: "checkstyle"

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ project.ext {
     //Tests
     awaitilityVersion = "3.1.6"
     junitVersion = "4.13"
-    robolectricVersion = "4.5-alpha-1"
+    robolectricVersion = "4.9"
     espressoVersion = "3.5.0"
     runnerVersion = "1.5.0"
     rulesVersion = "1.5.0"

--- a/common.gradle
+++ b/common.gradle
@@ -3,7 +3,7 @@ android {
 
     defaultConfig {
         minSdk 19
-        targetSdk 30
+        targetSdk 31
 
         multiDexEnabled true
         vectorDrawables.useSupportLibrary true

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     playApi "com.google.android.support:wearable:$wearableSupportVersion"
     compileOnly "com.google.android.wearable:wearable:$wearableSupportVersion"
 
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$testCoreVersion"
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation 'org.mockito:mockito-inline:3.5.13'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.blacklist=bcprov-jdk15on
 org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
Espresso needs to be updated because it adds activities without android:exported attribute otherwise, preventing build.

We need to upgrade in order to still upload to Google Play.
