### PR TITLE
Ignore 'new' action during sync

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/sync/EpisodeActionFilter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/EpisodeActionFilter.java
@@ -25,8 +25,6 @@ public class EpisodeActionFilter {
             Pair<String, String> key = new Pair<>(remoteAction.getPodcast(), remoteAction.getEpisode());
             switch (remoteAction.getAction()) {
                 case NEW:
-                    remoteActionsThatOverrideLocalActions.put(key, remoteAction);
-                    break;
                 case DOWNLOAD:
                     break;
                 case PLAY:

--- a/core/src/main/java/de/danoeh/antennapod/core/sync/SyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/sync/SyncService.java
@@ -274,10 +274,6 @@ public class SyncService extends Worker {
                 Log.i(TAG, "Feed item has no media: " + action);
                 continue;
             }
-            if (action.getAction() == EpisodeAction.NEW) {
-                DBWriter.markItemPlayed(feedItem, FeedItem.UNPLAYED, true);
-                continue;
-            }
             feedItem.getMedia().setPosition(action.getPosition() * 1000);
             if (FeedItemUtil.hasAlmostEnded(feedItem.getMedia())) {
                 Log.d(TAG, "Marking as played: " + action);


### PR DESCRIPTION
We never want to overwrite the local playback state.

Closes #5908