### PR TITLE
Make single filter button full-width

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SubscriptionsFilterDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SubscriptionsFilterDialog.java
@@ -10,7 +10,6 @@ import android.widget.LinearLayout;
 import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-import de.danoeh.antennapod.databinding.FilterDialogRowBinding;
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.Arrays;
@@ -18,9 +17,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.core.feed.SubscriptionsFilterGroup;
+import de.danoeh.antennapod.databinding.FilterDialogRowBinding;
 import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.SubscriptionsFilter;
-import de.danoeh.antennapod.core.feed.SubscriptionsFilterGroup;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 
 public class SubscriptionsFilterDialog {
@@ -37,6 +37,7 @@ public class SubscriptionsFilterDialog {
 
         for (SubscriptionsFilterGroup item : SubscriptionsFilterGroup.values()) {
             FilterDialogRowBinding binding = FilterDialogRowBinding.inflate(inflater);
+            binding.buttonGroup.setWeightSum(item.values.length);
             binding.filterButton1.setText(item.values[0].displayName);
             binding.filterButton1.setTag(item.values[0].filterId);
             if (item.values.length == 2) {

--- a/app/src/main/res/layout/filter_dialog_row.xml
+++ b/app/src/main/res/layout/filter_dialog_row.xml
@@ -2,6 +2,7 @@
 <com.google.android.material.button.MaterialButtonToggleGroup
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/buttonGroup"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:weightSum="2"


### PR DESCRIPTION
Fixes at least the 'Counter greater 0' button in #6452 which is the same behavior as in v2.7.1

![grafik](https://user-images.githubusercontent.com/22525368/234251573-3cfd8c19-df2d-4a76-9853-bc0193e67b4c.png)


<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
