### PR TITLE
Use more clear swipe action label

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SwipeActionsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SwipeActionsDialog.java
@@ -77,7 +77,7 @@ public class SwipeActionsDialog {
                         && !a.getId().equals(SwipeAction.START_DOWNLOAD)).toList();
                 break;
             case FeedItemlistFragment.TAG:
-                forFragment = context.getString(R.string.feeds_label);
+                forFragment = context.getString(R.string.individual_subscription);
                 keys = Stream.of(keys).filter(a -> !a.getId().equals(SwipeAction.REMOVE_FROM_HISTORY)).toList();
                 break;
             case QueueFragment.TAG:

--- a/app/src/main/res/xml/preferences_swipe.xml
+++ b/app/src/main/res/xml/preferences_swipe.xml
@@ -23,6 +23,6 @@
 
     <Preference
         android:key="prefSwipeFeed"
-        android:title="@string/feeds_label"/>
+        android:title="@string/individual_subscription"/>
 
 </PreferenceScreen>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="swipe_left">Swipe Left</string>
     <string name="enable_swipeactions">Enable Swipe Actions for this Screen</string>
     <string name="change_setting">Change</string>
+    <string name="individual_subscription">Individual subscription</string>
 
     <!-- Statistics fragment -->
     <string name="statistics_include_marked">Include duration of episodes that are just marked as played</string>


### PR DESCRIPTION
"Individual podcast" would be ambiguous here (could be misunderstood as "individual episode").

Closes #6339