### PR TITLE
Remove Iconify from SubscriptionFragment

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -11,8 +11,8 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -22,7 +22,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.joanzapata.iconify.Iconify;
 import com.leinardi.android.speeddial.SpeedDialView;
 
 import org.greenrobot.eventbus.EventBus;
@@ -80,7 +79,7 @@ public class SubscriptionFragment extends Fragment
     private RecyclerView subscriptionRecycler;
     private SubscriptionsRecyclerAdapter subscriptionAdapter;
     private EmptyViewHandler emptyView;
-    private TextView feedsFilteredMsg;
+    private LinearLayout feedsFilteredMsg;
     private MaterialToolbar toolbar;
     private ProgressBar progressBar;
     private String displayedFolder = null;
@@ -319,8 +318,6 @@ public class SubscriptionFragment extends Fragment
                     });
 
         if (UserPreferences.getSubscriptionsFilter().isEnabled()) {
-            feedsFilteredMsg.setText("{md-info-outline} " + getString(R.string.subscriptions_are_filtered));
-            Iconify.addIcons(feedsFilteredMsg);
             feedsFilteredMsg.setVisibility(View.VISIBLE);
         } else {
             feedsFilteredMsg.setVisibility(View.GONE);

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -40,8 +40,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="4dp"
                 android:paddingBottom="8dp"
-                android:text="@string/subscriptions_are_filtered"
-                tools:visibility="visible" />
+                android:text="@string/subscriptions_are_filtered" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -23,10 +23,12 @@
             android:id="@+id/feeds_filtered_message"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="60dp"
-            android:layout_marginStart="60dp"
+            android:paddingStart="60dp"
+            android:paddingEnd="0dp"
+            android:paddingVertical="4dp"
             android:layout_marginTop="-12dp"
             android:background="?android:attr/selectableItemBackground"
+            android:gravity="center_vertical"
             android:orientation="horizontal">
 
             <ImageView
@@ -38,7 +40,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="4dp"
-                android:paddingBottom="8dp"
                 android:text="@string/subscriptions_are_filtered" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -19,18 +19,31 @@
             app:title="@string/subscriptions_label"
             app:navigationIcon="?homeAsUpIndicator" />
 
-        <TextView
+        <LinearLayout
             android:id="@+id/feeds_filtered_message"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingBottom="8dp"
-            android:text="@string/filtered_label"
-            android:layout_marginTop="-12dp"
             android:layout_marginLeft="60dp"
             android:layout_marginStart="60dp"
+            android:layout_marginTop="-12dp"
             android:background="?android:attr/selectableItemBackground"
-            android:visibility="gone"
-            tools:visibility="visible" />
+            android:importantForAccessibility="no"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_info" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="4dp"
+                android:paddingBottom="8dp"
+                android:text="@string/subscriptions_are_filtered"
+                tools:visibility="visible" />
+
+        </LinearLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -21,13 +21,12 @@
 
         <LinearLayout
             android:id="@+id/feeds_filtered_message"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="60dp"
             android:layout_marginStart="60dp"
             android:layout_marginTop="-12dp"
             android:background="?android:attr/selectableItemBackground"
-            android:importantForAccessibility="no"
             android:orientation="horizontal">
 
             <ImageView

--- a/app/src/main/res/layout/nav_section_item.xml
+++ b/app/src/main/res/layout/nav_section_item.xml
@@ -20,7 +20,6 @@
         android:id="@+id/nav_feeds_filtered_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:importantForAccessibility="no"
         android:orientation="horizontal">
 
         <ImageView


### PR DESCRIPTION
Part of #5925
Icon sized to be consistent with #6578

Existing "subscriptions are filtered" screenshot

![existing-subscriptions-are-filtered](https://github.com/AntennaPod/AntennaPod/assets/1500358/f0d63e3f-dedf-421a-a7d0-a4efd6d59cc1)

New subscriptions are filtered screenshot (larger in order to use multiples of '4', but consistent with #6587)

![consistent-subscriptions-are-filtered](https://github.com/AntennaPod/AntennaPod/assets/1500358/70b458cf-4e11-4e65-87f9-6e5621a090c0)
