### PR TITLE
Force-refresh feeds that failed before

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadService.java
@@ -461,6 +461,9 @@ public class DownloadService extends Service {
             if (feed.getPreferences().getKeepUpdated()) {
                 DownloadRequest.Builder builder = DownloadRequestCreator.create(feed);
                 builder.withInitiatedByUser(initiatedByUser);
+                if (feed.hasLastUpdateFailed()) {
+                    builder.setForce(true);
+                }
                 addNewRequest(builder.build());
             }
         }


### PR DESCRIPTION
Apparently some servers return "Not Modified", even though a broken feed was fixed in the meantime. When refreshing all feeds, now force-refresh the feeds that previously failed.

Closes #6300