### PR TITLE
Share AntennaPod subscribe link instead of RSS url

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -10,6 +10,7 @@ import androidx.core.app.ShareCompat;
 import androidx.core.content.FileProvider;
 
 import java.io.File;
+import java.net.URLEncoder;
 
 import de.danoeh.antennapod.core.R;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -33,12 +34,12 @@ public class ShareUtils {
     }
 
     public static void shareFeedLink(Context context, Feed feed) {
-        String text = feed.getTitle();
-        if (feed.getLink() != null) {
-            text += "\n" + feed.getLink();
-        }
-        text += "\n\n" + context.getResources().getString(R.string.share_rss_address_label)
-                + " " + feed.getDownload_url();
+        String text = feed.getTitle()
+                + "\n\n"
+                + "https://antennapod.org/deeplink/subscribe/?url="
+                + URLEncoder.encode(feed.getDownload_url())
+                + "&title="
+                + URLEncoder.encode(feed.getTitle());
         shareLink(context, text);
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -185,7 +185,6 @@
     <string name="remove_feed_label">Remove podcast</string>
     <string name="share_label">Share</string>
     <string name="share_file_label">Share file</string>
-    <string name="share_rss_address_label">RSS address:</string>
     <string name="feed_delete_confirmation_msg">Please confirm that you want to delete the podcast \"%1$s\", ALL its episodes (including downloaded episodes), and its statistics.</string>
     <string name="feed_delete_confirmation_msg_batch">Please confirm that you want to remove the selected podcasts, ALL their episodes (including downloaded episodes), and its statistics.</string>
     <string name="feed_delete_confirmation_local_msg">Please confirm that you want to remove the podcast \"%1$s\" and its statistics. The files in the local source folder will not be deleted.</string>


### PR DESCRIPTION
Apparently users are confused by RSS links. Because of https://github.com/AntennaPod/antennapod.github.io/pull/303, we can now add a title.