### PR TITLE
Resume playback does not work when streaming after data connection drops

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -887,7 +887,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (mediaPlayer.getPlayerStatus() == PlayerStatus.PLAYING) {
             mediaPlayer.pause(true, false);
         }
-        PlaybackPreferences.writeNoMediaPlaying();
         stateManager.stopService();
     }
 


### PR DESCRIPTION
Fixes https://github.com/AntennaPod/AntennaPod/issues/5936 : Resume playback does not work when streaming after data connection drops

### Issue Video
https://www.loom.com/share/18d918fb17f04839a90b9ab7ece8e1dc

### Fix Video
https://www.loom.com/share/c0daf78f182f4f2aa777a6df591eb39d