### PR TITLE
Update SpeedDial library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,7 @@ dependencies {
 
     implementation "com.joanzapata.iconify:android-iconify-fontawesome:$iconifyVersion"
     implementation "com.joanzapata.iconify:android-iconify-material:$iconifyVersion"
-    implementation 'com.leinardi.android:speed-dial:3.2.0'
+    implementation 'com.leinardi.android:speed-dial:3.3.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.5.0'
     implementation 'com.github.skydoves:balloon:1.5.3'
     implementation 'com.github.xabaras:RecyclerViewSwipeDecorator:1.3'

--- a/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/SubscriptionFragment.java
@@ -87,6 +87,8 @@ public class SubscriptionFragment extends Fragment
     private Disposable disposable;
     private SharedPreferences prefs;
 
+    private FloatingActionButton subscriptionAddButton;
+
     private SpeedDialView speedDialView;
 
     private List<NavDrawerData.DrawerItem> listItems;
@@ -155,7 +157,7 @@ public class SubscriptionFragment extends Fragment
         progressBar = root.findViewById(R.id.progressBar);
         progressBar.setVisibility(View.VISIBLE);
 
-        FloatingActionButton subscriptionAddButton = root.findViewById(R.id.subscriptions_add);
+        subscriptionAddButton = root.findViewById(R.id.subscriptions_add);
         subscriptionAddButton.setOnClickListener(view -> {
             if (getActivity() instanceof MainActivity) {
                 ((MainActivity) getActivity()).loadChildFragment(new AddFeedFragment());
@@ -173,16 +175,6 @@ public class SubscriptionFragment extends Fragment
         speedDialView = root.findViewById(R.id.fabSD);
         speedDialView.setOverlayLayout(root.findViewById(R.id.fabSDOverlay));
         speedDialView.inflate(R.menu.nav_feed_action_speeddial);
-        speedDialView.setOnChangeListener(new SpeedDialView.OnChangeListener() {
-            @Override
-            public boolean onMainActionSelected() {
-                return false;
-            }
-
-            @Override
-            public void onToggleChanged(boolean isOpen) {
-            }
-        });
         speedDialView.setOnActionSelectedListener(actionItem -> {
             new FeedMultiSelectActionHandler((MainActivity) getActivity(), subscriptionAdapter.getSelectedItems())
                     .handleAction(actionItem.getId());
@@ -337,6 +329,7 @@ public class SubscriptionFragment extends Fragment
         Feed feed = ((NavDrawerData.FeedDrawerItem) drawerItem).feed;
         if (itemId == R.id.multi_select) {
             speedDialView.setVisibility(View.VISIBLE);
+            subscriptionAddButton.setVisibility(View.GONE);
             return subscriptionAdapter.onContextItemSelected(item);
         }
         return FeedMenuHandler.onMenuItemClicked(this, item.getItemId(), feed, this::loadSubscriptions);
@@ -356,6 +349,7 @@ public class SubscriptionFragment extends Fragment
     public void onEndSelectMode() {
         speedDialView.close();
         speedDialView.setVisibility(View.GONE);
+        subscriptionAddButton.setVisibility(View.VISIBLE);
         subscriptionAdapter.setItems(listItems);
     }
 


### PR DESCRIPTION
Update FloatingActionButtonSpeedDial 3.2.0 -> 3.3.0 ([changelog](https://github.com/leinardi/FloatingActionButtonSpeedDial/releases))

- Fixes unintended behavior where "TalkBack's focus should be on the last item in the menu"
- Not related to the library update itself, but I also fixed a separate bug where the "add podcast" FAB was still visible underneath the SpeedDial main FAB. It should be gone when the "multi select" option is active.
- Note: Does NOT fix the SpeedDial main FAB being unlabeled in TalkBack. I've [opened an issue for this](https://github.com/leinardi/FloatingActionButtonSpeedDial/issues/192).

Screenshots: Note the hidden FAB behind the SpeedDial FAB in the Before. Also note how the "Remove Podcast" button in the Before is darkened, while the one in After is not.
| Before | After |
| ------------- | ------------- |
| ![Screenshot_20240226-183911_AntennaPod](https://github.com/AntennaPod/AntennaPod/assets/32376686/cdef5df2-d422-4e94-b880-85f0013fe9f3) | ![Screenshot_20240226-183938_AntennaPod Debug](https://github.com/AntennaPod/AntennaPod/assets/32376686/0bc46ce7-6bb5-4ac1-870e-0212b7412758) |