### PR TITLE
Revert back to showing progress bars while loading

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/EpisodeItemListAdapter.java
@@ -39,7 +39,6 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
     private FeedItem longPressedItem;
     int longPressedPosition = 0; // used to init actionMode
     private int dummyViews = 0;
-    private boolean wasEverUpdated = false;
 
     public EpisodeItemListAdapter(MainActivity mainActivity) {
         super(mainActivity);
@@ -52,15 +51,8 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
         notifyDataSetChanged();
     }
 
-    public void showDummyViewsIfNeverUpdated(int dummyViews) {
-        if (!wasEverUpdated) {
-            setDummyViews(dummyViews);
-        }
-    }
-
     public void updateItems(List<FeedItem> items) {
         episodes = items;
-        wasEverUpdated = true;
         notifyDataSetChanged();
         updateTitle();
     }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
@@ -52,8 +52,6 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
     private List<NavDrawerData.DrawerItem> listItems;
     private NavDrawerData.DrawerItem selectedItem = null;
     int longPressedPosition = 0; // used to init actionMode
-    private int dummyViews = 0;
-    private boolean wasEverUpdated = false;
 
     public SubscriptionsRecyclerAdapter(MainActivity mainActivity) {
         super(mainActivity);
@@ -97,11 +95,6 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
 
     @Override
     public void onBindViewHolder(@NonNull SubscriptionViewHolder holder, int position) {
-        if (position >= listItems.size()) {
-            holder.selectView.setVisibility(View.GONE);
-            holder.bindDummy();
-            return;
-        }
         NavDrawerData.DrawerItem drawerItem = listItems.get(position);
         boolean isFeed = drawerItem.type == NavDrawerData.DrawerItem.Type.FEED;
         holder.bind(drawerItem);
@@ -164,7 +157,7 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
 
     @Override
     public int getItemCount() {
-        return listItems.size() + dummyViews;
+        return listItems.size();
     }
 
     @Override
@@ -212,20 +205,8 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
         return items;
     }
 
-    public void setDummyViews(int dummyViews) {
-        this.dummyViews = dummyViews;
-        notifyDataSetChanged();
-    }
-
-    public void showDummyViewsIfNeverUpdated(int dummyViews) {
-        if (!wasEverUpdated) {
-            setDummyViews(dummyViews);
-        }
-    }
-
     public void setItems(List<NavDrawerData.DrawerItem> listItems) {
         this.listItems = listItems;
-        wasEverUpdated = true;
         notifyDataSetChanged();
     }
 
@@ -292,17 +273,6 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
                         .withCoverView(imageView)
                         .load();
             }
-        }
-
-        public void bindDummy() {
-            feedTitle.setText("███████");
-            feedTitle.setVisibility(View.VISIBLE);
-            count.setVisibility(View.GONE);
-            new CoverLoader(mainActivityRef.get())
-                    .withResource(android.R.color.transparent)
-                    .withPlaceholderView(feedTitle, false)
-                    .withCoverView(imageView)
-                    .load();
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.fragment;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -8,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.appbar.MaterialToolbar;
@@ -58,7 +58,6 @@ public class CompletedDownloadsFragment extends Fragment
     public static final String TAG = "DownloadsFragment";
     public static final String ARG_SHOW_LOGS = "show_logs";
     private static final String KEY_UP_ARROW = "up_arrow";
-    private static final String PREF_PREVIOUS_EPISODE_COUNT = "episodeCount";
 
     private long[] runningDownloads = new long[0];
     private List<FeedItem> items = new ArrayList<>();
@@ -69,6 +68,7 @@ public class CompletedDownloadsFragment extends Fragment
     private boolean displayUpArrow;
     private SpeedDialView speedDialView;
     private SwipeActions swipeActions;
+    private ProgressBar progressBar;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
@@ -93,13 +93,13 @@ public class CompletedDownloadsFragment extends Fragment
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         adapter = new CompletedDownloadsListAdapter((MainActivity) getActivity());
         adapter.setOnSelectModeListener(this);
-        int previousEpisodesCount = getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE)
-                .getInt(PREF_PREVIOUS_EPISODE_COUNT, 5);
-        recyclerView.postDelayed(() -> adapter.showDummyViewsIfNeverUpdated(previousEpisodesCount), 250);
         recyclerView.setAdapter(adapter);
         recyclerView.addOnScrollListener(new LiftOnScrollListener(root.findViewById(R.id.appbar)));
         swipeActions = new SwipeActions(this, TAG).attachTo(recyclerView);
         swipeActions.setFilter(new FeedItemFilter(FeedItemFilter.DOWNLOADED));
+
+        progressBar = root.findViewById(R.id.progLoading);
+        progressBar.setVisibility(View.VISIBLE);
 
         speedDialView = root.findViewById(R.id.fabSD);
         speedDialView.setOverlayLayout(root.findViewById(R.id.fabSDOverlay));
@@ -164,9 +164,6 @@ public class CompletedDownloadsFragment extends Fragment
         if (disposable != null) {
             disposable.dispose();
         }
-        getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE).edit()
-                .putInt(PREF_PREVIOUS_EPISODE_COUNT, adapter.getItemCount())
-                .apply();
     }
 
     @Override
@@ -303,6 +300,7 @@ public class CompletedDownloadsFragment extends Fragment
                 result -> {
                     items = result;
                     adapter.setDummyViews(0);
+                    progressBar.setVisibility(View.GONE);
                     adapter.updateItems(result);
                 }, error -> {
                     adapter.setDummyViews(0);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.fragment;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.os.Handler;
@@ -12,6 +11,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
@@ -68,7 +68,6 @@ public abstract class EpisodesListFragment extends Fragment
         implements EpisodeItemListAdapter.OnSelectModeListener, Toolbar.OnMenuItemClickListener {
     public static final String TAG = "EpisodesListFragment";
     private static final String KEY_UP_ARROW = "up_arrow";
-    private static final String PREF_PREVIOUS_EPISODE_COUNT = "episodeCount";
     protected static final int EPISODES_PER_PAGE = 150;
     protected int page = 1;
     protected boolean isLoadingMore = false;
@@ -81,6 +80,7 @@ public abstract class EpisodesListFragment extends Fragment
     SpeedDialView speedDialView;
     MaterialToolbar toolbar;
     SwipeActions swipeActions;
+    private ProgressBar progressBar;
 
     @NonNull
     List<FeedItem> episodes = new ArrayList<>();
@@ -115,9 +115,6 @@ public abstract class EpisodesListFragment extends Fragment
         if (disposable != null) {
             disposable.dispose();
         }
-        getContext().getSharedPreferences(getPrefName(), Context.MODE_PRIVATE).edit()
-                .putInt(PREF_PREVIOUS_EPISODE_COUNT, episodes.size())
-                .apply();
     }
 
     @Override
@@ -204,10 +201,9 @@ public abstract class EpisodesListFragment extends Fragment
             }
         };
         listAdapter.setOnSelectModeListener(this);
-        int previousEpisodesCount = getContext().getSharedPreferences(getPrefName(), Context.MODE_PRIVATE)
-                .getInt(PREF_PREVIOUS_EPISODE_COUNT, 5);
-        recyclerView.postDelayed(() -> listAdapter.showDummyViewsIfNeverUpdated(previousEpisodesCount), 250);
         recyclerView.setAdapter(listAdapter);
+        progressBar = root.findViewById(R.id.progressBar);
+        progressBar.setVisibility(View.VISIBLE);
 
         emptyView = new EmptyViewHandler(getContext());
         emptyView.attachToRecyclerView(recyclerView);
@@ -432,6 +428,7 @@ public abstract class EpisodesListFragment extends Fragment
                         data -> {
                             episodes = data.first;
                             hasMoreItems = !(page == 1 && episodes.size() < EPISODES_PER_PAGE);
+                            progressBar.setVisibility(View.GONE);
                             listAdapter.setDummyViews(0);
                             listAdapter.updateItems(episodes);
                             listAdapter.setTotalNumberOfItems(data.second);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -144,9 +144,9 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         viewBinding.recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         adapter = new FeedItemListAdapter((MainActivity) getActivity());
         adapter.setOnSelectModeListener(this);
-        viewBinding.recyclerView.postDelayed(() -> adapter.showDummyViewsIfNeverUpdated(10), 250);
         viewBinding.recyclerView.setAdapter(adapter);
         swipeActions = new SwipeActions(this, TAG).attachTo(viewBinding.recyclerView);
+        viewBinding.progressBar.setVisibility(View.VISIBLE);
 
         ToolbarIconTintManager iconTintManager = new ToolbarIconTintManager(
                 getContext(), viewBinding.toolbar, viewBinding.collapsingToolbar) {
@@ -530,6 +530,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                         feed = result;
                         swipeActions.setFilter(feed.getItemFilter());
                         refreshHeaderView();
+                        viewBinding.progressBar.setVisibility(View.GONE);
                         adapter.setDummyViews(0);
                         adapter.updateItems(feed.getItems());
                         updateToolbar();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -14,6 +14,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -86,13 +87,13 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
 
     private static final String PREFS = "QueueFragment";
     private static final String PREF_SHOW_LOCK_WARNING = "show_lock_warning";
-    private static final String PREF_PREVIOUS_EPISODE_COUNT = "episodeCount";
 
     private Disposable disposable;
     private SwipeActions swipeActions;
     private SharedPreferences prefs;
 
     private SpeedDialView speedDialView;
+    private ProgressBar progressBar;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -124,7 +125,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         if (disposable != null) {
             disposable.dispose();
         }
-        prefs.edit().putInt(PREF_PREVIOUS_EPISODE_COUNT, queue == null ? 0 : queue.size()).apply();
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -445,6 +445,8 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
         toolbar.inflateMenu(R.menu.queue);
         refreshToolbarState();
+        progressBar = root.findViewById(R.id.progressBar);
+        progressBar.setVisibility(View.VISIBLE);
 
         infoBar = root.findViewById(R.id.info_bar);
         recyclerView = root.findViewById(R.id.recyclerView);
@@ -468,8 +470,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             }
         };
         recyclerAdapter.setOnSelectModeListener(this);
-        int previousEpisodes = Math.max(1, prefs.getInt(PREF_PREVIOUS_EPISODE_COUNT, 5));
-        recyclerView.postDelayed(() -> recyclerAdapter.showDummyViewsIfNeverUpdated(previousEpisodes), 250);
         recyclerView.setAdapter(recyclerAdapter);
 
         SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
@@ -559,6 +559,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(items -> {
                     queue = items;
+                    progressBar.setVisibility(View.GONE);
                     recyclerAdapter.setDummyViews(0);
                     recyclerAdapter.updateItems(queue);
                     if (restoreScrollPosition) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -75,7 +76,6 @@ public class SubscriptionFragment extends Fragment
     public static final String TAG = "SubscriptionFragment";
     private static final String PREFS = "SubscriptionFragment";
     private static final String PREF_NUM_COLUMNS = "columns";
-    private static final String PREF_PREVIOUS_EPISODE_COUNT = "episodeCount";
     private static final String KEY_UP_ARROW = "up_arrow";
     private static final String ARGUMENT_FOLDER = "folder";
 
@@ -91,6 +91,7 @@ public class SubscriptionFragment extends Fragment
     private EmptyViewHandler emptyView;
     private TextView feedsFilteredMsg;
     private MaterialToolbar toolbar;
+    private ProgressBar progressBar;
     private String displayedFolder = null;
     private boolean displayUpArrow;
 
@@ -161,10 +162,11 @@ public class SubscriptionFragment extends Fragment
             }
         };
         subscriptionAdapter.setOnSelectModeListener(this);
-        int previousEpisodes = Math.max(1, prefs.getInt(PREF_PREVIOUS_EPISODE_COUNT, 5));
-        subscriptionRecycler.postDelayed(() -> subscriptionAdapter.showDummyViewsIfNeverUpdated(previousEpisodes), 250);
         subscriptionRecycler.setAdapter(subscriptionAdapter);
         setupEmptyView();
+
+        progressBar = root.findViewById(R.id.progressBar);
+        progressBar.setVisibility(View.VISIBLE);
 
         FloatingActionButton subscriptionAddButton = root.findViewById(R.id.subscriptions_add);
         subscriptionAddButton.setOnClickListener(view -> {
@@ -284,8 +286,6 @@ public class SubscriptionFragment extends Fragment
         if (disposable != null) {
             disposable.dispose();
         }
-        prefs.edit().putInt(PREF_PREVIOUS_EPISODE_COUNT, subscriptionAdapter.getItemCount()).apply();
-
         if (subscriptionAdapter != null) {
             subscriptionAdapter.endSelectMode();
         }
@@ -317,7 +317,7 @@ public class SubscriptionFragment extends Fragment
                             subscriptionAdapter.endSelectMode();
                         }
                         listItems = result;
-                        subscriptionAdapter.setDummyViews(0);
+                        progressBar.setVisibility(View.GONE);
                         subscriptionAdapter.setItems(result);
                         emptyView.updateVisibility();
                     }, error -> {

--- a/app/src/main/res/layout/episodes_list_fragment.xml
+++ b/app/src/main/res/layout/episodes_list_fragment.xml
@@ -47,6 +47,16 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:indeterminateOnly="true"
+        android:visibility="gone"
+        android:layout_centerInParent="true"
+        tools:background="@android:color/holo_red_light" />
+
     <include
         layout="@layout/multi_select_speed_dial" />
 

--- a/app/src/main/res/layout/feed_item_list_fragment.xml
+++ b/app/src/main/res/layout/feed_item_list_fragment.xml
@@ -59,6 +59,14 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminateOnly="true"
+        android:visibility="gone" />
+
     <include
         android:id="@+id/more_content"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -52,6 +52,14 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:indeterminateOnly="true"
+        android:visibility="visible" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/subscriptions_add"
         android:layout_width="56dp"

--- a/app/src/main/res/layout/queue_fragment.xml
+++ b/app/src/main/res/layout/queue_fragment.xml
@@ -48,6 +48,14 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:indeterminateOnly="true"
+        android:visibility="gone" />
+
     <include
         layout="@layout/multi_select_speed_dial" />
 


### PR DESCRIPTION
Dummies are slower on some devices, even when disabling their animations.

Closes #5101