### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# Settings in .editorconfig should match checkstyle config
+
+root = true
+
+[*]
+charset = utf-8
+max_line_length = 120


### PR DESCRIPTION
This causes the 'max line length line' in Android Studio to be at 120 chars, which is the same limit as checkstyle uses.

<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
