### PR TITLE
Clarify "show in main list" checkbox title

### DIFF
--- a/app/src/main/res/layout/edit_tags_dialog.xml
+++ b/app/src/main/res/layout/edit_tags_dialog.xml
@@ -7,6 +7,12 @@
     android:orientation="vertical"
     android:padding="16dp">
 
+    <CheckBox
+        android:id="@+id/rootFolderCheckbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/feed_folders_include_root" />
+
     <com.joanzapata.iconify.widget.IconTextView
         android:id="@+id/commonTagsInfo"
         android:layout_width="match_parent"
@@ -21,12 +27,6 @@
         android:id="@+id/tagsRecycler"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
-
-    <CheckBox
-        android:id="@+id/rootFolderCheckbox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/feed_folders_include_root" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/newTagTextInput"

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -693,7 +693,7 @@
     <string name="authentication_descr">Change your username and password for this podcast and its episodes.</string>
     <string name="feed_tags_label">Tags</string>
     <string name="feed_tags_summary">Change the tags of this podcast to help organize your subscriptions</string>
-    <string name="feed_folders_include_root">Show in main list</string>
+    <string name="feed_folders_include_root">Show this subscription in main list</string>
     <string name="multi_feed_common_tags_info">{fa-info-circle} Only common tags from all selected subscriptions are shown. Other tags stay unaffected.</string>
     <string name="auto_download_settings_label">Auto Download Settings</string>
     <string name="episode_filters_label">Episode Filter</string>


### PR DESCRIPTION
People regularly don't understand tags/folders. I'm still convinced that this is because "tag" is harder to understand than "folder", because tags don't have a clear mental model. For now, changing the checkbox text to be a bit more explicit. If this does not help and users are still confused, we might have to rename "tag" back to "folder".

See https://github.com/AntennaPod/AntennaPod/issues/6323#issuecomment-1434953262