### PR TITLE
Handle a null timestamp in local/first actions

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/sync/EpisodeActionFilter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/EpisodeActionFilter.java
@@ -72,7 +72,8 @@ public class EpisodeActionFilter {
                                                             EpisodeAction secondAction) {
         return secondAction != null
                 && secondAction.getTimestamp() != null
-                && secondAction.getTimestamp().after(firstAction.getTimestamp());
+                && (firstAction.getTimestamp() == null
+                        || secondAction.getTimestamp().after(firstAction.getTimestamp()));
     }
 
 }

--- a/core/src/test/java/de/danoeh/antennapod/core/sync/EpisodeActionFilterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/sync/EpisodeActionFilterTest.java
@@ -184,4 +184,29 @@ public class EpisodeActionFilterTest extends TestCase {
                 .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
         assertEquals(0, uniqueList.size());
     }
+
+    public void testPresentRemoteTimestampOverridesMissingLocalTimestamp() throws ParseException {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date arbitraryTime = format.parse("2021-01-01 08:00:00");
+
+        List<EpisodeAction> episodeActions = new ArrayList<>();
+        episodeActions.add(new EpisodeAction
+                .Builder("podcast.a", "episode.1", EpisodeAction.Action.PLAY)
+                // no timestamp
+                .position(10)
+                .build()
+        );
+
+        List<EpisodeAction> remoteActions = new ArrayList<>();
+        remoteActions.add(new EpisodeAction
+                .Builder("podcast.a", "episode.1", EpisodeAction.Action.PLAY)
+                .timestamp(arbitraryTime)
+                .position(10)
+                .build()
+        );
+
+        Map<Pair<String, String>, EpisodeAction> uniqueList = episodeActionFilter
+                .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
+        assertSame(1, uniqueList.size());
+    }
 }


### PR DESCRIPTION
I noticed an exception and stack trace on pointing AntennaPod at my home server, where the local/first episode action would have a null timestamp - we check the second/remote action's timestamp, but not the local's.

I don't believe this is a misbehaving server, although am happy to be corrected.