### PR TITLE
Add option to add new episodes to queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedSettingsFragment.java
@@ -421,6 +421,9 @@ public class FeedSettingsFragment extends Fragment {
                 case ADD_TO_INBOX:
                     newEpisodesAction.setSummary(R.string.feed_new_episodes_action_add_to_inbox);
                     break;
+                case ADD_TO_QUEUE:
+                    newEpisodesAction.setSummary(R.string.feed_new_episodes_action_add_to_queue);
+                    break;
                 case NOTHING:
                     newEpisodesAction.setSummary(R.string.feed_new_episodes_action_nothing);
                     break;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -295,17 +295,18 @@ public final class DBTasks {
                     if (action == FeedPreferences.NewEpisodesAction.GLOBAL) {
                         action = UserPreferences.getNewEpisodesAction();
                     }
-                    if (item.getPubDate() == null
-                            || priorMostRecentDate == null
-                            || priorMostRecentDate.before(item.getPubDate())
-                            || priorMostRecentDate.equals(item.getPubDate())) {
-                        if (action == FeedPreferences.NewEpisodesAction.ADD_TO_INBOX) {
-                            Log.d(TAG, "Marking item published on " + item.getPubDate()
+                    if (action == FeedPreferences.NewEpisodesAction.ADD_TO_INBOX
+                            && (item.getPubDate() == null
+                                || priorMostRecentDate == null
+                                || priorMostRecentDate.before(item.getPubDate())
+                                || priorMostRecentDate.equals(item.getPubDate()))) {
+                        Log.d(TAG, "Marking item published on " + item.getPubDate()
                                 + " new, prior most recent date = " + priorMostRecentDate);
-                            item.setNew();
-                        } else if (action == FeedPreferences.NewEpisodesAction.ADD_TO_QUEUE) {
-                            itemsToAddToQueue.add(item);
-                        }
+                        item.setNew();
+                    }
+
+                    if (action == FeedPreferences.NewEpisodesAction.ADD_TO_QUEUE) {
+                        itemsToAddToQueue.add(item);
                     }
                 }
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -291,22 +291,26 @@ public final class DBTasks {
                         savedFeed.getItems().add(idx, item);
                     }
 
-                    FeedPreferences.NewEpisodesAction action = savedFeed.getPreferences().getNewEpisodesAction();
-                    if (action == FeedPreferences.NewEpisodesAction.GLOBAL) {
-                        action = UserPreferences.getNewEpisodesAction();
-                    }
-                    if (action == FeedPreferences.NewEpisodesAction.ADD_TO_INBOX
-                            && (item.getPubDate() == null
-                                || priorMostRecentDate == null
-                                || priorMostRecentDate.before(item.getPubDate())
-                                || priorMostRecentDate.equals(item.getPubDate()))) {
-                        Log.d(TAG, "Marking item published on " + item.getPubDate()
-                                + " new, prior most recent date = " + priorMostRecentDate);
-                        item.setNew();
-                    }
-
-                    if (action == FeedPreferences.NewEpisodesAction.ADD_TO_QUEUE) {
-                        itemsToAddToQueue.add(item);
+                    if (item.getPubDate() == null
+                            || priorMostRecentDate == null
+                            || priorMostRecentDate.before(item.getPubDate())
+                            || priorMostRecentDate.equals(item.getPubDate())) {
+                        Log.d(TAG, "Performing new episode action for item published on " + item.getPubDate()
+                                + ", prior most recent date = " + priorMostRecentDate);
+                        FeedPreferences.NewEpisodesAction action = savedFeed.getPreferences().getNewEpisodesAction();
+                        if (action == FeedPreferences.NewEpisodesAction.GLOBAL) {
+                            action = UserPreferences.getNewEpisodesAction();
+                        }
+                        switch (action) {
+                            case ADD_TO_INBOX:
+                                item.setNew();
+                                break;
+                            case ADD_TO_QUEUE:
+                                itemsToAddToQueue.add(item);
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -347,7 +347,7 @@ public final class DBTasks {
 
         // We need to add to queue after items are saved to database
         DBWriter.addQueueItem(context, itemsToAddToQueue.toArray(
-            new FeedItem[itemsToAddToQueue.size()]
+                new FeedItem[itemsToAddToQueue.size()]
         ));
 
         adapter.close();

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -295,17 +295,15 @@ public final class DBTasks {
                     if (action == FeedPreferences.NewEpisodesAction.GLOBAL) {
                         action = UserPreferences.getNewEpisodesAction();
                     }
-                    if ((action == FeedPreferences.NewEpisodesAction.ADD_TO_INBOX
-                            || action == FeedPreferences.NewEpisodesAction.ADD_TO_QUEUE)
-                            && (item.getPubDate() == null
-                                || priorMostRecentDate == null
-                                || priorMostRecentDate.before(item.getPubDate())
-                                || priorMostRecentDate.equals(item.getPubDate()))) {
-                        Log.d(TAG, "Marking item published on " + item.getPubDate()
+                    if (item.getPubDate() == null
+                            || priorMostRecentDate == null
+                            || priorMostRecentDate.before(item.getPubDate())
+                            || priorMostRecentDate.equals(item.getPubDate())) {
+                        if (action == FeedPreferences.NewEpisodesAction.ADD_TO_INBOX) {
+                            Log.d(TAG, "Marking item published on " + item.getPubDate()
                                 + " new, prior most recent date = " + priorMostRecentDate);
-                        item.setNew();
-
-                        if (action == FeedPreferences.NewEpisodesAction.ADD_TO_QUEUE) {
+                            item.setNew();
+                        } else if (action == FeedPreferences.NewEpisodesAction.ADD_TO_QUEUE) {
                             itemsToAddToQueue.add(item);
                         }
                     }
@@ -348,10 +346,9 @@ public final class DBTasks {
         }
 
         // We need to add to queue after items are saved to database
-        DBWriter.addQueueItem(
-                context,
-                itemsToAddToQueue.toArray(new FeedItem[itemsToAddToQueue.size()])
-        );
+        DBWriter.addQueueItem(context, itemsToAddToQueue.toArray(
+            new FeedItem[itemsToAddToQueue.size()]
+        ));
 
         adapter.close();
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -347,9 +347,7 @@ public final class DBTasks {
         }
 
         // We need to add to queue after items are saved to database
-        DBWriter.addQueueItem(context, itemsToAddToQueue.toArray(
-                new FeedItem[itemsToAddToQueue.size()]
-        ));
+        DBWriter.addQueueItem(context, itemsToAddToQueue.toArray(new FeedItem[0]));
 
         adapter.close();
 

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -65,12 +65,14 @@
 
     <string-array name="feedNewEpisodesActionItems">
         <item>@string/global_default</item>
+        <item>@string/feed_new_episodes_action_add_to_queue</item>
         <item>@string/feed_new_episodes_action_add_to_inbox</item>
         <item>@string/feed_new_episodes_action_nothing</item>
     </string-array>
 
     <string-array name="feedNewEpisodesActionValues">
         <item>0</item>
+        <item>3</item>
         <item>1</item>
         <item>2</item>
     </string-array>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -55,25 +55,27 @@
 
     <string-array name="globalNewEpisodesActionItems">
         <item>@string/feed_new_episodes_action_add_to_inbox</item>
+        <item>@string/feed_new_episodes_action_add_to_queue</item>
         <item>@string/feed_new_episodes_action_nothing</item>
     </string-array>
 
     <string-array name="globalNewEpisodesActionValues">
         <item>1</item>
+        <item>3</item>
         <item>2</item>
     </string-array>
 
     <string-array name="feedNewEpisodesActionItems">
         <item>@string/global_default</item>
-        <item>@string/feed_new_episodes_action_add_to_queue</item>
         <item>@string/feed_new_episodes_action_add_to_inbox</item>
+        <item>@string/feed_new_episodes_action_add_to_queue</item>
         <item>@string/feed_new_episodes_action_nothing</item>
     </string-array>
 
     <string-array name="feedNewEpisodesActionValues">
         <item>0</item>
-        <item>3</item>
         <item>1</item>
+        <item>3</item>
         <item>2</item>
     </string-array>
 

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
@@ -40,6 +40,7 @@ public class FeedPreferences implements Serializable {
     public enum NewEpisodesAction {
         GLOBAL(0),
         ADD_TO_INBOX(1),
+        ADD_TO_QUEUE(3),
         NOTHING(2);
 
         public final int code;

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="feed_auto_download_always">Always</string>
     <string name="feed_auto_download_never">Never</string>
     <string name="feed_new_episodes_action_add_to_inbox">Add to inbox</string>
+    <string name="feed_new_episodes_action_add_to_queue">Add to inbox &amp; queue</string>
     <string name="feed_new_episodes_action_nothing">Nothing</string>
     <string name="episode_cleanup_never">Never</string>
     <string name="episode_cleanup_except_favorite_removal">When not favorited</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@
     <string name="feed_auto_download_always">Always</string>
     <string name="feed_auto_download_never">Never</string>
     <string name="feed_new_episodes_action_add_to_inbox">Add to inbox</string>
-    <string name="feed_new_episodes_action_add_to_queue">Add to inbox &amp; queue</string>
+    <string name="feed_new_episodes_action_add_to_queue">Add to queue</string>
     <string name="feed_new_episodes_action_nothing">Nothing</string>
     <string name="episode_cleanup_never">Never</string>
     <string name="episode_cleanup_except_favorite_removal">When not favorited</string>


### PR DESCRIPTION
Added extra option to "New episodes action" to add all new episodes of a subscription to the queue. This is mostly useful for local feeds where there is no downloading.

I was not sure whether to include inbox or not (setting is radio-style, so user cannot choose one or another) and I decided to include it whenever user uses queue. Not sure if that is correct or not, please advise.

This fixes #5246