### PR TITLE
Catch quick settings tile exceptions

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -44,7 +44,7 @@ android {
     }
 
     lint {
-        disable "GradleDependency"
+        disable "GradleDependency", "OutdatedLibrary"
         checkDependencies true
         warningsAsErrors true
         abortOnError true

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -867,8 +867,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                TileService.requestListeningState(getApplicationContext(),
-                        new ComponentName(getApplicationContext(), QuickSettingsTileService.class));
+                try {
+                    TileService.requestListeningState(getApplicationContext(),
+                            new ComponentName(getApplicationContext(), QuickSettingsTileService.class));
+                } catch (IllegalArgumentException e) {
+                    Log.d(TAG, "Skipping quick settings tile setup");
+                }
             }
 
             IntentUtils.sendLocalBroadcast(getApplicationContext(), ACTION_PLAYER_STATUS_CHANGED);


### PR DESCRIPTION
### Description

Catch quick settings tile exceptions. The exception gets thrown if AntennaPod is installed in a work profile.

Closes #7001

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
