### PR TITLE
Replace SwitchCompat with MaterialSwitch

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/preferences/dialog/PreferenceSwitchDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/preferences/dialog/PreferenceSwitchDialog.java
@@ -5,7 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import androidx.appcompat.widget.SwitchCompat;
+import com.google.android.material.materialswitch.MaterialSwitch;
 
 import de.danoeh.antennapod.R;
 
@@ -38,7 +38,7 @@ public class PreferenceSwitchDialog {
 
         LayoutInflater inflater = LayoutInflater.from(this.context);
         View layout = inflater.inflate(R.layout.dialog_switch_preference, null, false);
-        SwitchCompat switchButton = layout.findViewById(R.id.dialogSwitch);
+        MaterialSwitch switchButton = layout.findViewById(R.id.dialogSwitch);
         switchButton.setText(text);
         builder.setView(layout);
 

--- a/app/src/main/res/layout/dialog_switch_preference.xml
+++ b/app/src/main/res/layout/dialog_switch_preference.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:padding="24dp">
 
-    <androidx.appcompat.widget.SwitchCompat
+    <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/dialogSwitch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/swipeactions_dialog.xml
+++ b/app/src/main/res/layout/swipeactions_dialog.xml
@@ -6,7 +6,7 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <androidx.appcompat.widget.SwitchCompat
+    <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/enableSwitch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### Description
- Replaces the old SwitchCompat with MaterialSwitch in multi-select and swipeactions preferences. This updates the switches to the [new look](https://github.com/material-components/material-components-android/blob/master/docs/components/Switch.md).

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
