### PR TITLE
No longer use 'metered' work-around for VPNs

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DownloadActionButton.java
@@ -52,12 +52,17 @@ public class DownloadActionButton extends ItemActionButton {
         } else {
             MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context)
                     .setTitle(R.string.confirm_mobile_download_dialog_title)
-                    .setMessage(R.string.confirm_mobile_download_dialog_message)
                     .setPositiveButton(R.string.confirm_mobile_download_dialog_download_later,
                             (d, w) -> DownloadServiceInterface.get().downloadNow(context, item, false))
                     .setNeutralButton(R.string.confirm_mobile_download_dialog_allow_this_time,
                             (d, w) -> DownloadServiceInterface.get().downloadNow(context, item, true))
                     .setNegativeButton(R.string.cancel_label, null);
+            if (NetworkUtils.isNetworkRestricted() && NetworkUtils.isVpnOverWifi()) {
+                builder.setMessage(R.string.confirm_mobile_download_dialog_message_vpn);
+            } else {
+                builder.setMessage(R.string.confirm_mobile_download_dialog_message);
+            }
+
             builder.show();
         }
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/NetworkUtils.java
@@ -78,18 +78,18 @@ public class NetworkUtils {
 
     private static boolean isNetworkMetered() {
         ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            NetworkCapabilities capabilities = connManager.getNetworkCapabilities(
-                    connManager.getActiveNetwork());
-
-            if (capabilities != null
-                    && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-                    && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
-                return false;
-            }
-        }
         return connManager.isActiveNetworkMetered();
+    }
+
+    public static boolean isVpnOverWifi() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return false;
+        }
+        ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkCapabilities capabilities = connManager.getNetworkCapabilities(connManager.getActiveNetwork());
+        return capabilities != null
+                && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+                && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN);
     }
 
     private static boolean isNetworkCellular() {

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/FeedUpdateManager.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/FeedUpdateManager.java
@@ -98,7 +98,6 @@ public class FeedUpdateManager {
     private static void confirmMobileRefresh(final Context context, @Nullable Feed feed) {
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context)
                 .setTitle(R.string.feed_refresh_title)
-                .setMessage(R.string.confirm_mobile_feed_refresh_dialog_message)
                 .setPositiveButton(R.string.confirm_mobile_streaming_button_once,
                         (dialog, which) -> runOnce(context, feed))
                 .setNeutralButton(R.string.confirm_mobile_streaming_button_always, (dialog, which) -> {
@@ -106,6 +105,11 @@ public class FeedUpdateManager {
                     runOnce(context, feed);
                 })
                 .setNegativeButton(R.string.no, null);
+        if (NetworkUtils.isNetworkRestricted() && NetworkUtils.isVpnOverWifi()) {
+            builder.setMessage(R.string.confirm_mobile_feed_refresh_dialog_message_vpn);
+        } else {
+            builder.setMessage(R.string.confirm_mobile_feed_refresh_dialog_message);
+        }
         builder.show();
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="add_tag">Add tag</string>
     <string name="rename_tag_label">Rename tag</string>
     <string name="confirm_mobile_feed_refresh_dialog_message">Refreshing podcasts over mobile data connection is disabled in the settings.\n\nDo you want to refresh anyway?</string>
+    <string name="confirm_mobile_feed_refresh_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Refreshing podcasts over mobile data connection is disabled in the settings.\n\nDo you want to refresh anyway? If you want this problem to be fixed, contact the creators of your VPN app.</string>
 
     <!-- actions on feeditems -->
     <string name="download_label">Download</string>
@@ -302,6 +303,7 @@
     <string name="authentication_notification_title">Authentication required</string>
     <string name="confirm_mobile_download_dialog_title">Confirm mobile download</string>
     <string name="confirm_mobile_download_dialog_message">Downloading over mobile data connection is disabled in the settings. AntennaPod can download the episode later automatically when Wi-Fi is available.</string>
+    <string name="confirm_mobile_download_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Downloading over mobile data connection is disabled in the settings. If you want this problem to be fixed, contact the creators of your VPN app.</string>
     <string name="confirm_mobile_download_dialog_download_later">Download later</string>
     <string name="confirm_mobile_download_dialog_allow_this_time">Download anyway</string>
     <string name="confirm_mobile_streaming_notification_title">Confirm mobile streaming</string>


### PR DESCRIPTION
WorkManager doesn't do the workaround either.
So we would launch a download that then never starts.

Closes #6631