### PR TITLE
More human readable player error message

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -30,11 +30,11 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.SeekBar;
 import androidx.annotation.Nullable;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.view.WindowCompat;
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
 import com.bumptech.glide.Glide;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.dialog.MediaPlayerErrorDialog;
 import de.danoeh.antennapod.dialog.VariableSpeedDialog;
 import de.danoeh.antennapod.event.playback.BufferUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
@@ -514,11 +514,7 @@ public class VideoplayerActivity extends CastEnabledActivity implements SeekBar.
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaPlayerError(PlayerErrorEvent event) {
-        final MaterialAlertDialogBuilder errorDialog = new MaterialAlertDialogBuilder(VideoplayerActivity.this);
-        errorDialog.setTitle(R.string.error_label);
-        errorDialog.setMessage(event.getMessage());
-        errorDialog.setNeutralButton(android.R.string.ok, (dialog, which) -> finish());
-        errorDialog.show();
+        MediaPlayerErrorDialog.show(this, event);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/dialog/MediaPlayerErrorDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/MediaPlayerErrorDialog.java
@@ -1,0 +1,37 @@
+package de.danoeh.antennapod.dialog;
+
+import android.app.Activity;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.snackbar.Snackbar;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.PlayerErrorEvent;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+
+public class MediaPlayerErrorDialog {
+    public static void show(Activity activity, PlayerErrorEvent event) {
+        final MaterialAlertDialogBuilder errorDialog = new MaterialAlertDialogBuilder(activity);
+        errorDialog.setTitle(R.string.error_label);
+
+        String genericMessage = activity.getString(R.string.playback_error_generic);
+        SpannableString errorMessage = new SpannableString(genericMessage + "\n\n" + event.getMessage());
+        errorMessage.setSpan(new ForegroundColorSpan(0x88888888),
+                genericMessage.length(), errorMessage.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+        errorDialog.setMessage(errorMessage);
+        errorDialog.setPositiveButton(android.R.string.ok, (dialog, which) ->
+                ((MainActivity) activity).getBottomSheet().setState(BottomSheetBehavior.STATE_COLLAPSED));
+        if (!UserPreferences.useExoplayer()) {
+            errorDialog.setNeutralButton(R.string.media_player_switch_to_exoplayer, (dialog, which) -> {
+                UserPreferences.enableExoplayer();
+                ((MainActivity) activity).showSnackbarAbovePlayer(
+                        R.string.media_player_switched_to_exoplayer, Snackbar.LENGTH_LONG);
+            });
+        }
+        errorDialog.create().show();
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -15,7 +15,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.appbar.MaterialToolbar;
 import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
@@ -25,10 +24,10 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.elevation.SurfaceColors;
-import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.core.receiver.MediaButtonReceiver;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
+import de.danoeh.antennapod.dialog.MediaPlayerErrorDialog;
 import de.danoeh.antennapod.event.playback.BufferUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackServiceEvent;
 import de.danoeh.antennapod.event.PlayerErrorEvent;
@@ -396,19 +395,7 @@ public class AudioPlayerFragment extends Fragment implements
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void mediaPlayerError(PlayerErrorEvent event) {
-        final MaterialAlertDialogBuilder errorDialog = new MaterialAlertDialogBuilder(getContext());
-        errorDialog.setTitle(R.string.error_label);
-        errorDialog.setMessage(event.getMessage());
-        errorDialog.setPositiveButton(android.R.string.ok, (dialog, which) ->
-                ((MainActivity) getActivity()).getBottomSheet().setState(BottomSheetBehavior.STATE_COLLAPSED));
-        if (!UserPreferences.useExoplayer()) {
-            errorDialog.setNeutralButton(R.string.media_player_switch_to_exoplayer, (dialog, which) -> {
-                UserPreferences.enableExoplayer();
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                        R.string.media_player_switched_to_exoplayer, Snackbar.LENGTH_LONG);
-            });
-        }
-        errorDialog.create().show();
+        MediaPlayerErrorDialog.show(getActivity(), event);
     }
 
     @Override

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -309,6 +309,7 @@
     <string name="confirm_mobile_download_dialog_enable_temporarily">Allow temporarily</string>
 
     <!-- Mediaplayer messages -->
+    <string name="playback_error_generic"><![CDATA[The media file could not be played.\n\n- Try deleting and re-downloading the episode.\n- Check your network connection, and make sure no VPN or login page is blocking access.\n- Try long-pressing and sharing the \"Media address\" to your web browser to see if it can be played there. If not, contact the podcast creators.]]></string>
     <string name="playback_error_server_died">Server died</string>
     <string name="playback_error_unsupported">Unsupported media type</string>
     <string name="playback_error_timeout">Operation timed out</string>


### PR DESCRIPTION
Closes #6302

I shortened the proposed text in #6302 significantly because it filled more than a full screen. The human readable message then looked way more scary than the actual error message (usually it's just something like "unable to connect to podcastserver.com").