### PR TITLE
Add Intent to Trigger Database Export for Automation

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -44,6 +44,14 @@
             android:exported="true"
             tools:ignore="ExportedReceiver" /> <!-- allow feeds update to be triggered by external apps -->
 
+        <receiver android:name=".receiver.ExportDatabaseReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="de.danoeh.antennapod.action.EXPORT_DATABASE" />
+            </intent-filter>
+        </receiver>
+
+
         <service
             android:name=".service.QuickSettingsTileService"
             android:enabled="true"

--- a/core/src/main/java/de/danoeh/antennapod/core/receiver/ExportDatabaseReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/receiver/ExportDatabaseReceiver.java
@@ -1,0 +1,29 @@
+package de.danoeh.antennapod.core.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import java.io.IOException;
+
+import de.danoeh.antennapod.core.storage.DatabaseExporter;
+
+public class ExportDatabaseReceiver extends BroadcastReceiver {
+    public static final String ACTION_EXPORT_DATABASE = "de.danoeh.antennapod.action.EXPORT_DATABASE";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (ACTION_EXPORT_DATABASE.equals(intent.getAction())) {
+            String uriString = intent.getStringExtra(Intent.EXTRA_STREAM);
+            if (uriString != null) {
+                Uri uri = Uri.parse(uriString);
+                try {
+                    DatabaseExporter.exportToDocument(uri, context);
+                } catch (IOException e) {
+                    // Handle any exceptions
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->
Hi. This is an attempt to resolve issue #4850, which requests automatic backup/export functionality. I've exposed a new intent that triggers the existing database export feature. This intent can be invoked from automation apps like Tasker or from any terminal app.

For example, to set up an automated backup in Tasker, create a new 'Send Intent' task with the following settings:

- Action: `de.danoeh.antennapod.action.EXPORT_DATABASE`
- Extra: `android.intent.extra.STREAM:file:///storage/emulated/0/Download/AntennaPodExport_%DATE.db`
- Package: `de.danoeh.antennapod`

Alternatively, you can trigger the backup from a terminal app like Termux, or via SSH or ADB shell, using the following command:

``` zsh
am broadcast -a de.danoeh.antennapod.action.EXPORT_DATABASE --es android.intent.extra.STREAM file:///storage/emulated/0/Download/AntennaPodExport.db -n de.danoeh.antennapod/de.danoeh.antennapod.core.receiver.ExportDatabaseReceiver
```

If this PR is accepted, I can follow up with another PR to update the [AntennaPod documentation](https://antennapod.org/documentation/automation/tasker) with these examples.