### PR TITLE
Remove audio player license

### DIFF
--- a/app/src/main/assets/licenses.xml
+++ b/app/src/main/assets/licenses.xml
@@ -7,12 +7,6 @@
         license="GPL-3.0"
         licenseText="LICENSE.txt" />
     <library
-        name="AntennaPod-AudioPlayer"
-        author="The AntennaPod team"
-        website="https://github.com/AntennaPod/AntennaPod-AudioPlayer"
-        license="Apache 2.0"
-        licenseText="LICENSE_APACHE-2.0.txt" />
-    <library
         name="Android Jetpack"
         author="Google"
         website="https://developer.android.com/jetpack"


### PR DESCRIPTION
We no longer use the external project, no need to keep the license