### PR TITLE
Move some Checkstyle rules from new-code file to main file

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -241,8 +241,9 @@ public class MainActivity extends CastEnabledActivity {
         outState.putInt(KEY_GENERATED_VIEW_ID, View.generateViewId());
     }
 
-    private final BottomSheetBehavior.BottomSheetCallback bottomSheetCallback =
-            new BottomSheetBehavior.BottomSheetCallback() {
+    private final BottomSheetBehavior.BottomSheetCallback bottomSheetCallback = new AntennaPodBottomSheetCallback();
+
+    private class AntennaPodBottomSheetCallback extends BottomSheetBehavior.BottomSheetCallback {
         @Override
         public void onStateChanged(@NonNull View view, int state) {
             if (state == BottomSheetBehavior.STATE_COLLAPSED) {
@@ -266,7 +267,7 @@ public class MainActivity extends CastEnabledActivity {
 
             audioPlayer.fadePlayerToToolbar(slideOffset);
         }
-    };
+    }
 
     public void setupToolbarToggle(@NonNull MaterialToolbar toolbar, boolean displayUpArrow) {
         if (drawerLayout != null) { // Tablet layout does not have a drawer

--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/DownloadsPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/DownloadsPreferencesFragment.java
@@ -96,13 +96,13 @@ public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
 
     private void showAutoDeleteEnableDialog() {
         new MaterialAlertDialogBuilder(requireContext())
-            .setMessage(R.string.pref_auto_local_delete_dialog_body)
-            .setPositiveButton(R.string.yes, (dialog, which) -> {
-                blockAutoDeleteLocal = false;
-                ((TwoStatePreference) findPreference(PREF_AUTO_DELETE_LOCAL)).setChecked(true);
-                blockAutoDeleteLocal = true;
-            })
-            .setNegativeButton(R.string.cancel_label, null)
-            .show();
+                .setMessage(R.string.pref_auto_local_delete_dialog_body)
+                .setPositiveButton(R.string.yes, (dialog, which) -> {
+                    blockAutoDeleteLocal = false;
+                    ((TwoStatePreference) findPreference(PREF_AUTO_DELETE_LOCAL)).setChecked(true);
+                    blockAutoDeleteLocal = true;
+                })
+                .setNegativeButton(R.string.cancel_label, null)
+                .show();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/PowerConnectionReceiver.java
@@ -16,9 +16,9 @@ import de.danoeh.antennapod.core.storage.DBTasks;
 // Since the intent doesn't have the EXTRA_STATUS like the android.com article says it does
 // (though it used to)
 public class PowerConnectionReceiver extends BroadcastReceiver {
-	private static final String TAG = "PowerConnectionReceiver";
+    private static final String TAG = "PowerConnectionReceiver";
 
-	@Override
+    @Override
     public void onReceive(Context context, Intent intent) {
         final String action = intent.getAction();
 

--- a/app/src/main/java/de/danoeh/antennapod/view/LocalDeleteModal.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/LocalDeleteModal.java
@@ -23,10 +23,10 @@ public class LocalDeleteModal {
         }
 
         new MaterialAlertDialogBuilder(context)
-            .setTitle(R.string.delete_episode_label)
-            .setMessage(R.string.delete_local_feed_warning_body)
-            .setPositiveButton(R.string.delete_label, (dialog, which) -> deleteCommand.run())
-            .setNegativeButton(R.string.cancel_label, null)
-            .show();
+                .setTitle(R.string.delete_episode_label)
+                .setMessage(R.string.delete_local_feed_warning_body)
+                .setPositiveButton(R.string.delete_label, (dialog, which) -> deleteCommand.run())
+                .setNegativeButton(R.string.cancel_label, null)
+                .show();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,12 @@ checkstyle {
 }
 
 tasks.register('checkstyle', Checkstyle) {
+    minHeapSize = "200m"
+    maxHeapSize = "2g"
     classpath = files()
     source "${project.rootDir}"
+    exclude("**/generated-sources/**")
     exclude("**/gen/**")
+    exclude("**/build/**")
     exclude("**/generated/**")
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -11,6 +11,10 @@
         <property name="file" value="${config_loc}/suppressions.xml" />
     </module>
 
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -125,6 +125,14 @@
                      value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
         <module name="MethodParamPad"/>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="8"/>
+            <property name="lineWrappingIndentation" value="8"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
         <module name="NoWhitespaceBefore">
             <property name="tokens"
              value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/export/opml/OpmlElement.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/export/opml/OpmlElement.java
@@ -1,46 +1,48 @@
 package de.danoeh.antennapod.core.export.opml;
 
-/** Represents a single feed in an OPML file. */
+/**
+ * Represents a single feed in an OPML file.
+ */
 public class OpmlElement {
-	private String text;
-	private String xmlUrl;
-	private String htmlUrl;
-	private String type;
+    private String text;
+    private String xmlUrl;
+    private String htmlUrl;
+    private String type;
 
-	public OpmlElement() {
+    public OpmlElement() {
 
-	}
+    }
 
-	public String getText() {
-		return text;
-	}
+    public String getText() {
+        return text;
+    }
 
-	public void setText(String text) {
-		this.text = text;
-	}
+    public void setText(String text) {
+        this.text = text;
+    }
 
-	public String getXmlUrl() {
-		return xmlUrl;
-	}
+    public String getXmlUrl() {
+        return xmlUrl;
+    }
 
-	public void setXmlUrl(String xmlUrl) {
-		this.xmlUrl = xmlUrl;
-	}
+    public void setXmlUrl(String xmlUrl) {
+        this.xmlUrl = xmlUrl;
+    }
 
-	public String getHtmlUrl() {
-		return htmlUrl;
-	}
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
 
-	public void setHtmlUrl(String htmlUrl) {
-		this.htmlUrl = htmlUrl;
-	}
+    public void setHtmlUrl(String htmlUrl) {
+        this.htmlUrl = htmlUrl;
+    }
 
-	public String getType() {
-		return type;
-	}
+    public String getType() {
+        return type;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/export/opml/OpmlReader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/export/opml/OpmlReader.java
@@ -12,78 +12,81 @@ import java.util.ArrayList;
 
 import de.danoeh.antennapod.core.BuildConfig;
 
-/** Reads OPML documents. */
+/**
+ * Reads OPML documents.
+ */
 public class OpmlReader {
-	private static final String TAG = "OpmlReader";
-	
-	// ATTRIBUTES
-	private boolean isInOpml = false;
-	private ArrayList<OpmlElement> elementList;
+    private static final String TAG = "OpmlReader";
 
-	/**
-	 * Reads an Opml document and returns a list of all OPML elements it can
-	 * find
-	 * 
-	 * @throws IOException
-	 * @throws XmlPullParserException
-	 */
-	public ArrayList<OpmlElement> readDocument(Reader reader)
-			throws XmlPullParserException, IOException {
-		elementList = new ArrayList<>();
-		XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
-		factory.setNamespaceAware(true);
-		XmlPullParser xpp = factory.newPullParser();
-		xpp.setInput(reader);
-		int eventType = xpp.getEventType();
+    private boolean isInOpml = false;
 
-		while (eventType != XmlPullParser.END_DOCUMENT) {
-			switch (eventType) {
-			case XmlPullParser.START_DOCUMENT:
-				if (BuildConfig.DEBUG)
-					Log.d(TAG, "Reached beginning of document");
-				break;
-			case XmlPullParser.START_TAG:
-				if (xpp.getName().equals(OpmlSymbols.OPML)) {
-					isInOpml = true;
-					if (BuildConfig.DEBUG)
-						Log.d(TAG, "Reached beginning of OPML tree.");
-				} else if (isInOpml && xpp.getName().equals(OpmlSymbols.OUTLINE)) {
-					if (BuildConfig.DEBUG)
-						Log.d(TAG, "Found new Opml element");
-					OpmlElement element = new OpmlElement();
-					
-					final String title = xpp.getAttributeValue(null, OpmlSymbols.TITLE);
-					if (title != null) {
-						Log.i(TAG, "Using title: " + title);
-						element.setText(title);
-					} else {
-						Log.i(TAG, "Title not found, using text");
-						element.setText(xpp.getAttributeValue(null, OpmlSymbols.TEXT));			
-					}
-					element.setXmlUrl(xpp.getAttributeValue(null, OpmlSymbols.XMLURL));
-					element.setHtmlUrl(xpp.getAttributeValue(null, OpmlSymbols.HTMLURL));
-					element.setType(xpp.getAttributeValue(null, OpmlSymbols.TYPE));
-					if (element.getXmlUrl() != null) {
-						if (element.getText() == null) {
-							Log.i(TAG, "Opml element has no text attribute.");
-							element.setText(element.getXmlUrl());
-						}
-						elementList.add(element);
-					} else {
-						if (BuildConfig.DEBUG)
-							Log.d(TAG,
-									"Skipping element because of missing xml url");
-					}
-				}
-				break;
-			}
-			eventType = xpp.next();
-		}
+    /**
+     * Reads an Opml document and returns a list of all OPML elements it can
+     * find
+     */
+    public ArrayList<OpmlElement> readDocument(Reader reader)
+            throws XmlPullParserException, IOException {
+        ArrayList<OpmlElement> elementList = new ArrayList<>();
+        XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        XmlPullParser xpp = factory.newPullParser();
+        xpp.setInput(reader);
+        int eventType = xpp.getEventType();
 
-		if (BuildConfig.DEBUG)
-			Log.d(TAG, "Parsing finished.");
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            switch (eventType) {
+                case XmlPullParser.START_DOCUMENT:
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "Reached beginning of document");
+                    }
+                    break;
+                case XmlPullParser.START_TAG:
+                    if (xpp.getName().equals(OpmlSymbols.OPML)) {
+                        isInOpml = true;
+                        if (BuildConfig.DEBUG) {
+                            Log.d(TAG, "Reached beginning of OPML tree.");
+                        }
+                    } else if (isInOpml && xpp.getName().equals(OpmlSymbols.OUTLINE)) {
+                        if (BuildConfig.DEBUG) {
+                            Log.d(TAG, "Found new Opml element");
+                        }
+                        OpmlElement element = new OpmlElement();
 
-		return elementList;
-	}
+                        final String title = xpp.getAttributeValue(null, OpmlSymbols.TITLE);
+                        if (title != null) {
+                            Log.i(TAG, "Using title: " + title);
+                            element.setText(title);
+                        } else {
+                            Log.i(TAG, "Title not found, using text");
+                            element.setText(xpp.getAttributeValue(null, OpmlSymbols.TEXT));
+                        }
+                        element.setXmlUrl(xpp.getAttributeValue(null, OpmlSymbols.XMLURL));
+                        element.setHtmlUrl(xpp.getAttributeValue(null, OpmlSymbols.HTMLURL));
+                        element.setType(xpp.getAttributeValue(null, OpmlSymbols.TYPE));
+                        if (element.getXmlUrl() != null) {
+                            if (element.getText() == null) {
+                                Log.i(TAG, "Opml element has no text attribute.");
+                                element.setText(element.getXmlUrl());
+                            }
+                            elementList.add(element);
+                        } else {
+                            if (BuildConfig.DEBUG) {
+                                Log.d(TAG, "Skipping element because of missing xml url");
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+            eventType = xpp.next();
+        }
+
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Parsing finished.");
+        }
+
+        return elementList;
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/export/opml/OpmlSymbols.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/export/opml/OpmlSymbols.java
@@ -2,20 +2,22 @@ package de.danoeh.antennapod.core.export.opml;
 
 import de.danoeh.antennapod.core.export.CommonSymbols;
 
-/** Contains symbols for reading and writing OPML documents. */
+/**
+ * Contains symbols for reading and writing OPML documents.
+ */
 final class OpmlSymbols extends CommonSymbols {
-	
-	public static final String OPML = "opml";
-	static final String OUTLINE = "outline";
-	static final String TEXT = "text";
-	static final String XMLURL = "xmlUrl";
-	static final String HTMLURL = "htmlUrl";
-	static final String TYPE = "type";
-	static final String VERSION = "version";
-	static final String DATE_CREATED = "dateCreated";
-	
-	private OpmlSymbols() {
-		
-	}
+
+    public static final String OPML = "opml";
+    static final String OUTLINE = "outline";
+    static final String TEXT = "text";
+    static final String XMLURL = "xmlUrl";
+    static final String HTMLURL = "htmlUrl";
+    static final String TYPE = "type";
+    static final String VERSION = "version";
+    static final String DATE_CREATED = "dateCreated";
+
+    private OpmlSymbols() {
+
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -221,8 +221,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
 
                 if (playerStatus == PlayerStatus.PREPARED && media.getPosition() > 0) {
                     int newPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
-                        media.getPosition(),
-                        media.getLastPlayedTime());
+                            media.getPosition(), media.getLastPlayedTime());
                     seekTo(newPosition);
                 }
                 mediaPlayer.start();

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1195,7 +1195,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             this.autoSkippedFeedMediaId = feedMedia.getItem().getIdentifyingValue();
             mediaPlayer.skip();
         }
-   }
+    }
 
     /**
      * Updates the Media Session for the corresponding status.
@@ -1624,11 +1624,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (getPlayable() instanceof FeedMedia) {
             if (((FeedMedia) getPlayable()).getItem().getFeed().getId() == event.getFeedId()) {
                 if (event.getSkipEnding() != 0) {
-                   FeedPreferences feedPreferences
-                           = ((FeedMedia) getPlayable()).getItem().getFeed().getPreferences();
-                   feedPreferences.setFeedSkipIntro(event.getSkipIntro());
-                   feedPreferences.setFeedSkipEnding(event.getSkipEnding());
-
+                    FeedPreferences feedPreferences
+                            = ((FeedMedia) getPlayable()).getItem().getFeed().getPreferences();
+                    feedPreferences.setFeedSkipIntro(event.getSkipIntro());
+                    feedPreferences.setFeedSkipEnding(event.getSkipEnding());
                 }
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/comparator/ChapterStartTimeComparator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/comparator/ChapterStartTimeComparator.java
@@ -6,9 +6,9 @@ import de.danoeh.antennapod.model.feed.Chapter;
 
 public class ChapterStartTimeComparator implements Comparator<Chapter> {
 
-	@Override
-	public int compare(Chapter lhs, Chapter rhs) {
-		return Long.compare(lhs.getStart(), rhs.getStart());
-	}
+    @Override
+    public int compare(Chapter lhs, Chapter rhs) {
+        return Long.compare(lhs.getStart(), rhs.getStart());
+    }
 
 }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/comparator/PlaybackCompletionDateComparator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/comparator/PlaybackCompletionDateComparator.java
@@ -5,15 +5,15 @@ import java.util.Comparator;
 import de.danoeh.antennapod.model.feed.FeedItem;
 
 public class PlaybackCompletionDateComparator implements Comparator<FeedItem> {
-	
-	public int compare(FeedItem lhs, FeedItem rhs) {
-		if (lhs.getMedia() != null
-				&& lhs.getMedia().getPlaybackCompletionDate() != null
-				&& rhs.getMedia() != null
-				&& rhs.getMedia().getPlaybackCompletionDate() != null) {
-			return rhs.getMedia().getPlaybackCompletionDate()
-					.compareTo(lhs.getMedia().getPlaybackCompletionDate());
-		}
-		return 0;
-	}
+
+    public int compare(FeedItem lhs, FeedItem rhs) {
+        if (lhs.getMedia() != null
+                && lhs.getMedia().getPlaybackCompletionDate() != null
+                && rhs.getMedia() != null
+                && rhs.getMedia().getPlaybackCompletionDate() != null) {
+            return rhs.getMedia().getPlaybackCompletionDate()
+                    .compareTo(lhs.getMedia().getPlaybackCompletionDate());
+        }
+        return 0;
+    }
 }

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Atom.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Atom.java
@@ -108,9 +108,9 @@ public class Atom extends Namespace {
                      * feed-object has no link yet b) type of link is
                      * LINK_TYPE_HTML or LINK_TYPE_XHTML
                      */
-                    if (state.getFeed() != null &&
-                        ((type == null && state.getFeed().getLink() == null) ||
-                            (LINK_TYPE_HTML.equals(type) || LINK_TYPE_XHTML.equals(type)))) {
+                    if (state.getFeed() != null
+                            && ((type == null && state.getFeed().getLink() == null)
+                                || (LINK_TYPE_HTML.equals(type) || LINK_TYPE_XHTML.equals(type)))) {
                         state.getFeed().setLink(href);
                     } else if (LINK_TYPE_ATOM.equals(type) || LINK_TYPE_RSS.equals(type)) {
                         // treat as podlove alternate feed
@@ -188,17 +188,17 @@ public class Atom extends Namespace {
                 } else if (ENTRY.equals(second) && state.getCurrentItem() != null) {
                     state.getCurrentItem().setTitle(textElement.getProcessedContent());
                 }
-            } else if (SUBTITLE.equals(top) && FEED.equals(second) && textElement != null &&
-                state.getFeed() != null) {
+            } else if (SUBTITLE.equals(top) && FEED.equals(second) && textElement != null
+                    && state.getFeed() != null) {
                 state.getFeed().setDescription(textElement.getProcessedContent());
-            } else if (CONTENT.equals(top) && ENTRY.equals(second) && textElement != null &&
-                state.getCurrentItem() != null) {
+            } else if (CONTENT.equals(top) && ENTRY.equals(second) && textElement != null
+                    && state.getCurrentItem() != null) {
                 state.getCurrentItem().setDescriptionIfLonger(textElement.getProcessedContent());
             } else if (SUMMARY.equals(top) && ENTRY.equals(second) && textElement != null
                     && state.getCurrentItem() != null) {
                 state.getCurrentItem().setDescriptionIfLonger(textElement.getProcessedContent());
-            } else if (UPDATED.equals(top) && ENTRY.equals(second) && state.getCurrentItem() != null &&
-                state.getCurrentItem().getPubDate() == null) {
+            } else if (UPDATED.equals(top) && ENTRY.equals(second) && state.getCurrentItem() != null
+                    && state.getCurrentItem().getPubDate() == null) {
                 state.getCurrentItem().setPubDate(DateUtils.parseOrNullIfFuture(content));
             } else if (PUBLISHED.equals(top) && ENTRY.equals(second) && state.getCurrentItem() != null) {
                 state.getCurrentItem().setPubDate(DateUtils.parseOrNullIfFuture(content));
@@ -206,8 +206,8 @@ public class Atom extends Namespace {
                 state.getFeed().setImageUrl(content);
             } else if (IMAGE_ICON.equals(top) && state.getFeed() != null) {
                 state.getFeed().setImageUrl(content);
-            } else if (AUTHOR_NAME.equals(top) && AUTHOR.equals(second) &&
-                    state.getFeed() != null && state.getCurrentItem() == null) {
+            } else if (AUTHOR_NAME.equals(top) && AUTHOR.equals(second)
+                    && state.getFeed() != null && state.getCurrentItem() == null) {
                 String currentName = state.getFeed().getAuthor();
                 if (currentName == null) {
                     state.getFeed().setAuthor(content);

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/DublinCore.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/DublinCore.java
@@ -22,8 +22,8 @@ public class DublinCore extends Namespace {
 
     @Override
     public void handleElementEnd(String localName, HandlerState state) {
-        if (state.getCurrentItem() != null && state.getContentBuf() != null &&
-            state.getTagstack() != null && state.getTagstack().size() >= 2) {
+        if (state.getCurrentItem() != null && state.getContentBuf() != null
+                && state.getTagstack() != null && state.getTagstack().size() >= 2) {
             FeedItem currentItem = state.getCurrentItem();
             String top = state.getTagstack().peek().getName();
             String second = state.getSecondTag().getName();

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -372,7 +372,9 @@ public class UserPreferences {
         prefs.edit().putBoolean(UserPreferences.PREF_FOLLOW_QUEUE, value).apply();
     }
 
-    public static boolean shouldSkipKeepEpisode() { return prefs.getBoolean(PREF_SKIP_KEEPS_EPISODE, true); }
+    public static boolean shouldSkipKeepEpisode() {
+        return prefs.getBoolean(PREF_SKIP_KEEPS_EPISODE, true);
+    }
 
     public static boolean shouldFavoriteKeepEpisode() {
         return prefs.getBoolean(PREF_FAVORITE_KEEPS_EPISODE, true);
@@ -589,33 +591,23 @@ public class UserPreferences {
     }
 
     public static void setFastForwardSecs(int secs) {
-        prefs.edit()
-             .putInt(PREF_FAST_FORWARD_SECS, secs)
-             .apply();
+        prefs.edit().putInt(PREF_FAST_FORWARD_SECS, secs).apply();
     }
 
     public static void setRewindSecs(int secs) {
-        prefs.edit()
-             .putInt(PREF_REWIND_SECS, secs)
-             .apply();
+        prefs.edit().putInt(PREF_REWIND_SECS, secs).apply();
     }
 
     public static void setPlaybackSpeed(float speed) {
-        prefs.edit()
-             .putString(PREF_PLAYBACK_SPEED, String.valueOf(speed))
-             .apply();
+        prefs.edit().putString(PREF_PLAYBACK_SPEED, String.valueOf(speed)).apply();
     }
 
     public static void setVideoPlaybackSpeed(float speed) {
-        prefs.edit()
-                .putString(PREF_VIDEO_PLAYBACK_SPEED, String.valueOf(speed))
-                .apply();
+        prefs.edit().putString(PREF_VIDEO_PLAYBACK_SPEED, String.valueOf(speed)).apply();
     }
 
     public static void setSkipSilence(boolean skipSilence) {
-        prefs.edit()
-                .putBoolean(PREF_PLAYBACK_SKIP_SILENCE, skipSilence)
-                .apply();
+        prefs.edit().putBoolean(PREF_PLAYBACK_SKIP_SILENCE, skipSilence).apply();
     }
 
     public static void setPlaybackSpeedArray(List<Float> speeds) {
@@ -626,15 +618,11 @@ public class UserPreferences {
         for (float speed : speeds) {
             jsonArray.put(speedFormat.format(speed));
         }
-        prefs.edit()
-             .putString(PREF_PLAYBACK_SPEED_ARRAY, jsonArray.toString())
-             .apply();
+        prefs.edit().putString(PREF_PLAYBACK_SPEED_ARRAY, jsonArray.toString()).apply();
     }
 
     public static void setAutodownloadSelectedNetworks(String[] value) {
-        prefs.edit()
-             .putString(PREF_AUTODL_SELECTED_NETWORKS, TextUtils.join(",", value))
-             .apply();
+        prefs.edit().putString(PREF_AUTODL_SELECTED_NETWORKS, TextUtils.join(",", value)).apply();
     }
 
     public static boolean gpodnetNotificationsEnabled() {
@@ -652,29 +640,21 @@ public class UserPreferences {
     }
 
     public static void setGpodnetNotificationsEnabled() {
-        prefs.edit()
-                .putBoolean(PREF_GPODNET_NOTIFICATIONS, true)
-                .apply();
+        prefs.edit().putBoolean(PREF_GPODNET_NOTIFICATIONS, true).apply();
     }
 
     public static void setHiddenDrawerItems(List<String> items) {
         String str = TextUtils.join(",", items);
-        prefs.edit()
-             .putString(PREF_HIDDEN_DRAWER_ITEMS, str)
-             .apply();
+        prefs.edit().putString(PREF_HIDDEN_DRAWER_ITEMS, str).apply();
     }
 
     public static void setFullNotificationButtons(List<Integer> items) {
         String str = TextUtils.join(",", items);
-        prefs.edit()
-             .putString(PREF_FULL_NOTIFICATION_BUTTONS, str)
-             .apply();
+        prefs.edit().putString(PREF_FULL_NOTIFICATION_BUTTONS, str).apply();
     }
 
     public static void setQueueLocked(boolean locked) {
-        prefs.edit()
-             .putBoolean(PREF_QUEUE_LOCKED, locked)
-             .apply();
+        prefs.edit().putBoolean(PREF_QUEUE_LOCKED, locked).apply();
     }
 
     private static List<Float> readPlaybackSpeedArray(String valueFromPrefs) {
@@ -700,9 +680,7 @@ public class UserPreferences {
     }
 
     public static void setEpisodeCleanupValue(int episodeCleanupValue) {
-        prefs.edit()
-                .putString(PREF_EPISODE_CLEANUP, Integer.toString(episodeCleanupValue))
-                .apply();
+        prefs.edit().putString(PREF_EPISODE_CLEANUP, Integer.toString(episodeCleanupValue)).apply();
     }
 
     /**
@@ -748,9 +726,7 @@ public class UserPreferences {
 
     public static void setDataFolder(String dir) {
         Log.d(TAG, "setDataFolder(dir: " + dir + ")");
-        prefs.edit()
-             .putString(PREF_DATA_FOLDER, dir)
-             .apply();
+        prefs.edit().putString(PREF_DATA_FOLDER, dir).apply();
     }
 
     /**
@@ -808,9 +784,7 @@ public class UserPreferences {
      * @see #setQueueKeepSortedOrder(SortOrder)
      */
     public static void setQueueKeepSorted(boolean keepSorted) {
-        prefs.edit()
-                .putBoolean(PREF_QUEUE_KEEP_SORTED, keepSorted)
-                .apply();
+        prefs.edit().putBoolean(PREF_QUEUE_KEEP_SORTED, keepSorted).apply();
     }
 
     /**
@@ -833,9 +807,7 @@ public class UserPreferences {
         if (sortOrder == null) {
             return;
         }
-        prefs.edit()
-                .putString(PREF_QUEUE_KEEP_SORTED_ORDER, sortOrder.name())
-                .apply();
+        prefs.edit().putString(PREF_QUEUE_KEEP_SORTED_ORDER, sortOrder.name()).apply();
     }
 
     public static FeedPreferences.NewEpisodesAction getNewEpisodesAction() {
@@ -874,9 +846,7 @@ public class UserPreferences {
     }
 
     public static void setSubscriptionsFilter(SubscriptionsFilter value) {
-        prefs.edit()
-                .putString(PREF_FILTER_FEED, value.serialize())
-                .apply();
+        prefs.edit().putString(PREF_FILTER_FEED, value.serialize()).apply();
     }
 
     public static boolean shouldShowSubscriptionTitle() {


### PR DESCRIPTION
### Description

Most files already fulfill these rules. Fix the last few remaining ones and move the rules to the main configuration file.

Some day in the future, we can then get rid of the diff-checkstyle check and do everything with the normal checkstyle. However, I want to avoid doing a large "re-format everything" commit, so we wait until almost all files comply with a rule before moving it to the main file.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
