### PR TITLE
Fix adding new playback speed preset when service is not running

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
@@ -98,7 +98,7 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
     }
 
     private void addCurrentSpeed() {
-        float newSpeed = controller.getCurrentPlaybackSpeedMultiplier();
+        float newSpeed = speedSeekBar.getCurrentSpeed();
         if (selectedSpeeds.contains(newSpeed)) {
             Snackbar.make(addCurrentSpeedChip,
                     getString(R.string.preset_already_exists, newSpeed), Snackbar.LENGTH_LONG).show();


### PR DESCRIPTION
<!-- Please make sure that you have read our contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request -->

Fixes #6728 

## **BUG**: While trying to add new playback speeds it gives errors.
<img width="300" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/d77076d8-7d62-48ba-9a17-14afddb8c678" />
<img width="300" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/4c8eb650-6163-4772-86bf-0d59788d5e27" />

## **OBSERVATION**: The bug appears only in cases when PlaybackService remains uninitiated ( whenever the user does not play any podcase once entering into the app.)

VariableSpeedDialog uses setPlaybackSpeed(float speed) method of PlaybackController to set the playback speed in the media player and also in preferences.
<img height="250" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/f0fe435d-67a8-4643-96c4-d7867c1696bf" />

The major setback in the above code is that whenever the user opens the application and directly goes to change the playback speed( whether in the player fragment or global playback settings ) without trying to play any audio/video podcast it keeps the PlaybackService uninitiated NULL state.
According to the above code, it only signals the fragments to update the UI of playback speed without actually updating them into the preferences.

<img height="250" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/0af7d5c5-e7ab-4b66-85c2-87ead266ecee" />

While adding the current playback speed to selectedSpeeds ( saved chips of speeds ), VariableSpeedDialog uses getCurrentPlaybackSpeedMultiplier() method of PlaybackController 

<img height="220" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/e06720f9-f992-4238-a75c-9e7f4ea9f7c4" />

Due to uninitiated PlaybackService getCurrentPlaybackSpeedMultiplier() uses playbackSpeedUtils.getCurrentPlaybackSpeed(getMedia()) method to retrieve the current playback speed from preferences cause this method expects that the playback speed in preferences in updates. But as we have seen before setPlaybackSpeed(float speed) fails to update the current playback speed which causes the BUG.

## **SOLUTION**
<img height="220" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/f61f030c-e068-498e-8b3f-3ec98af64b54" />
<img height="220" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/aeab13a0-97b9-4402-b497-d80136f6df3a" />

to resolve the bug added some lines of code to set the current playback speed to preferences both in setPlaybackSpeed(float speed) method of PlaybackController & in setSpeed(float speed) method in PlaybackService.

<img height="220" src="https://github.com/AntennaPod/AntennaPod/assets/61724808/8bb6e9b3-e37e-446d-a37f-8f7b903a0d96" />

(above is old code)

in setSpeed(float speed) I changed above prior lines above the code to set both 
UserPreferences.setVideoPlaybackSpeed(speed) &
UserPreferences.setPlaybackSpeed(speed)

at the same time. Cause whenever the methods are called from the  Global Playback Preferences Settings it does not explicitly say which playback speed we are setting, whether it is Video playback speed or Audio playback speed it is just configuring the playback speed. Setting different types of playback speeds based on the media type (Video/Audio) currently playing in the media player causes some unnecessary Bugs ( such as if you changed the Video playback speed and then switched to an Audio podcast then again playback speed will be changed to something else. )



 
