### PR TITLE
Show currently playing episode in Android Auto

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -410,8 +410,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
             if (currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING
                     || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
-                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode, R.drawable.ic_play_48dp,
-                        DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));
+                    mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
+                            R.drawable.ic_play_48dp,
+                            1));
             }
             mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_play_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -326,6 +326,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (rootHints != null && rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)) {
             Bundle extras = new Bundle();
             extras.putBoolean(BrowserRoot.EXTRA_RECENT, true);
+            Log.d(TAG, "OnGetRoot: Returning BrowserRoot " + R.string.recently_played_episodes);
             return new BrowserRoot(getResources().getString(R.string.recently_played_episodes), extras);
         }
 
@@ -409,7 +410,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (parentId.equals(getResources().getString(R.string.app_name))) {
             long currentlyPlaying = PlaybackPreferences.getCurrentPlayerStatus();
             if (currentlyPlaying == PlaybackPreferences.PLAYER_STATUS_PLAYING
-                    || currentlyPlaying== PlaybackPreferences.PLAYER_STATUS_PAUSED) {
+                    || currentlyPlaying == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
                 mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
                                R.drawable.ic_play_48dp,
                                1));

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -323,6 +323,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     public BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, Bundle rootHints) {
         Log.d(TAG, "OnGetRoot: clientPackageName=" + clientPackageName +
                 "; clientUid=" + clientUid + " ; rootHints=" + rootHints);
+
+/*
+        long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
+        if ((rootHints != null && rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)
+                || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING )) {
+ */
         if (rootHints != null && rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)) {
             Bundle extras = new Bundle();
             extras.putBoolean(BrowserRoot.EXTRA_RECENT, true);
@@ -407,6 +413,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     private List<MediaBrowserCompat.MediaItem> loadChildrenSynchronous(@NonNull String parentId) {
         List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
         if (parentId.equals(getResources().getString(R.string.app_name))) {
+            long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
+            if (currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING
+                    || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
+                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode, R.drawable.ic_play_48dp,
+                        DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));
+            }
             mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_play_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));
             mediaItems.add(createBrowsableMediaItem(R.string.downloads_label, R.drawable.ic_download_black,
@@ -433,7 +445,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             long feedId = Long.parseLong(parentId.split(":")[1]);
             Feed feed = DBReader.getFeed(feedId);
             feedItems = DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(), feed.getSortOrder());
-        } else if (parentId.equals(getString(R.string.recently_played_episodes))) {
+        } else if (parentId.equals(getString(R.string.recently_played_episodes))
+                || parentId.equals(getString(R.string.current_playing_episode))) {
             Playable playable = PlaybackPreferences.createInstanceFromPreferences(this);
             if (playable instanceof FeedMedia) {
                 feedItems = Collections.singletonList(((FeedMedia) playable).getItem());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -410,7 +410,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
             if (currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING
                     || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
-                       mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
+                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
                                R.drawable.ic_play_48dp,
                                1));
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -327,7 +327,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             Bundle extras = new Bundle();
             extras.putBoolean(BrowserRoot.EXTRA_RECENT, true);
             Log.d(TAG, "OnGetRoot: Returning BrowserRoot " + R.string.recently_played_episodes);
-            return new BrowserRoot(getResources().getString(R.string.recently_played_episodes), extras);
+            return new BrowserRoot(getResources().getString(R.string.current_playing_episode), extras);
         }
 
         // Name visible in Android Auto
@@ -441,8 +441,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             long feedId = Long.parseLong(parentId.split(":")[1]);
             Feed feed = DBReader.getFeed(feedId);
             feedItems = DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(), feed.getSortOrder());
-        } else if (parentId.equals(getString(R.string.recently_played_episodes))
-                || parentId.equals(getString(R.string.current_playing_episode))) {
+        } else if (parentId.equals(getString(R.string.current_playing_episode))) {
             Playable playable = PlaybackPreferences.createInstanceFromPreferences(this);
             if (playable instanceof FeedMedia) {
                 feedItems = Collections.singletonList(((FeedMedia) playable).getItem());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -410,9 +410,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
             if (currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING
                     || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
-                    mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
-                            R.drawable.ic_play_48dp,
-                            1));
+                       mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
+                               R.drawable.ic_play_48dp,
+                               1));
             }
             mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_play_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -323,12 +323,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     public BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, Bundle rootHints) {
         Log.d(TAG, "OnGetRoot: clientPackageName=" + clientPackageName +
                 "; clientUid=" + clientUid + " ; rootHints=" + rootHints);
-
-/*
-        long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
-        if ((rootHints != null && rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)
-                || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING )) {
- */
         if (rootHints != null && rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)) {
             Bundle extras = new Bundle();
             extras.putBoolean(BrowserRoot.EXTRA_RECENT, true);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -407,9 +407,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     private List<MediaBrowserCompat.MediaItem> loadChildrenSynchronous(@NonNull String parentId) {
         List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
         if (parentId.equals(getResources().getString(R.string.app_name))) {
-            long currentlyPlayingMedia = PlaybackPreferences.getCurrentlyPlayingMediaType();
-            if (currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PLAYING
-                    || currentlyPlayingMedia == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
+            long currentlyPlaying = PlaybackPreferences.getCurrentPlayerStatus();
+            if (currentlyPlaying == PlaybackPreferences.PLAYER_STATUS_PLAYING
+                    || currentlyPlaying== PlaybackPreferences.PLAYER_STATUS_PAUSED) {
                 mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
                                R.drawable.ic_play_48dp,
                                1));

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -326,7 +326,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (rootHints != null && rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)) {
             Bundle extras = new Bundle();
             extras.putBoolean(BrowserRoot.EXTRA_RECENT, true);
-            Log.d(TAG, "OnGetRoot: Returning BrowserRoot " + R.string.recently_played_episodes);
+            Log.d(TAG, "OnGetRoot: Returning BrowserRoot " + R.string.current_playing_episode);
             return new BrowserRoot(getResources().getString(R.string.current_playing_episode), extras);
         }
 
@@ -411,9 +411,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             long currentlyPlaying = PlaybackPreferences.getCurrentPlayerStatus();
             if (currentlyPlaying == PlaybackPreferences.PLAYER_STATUS_PLAYING
                     || currentlyPlaying == PlaybackPreferences.PLAYER_STATUS_PAUSED) {
-                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode,
-                               R.drawable.ic_play_48dp,
-                               1));
+                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode, R.drawable.ic_play_48dp, 1));
             }
             mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_play_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="years_statistics_label">Years</string>
     <string name="notification_pref_fragment">Notifications</string>
     <string name="recently_played_episodes">Recently played episodes</string>
+    <string name="current_playing_episode">Current</string>
     <string name="antennapod_echo" translatable="false">AntennaPod Echo</string>
     <string name="antennapod_echo_year" translatable="false">AntennaPod Echo %d</string>
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -26,7 +26,6 @@
     <string name="episode_cache_full_message">The episode cache limit has been reached. You can increase the cache size in the Settings.</string>
     <string name="years_statistics_label">Years</string>
     <string name="notification_pref_fragment">Notifications</string>
-    <string name="recently_played_episodes">Recently played episodes</string>
     <string name="current_playing_episode">Current</string>
     <string name="antennapod_echo" translatable="false">AntennaPod Echo</string>
     <string name="antennapod_echo_year" translatable="false">AntennaPod Echo %d</string>


### PR DESCRIPTION
fix #6698

(This is not a long term fix, just a patch until I can figure out why we are not getting BrowserRoot.EXTRA_RECENT)

To test this 
* Play an episode while *not* connected a car
* Plug in phone to car
* open AP
* There is a 'Current' tab that shows the current episode playing

2nd test
* Play an episode while *not* connected a car
* Delete the episode
* Plug in phone to car
* There should not be a 'current' tab

<img width="791" alt="Screenshot 2023-12-19 at 11 44 59 PM" src="https://github.com/AntennaPod/AntennaPod/assets/149837/e9ced758-21a2-41ff-899b-5b50847da5ae">
