### PR TITLE
Add error icon on subscriptions screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/SubscriptionsRecyclerAdapter.java
@@ -216,6 +216,7 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
         private final FrameLayout selectView;
         private final CheckBox selectCheckbox;
         private final CardView card;
+        private final View errorIcon;
 
         public SubscriptionViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -226,6 +227,7 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
             selectView = itemView.findViewById(R.id.selectContainer);
             selectCheckbox = itemView.findViewById(R.id.selectCheckBox);
             card = itemView.findViewById(R.id.outerContainer);
+            errorIcon = itemView.findViewById(R.id.errorIcon);
         }
 
         public void bind(NavDrawerData.DrawerItem drawerItem) {
@@ -249,9 +251,11 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
                 textAndImageCombined = feed.isLocalFeed() && feed.getImageUrl() != null
                         && feed.getImageUrl().startsWith(Feed.PREFIX_GENERATIVE_COVER);
                 coverLoader.withUri(feed.getImageUrl());
+                errorIcon.setVisibility(feed.hasLastUpdateFailed() ? View.VISIBLE : View.GONE);
             } else {
                 textAndImageCombined = true;
                 coverLoader.withResource(R.drawable.ic_tag);
+                errorIcon.setVisibility(View.GONE);
             }
             if (UserPreferences.shouldShowSubscriptionTitle()) {
                 // No need for fallback title when already showing title

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -57,6 +57,7 @@
         android:layout_toStartOf="@id/txtvCount"
         android:layout_toLeftOf="@id/txtvCount"
         android:visibility="gone"
+        android:contentDescription="@string/refresh_failed_msg"
         app:srcCompat="@drawable/ic_error"
         app:tint="?attr/icon_red"
         tools:text="!" />

--- a/app/src/main/res/layout/subscription_item.xml
+++ b/app/src/main/res/layout/subscription_item.xml
@@ -6,7 +6,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:padding="4dp">
+    android:padding="4dp"
+    tools:layout_width="150dp">
 
     <androidx.cardview.widget.CardView
         android:id="@+id/outerContainer"
@@ -69,6 +70,18 @@
                         android:layout_alignParentEnd="true"
                         android:textSize="14sp"
                         style="@style/TextPill" />
+
+                    <ImageView
+                        android:id="@+id/errorIcon"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_alignParentEnd="true"
+                        android:layout_alignBottom="@id/coverImage"
+                        android:layout_margin="8dp"
+                        android:visibility="gone"
+                        android:contentDescription="@string/refresh_failed_msg"
+                        app:srcCompat="@drawable/ic_error"
+                        tools:visibility="visible" />
 
                 </RelativeLayout>
 

--- a/core/src/main/res/drawable/ic_error.xml
+++ b/core/src/main/res/drawable/ic_error.xml
@@ -4,6 +4,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFFFFF"
+        android:fillColor="?android:attr/colorBackground"
+        android:pathData="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1z" />
+    <path
+        android:fillColor="?attr/icon_red"
         android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z" />
 </vector>


### PR DESCRIPTION
The icon does not have a dedicated click action, but clicking it opens the podcast page and there is a large banner with more information.

Closes #6653

<img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/0ad5e6bc-9f12-436a-bb29-196199fb0622" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/0b35dc62-284b-47ce-840f-78677718c39c" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/a6e50212-859c-4602-be34-628c2f9704ab" />

cc @keunes