### PR TITLE
Show skip button even if 'continuous playback' is disabled

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceNotificationBuilder.java
@@ -212,17 +212,14 @@ public class PlaybackServiceNotificationBuilder {
         }
         numActions++;
 
-        if (UserPreferences.isFollowQueue()) {
-            PendingIntent skipButtonPendingIntent = getPendingIntentForMediaAction(
-                    KeyEvent.KEYCODE_MEDIA_NEXT, numActions);
-            notification.addAction(R.drawable.ic_notification_skip,
-                    context.getString(R.string.skip_episode_label),
-                    skipButtonPendingIntent);
-            if (UserPreferences.showSkipOnCompactNotification()) {
-                compactActionList.add(numActions);
-            }
-            numActions++;
+        PendingIntent skipButtonPendingIntent = getPendingIntentForMediaAction(
+                KeyEvent.KEYCODE_MEDIA_NEXT, numActions);
+        notification.addAction(R.drawable.ic_notification_skip, context.getString(R.string.skip_episode_label),
+                skipButtonPendingIntent);
+        if (UserPreferences.showSkipOnCompactNotification()) {
+            compactActionList.add(numActions);
         }
+        numActions++;
 
         PendingIntent stopButtonPendingIntent = getPendingIntentForMediaAction(
                 KeyEvent.KEYCODE_MEDIA_STOP, numActions);


### PR DESCRIPTION
It can still be used to skip the rest of an episode and load the next one into the notification/miniplayer. There is no reason to hide the button and instead show no button at all.