### PR TITLE
reload chapters again, there could be network errors with chapters in…

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -82,8 +82,7 @@ public class ChapterUtils {
         List<Chapter> chaptersMergePhase1 = ChapterMerger.merge(chaptersFromDatabase, chaptersFromMediaFile);
         List<Chapter> chapters = ChapterMerger.merge(chaptersMergePhase1, chaptersFromPodcastIndex);
         if (chapters == null) {
-            // Do not try loading again. There are no chapters.
-            playable.setChapters(Collections.emptyList());
+            playable.setChapters(null);
         } else {
             playable.setChapters(chapters);
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -19,7 +19,6 @@ import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.parser.media.vorbis.VorbisCommentChapterReader;
 import de.danoeh.antennapod.parser.media.vorbis.VorbisCommentReaderException;
 import okhttp3.CacheControl;
-import okhttp3.Call;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.commons.io.input.CountingInputStream;
@@ -164,8 +163,7 @@ public class ChapterUtils {
         Response response = null;
         try {
             Request request = new Request.Builder().url(url).cacheControl(cacheControl).build();
-            Call call = AntennapodHttpClient.getHttpClient().newCall(request);
-            response = call.execute();
+            response = AntennapodHttpClient.getHttpClient().newCall(request).execute();
             if (response.isSuccessful() && response.body() != null) {
                 return PodcastIndexChapterParser.parse(response.body().string());
             }


### PR DESCRIPTION
fix #6499

When chapters are part of PodcastIndex 2.0, the button only shows up when the chapter data is loaded.

When chapters are part of the media file, the function`loadChaptersFromMediaFile` could get errors from the network such as `2023-12-27 21:15:07.036 19266-19346 ChapterUtils            de.danoeh.antennapod.debug           E  Unable to load ID3 chapters: interrupted`

When this happens, we don't want to set an empty chapter list, instead mark it as `null` so that we will refresh again