### PR TITLE
Improve toolbar

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -551,6 +551,14 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        boolean isLocked = UserPreferences.isQueueLocked();
+        menu.findItem(R.id.queue_lock).setVisible(!isLocked);
+        menu.findItem(R.id.queue_locked).setVisible(isLocked);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
     public void onBackPressed() {
         if (isDrawerOpen()) {
             drawerLayout.closeDrawer(navDrawer);

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -456,17 +456,6 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        menu.findItem(R.id.queue_lock).setVisible(false);
-        boolean isLocked = UserPreferences.isQueueLocked();
-        if (isLocked) {
-            menu.findItem(R.id.queue_lock).setVisible(!isLocked);
-            menu.findItem(R.id.queue_locked).setVisible(isLocked);
-        }
-        return super.onPrepareOptionsMenu(menu);
-    }
-
-    @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         if (drawerToggle != null) { // Tablet layout does not have a drawer

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -452,6 +453,17 @@ public class MainActivity extends CastEnabledActivity {
         if (drawerToggle != null) { // Tablet layout does not have a drawer
             drawerToggle.syncState();
         }
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.queue_lock).setVisible(false);
+        boolean isLocked = UserPreferences.isQueueLocked();
+        if (isLocked) {
+            menu.findItem(R.id.queue_lock).setVisible(!isLocked);
+            menu.findItem(R.id.queue_locked).setVisible(isLocked);
+        }
+        return super.onPrepareOptionsMenu(menu);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -551,14 +551,6 @@ public class MainActivity extends CastEnabledActivity {
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        boolean isLocked = UserPreferences.isQueueLocked();
-        menu.findItem(R.id.queue_lock).setVisible(!isLocked);
-        menu.findItem(R.id.queue_locked).setVisible(isLocked);
-        return super.onPrepareOptionsMenu(menu);
-    }
-
-    @Override
     public void onBackPressed() {
         if (isDrawerOpen()) {
             drawerLayout.closeDrawer(navDrawer);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -178,10 +178,10 @@ public class CompletedDownloadsFragment extends Fragment
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
-        /*if (item.getItemId() == R.id.refresh_item) {
+        if (item.getItemId() == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;
-        } else*/ if (item.getItemId() == R.id.action_download_logs) {
+        } else if (item.getItemId() == R.id.action_download_logs) {
             new DownloadLogFragment().show(getChildFragmentManager(), null);
             return true;
         } else if (item.getItemId() == R.id.action_search) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/CompletedDownloadsFragment.java
@@ -178,10 +178,10 @@ public class CompletedDownloadsFragment extends Fragment
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
-        if (item.getItemId() == R.id.refresh_item) {
+        /*if (item.getItemId() == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;
-        } else if (item.getItemId() == R.id.action_download_logs) {
+        } else*/ if (item.getItemId() == R.id.action_download_logs) {
             new DownloadLogFragment().show(getChildFragmentManager(), null);
             return true;
         } else if (item.getItemId() == R.id.action_search) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -77,6 +77,7 @@ public abstract class EpisodesListFragment extends Fragment
     EmptyViewHandler emptyView;
     SpeedDialView speedDialView;
     MaterialToolbar toolbar;
+    SwipeRefreshLayout swipeRefreshLayout;
     SwipeActions swipeActions;
     private ProgressBar progressBar;
 
@@ -180,7 +181,7 @@ public abstract class EpisodesListFragment extends Fragment
             ((SimpleItemAnimator) animator).setSupportsChangeAnimations(false);
         }
 
-        SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
+        swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
         swipeRefreshLayout.setDistanceToTriggerSync(getResources().getInteger(R.integer.swipe_refresh_distance));
         swipeRefreshLayout.setOnRefreshListener(() -> {
             FeedUpdateManager.runOnceOrAsk(requireContext());
@@ -456,9 +457,7 @@ public abstract class EpisodesListFragment extends Fragment
 
     /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        if (toolbar.getMenu().findItem(R.id.refresh_item) != null) {
-            MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item, event.isFeedUpdateRunning);
-        }
+        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
     }*/
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -122,10 +122,10 @@ public abstract class EpisodesListFragment extends Fragment
             return true;
         }
         final int itemId = item.getItemId();
-        /*if (itemId == R.id.refresh_item) {
+        if (itemId == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;
-        } else*/ if (itemId == R.id.action_search) {
+        } else if (itemId == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             return true;
         }
@@ -455,10 +455,14 @@ public abstract class EpisodesListFragment extends Fragment
     protected void updateToolbar() {
     }
 
-    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
-    }*/
+        if (event.isFeedUpdateRunning) {
+            swipeRefreshLayout.setRefreshing(true);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
+                    getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
+        }
+    }
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/EpisodesListFragment.java
@@ -121,10 +121,10 @@ public abstract class EpisodesListFragment extends Fragment
             return true;
         }
         final int itemId = item.getItemId();
-        if (itemId == R.id.refresh_item) {
+        /*if (itemId == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;
-        } else if (itemId == R.id.action_search) {
+        } else*/ if (itemId == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             return true;
         }
@@ -454,12 +454,12 @@ public abstract class EpisodesListFragment extends Fragment
     protected void updateToolbar() {
     }
 
-    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
         if (toolbar.getMenu().findItem(R.id.refresh_item) != null) {
             MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item, event.isFeedUpdateRunning);
         }
-    }
+    }*/
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -158,8 +158,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                 getContext(), viewBinding.toolbar, viewBinding.collapsingToolbar) {
             @Override
             protected void doTint(Context themedContext) {
-                viewBinding.toolbar.getMenu().findItem(R.id.refresh_item)
-                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_refresh));
+                /*viewBinding.toolbar.getMenu().findItem(R.id.refresh_item)
+                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_refresh));*/
                 viewBinding.toolbar.getMenu().findItem(R.id.action_search)
                         .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_search));
             }
@@ -275,8 +275,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             IntentUtils.openInBrowser(getContext(), feed.getLink());
         } else if (item.getItemId() == R.id.share_item) {
             ShareUtils.shareFeedLink(getContext(), feed);
-        } else if (item.getItemId() == R.id.refresh_item) {
-            FeedUpdateManager.runOnceOrAsk(getContext(), feed);
+        /*} else if (item.getItemId() == R.id.refresh_item) {
+            FeedUpdateManager.runOnceOrAsk(getContext(), feed);*/
         } else if (item.getItemId() == R.id.refresh_complete_item) {
             new Thread(() -> {
                 feed.setNextPageLink(feed.getDownload_url());
@@ -431,8 +431,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         if (!event.isFeedUpdateRunning) {
             nextPageLoader.getRoot().setVisibility(View.GONE);
         }
-        MenuItemUtils.updateRefreshMenuItem(viewBinding.toolbar.getMenu(),
-                R.id.refresh_item, event.isFeedUpdateRunning);
+        /*MenuItemUtils.updateRefreshMenuItem(viewBinding.toolbar.getMenu(),
+                R.id.refresh_item, event.isFeedUpdateRunning);*/
     }
 
     private void refreshHeaderView() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -431,8 +431,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         if (!event.isFeedUpdateRunning) {
             nextPageLoader.getRoot().setVisibility(View.GONE);
         }
-        /*MenuItemUtils.updateRefreshMenuItem(viewBinding.toolbar.getMenu(),
-                R.id.refresh_item, event.isFeedUpdateRunning);*/
+        /*swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);*/
     }
 
     private void refreshHeaderView() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -20,6 +20,8 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.appbar.MaterialToolbar;
@@ -158,8 +160,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                 getContext(), viewBinding.toolbar, viewBinding.collapsingToolbar) {
             @Override
             protected void doTint(Context themedContext) {
-                /*viewBinding.toolbar.getMenu().findItem(R.id.refresh_item)
-                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_refresh));*/
                 viewBinding.toolbar.getMenu().findItem(R.id.action_search)
                         .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_search));
             }
@@ -275,8 +275,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             IntentUtils.openInBrowser(getContext(), feed.getLink());
         } else if (item.getItemId() == R.id.share_item) {
             ShareUtils.shareFeedLink(getContext(), feed);
-        /*} else if (item.getItemId() == R.id.refresh_item) {
-            FeedUpdateManager.runOnceOrAsk(getContext(), feed);*/
+        } else if (item.getItemId() == R.id.refresh_item) {
+            FeedUpdateManager.runOnceOrAsk(getContext(), feed);
         } else if (item.getItemId() == R.id.refresh_complete_item) {
             new Thread(() -> {
                 feed.setNextPageLink(feed.getDownload_url());
@@ -431,7 +431,11 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         if (!event.isFeedUpdateRunning) {
             nextPageLoader.getRoot().setVisibility(View.GONE);
         }
-        /*swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);*/
+        if (event.isFeedUpdateRunning) {
+            viewBinding.swipeRefresh.setRefreshing(true);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> viewBinding.swipeRefresh.setRefreshing(false),
+                    getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
+        }
     }
 
     private void refreshHeaderView() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -274,6 +274,8 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         if (itemId == R.id.queue_lock) {
             toggleQueueLock();
             return true;
+        } else if (itemId == R.id.action_recent) {
+            ((MainActivity) getActivity()).loadFragment(PlaybackHistoryFragment.TAG, null);
         } else if (itemId == R.id.queue_sort) {
             new QueueSortDialog().show(getChildFragmentManager().beginTransaction(), "SortDialog");
             return true;

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -268,7 +268,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
 
     /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item, event.isFeedUpdateRunning);
+        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
     }*/
 
     @Override
@@ -306,6 +306,18 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             return true;
         }
         return false;
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        //TODO not working :(
+        menu.findItem(R.id.queue_locked).setVisible(false);
+        boolean isLocked = UserPreferences.isQueueLocked();
+        if (isLocked) {
+            menu.findItem(R.id.queue_lock).setVisible(!isLocked);
+            menu.findItem(R.id.queue_locked).setVisible(isLocked);
+        }
     }
 
     private void toggleQueueLock() {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -308,18 +308,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         return false;
     }
 
-    @Override
-    public void onPrepareOptionsMenu(@NonNull Menu menu) {
-        super.onPrepareOptionsMenu(menu);
-        //TODO not working :(
-        menu.findItem(R.id.queue_locked).setVisible(false);
-        boolean isLocked = UserPreferences.isQueueLocked();
-        if (isLocked) {
-            menu.findItem(R.id.queue_lock).setVisible(!isLocked);
-            menu.findItem(R.id.queue_locked).setVisible(isLocked);
-        }
-    }
-
     private void toggleQueueLock() {
         boolean isLocked = UserPreferences.isQueueLocked();
         if (isLocked) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -10,6 +10,8 @@ import android.util.Log;
 import android.view.ContextMenu;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,6 +20,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
@@ -271,8 +274,9 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         final int itemId = item.getItemId();
-        if (itemId == R.id.queue_lock) {
+        if (itemId == R.id.queue_lock || itemId == R.id.queue_locked) {
             toggleQueueLock();
+            requireActivity().invalidateOptionsMenu();
             return true;
         } else if (itemId == R.id.action_recent) {
             ((MainActivity) getActivity()).loadFragment(PlaybackHistoryFragment.TAG, null);
@@ -469,6 +473,17 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                     .handleAction(recyclerAdapter.getSelectedItems());
             recyclerAdapter.endSelectMode();
             return true;
+        });
+        requireActivity().addMenuProvider(new MenuProvider() {
+            @Override
+            public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+
+            }
+
+            @Override
+            public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+                return false;
+            }
         });
         return root;
     }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -164,7 +164,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 return;
         }
         recyclerAdapter.updateDragDropEnabled();
-        refreshToolbarState();
         recyclerView.saveScrollPosition(QueueFragment.TAG);
         refreshInfoBar();
     }
@@ -220,14 +219,12 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusChanged(PlayerStatusEvent event) {
         loadItems(false);
-        refreshToolbarState();
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
         // Sent when playback position is reset
         loadItems(false);
-        refreshToolbarState();
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -354,7 +351,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         }
         ((MainActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
         toolbar.inflateMenu(R.menu.queue);
-        refreshToolbarState();
         progressBar = root.findViewById(R.id.progressBar);
         progressBar.setVisibility(View.VISIBLE);
 
@@ -494,7 +490,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     public void onStartSelectMode() {
         swipeActions.detach();
         speedDialView.setVisibility(View.VISIBLE);
-        refreshToolbarState();
         infoBar.setVisibility(View.GONE);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -263,10 +263,10 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         toolbar.getMenu().findItem(R.id.queue_lock).setVisible(!keepSorted);
     }
 
-    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
         MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item, event.isFeedUpdateRunning);
-    }
+    }*/
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
@@ -277,9 +277,9 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         } else if (itemId == R.id.queue_sort) {
             new QueueSortDialog().show(getChildFragmentManager().beginTransaction(), "SortDialog");
             return true;
-        } else if (itemId == R.id.refresh_item) {
+        /*} else if (itemId == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
-            return true;
+            return true;*/
         } else if (itemId == R.id.clear_queue) {
             // make sure the user really wants to clear the queue
             ConfirmationDialog conDialog = new ConfirmationDialog(getActivity(),

--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueueFragment.java
@@ -98,6 +98,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
 
     private SpeedDialView speedDialView;
     private ProgressBar progressBar;
+    private SwipeRefreshLayout swipeRefreshLayout;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -266,10 +267,14 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         toolbar.getMenu().findItem(R.id.queue_lock).setVisible(!keepSorted);
     }
 
-    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
-    }*/
+        if (event.isFeedUpdateRunning) {
+            swipeRefreshLayout.setRefreshing(true);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
+                    getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
+        }
+    }
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
@@ -283,9 +288,9 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         } else if (itemId == R.id.queue_sort) {
             new QueueSortDialog().show(getChildFragmentManager().beginTransaction(), "SortDialog");
             return true;
-        /*} else if (itemId == R.id.refresh_item) {
+        } else if (itemId == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
-            return true;*/
+            return true;
         } else if (itemId == R.id.clear_queue) {
             // make sure the user really wants to clear the queue
             ConfirmationDialog conDialog = new ConfirmationDialog(getActivity(),
@@ -431,7 +436,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         recyclerAdapter.setOnSelectModeListener(this);
         recyclerView.setAdapter(recyclerAdapter);
 
-        SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
+        swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
         swipeRefreshLayout.setDistanceToTriggerSync(getResources().getInteger(R.integer.swipe_refresh_distance));
         swipeRefreshLayout.setOnRefreshListener(() -> {
             FeedUpdateManager.runOnceOrAsk(requireContext());

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -211,7 +211,7 @@ public class SubscriptionFragment extends Fragment
 
     /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item, event.isFeedUpdateRunning);
+        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
     }*/
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -209,18 +209,18 @@ public class SubscriptionFragment extends Fragment
         toolbar.getMenu().findItem(COLUMN_CHECKBOX_IDS[columns - MIN_NUM_COLUMNS]).setChecked(true);
     }
 
-    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
         MenuItemUtils.updateRefreshMenuItem(toolbar.getMenu(), R.id.refresh_item, event.isFeedUpdateRunning);
-    }
+    }*/
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         final int itemId = item.getItemId();
-        if (itemId == R.id.refresh_item) {
+        /*if (itemId == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;
-        } else if (itemId == R.id.subscriptions_filter) {
+        } else*/ if (itemId == R.id.subscriptions_filter) {
             SubscriptionsFilterDialog.showDialog(requireContext());
             return true;
         } else if (itemId == R.id.subscriptions_sort) {

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -81,6 +81,7 @@ public class SubscriptionFragment extends Fragment
     private EmptyViewHandler emptyView;
     private LinearLayout feedsFilteredMsg;
     private MaterialToolbar toolbar;
+    private SwipeRefreshLayout swipeRefreshLayout;
     private ProgressBar progressBar;
     private String displayedFolder = null;
     private boolean displayUpArrow;
@@ -168,7 +169,7 @@ public class SubscriptionFragment extends Fragment
         feedsFilteredMsg = root.findViewById(R.id.feeds_filtered_message);
         feedsFilteredMsg.setOnClickListener((l) -> SubscriptionsFilterDialog.showDialog(requireContext()));
 
-        SwipeRefreshLayout swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
+        swipeRefreshLayout = root.findViewById(R.id.swipeRefresh);
         swipeRefreshLayout.setDistanceToTriggerSync(getResources().getInteger(R.integer.swipe_refresh_distance));
         swipeRefreshLayout.setOnRefreshListener(() -> {
             FeedUpdateManager.runOnceOrAsk(requireContext());
@@ -209,18 +210,22 @@ public class SubscriptionFragment extends Fragment
         toolbar.getMenu().findItem(COLUMN_CHECKBOX_IDS[columns - MIN_NUM_COLUMNS]).setChecked(true);
     }
 
-    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
-    }*/
+        if (event.isFeedUpdateRunning) {
+            swipeRefreshLayout.setRefreshing(true);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> swipeRefreshLayout.setRefreshing(false),
+                    getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
+        }
+    }
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         final int itemId = item.getItemId();
-        /*if (itemId == R.id.refresh_item) {
+        if (itemId == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;
-        } else*/ if (itemId == R.id.subscriptions_filter) {
+        } else if (itemId == R.id.subscriptions_filter) {
             SubscriptionsFilterDialog.showDialog(requireContext());
             return true;
         } else if (itemId == R.id.subscriptions_sort) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
@@ -155,8 +155,7 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
 
     /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        MenuItemUtils.updateRefreshMenuItem(viewBinding.toolbar.getMenu(),
-                R.id.refresh_item, event.isFeedUpdateRunning);
+        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
     }*/
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
@@ -21,6 +21,7 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 
+import de.danoeh.antennapod.fragment.AddFeedFragment;
 import de.danoeh.antennapod.ui.echo.EchoActivity;
 import de.danoeh.antennapod.ui.home.sections.EchoSection;
 import org.greenrobot.eventbus.EventBus;
@@ -167,7 +168,7 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;*/
         } else if (item.getItemId() == R.id.action_addpodcast) {
-            //navigate to add
+            ((MainActivity) getActivity()).loadFragment(AddFeedFragment.TAG, null);
         } else if (item.getItemId() == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             return true;

--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
@@ -20,6 +20,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import de.danoeh.antennapod.fragment.AddFeedFragment;
 import de.danoeh.antennapod.ui.echo.EchoActivity;
@@ -153,19 +154,23 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
         return new ArrayList<>(Arrays.asList(TextUtils.split(hiddenSectionsString, ",")));
     }
 
-    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
-        swipeRefreshLayout.setRefreshing(event.isFeedUpdateRunning);
-    }*/
+        if (event.isFeedUpdateRunning) {
+            viewBinding.swipeRefresh.setRefreshing(true);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> viewBinding.swipeRefresh.setRefreshing(false),
+                    getResources().getInteger(R.integer.swipe_to_refresh_duration_in_ms));
+        }
+    }
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         if (item.getItemId() == R.id.homesettings_items) {
             HomeSectionsSettingsDialog.open(getContext(), (dialogInterface, i) -> populateSectionList());
             return true;
-        /*} else if (item.getItemId() == R.id.refresh_item) {
+        } else if (item.getItemId() == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
-            return true;*/
+            return true;
         } else if (item.getItemId() == R.id.action_addpodcast) {
             ((MainActivity) getActivity()).loadFragment(AddFeedFragment.TAG, null);
         } else if (item.getItemId() == R.id.action_search) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
@@ -166,6 +166,8 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
         /*} else if (item.getItemId() == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
             return true;*/
+        } else if (item.getItemId() == R.id.action_addpodcast) {
+            //navigate to add
         } else if (item.getItemId() == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             return true;

--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeFragment.java
@@ -152,20 +152,20 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
         return new ArrayList<>(Arrays.asList(TextUtils.split(hiddenSectionsString, ",")));
     }
 
-    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
+    /*@Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedUpdateRunningEvent event) {
         MenuItemUtils.updateRefreshMenuItem(viewBinding.toolbar.getMenu(),
                 R.id.refresh_item, event.isFeedUpdateRunning);
-    }
+    }*/
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         if (item.getItemId() == R.id.homesettings_items) {
             HomeSectionsSettingsDialog.open(getContext(), (dialogInterface, i) -> populateSectionList());
             return true;
-        } else if (item.getItemId() == R.id.refresh_item) {
+        /*} else if (item.getItemId() == R.id.refresh_item) {
             FeedUpdateManager.runOnceOrAsk(requireContext());
-            return true;
+            return true;*/
         } else if (item.getItemId() == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             return true;

--- a/app/src/main/res/menu/downloads_completed.xml
+++ b/app/src/main/res/menu/downloads_completed.xml
@@ -17,12 +17,6 @@
         custom:showAsAction="always" />
 
     <item
-        android:id="@+id/refresh_item"
-        android:title="@string/refresh_label"
-        android:menuCategory="container"
-        android:icon="@drawable/ic_refresh"
-        app:showAsAction="always" />
-    <item
         android:id="@+id/downloads_sort"
         android:title="@string/sort" />
 </menu>

--- a/app/src/main/res/menu/downloads_completed.xml
+++ b/app/src/main/res/menu/downloads_completed.xml
@@ -17,6 +17,12 @@
         custom:showAsAction="always" />
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
         android:id="@+id/downloads_sort"
         android:title="@string/sort" />
 </menu>

--- a/app/src/main/res/menu/episodes.xml
+++ b/app/src/main/res/menu/episodes.xml
@@ -10,13 +10,6 @@
         android:title="@string/search_label"/>
 
     <item
-        android:id="@+id/refresh_item"
-        android:title="@string/refresh_label"
-        android:menuCategory="container"
-        custom:showAsAction="always"
-        android:icon="@drawable/ic_refresh"/>
-
-    <item
         android:id="@+id/filter_items"
         android:icon="@drawable/ic_filter"
         android:menuCategory="container"

--- a/app/src/main/res/menu/episodes.xml
+++ b/app/src/main/res/menu/episodes.xml
@@ -14,7 +14,7 @@
         android:icon="@drawable/ic_filter"
         android:menuCategory="container"
         android:title="@string/filter"
-        custom:showAsAction="ifRoom"/>
+        custom:showAsAction="always"/>
 
     <item
         android:id="@+id/action_favorites"

--- a/app/src/main/res/menu/episodes.xml
+++ b/app/src/main/res/menu/episodes.xml
@@ -24,6 +24,12 @@
         custom:showAsAction="always"/>
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
         android:id="@+id/episodes_sort"
         android:title="@string/sort"
         custom:showAsAction="never" />

--- a/app/src/main/res/menu/feedlist.xml
+++ b/app/src/main/res/menu/feedlist.xml
@@ -9,13 +9,6 @@
         custom:showAsAction="never">
     </item>
     <item
-        android:id="@+id/refresh_item"
-        android:icon="@drawable/ic_refresh"
-        android:menuCategory="container"
-        android:title="@string/refresh_label"
-        custom:showAsAction="always">
-    </item>
-    <item
         android:id="@+id/refresh_complete_item"
         android:menuCategory="container"
         android:title="@string/load_complete_feed"

--- a/app/src/main/res/menu/feedlist.xml
+++ b/app/src/main/res/menu/feedlist.xml
@@ -31,6 +31,12 @@
     </item>
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
         android:id="@+id/share_item"
         android:menuCategory="container"
         custom:showAsAction="never"

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -9,6 +9,13 @@
         android:title="@string/search_label"/>
 
     <item
+        android:id="@+id/action_addpodcast"
+        android:title="@string/add_feed_label"
+        android:menuCategory="container"
+        custom:showAsAction="always"
+        android:icon="@drawable/ic_add"/>
+
+    <item
         android:id="@+id/homesettings_items"
         android:icon="@drawable/ic_settings"
         android:menuCategory="container"

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -16,6 +16,12 @@
         android:icon="@drawable/ic_add"/>
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
         android:id="@+id/homesettings_items"
         android:icon="@drawable/ic_settings"
         android:menuCategory="container"

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -9,13 +9,6 @@
         android:title="@string/search_label"/>
 
     <item
-        android:id="@+id/refresh_item"
-        android:title="@string/refresh_label"
-        android:menuCategory="container"
-        custom:showAsAction="always"
-        android:icon="@drawable/ic_refresh"/>
-
-    <item
         android:id="@+id/homesettings_items"
         android:icon="@drawable/ic_settings"
         android:menuCategory="container"

--- a/app/src/main/res/menu/inbox.xml
+++ b/app/src/main/res/menu/inbox.xml
@@ -9,6 +9,12 @@
         android:title="@string/search_label"/>
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
         android:id="@+id/inbox_sort"
         android:title="@string/sort" />
 

--- a/app/src/main/res/menu/inbox.xml
+++ b/app/src/main/res/menu/inbox.xml
@@ -9,13 +9,6 @@
         android:title="@string/search_label"/>
 
     <item
-        android:id="@+id/refresh_item"
-        android:title="@string/refresh_label"
-        android:menuCategory="container"
-        custom:showAsAction="always"
-        android:icon="@drawable/ic_refresh"/>
-
-    <item
         android:id="@+id/inbox_sort"
         android:title="@string/sort" />
 

--- a/app/src/main/res/menu/mediaplayer.xml
+++ b/app/src/main/res/menu/mediaplayer.xml
@@ -74,6 +74,7 @@
 
     <item
         android:id="@+id/share_item"
+        android:icon="@drawable/ic_share"
         android:menuCategory="container"
         custom:showAsAction="always"
         android:title="@string/share_label">

--- a/app/src/main/res/menu/mediaplayer.xml
+++ b/app/src/main/res/menu/mediaplayer.xml
@@ -32,7 +32,7 @@
         android:id="@+id/audio_controls"
         android:icon="@drawable/ic_sliders"
         android:title="@string/audio_controls"
-        custom:showAsAction="always">
+        custom:showAsAction="ifRoom">
     </item>
 
     <item
@@ -75,7 +75,7 @@
     <item
         android:id="@+id/share_item"
         android:menuCategory="container"
-        custom:showAsAction="never"
+        custom:showAsAction="always"
         android:title="@string/share_label">
     </item>
 </menu>

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -9,13 +9,6 @@
         android:title="@string/search_label"/>
 
     <item
-        android:id="@+id/refresh_item"
-        android:title="@string/refresh_label"
-        android:menuCategory="container"
-        custom:showAsAction="always"
-        android:icon="@drawable/ic_refresh"/>
-
-    <item
         android:id="@+id/queue_lock"
         android:title="@string/lock_queue"
         android:menuCategory="container"

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -7,6 +7,11 @@
         android:icon="@drawable/ic_search"
         custom:showAsAction="ifRoom"
         android:title="@string/search_label"/>
+    <item
+        android:id="@+id/action_recent"
+        android:icon="@drawable/ic_history"
+        custom:showAsAction="ifRoom"
+        android:title="@string/recently_played_episodes"/>
 
     <item
         android:id="@+id/queue_lock"

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -16,8 +16,14 @@
     <item
         android:id="@+id/queue_lock"
         android:title="@string/lock_queue"
-        android:menuCategory="container"
-        android:checkable="true" />
+        android:icon="@drawable/ic_lock"
+        custom:showAsAction="always"/>
+
+    <item
+        android:id="@+id/queue_locked"
+        android:title="@string/lock_queue"
+        android:icon="@drawable/ic_locked"
+        custom:showAsAction="always"/>
 
     <item
         android:id="@+id/queue_sort"

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -14,18 +14,6 @@
         android:title="@string/recently_played_episodes"/>
 
     <item
-        android:id="@+id/queue_lock"
-        android:title="@string/lock_queue"
-        android:icon="@drawable/ic_lock"
-        custom:showAsAction="always"/>
-
-    <item
-        android:id="@+id/queue_locked"
-        android:title="@string/lock_queue"
-        android:icon="@drawable/ic_locked"
-        custom:showAsAction="always"/>
-
-    <item
         android:id="@+id/refresh_item"
         android:title="@string/refresh_label"
         android:menuCategory="container"

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -17,13 +17,13 @@
         android:id="@+id/queue_lock"
         android:title="@string/lock_queue"
         android:icon="@drawable/ic_lock"
-        custom:showAsAction="always"/>
+        custom:showAsAction="ifRoom"/>
 
     <item
         android:id="@+id/queue_locked"
         android:title="@string/lock_queue"
         android:icon="@drawable/ic_locked"
-        custom:showAsAction="always"/>
+        custom:showAsAction="ifRoom"/>
 
     <item
         android:id="@+id/queue_sort"

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -26,6 +26,12 @@
         custom:showAsAction="always"/>
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
         android:id="@+id/queue_sort"
         android:title="@string/sort" />
 

--- a/app/src/main/res/menu/queue.xml
+++ b/app/src/main/res/menu/queue.xml
@@ -17,13 +17,13 @@
         android:id="@+id/queue_lock"
         android:title="@string/lock_queue"
         android:icon="@drawable/ic_lock"
-        custom:showAsAction="ifRoom"/>
+        custom:showAsAction="always"/>
 
     <item
         android:id="@+id/queue_locked"
         android:title="@string/lock_queue"
         android:icon="@drawable/ic_locked"
-        custom:showAsAction="ifRoom"/>
+        custom:showAsAction="always"/>
 
     <item
         android:id="@+id/queue_sort"

--- a/app/src/main/res/menu/subscriptions.xml
+++ b/app/src/main/res/menu/subscriptions.xml
@@ -11,12 +11,7 @@
             android:icon="@drawable/ic_chart_box"
             android:title="@string/statistics_label"
             custom:showAsAction="always" />
-    <item
-            android:id="@+id/refresh_item"
-            android:title="@string/refresh_label"
-            android:menuCategory="container"
-            custom:showAsAction="always"
-            android:icon="@drawable/ic_refresh"/>
+
     <item
             android:id="@+id/subscriptions_filter"
             android:title="@string/filter"

--- a/app/src/main/res/menu/subscriptions.xml
+++ b/app/src/main/res/menu/subscriptions.xml
@@ -13,6 +13,12 @@
             custom:showAsAction="always" />
 
     <item
+        android:id="@+id/refresh_item"
+        android:title="@string/refresh_label"
+        android:menuCategory="container"
+        custom:showAsAction="never"/>
+
+    <item
             android:id="@+id/subscriptions_filter"
             android:title="@string/filter"
             custom:showAsAction="never" />

--- a/core/src/main/res/drawable/ic_lock.xml
+++ b/core/src/main/res/drawable/ic_lock.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
+</vector>

--- a/core/src/main/res/drawable/ic_lock.xml
+++ b/core/src/main/res/drawable/ic_lock.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
+    <path android:fillColor="?attr/action_icon_color" android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
 </vector>

--- a/core/src/main/res/drawable/ic_locked.xml
+++ b/core/src/main/res/drawable/ic_locked.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/core/src/main/res/drawable/ic_locked.xml
+++ b/core/src/main/res/drawable/ic_locked.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+    <path android:fillColor="?attr/action_icon_color" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
 </vector>


### PR DESCRIPTION
I propose to remove the refresh buttons, they are unnecessary, confusing and possibly prevent discovery of pull to refresh. If they are essential for which it yet have to hear an argument, let us at least hide them in the menu.
I have to great suggestions: 
- for the home toolbar i added a link to the add-podcast-screen because this it is not yet accessible from home but is needed rather frequently, for adding new podcasts or looking at trends.
- Also i felt recently played history was missing in the queue toolbar - it just naturally goes together: i add them to queue, then listen and then they are moved to recently played.

Happy new years everybody :)
