### PR TITLE
Fix shownotes-button text border overlap for long translations

### DIFF
--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -90,6 +90,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="8dp"
+            android:paddingHorizontal="8dp"
             android:background="@drawable/grey_border"
             android:clickable="true"
             android:focusable="true"


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->

When text of shownotes-button are longer then the default min-with it runs in to the button border. This improoves that, please see screenshorts.

shownotes and chapters

original | fixed
--------|------
![Screenshot_1648583730_org](https://user-images.githubusercontent.com/1887628/216784699-55f8ff0a-fc08-448f-9592-c8424d33f3c0.png) |![Screenshot_1648583753_fix](https://user-images.githubusercontent.com/1887628/216784698-4d2fbb43-3322-49d9-81ec-d99315142879.png)

(only) shownotes
 
short copy for ref | original | fixed
---|--------|------
![Screenshot_1648583604](https://user-images.githubusercontent.com/1887628/216784974-667c257c-459d-4c95-8ec4-fe92d7f1fefd.png)|![Screenshot_1648583414_org](https://user-images.githubusercontent.com/1887628/216784795-843524cd-687e-41f9-9b42-4e1b61df6c4a.png) | ![Screenshot_1648583390_fix](https://user-images.githubusercontent.com/1887628/216784796-4ec9b94d-75a3-4ba6-addf-c704989434a4.png)




