### PR TITLE
Mark quick settings tile as toggleable

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
             <meta-data android:name="android.service.quicksettings.ACTIVE_TILE" android:value="true" />
+            <meta-data android:name="android.service.quicksettings.TOGGLEABLE_TILE" android:value="true" />
         </service>
     </application>
 


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->

This removes the arrow that is currently displayed in the tile. That arrow is only shown on tiles that open a dialog or activity.

![grafik](https://user-images.githubusercontent.com/22525368/235340942-12e1d5ee-17d3-4500-b0fa-b1970e3668b7.png)
