### PR TITLE
Remove notification channel groups

### DIFF
--- a/app/src/main/res/xml/preferences_notifications.xml
+++ b/app/src/main/res/xml/preferences_notifications.xml
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
         xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <PreferenceCategory
-            android:title="@string/notification_group_news">
-        <SwitchPreferenceCompat
-                android:defaultValue="false"
-                android:enabled="true"
-                android:key="prefShowAutoDownloadReport"
-                android:summary="@string/notification_channel_episode_auto_download"
-                android:title="@string/notification_channel_auto_download" />
-    </PreferenceCategory>
-
-    <PreferenceCategory
-            android:title="@string/notification_group_errors">
-        <SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:enabled="true"
-                android:key="prefShowDownloadReport"
-                android:summary="@string/notification_channel_download_error_description"
-                android:title="@string/notification_channel_download_error" />
-        <SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:key="pref_gpodnet_notifications"
-                android:summary="@string/notification_channel_sync_error_description"
-                android:title="@string/notification_channel_sync_error" />
-    </PreferenceCategory>
+    <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefShowAutoDownloadReport"
+            android:summary="@string/notification_channel_episode_auto_download"
+            android:title="@string/notification_channel_auto_download" />
+    <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="prefShowDownloadReport"
+            android:summary="@string/notification_channel_download_error_description"
+            android:title="@string/notification_channel_download_error" />
+    <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_gpodnet_notifications"
+            android:summary="@string/notification_channel_sync_error_description"
+            android:title="@string/notification_channel_sync_error" />
 </PreferenceScreen>

--- a/core/src/main/java/de/danoeh/antennapod/core/util/gui/NotificationUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/gui/NotificationUtils.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.core.util.gui;
 import android.content.Context;
 
 import androidx.core.app.NotificationChannelCompat;
-import androidx.core.app.NotificationChannelGroupCompat;
 import androidx.core.app.NotificationManagerCompat;
 
 import java.util.Arrays;
@@ -21,16 +20,8 @@ public class NotificationUtils {
     public static final String CHANNEL_ID_AUTO_DOWNLOAD = "auto_download";
     public static final String CHANNEL_ID_EPISODE_NOTIFICATIONS = "episode_notifications";
 
-    public static final String GROUP_ID_ERRORS = "group_errors";
-    public static final String GROUP_ID_NEWS = "group_news";
-
     public static void createChannels(final Context context) {
         final NotificationManagerCompat mNotificationManager = NotificationManagerCompat.from(context);
-
-        final List<NotificationChannelGroupCompat> channelGroups = Arrays.asList(
-                createGroupErrors(context),
-                createGroupNews(context));
-        mNotificationManager.createNotificationChannelGroupsCompat(channelGroups);
 
         final List<NotificationChannelCompat> channels = Arrays.asList(
                 createChannelUserAction(context),
@@ -48,7 +39,6 @@ public class NotificationUtils {
                         CHANNEL_ID_USER_ACTION, NotificationManagerCompat.IMPORTANCE_HIGH)
                 .setName(c.getString(R.string.notification_channel_user_action))
                 .setDescription(c.getString(R.string.notification_channel_user_action_description))
-                .setGroup(GROUP_ID_ERRORS)
                 .build();
     }
 
@@ -74,8 +64,7 @@ public class NotificationUtils {
         final NotificationChannelCompat.Builder notificationChannel = new NotificationChannelCompat.Builder(
                         CHANNEL_ID_DOWNLOAD_ERROR, NotificationManagerCompat.IMPORTANCE_HIGH)
                 .setName(c.getString(R.string.notification_channel_download_error))
-                .setDescription(c.getString(R.string.notification_channel_download_error_description))
-                .setGroup(GROUP_ID_ERRORS);
+                .setDescription(c.getString(R.string.notification_channel_download_error_description));
 
         if (!UserPreferences.getShowDownloadReportRaw()) {
             // Migration from app managed setting: disable notification
@@ -88,8 +77,7 @@ public class NotificationUtils {
         final NotificationChannelCompat.Builder notificationChannel = new NotificationChannelCompat.Builder(
                         CHANNEL_ID_SYNC_ERROR, NotificationManagerCompat.IMPORTANCE_HIGH)
                 .setName(c.getString(R.string.notification_channel_sync_error))
-                .setDescription(c.getString(R.string.notification_channel_sync_error_description))
-                .setGroup(GROUP_ID_ERRORS);
+                .setDescription(c.getString(R.string.notification_channel_sync_error_description));
 
         if (!UserPreferences.getGpodnetNotificationsEnabledRaw()) {
             // Migration from app managed setting: disable notification
@@ -102,8 +90,7 @@ public class NotificationUtils {
         final NotificationChannelCompat.Builder notificationChannel = new NotificationChannelCompat.Builder(
                         CHANNEL_ID_AUTO_DOWNLOAD, NotificationManagerCompat.IMPORTANCE_NONE)
                 .setName(c.getString(R.string.notification_channel_auto_download))
-                .setDescription(c.getString(R.string.notification_channel_episode_auto_download))
-                .setGroup(GROUP_ID_NEWS);
+                .setDescription(c.getString(R.string.notification_channel_episode_auto_download));
 
         if (UserPreferences.getShowAutoDownloadReportRaw()) {
             // Migration from app managed setting: enable notification
@@ -117,19 +104,6 @@ public class NotificationUtils {
                         CHANNEL_ID_EPISODE_NOTIFICATIONS, NotificationManagerCompat.IMPORTANCE_DEFAULT)
                 .setName(c.getString(R.string.notification_channel_new_episode))
                 .setDescription(c.getString(R.string.notification_channel_new_episode_description))
-                .setGroup(GROUP_ID_NEWS)
-                .build();
-    }
-
-    private static NotificationChannelGroupCompat createGroupErrors(final Context c) {
-        return new NotificationChannelGroupCompat.Builder(GROUP_ID_ERRORS)
-                .setName(c.getString(R.string.notification_group_errors))
-                .build();
-    }
-
-    private static NotificationChannelGroupCompat createGroupNews(final Context c) {
-        return new NotificationChannelGroupCompat.Builder(GROUP_ID_NEWS)
-                .setName(c.getString(R.string.notification_group_news))
                 .build();
     }
 }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -810,8 +810,6 @@
     <string name="subscription_num_columns">Number of columns</string>
 
     <!-- Notification channels -->
-    <string name="notification_group_errors">Errors</string>
-    <string name="notification_group_news">News</string>
     <string name="notification_channel_user_action">Action required</string>
     <string name="notification_channel_user_action_description">Shown if your action is required, for example if you need to enter a password.</string>
     <string name="notification_channel_downloading">Downloading</string>


### PR DESCRIPTION
They just clutter the settings screen and make it look more complex than it is. This only affects new installs.