### PR TITLE
Update 'show in main list' string

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -696,7 +696,7 @@
     <string name="authentication_descr">Change your username and password for this podcast and its episodes.</string>
     <string name="feed_tags_label">Tags</string>
     <string name="feed_tags_summary">Change the tags of this podcast to help organize your subscriptions</string>
-    <string name="feed_folders_include_root">Show this subscription in main list</string>
+    <string name="feed_folders_include_root">Show this podcast in main list</string>
     <string name="multi_feed_common_tags_info">{fa-info-circle} Only common tags from all selected subscriptions are shown. Other tags stay unaffected.</string>
     <string name="auto_download_settings_label">Auto Download Settings</string>
     <string name="episode_filters_label">Episode Filter</string>


### PR DESCRIPTION
Following up on https://github.com/AntennaPod/AntennaPod/pull/6326#discussion_r1110387894

I have a few arguments for this change:
* the main point of confusion for the user was that we didn't specify the entity (the 'what'), and that the setting was unlogically placed (making it seem to refer to 'tag' instead of 'podcast')
* 'Subscription' is actually a rather technical term. In the non-technical sense of the word, it is understood by some users as a 'paid' thing (which is why Apple [moved away](https://podnews.net/update/follow-not-subscribe) from the term).
* 'Subscription' is not used more frequently across AntennaPod than 'Podcast'

In terms of meaning, I would follow these guidelines:
* Subscriptions: refers to the collectivity of podcasts that users added in AntennPod
* Podcast: refers to a single brand/source that the user is following in AntennaPod, and which has episodes