### PR TITLE
Make swipe gestures less slippery

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/SwipeActions.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/SwipeActions.java
@@ -178,14 +178,12 @@ public class SwipeActions extends ItemTouchHelper.SimpleCallback implements Life
         float sign = dx > 0 ? 1 : -1;
         float limitMovement = Math.min(maxMovement, sign * dx);
         float displacementPercentage = limitMovement / maxMovement;
+        boolean swipeThresholdReached = displacementPercentage >= 0.85;
 
         if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE && wontLeave) {
             swipeOutEnabled = false;
-
-            boolean swipeThresholdReached = displacementPercentage == 1;
-
             // Move slower when getting near the maxMovement
-            dx = sign * maxMovement * (float) Math.sin((Math.PI / 2) * displacementPercentage);
+            dx = sign * maxMovement * 0.7f * (float) Math.sin((Math.PI / 2) * displacementPercentage);
 
             if (isCurrentlyActive) {
                 int dir = dx > 0 ? ItemTouchHelper.RIGHT : ItemTouchHelper.LEFT;
@@ -206,12 +204,9 @@ public class SwipeActions extends ItemTouchHelper.SimpleCallback implements Life
                 .addSwipeLeftActionIcon(left.getActionIcon())
                 .addSwipeRightBackgroundColor(ThemeUtils.getColorFromAttr(context, R.attr.background_elevated))
                 .addSwipeLeftBackgroundColor(ThemeUtils.getColorFromAttr(context, R.attr.background_elevated))
-                .setActionIconTint(
-                        ColorUtils.blendARGB(themeColor,
-                                actionColor,
-                                Math.max(0.5f, displacementPercentage)));
+                .setActionIconTint(ColorUtils.blendARGB(themeColor, actionColor,
+                        (!wontLeave || swipeThresholdReached) ? 1.0f : 0.7f));
         builder.create().decorate();
-
 
         super.onChildDraw(c, recyclerView, viewHolder, dx, dy, actionState, isCurrentlyActive);
     }


### PR DESCRIPTION
### Description

Make swipe gestures less slippery. The sine function made the item move faster than the finger. Note that the reason for using the sine function is that the item comes to a stop gracefully instead of just stopping immediately.

See #7000

Before / After (blue=finger position, yellow=item position)
<img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/566e0ace-4506-4e16-b72a-0218164e4903" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/66ade80a-5b53-4626-a882-5709285ebbc4" />

It stops a bit earlier now but the difference is not really noticeable in practice. Making it visually the same again (eg larger) would require more finger movement, making it harder to swipe.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
