### PR TITLE
Play last episode on empty search query

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1765,6 +1765,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         public void onPlayFromSearch(String query, Bundle extras) {
             Log.d(TAG, "onPlayFromSearch  query=" + query + " extras=" + extras.toString());
 
+            if (query.equals("")) {
+                Log.d(TAG, "onPlayFromSearch called with empty query, resuming from the last position");
+                startPlayingFromPreferences();
+                return;
+            }
+
             List<FeedItem> results = FeedSearcher.searchFeedItems(query, 0);
             if (results.size() > 0 && results.get(0).getMedia() != null) {
                 FeedMedia media = results.get(0).getMedia();


### PR DESCRIPTION
As described in #6777, when an external contoller play button is clicked, an arbitrary episode is started. It happens because on a call to the `onPlayFromSearch` method with an empty query, when, according to the [android documentation](https://developer.android.com/reference/android/media/session/MediaSession.Callback#onPlayFromSearch(java.lang.String,%20android.os.Bundle)), the app should make a decision what to play, a database search with this empty query is performed. Continuing from the last position appears more logical when just a play button is hit, so this pull requests makes the `onPlayFromSearch` method  do that when it is called with an empty query.