### PR TITLE
Update AndroidX libraries

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/ImportExportPreferencesFragment.java
@@ -296,6 +296,11 @@ public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private static class BackupDatabase extends ActivityResultContracts.CreateDocument {
+
+        BackupDatabase() {
+            super("application/x-sqlite3");
+        }
+
         @NonNull
         @Override
         public Intent createIntent(@NonNull final Context context, @NonNull final String input) {

--- a/app/src/main/java/de/danoeh/antennapod/view/LiftOnScrollListener.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/LiftOnScrollListener.java
@@ -41,7 +41,7 @@ public class LiftOnScrollListener extends RecyclerView.OnScrollListener
     }
 
     @Override
-    public void onScrollChange(NestedScrollView v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+    public void onScrollChange(@NonNull NestedScrollView v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
         elevate(scrollY != 0);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ allprojects {
 
 project.ext {
     // AndroidX
-    annotationVersion = "1.2.0"
-    appcompatVersion = "1.3.1"
-    coreVersion = "1.5.0"
-    fragmentVersion = "1.3.6"
-    mediaVersion = "1.4.3"
+    annotationVersion = "1.4.0"
+    appcompatVersion = "1.5.1"
+    coreVersion = "1.8.0"
+    fragmentVersion = "1.5.5"
+    mediaVersion = "1.6.0"
     paletteVersion = "1.0.0"
     preferenceVersion = "1.1.1"
     recyclerViewVersion = "1.2.1"

--- a/playback/cast/build.gradle
+++ b/playback/cast/build.gradle
@@ -18,6 +18,6 @@ dependencies {
     implementation "org.greenrobot:eventbus:$eventbusVersion"
     annotationProcessor "org.greenrobot:eventbus-annotation-processor:$eventbusVersion"
 
-    playApi 'androidx.mediarouter:mediarouter:1.2.5'
+    playApi 'androidx.mediarouter:mediarouter:1.3.0'
     playApi 'com.google.android.gms:play-services-cast-framework:21.2.0'
 }


### PR DESCRIPTION
If you take the AntennaPod v3.2.0 APK, disassemble it, and look at the metadata, you'll find that most of these newer library versions were already being compiled, despite the lower versions in gradle. Basically it's #5474 again. There's no reason not to update these, since they were already being used anyway. Any possible bugs would have been evident and fixed already.

- Annotation was not 1.2.0, but actually 1.4.0. ~~I updated further to [1.7.1](https://developer.android.com/jetpack/androidx/releases/annotation).~~
- AppCompat was not 1.3.1, but 1.5.1.
- Core was not 1.5.0, but 1.8.0.
- Fragment was not 1.3.6, but 1.5.5. ~~I updated further to [1.5.7](https://developer.android.com/jetpack/androidx/releases/fragment#version_15_2).~~
- Media was not 1.4.3, but 1.6.0.
- Mediarouter was not 1.2.5, but 1.3.0.

Some other changes:
- Fixed an ActivityResult deprecation.
~~- CoordinatorLayout 1.1.0 -> 1.2.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/coordinatorlayout#version_12_2))~~
~~- Core Splashscreen 1.0.0 -> 1.0.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/core#core-splashscreen-1.0.1))~~
~~- Added POST_NOTIFICATIONS checks. Tell me if these should be done differently.~~ Done in another PR: #6951