### PR TITLE
BackupAgent: Fix OPML restoration

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.core.backup.OpmlBackupAgent;
 import de.danoeh.antennapod.core.event.DownloadEvent;
 import de.danoeh.antennapod.core.menuhandler.MenuItemUtils;
 import de.danoeh.antennapod.core.service.download.DownloadService;
@@ -79,6 +80,8 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
             new Handler(Looper.getMainLooper()).postDelayed(() -> viewBinding.swipeRefresh.setRefreshing(false),
                     getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
         });
+
+        (new OpmlBackupAgent.OpmlBackupHelper(requireContext())).restorePendingOpmlIfAny();
 
         return viewBinding.getRoot();
     }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -839,4 +839,7 @@
     <string name="shortcut_subscription_label">Subscription shortcut</string>
     <string name="shortcut_select_subscription">Select subscription</string>
     <string name="add_shortcut">Add Shortcut</string>
+
+    <!-- Internal data files -->
+    <string name="backup_agent_pending_opml_file" translatable="false">backupAgent.opml</string>
 </resources>


### PR DESCRIPTION
* Handle BackupDataInputStream in the manner described by AOSP.
* Save the restored OPML to be processed on AntennaPod launch. The BackupAgent cannot initiate downloads directly because it is not allowed to launch a foreground service.

<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
