### PR TITLE
resize home cards

### DIFF
--- a/app/src/main/res/layout/horizontal_itemlist_item.xml
+++ b/app/src/main/res/layout/horizontal_itemlist_item.xml
@@ -36,8 +36,8 @@
                     android:orientation="vertical">
 
                     <FrameLayout
-                        android:layout_width="128dp"
-                        android:layout_height="128dp"
+                        android:layout_width="112dp"
+                        android:layout_height="112dp"
                         android:background="@color/image_readability_tint">
 
                         <de.danoeh.antennapod.ui.common.SquareImageView
@@ -100,7 +100,7 @@
 
             <TextView
                 android:id="@+id/titleLabel"
-                android:layout_width="128dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:ellipsize="end"


### PR DESCRIPTION
they feel to big, and they take up too much space relatively to the rest of the home sections.
i think there was quite some debate about this (?) - i dont want necessarily reopen...but here is a suggestion :)

_it would fit nicer with expandable bottomhalf as well_ https://forum.antennapod.org/t/home-feature-expanable-episodes-list-and-inbox/3891/12?u=ueen
<img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5067479/b5cb77e2-4b5f-450f-a722-476cc3f2dddd" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5067479/8f5e7c1a-9e2e-42b1-95cf-769fa895668c" />
