### PR TITLE
Parse podcast:transcript url and store in SQLite

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -482,7 +482,7 @@ public class FeedItem extends FeedComponent implements Serializable {
             case "application/srr":
             case "application/srt":
             case "application/x-subrip":
-                if (! podcastIndexTranscriptType.equals(jsonType)) {
+                if (podcastIndexTranscriptUrl == null || ! podcastIndexTranscriptType.equals(jsonType)) {
                     podcastIndexTranscriptUrl = url;
                     podcastIndexTranscriptType = canonicalSrr;
                 }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -5,7 +5,6 @@ import android.util.Pair;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -1,17 +1,16 @@
 package de.danoeh.antennapod.model.feed;
 
-import android.util.Pair;
-
+import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +21,8 @@ import java.util.concurrent.TimeUnit;
  * @author daniel
  */
 public class FeedItem extends FeedComponent implements Serializable {
+
+    public static String TAG = "FeedItem";
 
     /** tag that indicates this item is in the queue */
     public static final String TAG_QUEUE = "Queue";
@@ -45,7 +46,8 @@ public class FeedItem extends FeedComponent implements Serializable {
     private transient Feed feed;
     private long feedId;
     private String podcastIndexChapterUrl;
-    private Hashtable<String, String> podcastIndexTranscriptUrls;
+    private String podcastIndexTranscriptUrl;
+    private String podcastIndexTranscriptType;
 
     private int state;
     public static final int NEW = -1;
@@ -101,8 +103,8 @@ public class FeedItem extends FeedComponent implements Serializable {
         this.autoDownload = autoDownload;
         this.podcastIndexChapterUrl = podcastIndexChapterUrl;
         if (transcriptUrl != null) {
-            this.podcastIndexTranscriptUrls = new Hashtable<String, String>();
-            this.podcastIndexTranscriptUrls.put(transcriptType, transcriptUrl);
+            this.podcastIndexTranscriptUrl = transcriptUrl;
+            this.podcastIndexTranscriptType = transcriptType;
         }
     }
 
@@ -171,8 +173,8 @@ public class FeedItem extends FeedComponent implements Serializable {
         if (other.podcastIndexChapterUrl != null) {
             podcastIndexChapterUrl = other.podcastIndexChapterUrl;
         }
-        if (other.getPodcastIndexTranscriptUrls() != null) {
-            podcastIndexTranscriptUrls = other.podcastIndexTranscriptUrls;
+        if (other.getPodcastIndexTranscriptUrl() != null) {
+            podcastIndexTranscriptUrl = other.podcastIndexTranscriptUrl;
         }
     }
 
@@ -452,48 +454,43 @@ public class FeedItem extends FeedComponent implements Serializable {
         podcastIndexChapterUrl = url;
     }
 
-    public void setPodcastIndexTranscriptUrl(String t, String url) {
-        if (podcastIndexTranscriptUrls == null) {
-            podcastIndexTranscriptUrls = new Hashtable<String, String>();
-        }
-        podcastIndexTranscriptUrls.put(t, url);
+    public void setPodcastIndexTranscriptUrl(String type, String url) {
+        updateTranscriptPreferredFormat(type, url);
     }
 
-
-    public String getPodcastIndexTranscriptUrls(String t) {
-        if (podcastIndexTranscriptUrls == null) {
-            return null;
-        }
-        return podcastIndexTranscriptUrls.get(t);
+    public String getPodcastIndexTranscriptUrl() {
+        return podcastIndexTranscriptUrl;
     }
 
-    public Hashtable<String, String> getPodcastIndexTranscriptUrls() {
-        if (podcastIndexTranscriptUrls == null) {
-            return null;
-        }
-        return podcastIndexTranscriptUrls;
+    public String getPodcastIndexTranscriptType() {
+        return podcastIndexTranscriptType;
     }
 
-    public Pair<String, String> getPodcastIndexTranscriptUrlPreferred() {
-        if (podcastIndexTranscriptUrls == null) {
-            return null;
-        }
-        // We prefer JSON if that is available
-        if (podcastIndexTranscriptUrls.get("application/json") != null) {
-            return new Pair("application/json", podcastIndexTranscriptUrls.get("application/json"));
+    public void updateTranscriptPreferredFormat(String type, String url) {
+        if (StringUtils.isEmpty(type) || StringUtils.isEmpty(url)) {
+            return;
         }
 
-        // SRR format, but feeds use different mime types
-        if (podcastIndexTranscriptUrls.get("application/srr") != null) {
-            return new Pair("application/srr", podcastIndexTranscriptUrls.get("application/srr"));
+        String canonical_srr = "application/srr";
+        String json_type_str = "application/json";
+
+        switch (type) {
+            case "application/json":
+                podcastIndexTranscriptUrl = url;
+                podcastIndexTranscriptType = type;
+                break;
+            case "application/srr":
+            case "application/srt":
+            case "application/x-subrip":
+                if (! podcastIndexTranscriptType.equals(json_type_str)) {
+                    podcastIndexTranscriptUrl = url;
+                    podcastIndexTranscriptType = canonical_srr;
+                }
+                break;
+            default:
+                Log.d(TAG, "Invalid format for transcript " + type);
+                break;
         }
-        if (podcastIndexTranscriptUrls.get("application/srt") != null) {
-            return new Pair("application/srt", podcastIndexTranscriptUrls.get("application/srt"));
-        }
-        if (podcastIndexTranscriptUrls.get("application/x-subrip") != null) {
-            return new Pair("application/srr", podcastIndexTranscriptUrls.get("application/x-subrip"));
-        }
-        return null;
     }
 
     @NonNull

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -46,7 +46,6 @@ public class FeedItem extends FeedComponent implements Serializable {
     private transient Feed feed;
     private long feedId;
     private String podcastIndexChapterUrl;
-    private String podcastIndexTranscriptText;
     private Hashtable<String, String> podcastIndexTranscriptUrls;
 
     private int state;
@@ -65,11 +64,6 @@ public class FeedItem extends FeedComponent implements Serializable {
     private final boolean hasChapters;
 
     /**
-     * Is true if database or feeditem has podcast:transcript
-     */
-    private boolean hasTranscript;
-
-    /**
      * The list of chapters of this item. This might be null even if there are chapters of this item
      * in the database. The 'hasChapters' attribute should be used to check if this item has any chapters.
      * */
@@ -86,7 +80,6 @@ public class FeedItem extends FeedComponent implements Serializable {
     public FeedItem() {
         this.state = UNPLAYED;
         this.hasChapters = false;
-        this.hasTranscript = false;
     }
 
     /**
@@ -111,10 +104,7 @@ public class FeedItem extends FeedComponent implements Serializable {
         if (transcriptUrl != null) {
             this.podcastIndexTranscriptUrls = new Hashtable<String, String>();
             this.podcastIndexTranscriptUrls.put(transcriptType, transcriptUrl);
-            this.hasTranscript = true;
         }
-        // TT TODO  Load this from disk
-        // this.podcastIndexTranscriptText = transcriptText;
     }
 
     /**
@@ -184,11 +174,6 @@ public class FeedItem extends FeedComponent implements Serializable {
         }
         if (other.getPodcastIndexTranscriptUrls() != null) {
             podcastIndexTranscriptUrls = other.podcastIndexTranscriptUrls;
-            hasTranscript = true;
-        }
-
-        if (other.podcastIndexTranscriptText != null) {
-            podcastIndexTranscriptText = other.podcastIndexTranscriptText;
         }
     }
 
@@ -473,7 +458,6 @@ public class FeedItem extends FeedComponent implements Serializable {
             podcastIndexTranscriptUrls = new Hashtable<String, String>();
         }
         podcastIndexTranscriptUrls.put(t, url);
-        hasTranscript = true;
     }
 
 
@@ -511,19 +495,6 @@ public class FeedItem extends FeedComponent implements Serializable {
             return new Pair("application/srr", podcastIndexTranscriptUrls.get("application/x-subrip"));
         }
         return null;
-    }
-
-    public String getPodcastIndexTranscriptText() {
-        return podcastIndexTranscriptText;
-    }
-
-    public String setPodcastIndexTranscriptText(String str) {
-        hasTranscript = !StringUtils.isBlank(str);
-        return podcastIndexTranscriptText = str;
-    }
-
-    public boolean hasTranscript() {
-        return hasTranscript;
     }
 
     @NonNull

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -482,7 +482,7 @@ public class FeedItem extends FeedComponent implements Serializable {
             case "application/srr":
             case "application/srt":
             case "application/x-subrip":
-                if (podcastIndexTranscriptUrl == null || ! podcastIndexTranscriptType.equals(jsonType)) {
+                if (podcastIndexTranscriptUrl == null || !podcastIndexTranscriptType.equals(jsonType)) {
                     podcastIndexTranscriptUrl = url;
                     podcastIndexTranscriptType = canonicalSrr;
                 }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -5,6 +5,7 @@ import android.util.Pair;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -517,7 +518,7 @@ public class FeedItem extends FeedComponent implements Serializable {
     }
 
     public String setPodcastIndexTranscriptText(String str) {
-        hasTranscript = true;
+        hasTranscript = !StringUtils.isBlank(str);
         return podcastIndexTranscriptText = str;
     }
 

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -471,8 +471,8 @@ public class FeedItem extends FeedComponent implements Serializable {
             return;
         }
 
-        String canonical_srr = "application/srr";
-        String json_type_str = "application/json";
+        String canonicalSrr = "application/srr";
+        String jsonType = "application/json";
 
         switch (type) {
             case "application/json":
@@ -482,9 +482,9 @@ public class FeedItem extends FeedComponent implements Serializable {
             case "application/srr":
             case "application/srt":
             case "application/x-subrip":
-                if (! podcastIndexTranscriptType.equals(json_type_str)) {
+                if (! podcastIndexTranscriptType.equals(jsonType)) {
                     podcastIndexTranscriptUrl = url;
-                    podcastIndexTranscriptType = canonical_srr;
+                    podcastIndexTranscriptType = canonicalSrr;
                 }
                 break;
             default:

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -496,7 +496,7 @@ public class FeedItem extends FeedComponent implements Serializable {
         }
         // We prefer JSON if that is available
         if (podcastIndexTranscriptUrls.get("application/json") != null) {
-           return new Pair("application/json", podcastIndexTranscriptUrls.get("application/json"));
+            return new Pair("application/json", podcastIndexTranscriptUrls.get("application/json"));
         }
 
         // SRR format, but feeds use different mime types

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/PodcastIndex.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/PodcastIndex.java
@@ -14,6 +14,8 @@ public class PodcastIndex extends Namespace {
     private static final String URL = "url";
     private static final String FUNDING = "funding";
     private static final String CHAPTERS = "chapters";
+    private static final String TRANSCRIPT = "transcript";
+    private static final String TYPE = "type";
 
     @Override
     public SyndElement handleElementStart(String localName, HandlerState state,
@@ -27,6 +29,12 @@ public class PodcastIndex extends Namespace {
             String href = attributes.getValue(URL);
             if (!TextUtils.isEmpty(href)) {
                 state.getCurrentItem().setPodcastIndexChapterUrl(href);
+            }
+        } else if (TRANSCRIPT.equals(localName)) {
+            String href = attributes.getValue(URL);
+            String type = attributes.getValue(TYPE);
+            if (!TextUtils.isEmpty(href) && !TextUtils.isEmpty(type)) {
+                state.getCurrentItem().setPodcastIndexTranscriptUrl(type, href);
             }
         }
         return new SyndElement(localName, this);

--- a/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
+++ b/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
@@ -101,7 +101,8 @@ public class RssParserTest {
     public void testPodcastIndexTranscript() throws Exception {
         File feedFile = FeedParserTestHelper.getFeedFile("feed-rss-testPodcastIndexTranscript.xml");
         Feed feed = FeedParserTestHelper.runFeedParser(feedFile);
-        assertEquals("https://podnews.net/audio/podnews231011.mp3.json", feed.getItems().get(0).getPodcastIndexTranscriptUrls("application/json"));
+        assertEquals("https://podnews.net/audio/podnews231011.mp3.json", feed.getItems().get(0).getPodcastIndexTranscriptUrl());
+        assertEquals("application/json", feed.getItems().get(0).getPodcastIndexTranscriptType());
     }
 
     @Test

--- a/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
+++ b/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
@@ -98,6 +98,13 @@ public class RssParserTest {
     }
 
     @Test
+    public void testPodcastIndexTranscript() throws Exception {
+        File feedFile = FeedParserTestHelper.getFeedFile("feed-rss-testPodcastIndexTranscript.xml");
+        Feed feed = FeedParserTestHelper.runFeedParser(feedFile);
+        assertEquals("https://podnews.net/audio/podnews231011.mp3.json", feed.getItems().get(0).getPodcastIndexTranscriptUrls("application/json"));
+    }
+
+    @Test
     public void testUnsupportedElements() throws Exception {
         File feedFile = FeedParserTestHelper.getFeedFile("feed-rss-testUnsupportedElements.xml");
         Feed feed = FeedParserTestHelper.runFeedParser(feedFile);

--- a/parser/feed/src/test/resources/feed-rss-testPodcastIndexTranscript.xml
+++ b/parser/feed/src/test/resources/feed-rss-testPodcastIndexTranscript.xml
@@ -2,12 +2,12 @@
 <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
     <channel>
         <title>title</title>
-<item>
-    <title>Podcasts in YouTube make it to the UK</title>
-    <link>https://podnews.net/update/youtube-podcasts-uk</link>
-    <pubDate>Tue, 10 Oct 2023 08:46:31 +0000</pubDate>
-    <podcast:transcript url="https://podnews.net/audio/podnews231011.mp3.json" type="application/json" />
-    <podcast:transcript url="https://podnews.net/audio/podnews231011.mp3.srt" type="application/srt" />
-</item>
+        <item>
+            <title>Podcasts in YouTube make it to the UK</title>
+            <link>https://podnews.net/update/youtube-podcasts-uk</link>
+            <pubDate>Tue, 10 Oct 2023 08:46:31 +0000</pubDate>
+            <podcast:transcript url="https://podnews.net/audio/podnews231011.mp3.json" type="application/json" />
+            <podcast:transcript url="https://podnews.net/audio/podnews231011.mp3.srt" type="application/srt" />
+        </item>
     </channel>
 </rss>

--- a/parser/feed/src/test/resources/feed-rss-testPodcastIndexTranscript.xml
+++ b/parser/feed/src/test/resources/feed-rss-testPodcastIndexTranscript.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+    <channel>
+        <title>title</title>
+<item>
+    <title>Podcasts in YouTube make it to the UK</title>
+    <link>https://podnews.net/update/youtube-podcasts-uk</link>
+    <pubDate>Tue, 10 Oct 2023 08:46:31 +0000</pubDate>
+    <podcast:transcript url="https://podnews.net/audio/podnews231011.mp3.json" type="application/json" />
+    <podcast:transcript url="https://podnews.net/audio/podnews231011.mp3.srt" type="application/srt" />
+</item>
+    </channel>
+</rss>

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -334,7 +334,6 @@ class DBUpgrader {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                     + " ADD COLUMN " + PodDBAdapter.KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0");
         }
-
         if (oldVersion < 3030000) {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
                     + " ADD COLUMN " + PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_URL + " TEXT");

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -334,6 +334,13 @@ class DBUpgrader {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
                     + " ADD COLUMN " + PodDBAdapter.KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0");
         }
+
+        if (oldVersion < 3020000) {
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_URL + " TEXT");
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_TYPE + " TEXT");
+        }
     }
 
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -335,7 +335,7 @@ class DBUpgrader {
                     + " ADD COLUMN " + PodDBAdapter.KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0");
         }
 
-        if (oldVersion < 3020000) {
+        if (oldVersion < 3030000) {
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS
                     + " ADD COLUMN " + PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_URL + " TEXT");
             db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -53,7 +53,7 @@ public class PodDBAdapter {
 
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
-    public static final int VERSION = 3020000;
+    public static final int VERSION = 3030000;
 
     /**
      * Maximum number of arguments for IN-operator.

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -12,7 +12,6 @@ import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.text.TextUtils;
 import android.util.Log;
-import android.util.Pair;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -664,10 +663,11 @@ public class PodDBAdapter {
         values.put(KEY_PODCASTINDEX_CHAPTER_URL, item.getPodcastIndexChapterUrl());
 
         // We only store one transcript url, we prefer JSON if it exists
-        Pair<String, String> typeUrl = item.getPodcastIndexTranscriptUrlPreferred();
-        if (typeUrl != null) {
-            values.put(KEY_PODCASTINDEX_TRANSCRIPT_TYPE, typeUrl.first);
-            values.put(KEY_PODCASTINDEX_TRANSCRIPT_URL, typeUrl.second);
+        String type = item.getPodcastIndexTranscriptType();
+        String url = item.getPodcastIndexTranscriptUrl();
+        if (url != null) {
+            values.put(KEY_PODCASTINDEX_TRANSCRIPT_TYPE, type);
+            values.put(KEY_PODCASTINDEX_TRANSCRIPT_URL, url);
         }
 
         if (item.getId() == 0) {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -12,6 +12,7 @@ import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.Pair;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -52,7 +54,7 @@ public class PodDBAdapter {
 
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
-    public static final int VERSION = 3010000;
+    public static final int VERSION = 3020000;
 
     /**
      * Maximum number of arguments for IN-operator.
@@ -120,6 +122,8 @@ public class PodDBAdapter {
     public static final String KEY_EPISODE_NOTIFICATION = "episode_notification";
     public static final String KEY_NEW_EPISODES_ACTION = "new_episodes_action";
     public static final String KEY_PODCASTINDEX_CHAPTER_URL = "podcastindex_chapter_url";
+    public static final String KEY_PODCASTINDEX_TRANSCRIPT_URL = "podcastindex_transcript_url";
+    public static final String KEY_PODCASTINDEX_TRANSCRIPT_TYPE = "podcastindex_transcript_type";
 
     // Table names
     public static final String TABLE_NAME_FEEDS = "Feeds";
@@ -172,7 +176,9 @@ public class PodDBAdapter {
             + KEY_HAS_CHAPTERS + " INTEGER," + KEY_ITEM_IDENTIFIER + " TEXT,"
             + KEY_IMAGE_URL + " TEXT,"
             + KEY_AUTO_DOWNLOAD_ATTEMPTS + " INTEGER,"
-            + KEY_PODCASTINDEX_CHAPTER_URL + " TEXT)";
+            + KEY_PODCASTINDEX_CHAPTER_URL + " TEXT,"
+            + KEY_PODCASTINDEX_TRANSCRIPT_TYPE + " TEXT,"
+            + KEY_PODCASTINDEX_TRANSCRIPT_URL + " TEXT" + ")";
 
     private static final String CREATE_TABLE_FEED_MEDIA = "CREATE TABLE "
             + TABLE_NAME_FEED_MEDIA + " (" + TABLE_PRIMARY_KEY + KEY_DURATION
@@ -260,7 +266,9 @@ public class PodDBAdapter {
             + TABLE_NAME_FEED_ITEMS + "." + KEY_ITEM_IDENTIFIER + ", "
             + TABLE_NAME_FEED_ITEMS + "." + KEY_IMAGE_URL + ", "
             + TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD_ATTEMPTS + ", "
-            + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_CHAPTER_URL;
+            + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_CHAPTER_URL + ", "
+            + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_TRANSCRIPT_TYPE + ", "
+            + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_TRANSCRIPT_URL;
 
     private static final String KEYS_FEED_MEDIA =
             TABLE_NAME_FEED_MEDIA + "." + KEY_ID + " AS " + SELECT_KEY_MEDIA_ID + ", "
@@ -655,6 +663,13 @@ public class PodDBAdapter {
         values.put(KEY_AUTO_DOWNLOAD_ATTEMPTS, item.getAutoDownloadAttemptsAndTime());
         values.put(KEY_IMAGE_URL, item.getImageUrl());
         values.put(KEY_PODCASTINDEX_CHAPTER_URL, item.getPodcastIndexChapterUrl());
+
+        // We only store one transcript url, we prefer JSON if it exists
+        Pair<String, String> typeUrl = item.getPodcastIndexTranscriptUrlPreferred();
+        if (typeUrl != null) {
+            values.put(KEY_PODCASTINDEX_TRANSCRIPT_TYPE, typeUrl.first);
+            values.put(KEY_PODCASTINDEX_TRANSCRIPT_URL, typeUrl.second);
+        }
 
         if (item.getId() == 0) {
             item.setId(db.insert(TABLE_NAME_FEED_ITEMS, null, values));

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemCursorMapper.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemCursorMapper.java
@@ -28,6 +28,9 @@ public abstract class FeedItemCursorMapper {
         int indexAutoDownload = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_AUTO_DOWNLOAD_ATTEMPTS);
         int indexImageUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_IMAGE_URL);
         int indexPodcastIndexChapterUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PODCASTINDEX_CHAPTER_URL);
+        int indexPodcastIndexTranscriptUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_URL);
+        int indexPodcastIndexTranscriptType = cursor.getColumnIndexOrThrow(
+                PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_TYPE);
 
         long id = cursor.getInt(indexId);
         String title = cursor.getString(indexTitle);
@@ -41,8 +44,11 @@ public abstract class FeedItemCursorMapper {
         long autoDownload = cursor.getLong(indexAutoDownload);
         String imageUrl = cursor.getString(indexImageUrl);
         String podcastIndexChapterUrl = cursor.getString(indexPodcastIndexChapterUrl);
+        String podcastIndexTranscriptUrl = cursor.getString(indexPodcastIndexTranscriptUrl);
+        String podcastIndexTranscriptType = cursor.getString(indexPodcastIndexTranscriptType);
 
         return new FeedItem(id, title, link, pubDate, paymentLink, feedId,
-                hasChapters, imageUrl, state, itemIdentifier, autoDownload, podcastIndexChapterUrl);
+                hasChapters, imageUrl, state, itemIdentifier, autoDownload, podcastIndexChapterUrl,
+                podcastIndexTranscriptType, podcastIndexTranscriptUrl);
     }
 }


### PR DESCRIPTION
Fix #4935 

@keunes , @ByteHamster mentioned that for the big feature for transcript, we will use the `transcript` branch and target many small PR's

This PR parses the `<podcast:transcript>` tag from a feed and store the URL of most preferred format (JSON and then SRT)

It's ready for review

Validation using the `Podnews Daily` podcast and `No Agenda`
```
sqlite> .schema

CREATE TABLE FeedItems (id INTEGER PRIMARY KEY AUTOINCREMENT ,title TEXT,pubDate INTEGER,read INTEGER,link TEXT,description TEXT,payment_link TEXT,media INTEGER,feed INTEGER,has_simple_chapters INTEGER,item_identifier TEXT,image_url TEXT,auto_download INTEGER,podcastindex_chapter_url TEXT,podcastindex_transcript_type TEXT,podcastindex_transcript_url TEXT);

sqlite> select podcastindex_transcript_type, podcastindex_transcript_url from FeedItems;
application/json|https://podnews.net/audio/podnews231102.mp3.json
application/json|https://podnews.net/audio/podnews231101.mp3.json
application/json|https://podnews.net/audio/podnews231031.mp3.json
...
application/srt|https://mp3s.nashownotes.com/NA-1604-Captions.srt
application/srt|https://mp3s.nashownotes.com/NA-1603-Captions.srt
application/srt|https://mp3s.nashownotes.com/NA-1602-Captions.srt
```