### PR TITLE
tap on cover now opens feed without hindering scrolling

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.view.viewholder;
 
+import android.content.Intent;
 import android.os.Build;
 import android.text.Layout;
 import android.text.format.Formatter;
@@ -136,6 +137,9 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
                     .withCoverView(cover)
                     .load();
         }
+
+        Intent openFeed = MainActivity.getIntentToOpenFeed(activity, item.getFeedId());
+        cover.setOnClickListener(view -> activity.startActivity(openFeed));
     }
 
     private void bind(FeedMedia media) {

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -80,6 +80,7 @@
                     android:layout_height="@dimen/thumbnail_length_queue_item"
                     android:layout_centerVertical="true"
                     android:importantForAccessibility="no"
+                    android:foreground="?android:attr/selectableItemBackground"
                     tools:src="@tools:sample/avatars" />
 
             </RelativeLayout>


### PR DESCRIPTION
same as on the individual episode screen, where tapping on the cover also leads to the feed