### PR TITLE
Fix Gradle deprecations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
     }
 
     androidResources {
-        additionalParameters "--no-version-vectors"
+        additionalParameters += ["--no-version-vectors"]
     }
 }
 
@@ -150,7 +150,7 @@ if (project.hasProperty("antennaPodPlayPublisherCredentials")) {
     }
 }
 
-task copyLicense(type: Copy) {
+tasks.register('copyLicense', Copy) {
     from "../LICENSE"
     into "src/main/assets/"
     rename { String fileName ->

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ checkstyle {
     toolVersion '10.3.1'
 }
 
-task checkstyle(type: Checkstyle) {
+tasks.register('checkstyle', Checkstyle) {
     classpath = files()
     source "${project.rootDir}"
     exclude("**/gen/**")

--- a/common.gradle
+++ b/common.gradle
@@ -56,7 +56,7 @@ android {
     }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     testLogging {
         exceptionFormat "full"
         events "skipped", "passed", "failed"
@@ -66,8 +66,10 @@ tasks.withType(Test) {
 }
 
 gradle.projectsEvaluated {
-    tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint"
+    tasks.withType(JavaCompile).tap {
+        configureEach {
+            options.compilerArgs << "-Xlint"
+        }
     }
 }
 
@@ -80,24 +82,26 @@ spotbugs {
     ignoreFailures = true // Handled by printing task
 }
 
-gradle.taskGraph.beforeTask { task ->
-    if (task.name.toLowerCase().contains('spotbugs')) {
-        task.doLast {
-            def reportFile = task.project.file("build/reports/spotbugs/playDebug.xml")
-            if (!reportFile.exists()) return
-            def slurped = new groovy.xml.XmlSlurper().parse(reportFile)
+gradle.taskGraph.whenReady { taskGraph ->
+    taskGraph.allTasks.each { task ->
+        if (task.name.toLowerCase().contains('spotbugs')) {
+            task.doLast {
+                def reportFile = task.project.file("build/reports/spotbugs/playDebug.xml")
+                if (!reportFile.exists()) return
+                def slurped = new groovy.xml.XmlSlurper().parse(reportFile)
 
-            def foundErrors = false
-            slurped['BugInstance'].each { bug ->
-                logger.error "[SpotBugs] ${bug['LongMessage']} [${bug.@'type'}]"
-                bug['SourceLine'].each { line ->
-                    logger.error "[SpotBugs]     ${line['Message']}"
-                    foundErrors = true
+                def foundErrors = false
+                slurped['BugInstance'].each { bug ->
+                    logger.error "[SpotBugs] ${bug['LongMessage']} [${bug.@'type'}]"
+                    bug['SourceLine'].each { line ->
+                        logger.error "[SpotBugs]     ${line['Message']}"
+                        foundErrors = true
+                    }
                 }
-            }
-            if (foundErrors) {
-                throw new TaskExecutionException(task,
-                        new Exception("SpotBugs violations were found. See output above for details."))
+                if (foundErrors) {
+                    throw new TaskExecutionException(task,
+                            new Exception("SpotBugs violations were found. See output above for details."))
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed some Gradle deprecations.

They want us to use tasks.register now, with configureEach.

Also beforeTask isn't a thing anymore, so I switched to the closest replacement.
