### PR TITLE
Disable f-droid rating dialog

### DIFF
--- a/app/src/free/java/de/danoeh/antennapod/dialog/RatingDialog.java
+++ b/app/src/free/java/de/danoeh/antennapod/dialog/RatingDialog.java
@@ -1,116 +1,13 @@
 package de.danoeh.antennapod.dialog;
 
-import android.app.Dialog;
 import android.content.Context;
-import android.content.SharedPreferences;
-import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import android.util.Log;
-
-import java.lang.ref.WeakReference;
-import java.util.concurrent.TimeUnit;
-
-import androidx.appcompat.app.AlertDialog;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-
-import de.danoeh.antennapod.BuildConfig;
-import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.core.util.IntentUtils;
 
 public class RatingDialog {
+    public static void init(Context context) {}
 
-    private RatingDialog(){}
-
-    private static final String TAG = RatingDialog.class.getSimpleName();
-    private static final int AFTER_DAYS = 7;
-
-    private static WeakReference<Context> mContext;
-    private static SharedPreferences mPreferences;
-    private static Dialog mDialog;
-
-    private static final String PREFS_NAME = "RatingPrefs";
-    private static final String KEY_RATED = "KEY_WAS_RATED";
-    private static final String KEY_FIRST_START_DATE = "KEY_FIRST_HIT_DATE";
-
-    public static void init(Context context) {
-        mContext = new WeakReference<>(context);
-        mPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-
-        long firstDate = mPreferences.getLong(KEY_FIRST_START_DATE, 0);
-        if (firstDate == 0) {
-            resetStartDate();
-        }
-    }
-
-    public static void check() {
-        if (mDialog != null && mDialog.isShowing()) {
-            return;
-        }
-        if (shouldShow()) {
-            try {
-                mDialog = createDialog();
-                if (mDialog != null) {
-                    mDialog.show();
-                }
-            } catch (Exception e) {
-                Log.e(TAG, Log.getStackTraceString(e));
-            }
-        }
-    }
-
-    private static void rateNow() {
-        Context context = mContext.get();
-        if (context == null) {
-            return;
-        }
-        IntentUtils.openInBrowser(context, "https://play.google.com/store/apps/details?id=de.danoeh.antennapod");
-        saveRated();
-    }
-
-    private static boolean rated() {
-        return mPreferences.getBoolean(KEY_RATED, false);
-    }
+    public static void check() {}
 
     @VisibleForTesting
-    public static void saveRated() {
-        mPreferences
-                .edit()
-                .putBoolean(KEY_RATED, true)
-                .apply();
-    }
-
-    private static void resetStartDate() {
-        mPreferences
-                .edit()
-                .putLong(KEY_FIRST_START_DATE, System.currentTimeMillis())
-                .apply();
-    }
-
-    private static boolean shouldShow() {
-        if (rated() || BuildConfig.DEBUG) {
-            return false;
-        }
-
-        long now = System.currentTimeMillis();
-        long firstDate = mPreferences.getLong(KEY_FIRST_START_DATE, now);
-        long diff = now - firstDate;
-        long diffDays = TimeUnit.DAYS.convert(diff, TimeUnit.MILLISECONDS);
-        return diffDays >= AFTER_DAYS;
-    }
-
-    @Nullable
-    private static AlertDialog createDialog() {
-        Context context = mContext.get();
-        if (context == null) {
-            return null;
-        }
-        return new MaterialAlertDialogBuilder(context)
-                .setTitle(R.string.rating_title)
-                .setMessage(R.string.rating_message)
-                .setPositiveButton(R.string.rating_now_label, (dialog, which) -> rateNow())
-                .setNegativeButton(R.string.rating_never_label, (dialog, which) -> saveRated())
-                .setNeutralButton(R.string.rating_later_label, (dialog, which) -> resetStartDate())
-                .setOnCancelListener(dialog1 -> resetStartDate())
-                .create();
-    }
+    public static void saveRated() {}
 }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -769,13 +769,6 @@
     <string name="sort_short_long">Short \u2192 Long</string>
     <string name="sort_long_short">Long \u2192 Short</string>
 
-    <!-- Rating dialog -->
-    <string name="rating_title" tools:ignore="UnusedResources">Like AntennaPod?</string>
-    <string name="rating_message" tools:ignore="UnusedResources">We would appreciate it if you take the time to rate AntennaPod.</string>
-    <string name="rating_never_label" tools:ignore="UnusedResources">Leave me alone</string>
-    <string name="rating_later_label" tools:ignore="UnusedResources">Remind me later</string>
-    <string name="rating_now_label" tools:ignore="UnusedResources">Sure, let\'s do this!</string>
-
     <!-- Share episode dialog -->
     <string name="share_playback_position_dialog_label">Include playback position</string>
     <string name="share_dialog_episode_website_label">Episode webpage</string>


### PR DESCRIPTION
This pull request deletes the ReviewDialog class in the free build so that F-Droid users are no longer asked to do a review on Google Play. Also deleting strings that would otherwise be obsolete. Closes #6492.