### PR TITLE
Replace "+ 20 min" sleep timer with "Until end" of episode

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -83,8 +83,7 @@ public class SleepTimerDialog extends DialogFragment {
         extendSleepFiveMinutesButton.setText(getString(R.string.extend_sleep_timer_label, 5));
         Button extendSleepTenMinutesButton = content.findViewById(R.id.extendSleepTenMinutesButton);
         extendSleepTenMinutesButton.setText(getString(R.string.extend_sleep_timer_label, 10));
-        Button extendSleepTwentyMinutesButton = content.findViewById(R.id.extendSleepTwentyMinutesButton);
-        extendSleepTwentyMinutesButton.setText(getString(R.string.extend_sleep_timer_label, 20));
+        Button extendSleepUntilEndEpisodeButton = content.findViewById(R.id.extendSleepUntilEndEpisodeButton);
         extendSleepFiveMinutesButton.setOnClickListener(v -> {
             if (controller != null) {
                 controller.extendSleepTimer(5 * 1000 * 60);
@@ -95,9 +94,9 @@ public class SleepTimerDialog extends DialogFragment {
                 controller.extendSleepTimer(10 * 1000 * 60);
             }
         });
-        extendSleepTwentyMinutesButton.setOnClickListener(v -> {
+        extendSleepUntilEndEpisodeButton.setOnClickListener(v -> {
             if (controller != null) {
-                controller.extendSleepTimer(20 * 1000 * 60);
+                controller.setSleepTimer(controller.getDuration() - controller.getPosition());
             }
         });
 

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -101,17 +101,17 @@
                 tools:text="+10 min" />
 
             <Button
-                    android:id="@+id/extendSleepUntilEndEpisodeButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginRight="4dp"
-                    android:layout_marginLeft="4dp"
-                    android:paddingHorizontal="2dp"
-                    android:paddingVertical="4dp"
-                    android:layout_weight="1"
-                    android:text="@string/extend_sleep_timer_until_end_episode_label"
-                    style="?attr/materialButtonOutlinedStyle"/>
+                android:id="@+id/extendSleepUntilEndEpisodeButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginRight="4dp"
+                android:layout_marginLeft="4dp"
+                android:paddingHorizontal="2dp"
+                android:paddingVertical="4dp"
+                android:layout_weight="1"
+                android:text="@string/extend_sleep_timer_until_end_episode_label"
+                style="?attr/materialButtonOutlinedStyle" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -110,8 +110,8 @@
                     android:paddingHorizontal="2dp"
                     android:paddingVertical="4dp"
                     android:layout_weight="1"
-                    style="?attr/materialButtonOutlinedStyle"
-                    android:text="@string/extend_sleep_timer_until_end_episode_label"/>
+                    android:text="@string/extend_sleep_timer_until_end_episode_label"
+                    style="?attr/materialButtonOutlinedStyle"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -101,17 +101,17 @@
                 tools:text="+10 min" />
 
             <Button
-                android:id="@+id/extendSleepTwentyMinutesButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginRight="4dp"
-                android:layout_marginLeft="4dp"
-                android:paddingHorizontal="2dp"
-                android:paddingVertical="4dp"
-                android:layout_weight="1"
-                style="?attr/materialButtonOutlinedStyle"
-                tools:text="+20 min" />
+                    android:id="@+id/extendSleepUntilEndEpisodeButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginRight="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:paddingHorizontal="2dp"
+                    android:paddingVertical="4dp"
+                    android:layout_weight="1"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:text="@string/extend_sleep_timer_until_end_episode_label"/>
 
         </LinearLayout>
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -591,6 +591,7 @@
     <!-- Sleep timer -->
     <string name="set_sleeptimer_label">Set sleep timer</string>
     <string name="disable_sleeptimer_label">Disable sleep timer</string>
+    <string name="extend_sleep_timer_until_end_episode_label">Until end</string>
     <string name="extend_sleep_timer_label">+%d min</string>
     <string name="sleep_timer_always">Always</string>
     <string name="sleep_timer_label">Sleep timer</string>


### PR DESCRIPTION
As an alternative approach to topic [#4754](https://github.com/AntennaPod/AntennaPod/pull/4754):
This one replaces the option to extend sleep timer +20 min by "until end" of episode which calculates the difference from current position to the end of episode.

No big change but "+20 min" could still be reached by clicking twice on "+10 min". Therefore this would improve the current app behaviour by simply replacing that button.
