### PR TITLE
Rounded corners of cover in widget

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdater.java
@@ -13,6 +13,9 @@ import android.view.View;
 import android.widget.RemoteViews;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.bitmap.FitCenter;
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
+import com.bumptech.glide.request.RequestOptions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -83,10 +86,20 @@ public abstract class WidgetUpdater {
             views.setOnClickPendingIntent(R.id.imgvCover, startMediaPlayer);
             views.setOnClickPendingIntent(R.id.butPlaybackSpeed, startPlaybackSpeedDialog);
 
+            RequestOptions options = new RequestOptions()
+                    .dontAnimate()
+                    .transform(
+                            new FitCenter(),
+                            new RoundedCorners(
+                                    context.getResources().getDimensionPixelSize(R.dimen.widget_inner_radius)
+                            )
+                    );
+
             try {
                 icon = Glide.with(context)
                         .asBitmap()
                         .load(widgetState.media.getImageLocation())
+                        .apply(options)
                         .submit(iconSize, iconSize)
                         .get(500, TimeUnit.MILLISECONDS);
                 views.setImageViewBitmap(R.id.imgvCover, icon);
@@ -95,6 +108,7 @@ public abstract class WidgetUpdater {
                     icon = Glide.with(context)
                             .asBitmap()
                             .load(ImageResourceUtils.getFallbackImageLocation(widgetState.media))
+                            .apply(options)
                             .submit(iconSize, iconSize)
                             .get(500, TimeUnit.MILLISECONDS);
                     views.setImageViewBitmap(R.id.imgvCover, icon);

--- a/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/widget/WidgetUpdater.java
@@ -86,14 +86,10 @@ public abstract class WidgetUpdater {
             views.setOnClickPendingIntent(R.id.imgvCover, startMediaPlayer);
             views.setOnClickPendingIntent(R.id.butPlaybackSpeed, startPlaybackSpeedDialog);
 
+            int radius = context.getResources().getDimensionPixelSize(R.dimen.widget_inner_radius);
             RequestOptions options = new RequestOptions()
                     .dontAnimate()
-                    .transform(
-                            new FitCenter(),
-                            new RoundedCorners(
-                                    context.getResources().getDimensionPixelSize(R.dimen.widget_inner_radius)
-                            )
-                    );
+                    .transform(new FitCenter(), new RoundedCorners(radius));
 
             try {
                 icon = Glide.with(context)

--- a/core/src/main/res/values-v31/dimens.xml
+++ b/core/src/main/res/values-v31/dimens.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="widget_inner_radius">@android:dimen/system_app_widget_inner_radius</dimen>
-</resources>

--- a/core/src/main/res/values-v31/dimens.xml
+++ b/core/src/main/res/values-v31/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="widget_inner_radius">@android:dimen/system_app_widget_inner_radius</dimen>
+</resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="widget_margin">0dp</dimen>
+    <dimen name="widget_inner_radius">4dp</dimen>
     <dimen name="external_player_height">64dp</dimen>
     <dimen name="text_size_micro">12sp</dimen>
     <dimen name="text_size_small">14sp</dimen>


### PR DESCRIPTION
Use 4dp like on many other places as corner radius. For Android 12+ use the launcher-chosen radius: https://developer.android.com/develop/ui/views/appwidgets#rounded-corner

<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
