### PR TITLE
Fix sometimes stopping at the end of each episode

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -799,6 +799,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     updateNotificationAndMediaSession(newInfo.playable);
                     break;
                 case PREPARED:
+                    if (mediaPlayer.getPSMPInfo().playable != null) {
+                        PlaybackPreferences.writeMediaPlaying(mediaPlayer.getPSMPInfo().playable,
+                                mediaPlayer.getPSMPInfo().playerStatus);
+                    }
                     taskManager.startChapterLoader(newInfo.playable);
                     break;
                 case PAUSED:


### PR DESCRIPTION
Fix #6533

The bug is on this line [#145](https://github.com/AntennaPod/AntennaPod/blob/f7a13065a9c92ba26d3686aeb18269f2313bd0b6/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java#L145) - the call to `PlaybackPreferences.getCurrentlyPlayingFeedMediaId()` returns the episode that was playing and deinf deleted, hence it stops playing the next episode like it is supposed to.  Because it's called in a Thread, the next episode already started playing for 1 second or so and then stops

The fix will now save into the preference the correct episode that is playing on the PREPARE stage.
