### PR TITLE
Ignore skip in first second of playback

### DIFF
--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/PlaybackServiceMediaPlayer.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/PlaybackServiceMediaPlayer.java
@@ -215,6 +215,10 @@ public abstract class PlaybackServiceMediaPlayer {
     public abstract int getSelectedAudioTrack();
 
     public void skip() {
+        if (getPosition() < 1000) {
+            Log.d(TAG, "Ignoring skip, is in first second of playback");
+            return;
+        }
         endPlayback(false, true, true, true);
     }
 


### PR DESCRIPTION
Users complained that they wanted to skip the ending of an episode and accidentally skipped the next one that started while their finger was moving.

Closes #6480