### PR TITLE
added a reset button to the filter dialog

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SubscriptionsFilterDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SubscriptionsFilterDialog.java
@@ -57,6 +57,10 @@ public class SubscriptionsFilterDialog {
             }
         }
 
+        builder.setNeutralButton(R.string.reset_label, (dialog, which) -> {
+            filterValues.clear();
+            updateFilter(filterValues);
+        });
         builder.setPositiveButton(R.string.confirm_label, (dialog, which) -> {
             filterValues.clear();
             for (int i = 0; i < rows.getChildCount(); i++) {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="removed_history_label">Removed from history</string>
 
     <!-- Other -->
+    <string name="reset_label">Reset</string>
     <string name="confirm_label">Confirm</string>
     <string name="cancel_label">Cancel</string>
     <string name="yes">Yes</string>


### PR DESCRIPTION
Resolves issue #6383. 
Added a button to the subscription filter dialog, that resets all set filters and applies that change automatically.