### PR TITLE
Fix file deletion and queueing after download

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/CancelDownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/CancelDownloadActionButton.java
@@ -32,7 +32,7 @@ public class CancelDownloadActionButton extends ItemActionButton {
     @Override
     public void onClick(Context context) {
         FeedMedia media = item.getMedia();
-        DownloadServiceInterface.get().cancel(context, media.getDownload_url());
+        DownloadServiceInterface.get().cancel(context, media);
         if (UserPreferences.isEnableAutodownload()) {
             item.disableAutoDownload();
             DBWriter.setFeedItem(item);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceInterfaceImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceInterfaceImpl.java
@@ -7,12 +7,18 @@ import androidx.work.ExistingWorkPolicy;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.OutOfQuotaPolicy;
+import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
 
+import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
@@ -40,13 +46,11 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
                 .setInitialDelay(0L, TimeUnit.MILLISECONDS)
                 .addTag(DownloadServiceInterface.WORK_TAG)
                 .addTag(DownloadServiceInterface.WORK_TAG_EPISODE_URL + item.getMedia().getDownload_url());
-        Data.Builder builder = new Data.Builder();
-        builder.putLong(WORK_DATA_MEDIA_ID, item.getMedia().getId());
         if (!item.isTagged(FeedItem.TAG_QUEUE) && UserPreferences.enqueueDownloadedEpisodes()) {
             DBWriter.addQueueItem(context, false, item.getId());
-            builder.putBoolean(WORK_DATA_WAS_QUEUED, true);
+            workRequest.addTag(DownloadServiceInterface.WORK_DATA_WAS_QUEUED);
         }
-        workRequest.setInputData(builder.build());
+        workRequest.setInputData(new Data.Builder().putLong(WORK_DATA_MEDIA_ID, item.getMedia().getId()).build());
         return workRequest;
     }
 
@@ -61,8 +65,26 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
     }
 
     @Override
-    public void cancel(Context context, String url) {
-        WorkManager.getInstance(context).cancelAllWorkByTag(WORK_TAG_EPISODE_URL + url);
+    public void cancel(Context context, FeedMedia media) {
+        // This needs to be done here, not in the worker. Reason: The worker might or might not be running.
+        DBWriter.deleteFeedMediaOfItem(context, media.getId()); // Remove partially downloaded file
+        String tag = WORK_TAG_EPISODE_URL + media.getDownload_url();
+        Future<List<WorkInfo>> future = WorkManager.getInstance(context).getWorkInfosByTag(tag);
+        Observable.fromFuture(future)
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.io())
+                .subscribe(
+                    workInfos -> {
+                        for (WorkInfo info : workInfos) {
+                            if (info.getTags().contains(DownloadServiceInterface.WORK_DATA_WAS_QUEUED)) {
+                                DBWriter.removeQueueItem(context, false, media.getItem());
+                            }
+                        }
+                        WorkManager.getInstance(context).cancelAllWorkByTag(tag);
+                    }, exception -> {
+                        WorkManager.getInstance(context).cancelAllWorkByTag(tag);
+                        exception.printStackTrace();
+                    });
     }
 
     @Override

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -110,7 +110,7 @@ public class DBWriter {
             @NonNull Context context, @NonNull FeedMedia media) {
         Log.i(TAG, String.format(Locale.US, "Requested to delete FeedMedia [id=%d, title=%s, downloaded=%s",
                 media.getId(), media.getEpisodeTitle(), media.isDownloaded()));
-        if (media.isDownloaded()) {
+        if (media.isDownloaded() || media.getFile_url() != null) {
             // delete downloaded media file
             File mediaFile = new File(media.getFile_url());
             if (mediaFile.exists() && !mediaFile.delete()) {
@@ -206,7 +206,7 @@ public class DBWriter {
                 if (item.getMedia().isDownloaded()) {
                     deleteFeedMediaSynchronous(context, item.getMedia());
                 }
-                DownloadServiceInterface.get().cancel(context, item.getMedia().getDownload_url());
+                DownloadServiceInterface.get().cancel(context, item.getMedia());
             }
         }
 

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.net.download.serviceinterface;
 import android.content.Context;
 import de.danoeh.antennapod.model.download.DownloadStatus;
 import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +39,7 @@ public abstract class DownloadServiceInterface {
      */
     public abstract void download(Context context, FeedItem item);
 
-    public abstract void cancel(Context context, String url);
+    public abstract void cancel(Context context, FeedMedia media);
 
     public abstract void cancelAll(Context context);
 

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterfaceStub.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterfaceStub.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.net.download.serviceinterface;
 
 import android.content.Context;
 import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
 
 public class DownloadServiceInterfaceStub extends DownloadServiceInterface {
 
@@ -14,7 +15,7 @@ public class DownloadServiceInterfaceStub extends DownloadServiceInterface {
     }
 
     @Override
-    public void cancel(Context context, String url) {
+    public void cancel(Context context, FeedMedia media) {
     }
 
     @Override


### PR DESCRIPTION
WorkManager does not tell us whether it was cancelled by the user (not retried) or by the system (retried later). So we need to delete the file and remove from queue when we know that it was actually the user. Also makes sure to always delete the file when the download fails.

Also, don't show "will retry" message on last retry attempt.

Closes #6596
