### PR TITLE
Fix OkHttp deprecations

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -28,9 +28,6 @@
     public *;
 }
 
-# for okhttp
--dontwarn okhttp3.**
-
 # android-iconify
 -keep class com.joanzapata.** { *; }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/ExoPlayerWrapper.java
@@ -53,6 +53,7 @@ import de.danoeh.antennapod.model.playback.Playable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
+import okhttp3.Call;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -232,7 +233,7 @@ public class ExoPlayerWrapper {
             throws IllegalArgumentException, IllegalStateException {
         Log.d(TAG, "setDataSource: " + s);
         final OkHttpDataSource.Factory httpDataSourceFactory =
-                new OkHttpDataSource.Factory((okhttp3.Call.Factory) AntennapodHttpClient.getHttpClient())
+                new OkHttpDataSource.Factory((Call.Factory) AntennapodHttpClient.getHttpClient())
                         .setUserAgent(ClientConfig.USER_AGENT);
 
         if (!TextUtils.isEmpty(user) && !TextUtils.isEmpty(password)) {

--- a/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/gpoddernet/GpodnetService.java
+++ b/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/gpoddernet/GpodnetService.java
@@ -157,7 +157,7 @@ public class GpodnetService implements ISyncService {
             } else {
                 content = "";
             }
-            RequestBody body = RequestBody.create(JSON, content);
+            RequestBody body = RequestBody.create(content, JSON);
             Request.Builder request = new Request.Builder().post(body).url(url);
             executeRequest(request);
         } catch (JSONException | MalformedURLException | URISyntaxException e) {
@@ -190,7 +190,7 @@ public class GpodnetService implements ISyncService {
             requestObject.put("add", new JSONArray(added));
             requestObject.put("remove", new JSONArray(removed));
 
-            RequestBody body = RequestBody.create(JSON, requestObject.toString());
+            RequestBody body = RequestBody.create(requestObject.toString(), JSON);
             Request.Builder request = new Request.Builder().post(body).url(url);
 
             final String response = executeRequest(request);
@@ -272,7 +272,7 @@ public class GpodnetService implements ISyncService {
                 }
             }
 
-            RequestBody body = RequestBody.create(JSON, list.toString());
+            RequestBody body = RequestBody.create(list.toString(), JSON);
             Request.Builder request = new Request.Builder().post(body).url(url);
 
             final String response = executeRequest(request);
@@ -330,7 +330,7 @@ public class GpodnetService implements ISyncService {
             e.printStackTrace();
             throw new GpodnetServiceException(e);
         }
-        RequestBody requestBody = RequestBody.create(TEXT, "");
+        RequestBody requestBody = RequestBody.create("", TEXT);
         Request request = new Request.Builder().url(url).post(requestBody).build();
         try {
             String credential = Credentials.basic(username, password, Charset.forName("UTF-8"));

--- a/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/nextcloud/NextcloudLoginFlow.java
+++ b/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/nextcloud/NextcloudLoginFlow.java
@@ -117,7 +117,7 @@ public class NextcloudLoginFlow {
 
     private JSONObject doRequest(URL url, String bodyContent) throws IOException, JSONException {
         RequestBody requestBody = RequestBody.create(
-                MediaType.get("application/x-www-form-urlencoded"), bodyContent);
+                bodyContent, MediaType.get("application/x-www-form-urlencoded"));
         Request request = new Request.Builder().url(url).method("POST", requestBody).build();
         Response response = httpClient.newCall(request).execute();
         if (response.code() != 200) {

--- a/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/nextcloud/NextcloudSyncService.java
+++ b/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/nextcloud/NextcloudSyncService.java
@@ -71,7 +71,7 @@ public class NextcloudSyncService implements ISyncService {
             requestObject.put("add", new JSONArray(addedFeeds));
             requestObject.put("remove", new JSONArray(removedFeeds));
             RequestBody requestBody = RequestBody.create(
-                    MediaType.get("application/json"), requestObject.toString());
+                    requestObject.toString(), MediaType.get("application/json"));
             performRequest(url, "POST", requestBody);
         } catch (Exception e) {
             e.printStackTrace();
@@ -121,7 +121,7 @@ public class NextcloudSyncService implements ISyncService {
             }
             HttpUrl.Builder url = makeUrl("/index.php/apps/gpoddersync/episode_action/create");
             RequestBody requestBody = RequestBody.create(
-                    MediaType.get("application/json"), list.toString());
+                    list.toString(), MediaType.get("application/json"));
             performRequest(url, "POST", requestBody);
         } catch (Exception e) {
             e.printStackTrace();

--- a/ui/glide/src/main/java/de/danoeh/antennapod/ui/glide/ApOkHttpUrlLoader.java
+++ b/ui/glide/src/main/java/de/danoeh/antennapod/ui/glide/ApOkHttpUrlLoader.java
@@ -104,7 +104,7 @@ class ApOkHttpUrlLoader implements ModelLoader<String, InputStream> {
                         .protocol(Protocol.HTTP_2)
                         .code(420)
                         .message("Policy Not Fulfilled")
-                        .body(ResponseBody.create(null, new byte[0]))
+                        .body(ResponseBody.create(new byte[0], null))
                         .request(chain.request())
                         .build();
             }


### PR DESCRIPTION
### Description
- Fix OkHttp deprecations
- Remove [no longer needed ProGuard rule](https://square.github.io/okhttp/changelogs/changelog_4x/#version-401:~:text=Fix%3A%20Embed%20Proguard%20rules%20to%20prevent%20warnings%20from%20tools%20like%20DexGuard%20and%20R8.%20These%20warnings%20were%20triggered%20by%20OkHttp%E2%80%99s%20feature%20detection%20for%20TLS%20packages%20like%20org.conscrypt%2C%20org.bouncycastle%2C%20and%20org.openjsse.).

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
