### PR TITLE
Multi-select actions on search results

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -217,7 +217,8 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
             @Override
             public void onToggleChanged(boolean open) {
                 if (open && adapter.getSelectedCount() == 0) {
-                    ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected, Snackbar.LENGTH_SHORT);
+                    ((MainActivity) getActivity())
+                            .showSnackbarAbovePlayer(R.string.no_items_selected, Snackbar.LENGTH_SHORT);
                     speedDialBinding.fabSD.close();
                 }
             }
@@ -289,16 +290,16 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     @Override
     public boolean onContextItemSelected(@NonNull MenuItem item) {
         Feed selectedFeedItem  = adapterFeeds.getLongPressedItem();
-        if (selectedFeedItem != null
-                && FeedMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedFeedItem, () -> { })) {
+        if(selectedFeedItem != null
+                && FeedMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedFeedItem, () -> {})){
             return true;
         }
         FeedItem selectedItem = adapter.getLongPressedItem();
         if(selectedItem != null){
-            if (adapter.onContextItemSelected(item)) {
+            if(adapter.onContextItemSelected(item)){
                 return true;
             }
-            if (FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem)) {
+            if(FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem)){
                 return true;
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -67,7 +67,7 @@ import de.danoeh.antennapod.event.FeedListUpdateEvent;
 /**
  * Performs a search operation on all feeds or one specific feed and displays the search result.
  */
-public class SearchFragment extends Fragment implements EpisodeItemListAdapter.OnSelectModeListener  {
+public class SearchFragment extends Fragment implements EpisodeItemListAdapter.OnSelectModeListener {
     private static final String TAG = "SearchFragment";
     private static final String ARG_QUERY = "query";
     private static final String ARG_FEED = "feed";
@@ -224,7 +224,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
             }
         });
         speedDialBinding.fabSD.setOnActionSelectedListener(actionItem -> {
-            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItem.getId())
+            new EpisodeMultiSelectActionHandler((MainActivity) getActivity(), actionItem.getId())
                     .handleAction(adapter.getSelectedItems());
             adapter.endSelectMode();
             return true;
@@ -290,16 +290,16 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     @Override
     public boolean onContextItemSelected(@NonNull MenuItem item) {
         Feed selectedFeedItem  = adapterFeeds.getLongPressedItem();
-        if(selectedFeedItem != null
-                && FeedMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedFeedItem, () -> {})){
+        if (selectedFeedItem != null
+                && FeedMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedFeedItem, () -> { })) {
             return true;
         }
         FeedItem selectedItem = adapter.getLongPressedItem();
-        if(selectedItem != null){
-            if(adapter.onContextItemSelected(item)){
+        if (selectedItem != null) {
+            if (adapter.onContextItemSelected(item)) {
                 return true;
             }
-            if(FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem)){
+            if (FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem)) {
                 return true;
             }
         }
@@ -450,7 +450,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         searchViewFocusOn();
     }
 
-    private void searchViewFocusOff(){
+    private void searchViewFocusOff() {
         isOtherViewInFoucus = true;
         searchView.clearFocus();
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -449,7 +449,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         searchViewFocusOn();
     }
 
-    void searchViewFocusOff(){
+    private void searchViewFocusOff(){
         isOtherViewInFoucus = true;
         searchView.clearFocus();
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -24,6 +24,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.chip.Chip;
+import com.google.android.material.snackbar.Snackbar;
+import com.leinardi.android.speeddial.SpeedDialView;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
@@ -31,11 +33,13 @@ import de.danoeh.antennapod.activity.OnlineFeedViewActivity;
 import de.danoeh.antennapod.adapter.EpisodeItemListAdapter;
 import de.danoeh.antennapod.adapter.HorizontalFeedListAdapter;
 import de.danoeh.antennapod.core.menuhandler.MenuItemUtils;
+import de.danoeh.antennapod.databinding.MultiSelectSpeedDialBinding;
 import de.danoeh.antennapod.event.EpisodeDownloadEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
+import de.danoeh.antennapod.fragment.actions.EpisodeMultiSelectActionHandler;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.core.storage.FeedSearcher;
@@ -63,7 +67,7 @@ import de.danoeh.antennapod.event.FeedListUpdateEvent;
 /**
  * Performs a search operation on all feeds or one specific feed and displays the search result.
  */
-public class SearchFragment extends Fragment {
+public class SearchFragment extends Fragment implements EpisodeItemListAdapter.OnSelectModeListener  {
     private static final String TAG = "SearchFragment";
     private static final String ARG_QUERY = "query";
     private static final String ARG_FEED = "feed";
@@ -81,6 +85,9 @@ public class SearchFragment extends Fragment {
     private SearchView searchView;
     private Handler automaticSearchDebouncer;
     private long lastQueryChange = 0;
+    private MultiSelectSpeedDialBinding speedDialBinding;
+    private boolean isOtherViewInFoucus = false;
+
 
     /**
      * Create a new SearchFragment that searches all feeds.
@@ -133,8 +140,8 @@ public class SearchFragment extends Fragment {
                              @Nullable Bundle savedInstanceState) {
         View layout = inflater.inflate(R.layout.search_fragment, container, false);
         setupToolbar(layout.findViewById(R.id.toolbar));
+        speedDialBinding = MultiSelectSpeedDialBinding.bind(layout);
         progressBar = layout.findViewById(R.id.progressBar);
-
         recyclerView = layout.findViewById(R.id.recyclerView);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         registerForContextMenu(recyclerView);
@@ -142,9 +149,13 @@ public class SearchFragment extends Fragment {
             @Override
             public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
                 super.onCreateContextMenu(menu, v, menuInfo);
+                if (!inActionMode()) {
+                    menu.findItem(R.id.multi_select).setVisible(true);
+                }
                 MenuItemUtils.setOnClickListeners(menu, SearchFragment.this::onContextItemSelected);
             }
         };
+        adapter.setOnSelectModeListener(this);
         recyclerView.setAdapter(adapter);
         recyclerView.addOnScrollListener(new LiftOnScrollListener(layout.findViewById(R.id.appbar)));
 
@@ -180,7 +191,7 @@ public class SearchFragment extends Fragment {
             search();
         }
         searchView.setOnQueryTextFocusChangeListener((view, hasFocus) -> {
-            if (hasFocus) {
+            if (hasFocus && !isOtherViewInFoucus) {
                 showInputMethod(view.findFocus());
             }
         });
@@ -195,6 +206,29 @@ public class SearchFragment extends Fragment {
                 }
             }
         });
+        speedDialBinding.fabSD.setOverlayLayout(speedDialBinding.fabSDOverlay);
+        speedDialBinding.fabSD.inflate(R.menu.episodes_apply_action_speeddial);
+        speedDialBinding.fabSD.setOnChangeListener(new SpeedDialView.OnChangeListener() {
+            @Override
+            public boolean onMainActionSelected() {
+                return false;
+            }
+
+            @Override
+            public void onToggleChanged(boolean open) {
+                if (open && adapter.getSelectedCount() == 0) {
+                    ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected, Snackbar.LENGTH_SHORT);
+                    speedDialBinding.fabSD.close();
+                }
+            }
+        });
+        speedDialBinding.fabSD.setOnActionSelectedListener(actionItem -> {
+            new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItem.getId())
+                    .handleAction(adapter.getSelectedItems());
+            adapter.endSelectMode();
+            return true;
+        });
+
         return layout;
     }
 
@@ -260,8 +294,13 @@ public class SearchFragment extends Fragment {
             return true;
         }
         FeedItem selectedItem = adapter.getLongPressedItem();
-        if (selectedItem != null && FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem)) {
-            return true;
+        if(selectedItem != null){
+            if (adapter.onContextItemSelected(item)) {
+                return true;
+            }
+            if (FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem)) {
+                return true;
+            }
         }
         return super.onContextItemSelected(item);
     }
@@ -392,5 +431,30 @@ public class SearchFragment extends Fragment {
         }
         ((MainActivity) getActivity()).loadChildFragment(
                 OnlineSearchFragment.newInstance(CombinedSearcher.class, query));
+    }
+
+    @Override
+    public void onStartSelectMode() {
+        searchViewFocusOff();
+        speedDialBinding.fabSD.removeActionItemById(R.id.remove_from_inbox_batch);
+        speedDialBinding.fabSD.removeActionItemById(R.id.remove_from_queue_batch);
+        speedDialBinding.fabSD.removeActionItemById(R.id.delete_batch);
+        speedDialBinding.fabSD.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void onEndSelectMode() {
+        speedDialBinding.fabSD.close();
+        speedDialBinding.fabSD.setVisibility(View.GONE);
+        searchViewFocusOn();
+    }
+
+    void searchViewFocusOff(){
+        isOtherViewInFoucus = true;
+        searchView.clearFocus();
+    }
+    private void searchViewFocusOn() {
+        isOtherViewInFoucus = false;
+        searchView.requestFocus();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SearchFragment.java
@@ -453,6 +453,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         isOtherViewInFoucus = true;
         searchView.clearFocus();
     }
+
     private void searchViewFocusOn() {
         isOtherViewInFoucus = false;
         searchView.requestFocus();

--- a/app/src/main/res/layout/search_fragment.xml
+++ b/app/src/main/res/layout/search_fragment.xml
@@ -61,4 +61,7 @@
         android:paddingTop="12dp"
         android:paddingHorizontal="@dimen/additional_horizontal_spacing" />
 
+    <include
+        layout="@layout/multi_select_speed_dial" />
+
 </RelativeLayout>


### PR DESCRIPTION
Multi-select feature is added in the search fragment for search results.

<img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/62adfc84-004f-42f3-a7bc-1140a1b72f4a" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/8bea8854-7f52-4491-8765-5af315492a6d" />

limited context menu options for the fab button are added considering the most useful for the search result page.
if needed more features that can be done by simply changing some lines of onStartSelectMode() function of SearchFragment.java file.

For the search result page focus for searchView is handled properly to close and open the keyboard on right times.

Also, this is my first pull request. Please help if anything is wrong. This will help me a lot.

Closes #6398