### PR TITLE
[3.2.0-beta1] Fix seeking to end using seek bar

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -345,7 +345,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
         if (t >= getDuration()) {
             Log.d(TAG, "Seek reached end of file, skipping to next episode");
-            skip();
+            endPlayback(true, true, true, true);
             return;
         }
 


### PR DESCRIPTION
Merging #6074 has caused a new edge case for VBR audio files, in which using the seek bar to seek to the end of an episode sometimes hits the new code path, and the `skip()` function is called.

Because `skip()` invokes `endPlayback()` with `hasEnded` set to `false`, post-processing tasks are not executed unless the pre-seek position falls within the "Smart mark as played" range. If "Smart mark as played" is set to `Disabled`, or the pre-seek position is outside that range, then the episode is not marked as played, and not removed from queue.

This commit fixes that edge case by replacing `skip()` with a direct call to `endPlayback()`, with `hasEnded` set to `true`.
