### PR TITLE
Honor sort in episode list view in Android Auto

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         // Version code schema:
         // "1.2.3-beta4"    -> 1020304
         // "1.2.3"          -> 1020395
-        versionCode 3020002
-        versionName "3.2.0-beta2"
+        versionCode 3020001
+        versionName "3.2.0-beta1"
 
         def commit = ""
         try {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         // Version code schema:
         // "1.2.3-beta4"    -> 1020304
         // "1.2.3"          -> 1020395
-        versionCode 3020001
-        versionName "3.2.0-beta1"
+        versionCode 3020002
+        versionName "3.2.0-beta2"
 
         def commit = ""
         try {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -26,6 +26,7 @@ import java.util.List;
  */
 public class AllEpisodesFragment extends EpisodesListFragment {
     public static final String TAG = "EpisodesFragment";
+    public static final String PREF_NAME = "PrefAllEpisodesFragment";
 
     @NonNull
     @Override
@@ -72,7 +73,6 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         return DBReader.getTotalEpisodeCount(getFilter());
     }
 
-
     @Override
     protected FeedItemFilter getFilter() {
         return new FeedItemFilter(UserPreferences.getPrefFilterAllEpisodes());
@@ -81,6 +81,10 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     @Override
     protected String getFragmentTag() {
         return TAG;
+    }
+
+    protected String getPrefName() {
+        return PREF_NAME;
     }
 
     @Override
@@ -111,7 +115,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     }
 
     private void saveSortOrderAndRefresh(SortOrder type) {
-        UserPreferences.setAllEpisodeSortOrder(type);
+        UserPreferences.setAllEpisodesSortOrder(type);
         loadItems();
     }
 
@@ -121,10 +125,6 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         updateFilterUi();
         page = 1;
         loadItems();
-    }
-
-    protected String getPrefName() {
-        return "PrefAllEpisodesFragment";
     }
 
     private void updateFilterUi() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -28,9 +28,6 @@ import java.util.List;
  */
 public class AllEpisodesFragment extends EpisodesListFragment {
     public static final String TAG = "EpisodesFragment";
-    private static final String PREF_NAME = "PrefAllEpisodesFragment";
-    private static final String PREF_FILTER = "filter";
-    private SharedPreferences prefs;
 
     @NonNull
     @Override
@@ -41,7 +38,6 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         toolbar.setTitle(R.string.episodes_label);
         updateToolbar();
         updateFilterUi();
-        prefs = getActivity().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
         txtvInformation.setOnClickListener(
                 v -> AllEpisodesFilterDialog.newInstance(getFilter()).show(getChildFragmentManager(), null));
         return root;
@@ -78,20 +74,15 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         return DBReader.getTotalEpisodeCount(getFilter());
     }
 
+
     @Override
     protected FeedItemFilter getFilter() {
-        SharedPreferences prefs = getActivity().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
-        return new FeedItemFilter(prefs.getString(PREF_FILTER, ""));
+        return new FeedItemFilter(UserPreferences.getPrefFilterAllEpisodes());
     }
 
     @Override
     protected String getFragmentTag() {
         return TAG;
-    }
-
-    @Override
-    protected String getPrefName() {
-        return PREF_NAME;
     }
 
     @Override
@@ -128,11 +119,15 @@ public class AllEpisodesFragment extends EpisodesListFragment {
 
     @Subscribe
     public void onFilterChanged(AllEpisodesFilterDialog.AllEpisodesFilterChangedEvent event) {
-        prefs.edit().putString(PREF_FILTER, StringUtils.join(event.filterValues, ",")).apply();
+        UserPreferences.setPrefFilterAllEpisodes(StringUtils.join(event.filterValues, ","));
         updateFilterUi();
         page = 1;
         loadItems();
     }
+
+    protected String getPrefName() {
+        return "PrefAllEpisodesFragment";
+    };
 
     private void updateFilterUi() {
         swipeActions.setFilter(getFilter());

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -14,6 +14,8 @@ import de.danoeh.antennapod.dialog.AllEpisodesFilterDialog;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.SortOrder;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+
 import org.apache.commons.lang3.StringUtils;
 import org.greenrobot.eventbus.Subscribe;
 
@@ -28,7 +30,6 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     public static final String TAG = "EpisodesFragment";
     private static final String PREF_NAME = "PrefAllEpisodesFragment";
     private static final String PREF_FILTER = "filter";
-    public static final String PREF_SORT = "prefEpisodesSort";
     private SharedPreferences prefs;
 
     @NonNull
@@ -61,13 +62,15 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     @NonNull
     @Override
     protected List<FeedItem> loadData() {
-        return DBReader.getEpisodes(0, page * EPISODES_PER_PAGE, getFilter(), getSortOrder());
+        return DBReader.getEpisodes(0, page * EPISODES_PER_PAGE, getFilter(),
+                UserPreferences.getAllEpisodeSortOrder());
     }
 
     @NonNull
     @Override
     protected List<FeedItem> loadMoreData(int page) {
-        return DBReader.getEpisodes((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE, getFilter(), getSortOrder());
+        return DBReader.getEpisodes((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE, getFilter(),
+                UserPreferences.getAllEpisodeSortOrder());
     }
 
     @Override
@@ -119,7 +122,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     }
 
     private void saveSortOrderAndRefresh(SortOrder type) {
-        prefs.edit().putString(PREF_SORT, "" + type.code).apply();
+        UserPreferences.setAllEpisodeSortOrder(type);
         loadItems();
     }
 
@@ -142,9 +145,5 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         }
         toolbar.getMenu().findItem(R.id.action_favorites).setIcon(
                 getFilter().showIsFavorite ? R.drawable.ic_star : R.drawable.ic_star_border);
-    }
-
-    private SortOrder getSortOrder() {
-        return SortOrder.fromCodeString(prefs.getString(PREF_SORT, "" + SortOrder.DATE_NEW_OLD.code));
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.fragment;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -127,7 +125,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
 
     protected String getPrefName() {
         return "PrefAllEpisodesFragment";
-    };
+    }
 
     private void updateFilterUi() {
         swipeActions.setFilter(getFilter());

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -58,14 +58,14 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     @Override
     protected List<FeedItem> loadData() {
         return DBReader.getEpisodes(0, page * EPISODES_PER_PAGE, getFilter(),
-                UserPreferences.getAllEpisodeSortOrder());
+                UserPreferences.getAllEpisodesSortOrder());
     }
 
     @NonNull
     @Override
     protected List<FeedItem> loadMoreData(int page) {
         return DBReader.getEpisodes((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE, getFilter(),
-                UserPreferences.getAllEpisodeSortOrder());
+                UserPreferences.getAllEpisodesSortOrder());
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AllEpisodesFragment.java
@@ -83,6 +83,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         return TAG;
     }
 
+    @Override
     protected String getPrefName() {
         return PREF_NAME;
     }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -157,7 +157,7 @@ public class PreferenceUpgrader {
             SharedPreferences allEpisodesPreferences =
                     context.getSharedPreferences(AllEpisodesFragment.PREF_NAME, Context.MODE_PRIVATE);
             String oldEpisodeSort = allEpisodesPreferences.getString(UserPreferences.PREF_SORT_ALL_EPISODES, "");
-            if (! StringUtils.isAllEmpty(oldEpisodeSort)) {
+            if (!StringUtils.isAllEmpty(oldEpisodeSort)) {
                 prefs.edit().putString(UserPreferences.PREF_SORT_ALL_EPISODES, oldEpisodeSort).apply();
             }
 

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -6,12 +6,15 @@ import android.view.KeyEvent;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.preference.PreferenceManager;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.concurrent.TimeUnit;
 
 import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.core.preferences.SleepTimerPreferences;
 import de.danoeh.antennapod.error.CrashReportWriter;
+import de.danoeh.antennapod.fragment.AllEpisodesFragment;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences.EnqueueLocation;
 import de.danoeh.antennapod.fragment.QueueFragment;
@@ -148,6 +151,20 @@ public class PreferenceUpgrader {
         }
         if (oldVersion < 3020000) {
             NotificationManagerCompat.from(context).deleteNotificationChannel("auto_download");
+        }
+
+        if (oldVersion < 3020002) {
+            SharedPreferences allEpisodesPreferences =
+                    context.getSharedPreferences(AllEpisodesFragment.PREF_NAME, Context.MODE_PRIVATE);
+            String oldEpisodeSort = allEpisodesPreferences.getString(UserPreferences.PREF_SORT_ALL_EPISODES, "");
+            if (! StringUtils.isAllEmpty(oldEpisodeSort)) {
+                prefs.edit().putString(UserPreferences.PREF_SORT_ALL_EPISODES, oldEpisodeSort).apply();
+            }
+
+            String oldEpisodeFilter = allEpisodesPreferences.getString("filter", "");
+            if (! StringUtils.isAllEmpty(oldEpisodeFilter)) {
+                prefs.edit().putString(UserPreferences.PREF_FILTER_ALL_EPISODES, oldEpisodeFilter).apply();
+            }
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -162,7 +162,7 @@ public class PreferenceUpgrader {
             }
 
             String oldEpisodeFilter = allEpisodesPreferences.getString("filter", "");
-            if (! StringUtils.isAllEmpty(oldEpisodeFilter)) {
+            if (!StringUtils.isAllEmpty(oldEpisodeFilter)) {
                 prefs.edit().putString(UserPreferences.PREF_FILTER_ALL_EPISODES, oldEpisodeFilter).apply();
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceUpgrader.java
@@ -153,7 +153,7 @@ public class PreferenceUpgrader {
             NotificationManagerCompat.from(context).deleteNotificationChannel("auto_download");
         }
 
-        if (oldVersion < 3020002) {
+        if (oldVersion < 3030000) {
             SharedPreferences allEpisodesPreferences =
                     context.getSharedPreferences(AllEpisodesFragment.PREF_NAME, Context.MODE_PRIVATE);
             String oldEpisodeSort = allEpisodesPreferences.getString(UserPreferences.PREF_SORT_ALL_EPISODES, "");

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -432,7 +432,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     new FeedItemFilter(FeedItemFilter.UNPLAYED), SortOrder.DATE_NEW_OLD);
         } else if (parentId.startsWith("FeedId:")) {
             long feedId = Long.parseLong(parentId.split(":")[1]);
-            feedItems = DBReader.getFeedItemList(DBReader.getFeed(feedId));
+            Feed feed = DBReader.getFeed(feedId);
+            feedItems = DBReader.getFeedItemList(feed,
+                    FeedItemFilter.unfiltered(),
+                    feed.getSortOrder());
         } else if (parentId.equals(getString(R.string.recently_played_episodes))) {
             Playable playable = PlaybackPreferences.createInstanceFromPreferences(this);
             if (playable instanceof FeedMedia) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -432,9 +432,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         } else if (parentId.startsWith("FeedId:")) {
             long feedId = Long.parseLong(parentId.split(":")[1]);
             Feed feed = DBReader.getFeed(feedId);
-            feedItems = DBReader.getFeedItemList(feed,
-                    FeedItemFilter.unfiltered(),
-                    feed.getSortOrder());
+            feedItems = DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(), feed.getSortOrder());
         } else if (parentId.equals(getString(R.string.recently_played_episodes))) {
             Playable playable = PlaybackPreferences.createInstanceFromPreferences(this);
             if (playable instanceof FeedMedia) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -429,7 +429,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     new FeedItemFilter(FeedItemFilter.DOWNLOADED), UserPreferences.getDownloadsSortedOrder());
         } else if (parentId.equals(getResources().getString(R.string.episodes_label))) {
             feedItems = DBReader.getEpisodes(0, MAX_ANDROID_AUTO_EPISODES_PER_FEED,
-                    new FeedItemFilter(FeedItemFilter.UNPLAYED), SortOrder.DATE_NEW_OLD);
+                    new FeedItemFilter(FeedItemFilter.UNPLAYED), UserPreferences.getAllEpisodeSortOrder());
         } else if (parentId.startsWith("FeedId:")) {
             long feedId = Long.parseLong(parentId.split(":")[1]);
             Feed feed = DBReader.getFeed(feedId);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -428,7 +428,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     new FeedItemFilter(FeedItemFilter.DOWNLOADED), UserPreferences.getDownloadsSortedOrder());
         } else if (parentId.equals(getResources().getString(R.string.episodes_label))) {
             feedItems = DBReader.getEpisodes(0, MAX_ANDROID_AUTO_EPISODES_PER_FEED,
-                    new FeedItemFilter(FeedItemFilter.UNPLAYED), UserPreferences.getAllEpisodeSortOrder());
+                    new FeedItemFilter(FeedItemFilter.UNPLAYED), UserPreferences.getAllEpisodesSortOrder());
         } else if (parentId.startsWith("FeedId:")) {
             long feedId = Long.parseLong(parentId.split(":")[1]);
             Feed feed = DBReader.getFeed(feedId);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -89,7 +89,6 @@ import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
-import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.model.playback.MediaType;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.playback.base.PlaybackServiceMediaPlayer;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import de.danoeh.antennapod.core.util.FeedItemPermutors;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.comparator.DownloadResultComparator;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
@@ -170,13 +171,18 @@ public final class DBReader {
     }
 
     public static List<FeedItem> getFeedItemList(final Feed feed, final FeedItemFilter filter) {
+        return getFeedItemList(feed, filter, SortOrder.DATE_NEW_OLD);
+    }
+
+    public static List<FeedItem> getFeedItemList(final Feed feed, final FeedItemFilter filter, SortOrder sortOrder) {
         Log.d(TAG, "getFeedItemList() called with: " + "feed = [" + feed + "]");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (Cursor cursor = adapter.getItemsOfFeedCursor(feed, filter)) {
             List<FeedItem> items = extractItemlistFromCursor(adapter, cursor);
-            Collections.sort(items, new FeedItemPubdateComparator());
+            FeedItemPermutors.getPermutor(sortOrder).reorder(items);
+            feed.setItems(items);
             for (FeedItem item : items) {
                 item.setFeed(feed);
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBReader.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import de.danoeh.antennapod.core.util.FeedItemPermutors;
 import de.danoeh.antennapod.core.util.LongList;
 import de.danoeh.antennapod.core.util.comparator.DownloadResultComparator;
-import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 import de.danoeh.antennapod.core.util.comparator.PlaybackCompletionDateComparator;
 import de.danoeh.antennapod.model.feed.Chapter;
 import de.danoeh.antennapod.model.feed.Feed;

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -876,7 +876,6 @@ public class UserPreferences {
     public static void setAllEpisodeSortOrder(SortOrder s) {
         prefs.edit()
                 .putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
-        prefs.edit().commit();
     }
 
     public static SortOrder getAllEpisodeSortOrder() {

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -873,8 +873,7 @@ public class UserPreferences {
     }
 
     public static void setAllEpisodesSortOrder(SortOrder s) {
-        prefs.edit()
-                .putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
+        prefs.edit().putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
     }
 
     public static SortOrder getAllEpisodeSortOrder() {

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -620,6 +620,7 @@ public class UserPreferences {
              .apply();
 
     }
+
     public static void setAutodownloadSelectedNetworks(String[] value) {
         prefs.edit()
              .putString(PREF_AUTODL_SELECTED_NETWORKS, TextUtils.join(",", value))

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -876,7 +876,7 @@ public class UserPreferences {
         prefs.edit().putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
     }
 
-    public static SortOrder getAllEpisodeSortOrder() {
+    public static SortOrder getAllEpisodesSortOrder() {
         return SortOrder.fromCodeString(prefs.getString(PREF_SORT_ALL_EPISODES,
                 "" + SortOrder.DATE_NEW_OLD.code));
     }

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -67,6 +67,9 @@ public class UserPreferences {
     private static final String PREF_DOWNLOADS_SORTED_ORDER = "prefDownloadSortedOrder";
     private static final String PREF_INBOX_SORTED_ORDER = "prefInboxSortedOrder";
 
+    // Episode
+    public static final String PREF_SORT_ALL_EPISODES = "prefEpisodesSort";
+
     // Playback
     public static final String PREF_PAUSE_ON_HEADSET_DISCONNECT = "prefPauseOnHeadsetDisconnect";
     public static final String PREF_UNPAUSE_ON_HEADSET_RECONNECT = "prefUnpauseOnHeadsetReconnect";
@@ -866,5 +869,16 @@ public class UserPreferences {
 
     public static boolean shouldShowSubscriptionTitle() {
         return prefs.getBoolean(PREF_SUBSCRIPTION_TITLE, false);
+    }
+
+    public static void setAllEpisodeSortOrder(SortOrder s) {
+        prefs.edit()
+                .putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
+        prefs.edit().commit();
+    }
+
+    public static SortOrder getAllEpisodeSortOrder() {
+        return SortOrder.fromCodeString(prefs.getString(PREF_SORT_ALL_EPISODES,
+                "" + SortOrder.DATE_NEW_OLD.code));
     }
 }

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -69,6 +69,7 @@ public class UserPreferences {
 
     // Episode
     public static final String PREF_SORT_ALL_EPISODES = "prefEpisodesSort";
+    private static final String PREF_FILTER_ALL_EPISODES = "prefEpisodeFilter";
 
     // Playback
     public static final String PREF_PAUSE_ON_HEADSET_DISCONNECT = "prefPauseOnHeadsetDisconnect";
@@ -617,8 +618,8 @@ public class UserPreferences {
         prefs.edit()
              .putString(PREF_PLAYBACK_SPEED_ARRAY, jsonArray.toString())
              .apply();
-    }
 
+    }
     public static void setAutodownloadSelectedNetworks(String[] value) {
         prefs.edit()
              .putString(PREF_AUTODL_SELECTED_NETWORKS, TextUtils.join(",", value))
@@ -880,5 +881,13 @@ public class UserPreferences {
     public static SortOrder getAllEpisodeSortOrder() {
         return SortOrder.fromCodeString(prefs.getString(PREF_SORT_ALL_EPISODES,
                 "" + SortOrder.DATE_NEW_OLD.code));
+    }
+
+    public static String getPrefFilterAllEpisodes() {
+        return prefs.getString(PREF_FILTER_ALL_EPISODES, "");
+    }
+
+    public static void setPrefFilterAllEpisodes(String filter) {
+        prefs.edit().putString(PREF_FILTER_ALL_EPISODES, filter).apply();
     }
 }

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -69,7 +69,7 @@ public class UserPreferences {
 
     // Episode
     public static final String PREF_SORT_ALL_EPISODES = "prefEpisodesSort";
-    private static final String PREF_FILTER_ALL_EPISODES = "prefEpisodeFilter";
+    public static final String PREF_FILTER_ALL_EPISODES = "prefEpisodesFilter";
 
     // Playback
     public static final String PREF_PAUSE_ON_HEADSET_DISCONNECT = "prefPauseOnHeadsetDisconnect";
@@ -618,7 +618,6 @@ public class UserPreferences {
         prefs.edit()
              .putString(PREF_PLAYBACK_SPEED_ARRAY, jsonArray.toString())
              .apply();
-
     }
 
     public static void setAutodownloadSelectedNetworks(String[] value) {
@@ -873,7 +872,7 @@ public class UserPreferences {
         return prefs.getBoolean(PREF_SUBSCRIPTION_TITLE, false);
     }
 
-    public static void setAllEpisodeSortOrder(SortOrder s) {
+    public static void setAllEpisodesSortOrder(SortOrder s) {
         prefs.edit()
                 .putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
     }


### PR DESCRIPTION
Fix #6752

Honor sort order in all episode list as well as episode list per feed view in Android Auto

This is the new preference for the AllEpisodesFragment in order for this preference to be shared

`/data/data/de.danoeh.antennapod.debug/shared_prefs/de.danoeh.antennapod.debug_preferences.xml`

```
<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
<map>
    <string name="prefEpisodesSort">2</string>
    <string name="prefEpisodeFilter">unplayed</string>
</map>

```