### PR TITLE
Do not jump bottom sheet when playing

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -528,7 +528,7 @@ public class AudioPlayerFragment extends Fragment implements
         float playerFadeProgress = Math.max(0.0f, Math.min(0.2f, slideOffset - 0.2f)) / 0.2f;
         View player = getView().findViewById(R.id.playerFragment);
         player.setAlpha(1 - playerFadeProgress);
-        player.setVisibility(playerFadeProgress > 0.99f ? View.GONE : View.VISIBLE);
+        player.setVisibility(playerFadeProgress > 0.99f ? View.INVISIBLE : View.VISIBLE);
         float toolbarFadeProgress = Math.max(0.0f, Math.min(0.2f, slideOffset - 0.6f)) / 0.2f;
         toolbar.setAlpha(toolbarFadeProgress);
         toolbar.setVisibility(toolbarFadeProgress < 0.01f ? View.INVISIBLE : View.VISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/view/NoRelayoutTextView.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/NoRelayoutTextView.java
@@ -1,0 +1,28 @@
+package de.danoeh.antennapod.view;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.util.AttributeSet;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatTextView;
+
+public class NoRelayoutTextView extends AppCompatTextView {
+    public NoRelayoutTextView(@NonNull Context context) {
+        super(context);
+    }
+
+    public NoRelayoutTextView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public NoRelayoutTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @SuppressLint("MissingSuperCall")
+    @Override
+    public void requestLayout() {
+        // Deliberate no-op
+    }
+}

--- a/app/src/main/res/layout/audioplayer_fragment.xml
+++ b/app/src/main/res/layout/audioplayer_fragment.xml
@@ -104,7 +104,7 @@
                 android:paddingLeft="8dp"
                 android:paddingRight="8dp">
 
-                <TextView
+                <de.danoeh.antennapod.view.NoRelayoutTextView
                     android:id="@+id/txtvPosition"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -116,7 +116,7 @@
                     android:textColor="?android:attr/textColorSecondary"
                     android:textSize="@dimen/text_size_micro" />
 
-                <TextView
+                <de.danoeh.antennapod.view.NoRelayoutTextView
                     android:id="@+id/txtvLength"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -124,6 +124,7 @@
                     android:layout_alignParentRight="true"
                     android:layout_marginEnd="16dp"
                     android:layout_marginRight="16dp"
+                    android:textAlignment="textEnd"
                     android:background="?android:attr/selectableItemBackground"
                     android:text="@string/position_default_label"
                     android:textColor="?android:attr/textColorSecondary"


### PR DESCRIPTION
Whenever some view calls requestLayout(), the bottom view jumps. This happens during slide when setting the player from GONE to VISIBLE. Also, it happens every time the position changes because the TextView has a dynamic width. We are not actually interested in the dynamic width and can simply keep the initial width. This avoids requestLayout() calls every time the position is updated.

Closes #5673