### PR TITLE
Hide 'reconnect' settings

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/PlaybackPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/PlaybackPreferencesFragment.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.fragment.preferences;
 
 import android.app.Activity;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.collection.ArrayMap;
@@ -60,6 +61,10 @@ public class PlaybackPreferencesFragment extends PreferenceFragmentCompat {
             UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM);
             return true;
         });
+        if (Build.VERSION.SDK_INT >= 31) {
+            findPreference(UserPreferences.PREF_UNPAUSE_ON_HEADSET_RECONNECT).setVisible(false);
+            findPreference(UserPreferences.PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT).setVisible(false);
+        }
 
         buildEnqueueLocationPreference();
     }

--- a/app/src/main/res/xml/preferences_playback.xml
+++ b/app/src/main/res/xml/preferences_playback.xml
@@ -28,12 +28,6 @@
                 android:key="prefPauseForFocusLoss"
                 android:summary="@string/pref_pausePlaybackForFocusLoss_sum"
                 android:title="@string/pref_pausePlaybackForFocusLoss_title"/>
-        <SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:enabled="true"
-                android:key="prefResumeAfterCall"
-                android:summary="@string/pref_resumeAfterCall_sum"
-                android:title="@string/pref_resumeAfterCall_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/playback_control">

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/MediaButtonReceiver.java
@@ -37,7 +37,11 @@ public class MediaButtonReceiver extends BroadcastReceiver {
             serviceIntent.putExtra(EXTRA_KEYCODE, event.getKeyCode());
             serviceIntent.putExtra(EXTRA_SOURCE, event.getSource());
             serviceIntent.putExtra(EXTRA_HARDWAREBUTTON, event.getEventTime() > 0 || event.getDownTime() > 0);
-            ContextCompat.startForegroundService(context, serviceIntent);
+            try {
+                ContextCompat.startForegroundService(context, serviceIntent);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1460,6 +1460,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
         if (transientPause) {
             transientPause = false;
+            if (Build.VERSION.SDK_INT >= 31) {
+                stateManager.stopService();
+                return;
+            }
             if (!bluetooth && UserPreferences.isUnpauseOnHeadsetReconnect()) {
                 mediaPlayer.resume();
             } else if (bluetooth && UserPreferences.isUnpauseOnBluetoothReconnect()) {

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -71,7 +71,7 @@ public class UserPreferences {
     // Playback
     public static final String PREF_PAUSE_ON_HEADSET_DISCONNECT = "prefPauseOnHeadsetDisconnect";
     public static final String PREF_UNPAUSE_ON_HEADSET_RECONNECT = "prefUnpauseOnHeadsetReconnect";
-    private static final String PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT = "prefUnpauseOnBluetoothReconnect";
+    public static final String PREF_UNPAUSE_ON_BLUETOOTH_RECONNECT = "prefUnpauseOnBluetoothReconnect";
     public static final String PREF_HARDWARE_FORWARD_BUTTON = "prefHardwareForwardButton";
     public static final String PREF_HARDWARE_PREVIOUS_BUTTON = "prefHardwarePreviousButton";
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
@@ -81,7 +81,6 @@ public class UserPreferences {
     public static final String PREF_SMART_MARK_AS_PLAYED_SECS = "prefSmartMarkAsPlayedSecs";
     private static final String PREF_PLAYBACK_SPEED_ARRAY = "prefPlaybackSpeedArray";
     public static final String PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS = "prefPauseForFocusLoss";
-    private static final String PREF_RESUME_AFTER_CALL = "prefResumeAfterCall";
     private static final String PREF_TIME_RESPECTS_SPEED = "prefPlaybackTimeRespectsSpeed";
     public static final String PREF_STREAM_OVER_DOWNLOAD = "prefStreamOverDownload";
 
@@ -613,10 +612,6 @@ public class UserPreferences {
         String username = prefs.getString(PREF_PROXY_USER, null);
         String password = prefs.getString(PREF_PROXY_PASSWORD, null);
         return new ProxyConfig(type, host, port, username, password);
-    }
-
-    public static boolean shouldResumeAfterCall() {
-        return prefs.getBoolean(PREF_RESUME_AFTER_CALL, true);
     }
 
     public static boolean isQueueLocked() {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -664,8 +664,6 @@
     <string name="choose_data_directory_available_space">%1$s of %2$s free</string>
     <string name="pref_pausePlaybackForFocusLoss_sum">Pause playback instead of lowering volume when another app wants to play sounds</string>
     <string name="pref_pausePlaybackForFocusLoss_title">Pause for Interruptions</string>
-    <string name="pref_resumeAfterCall_sum">Resume playback after a phone call completes</string>
-    <string name="pref_resumeAfterCall_title">Resume after Call</string>
 
     <!-- Online feed view -->
     <string name="subscribe_label">Subscribe</string>


### PR DESCRIPTION
Android 12+ doesn't let us start the foreground service from an event like "headset reconnected". Hide the corresponding settings and avoid crashing.

<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
