### PR TITLE
Send first sleep timer tick earlier

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackServiceTaskManager.java
@@ -294,6 +294,7 @@ public class PlaybackServiceTaskManager {
         public void run() {
             Log.d(TAG, "Starting");
             long lastTick = System.currentTimeMillis();
+            EventBus.getDefault().post(SleepTimerUpdatedEvent.updated(timeLeft));
             while (timeLeft > 0) {
                 try {
                     Thread.sleep(UPDATE_INTERVAL);


### PR DESCRIPTION
Fixes #6284
(The timer sometimes still needs some time to start, so the situation can still happen. It's just a bit less likely)