### PR TITLE
Close unresponsive tickets earlier

### DIFF
--- a/.github/workflows/close-if-no-reply.yml
+++ b/.github/workflows/close-if-no-reply.yml
@@ -13,15 +13,15 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          days-before-stale: 15
-          days-before-close: 15
+          days-before-stale: 7
+          days-before-close: 7
           only-labels: 'Awaiting reply'
           stale-issue-label: 'Still awaiting reply'
           stale-pr-label: 'Still awaiting reply'
-          stale-issue-message: "This issue will be closed when we don't get a reply within 15 days."
-          stale-pr-message: "This PR will be closed when we don't get a reply within 15 days."
+          stale-issue-message: "This issue will be closed when we don't get a reply within 7 days."
+          stale-pr-message: "This PR will be closed when we don't get a reply within 7 days."
           labels-to-remove-when-unstale: 'Awaiting reply'
           close-issue-label: "Close reason: no reply"
           close-pr-label: "Close reason: no reply"
-          close-issue-message: "This issue was closed because we didn't get a reply for 30 days."
-          close-pr-message: "This PR was closed because we didn't get a reply for 30 days."
+          close-issue-message: "This issue was closed because we didn't get a reply for 14 days."
+          close-pr-message: "This PR was closed because we didn't get a reply for 14 days."


### PR DESCRIPTION
We had this before and I thought it's maybe a bit quick. Lately, I regularly went through the issues list and saw some that are still open because of the 30 days but I don't think the authors will ever reply. So 2 weeks is probably enough.