### PR TITLE
Remove 'set lockscreen background' setting

### DIFF
--- a/app/src/main/res/xml/preferences_user_interface.xml
+++ b/app/src/main/res/xml/preferences_user_interface.xml
@@ -73,12 +73,6 @@
                 android:key="prefCompactNotificationButtons"
                 android:summary="@string/pref_compact_notification_buttons_sum"
                 android:title="@string/pref_compact_notification_buttons_title"/>
-        <SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:enabled="true"
-                android:key="prefLockscreenBackground"
-                android:summary="@string/pref_lockscreen_background_sum"
-                android:title="@string/pref_lockscreen_background_title"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/behavior">
         <de.danoeh.antennapod.preferences.MaterialListPreference

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -55,7 +55,6 @@ public class UserPreferences {
     public static final String PREF_SHOW_TIME_LEFT = "showTimeLeft";
     private static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
     public static final String PREF_COMPACT_NOTIFICATION_BUTTONS = "prefCompactNotificationButtons";
-    public static final String PREF_LOCKSCREEN_BACKGROUND = "prefLockscreenBackground";
     private static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
     private static final String PREF_SHOW_AUTO_DOWNLOAD_REPORT = "prefShowAutoDownloadReport";
     public static final String PREF_DEFAULT_PAGE = "prefDefaultPage";
@@ -289,15 +288,6 @@ public class UserPreferences {
      */
     public static boolean isPersistNotify() {
         return prefs.getBoolean(PREF_PERSISTENT_NOTIFICATION, true);
-    }
-
-    /**
-     * Returns true if the lockscreen background should be set to the current episode's image
-     *
-     * @return {@code true} if the lockscreen background should be set, {@code false}  otherwise
-     */
-    public static boolean setLockscreenBackground() {
-        return prefs.getBoolean(PREF_LOCKSCREEN_BACKGROUND, true);
     }
 
     /**

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -485,8 +485,6 @@
     <string name="pref_compact_notification_buttons_sum">Change the playback buttons when the notification is collapsed. The play/pause button is always included.</string>
     <string name="pref_compact_notification_buttons_dialog_title">Select a maximum of %1$d items</string>
     <string name="pref_compact_notification_buttons_dialog_error">You can only select a maximum of %1$d items.</string>
-    <string name="pref_lockscreen_background_title">Set Lockscreen Background</string>
-    <string name="pref_lockscreen_background_sum">Set the lockscreen background to the current episode\'s image. As a side effect, this will also show the image in third party apps.</string>
     <string name="pref_enqueue_location_title">Enqueue Location</string>
     <string name="pref_enqueue_location_sum">Add episodes to: %1$s</string>
     <string name="enqueue_location_back">Back</string>


### PR DESCRIPTION
Users disable the setting and then wonder why other apps (like Android Auto) do not display the cover image, even though it says so in the setting summary.

Closes #6320