### PR TITLE
Fix crash in item pager

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemPagerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemPagerFragment.java
@@ -70,7 +70,7 @@ public class ItemPagerFragment extends Fragment implements MaterialToolbar.OnMen
         toolbar.setOnMenuItemClickListener(this);
 
         feedItems = getArguments().getLongArray(ARG_FEEDITEMS);
-        int feedItemPos = getArguments().getInt(ARG_FEEDITEM_POS);
+        final int feedItemPos = Math.max(0, getArguments().getInt(ARG_FEEDITEM_POS));
 
         pager = layout.findViewById(R.id.pager);
         // FragmentStatePagerAdapter documentation:


### PR DESCRIPTION
There should be no code path for feedItemPos to still be -1, but the crash reports indicate that it does. So this is now the dirty fix to avoid app crashes.