### PR TITLE
Fix file provider not being able to share all files

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -3,4 +3,5 @@
     <external-path name="external_storage" path="." />
     <external-files-path name="external_file_storage" path="." />
     <files-path name="name" path="." />
+    <root-path name="root" path="." />
 </paths>


### PR DESCRIPTION
The library only looks at one of the external storage devices. If the exported log file doesn't happen to be stored on the first device, sharing it doesn't work.
This is a known issue in the Android libraries:
https://issuetracker.google.com/issues/37125252

This commit works around it by using an undocumented element that covers the entire file system.

Closes #6440
