### PR TITLE
Playback speed fixes

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/VariableSpeedDialog.java
@@ -86,6 +86,7 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
         View root = View.inflate(getContext(), R.layout.speed_select_dialog, null);
         speedSeekBar = root.findViewById(R.id.speed_seek_bar);
         speedSeekBar.setProgressChangedListener(multiplier -> {
+            UserPreferences.setPlaybackSpeed(multiplier);
             if (controller != null) {
                 controller.setPlaybackSpeed(multiplier);
             }
@@ -148,10 +149,11 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
                 return true;
             });
             holder.chip.setOnClickListener(v -> {
+                UserPreferences.setPlaybackSpeed(speed);
                 new Handler(Looper.getMainLooper()).postDelayed(() -> {
                     if (controller != null) {
-                        dismiss();
                         controller.setPlaybackSpeed(speed);
+                        dismiss();
                     }
                 }, 200);
             });

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/util/PlaybackSpeedUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/util/PlaybackSpeedUtils.java
@@ -1,54 +1,36 @@
 package de.danoeh.antennapod.core.feed.util;
 
-import android.util.Log;
 import de.danoeh.antennapod.model.feed.Feed;
-import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
-import de.danoeh.antennapod.model.playback.MediaType;
 import de.danoeh.antennapod.core.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.model.playback.Playable;
 
-import static de.danoeh.antennapod.model.feed.FeedPreferences.SPEED_USE_GLOBAL;
-
 /**
  * Utility class to use the appropriate playback speed based on {@link PlaybackPreferences}
  */
-public final class PlaybackSpeedUtils {
-    private static final String TAG = "PlaybackSpeedUtils";
-
-    private PlaybackSpeedUtils() {
-    }
-
+public abstract class PlaybackSpeedUtils {
     /**
      * Returns the currently configured playback speed for the specified media.
      */
     public static float getCurrentPlaybackSpeed(Playable media) {
-        float playbackSpeed = SPEED_USE_GLOBAL;
-        MediaType mediaType = null;
-
-        if (media != null) {
-            mediaType = media.getMediaType();
-            playbackSpeed = PlaybackPreferences.getCurrentlyPlayingTemporaryPlaybackSpeed();
-
-            if (playbackSpeed == SPEED_USE_GLOBAL && media instanceof FeedMedia) {
-                FeedItem item = ((FeedMedia) media).getItem();
-                if (item != null) {
-                    Feed feed = item.getFeed();
-                    if (feed != null && feed.getPreferences() != null) {
-                        playbackSpeed = feed.getPreferences().getFeedPlaybackSpeed();
-                    } else {
-                        Log.d(TAG, "Can not get feed specific playback speed: " + feed);
-                    }
+        float playbackSpeed = FeedPreferences.SPEED_USE_GLOBAL;
+        if (media instanceof FeedMedia) {
+            FeedMedia feedMedia = (FeedMedia) media;
+            if (PlaybackPreferences.getCurrentlyPlayingFeedMediaId() == feedMedia.getId()) {
+                playbackSpeed = PlaybackPreferences.getCurrentlyPlayingTemporaryPlaybackSpeed();
+            }
+            if (playbackSpeed == FeedPreferences.SPEED_USE_GLOBAL && feedMedia.getItem() != null) {
+                Feed feed = feedMedia.getItem().getFeed();
+                if (feed != null && feed.getPreferences() != null) {
+                    playbackSpeed = feed.getPreferences().getFeedPlaybackSpeed();
                 }
             }
         }
-
-        if (playbackSpeed == SPEED_USE_GLOBAL) {
-            playbackSpeed = UserPreferences.getPlaybackSpeed(mediaType);
+        if (playbackSpeed == FeedPreferences.SPEED_USE_GLOBAL) {
+            playbackSpeed = UserPreferences.getPlaybackSpeed();
         }
-
         return playbackSpeed;
     }
 
@@ -57,12 +39,15 @@ public final class PlaybackSpeedUtils {
      */
     public static FeedPreferences.SkipSilence getCurrentSkipSilencePreference(Playable media) {
         FeedPreferences.SkipSilence skipSilence = FeedPreferences.SkipSilence.GLOBAL;
-        if (media != null) {
-            skipSilence = PlaybackPreferences.getCurrentlyPlayingTemporarySkipSilence();
-            if (skipSilence == FeedPreferences.SkipSilence.GLOBAL && media instanceof FeedMedia) {
-                FeedItem item = ((FeedMedia) media).getItem();
-                if (item != null && item.getFeed() != null && item.getFeed().getPreferences() != null) {
-                    skipSilence = item.getFeed().getPreferences().getFeedSkipSilence();
+        if (media instanceof FeedMedia) {
+            FeedMedia feedMedia = (FeedMedia) media;
+            if (PlaybackPreferences.getCurrentlyPlayingFeedMediaId() == feedMedia.getId()) {
+                skipSilence = PlaybackPreferences.getCurrentlyPlayingTemporarySkipSilence();
+            }
+            if (skipSilence == FeedPreferences.SkipSilence.GLOBAL && feedMedia.getItem() != null) {
+                Feed feed = feedMedia.getItem().getFeed();
+                if (feed != null && feed.getPreferences() != null) {
+                    skipSilence = feed.getPreferences().getFeedSkipSilence();
                 }
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1616,18 +1616,17 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     @SuppressWarnings("unused")
     public void speedPresetChanged(SpeedPresetChangedEvent event) {
         if (getPlayable() instanceof FeedMedia) {
-            if (((FeedMedia) getPlayable()).getItem().getFeed().getId() == event.getFeedId()) {
+            FeedMedia playable = (FeedMedia) getPlayable();
+            if (playable.getItem().getFeed().getId() == event.getFeedId()) {
                 if (event.getSpeed() == SPEED_USE_GLOBAL) {
-                    setSpeed(UserPreferences.getPlaybackSpeed(getPlayable().getMediaType()));
-                    setSkipSilence(UserPreferences.isSkipSilence());
+                    setSpeed(UserPreferences.getPlaybackSpeed());
                 } else {
                     setSpeed(event.getSpeed());
-                    FeedPreferences.SkipSilence skipSilence = event.getSkipSilence();
-                    if (skipSilence == FeedPreferences.SkipSilence.GLOBAL) {
-                        setSkipSilence(UserPreferences.isSkipSilence());
-                    } else {
-                        setSkipSilence(skipSilence == FeedPreferences.SkipSilence.AGGRESSIVE);
-                    }
+                }
+                if (event.getSkipSilence() == FeedPreferences.SkipSilence.GLOBAL) {
+                    setSkipSilence(UserPreferences.isSkipSilence());
+                } else {
+                    setSkipSilence(event.getSkipSilence() == FeedPreferences.SkipSilence.AGGRESSIVE);
                 }
             }
         }
@@ -1637,10 +1636,10 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     @SuppressWarnings("unused")
     public void skipIntroEndingPresetChanged(SkipIntroEndingChangedEvent event) {
         if (getPlayable() instanceof FeedMedia) {
-            if (((FeedMedia) getPlayable()).getItem().getFeed().getId() == event.getFeedId()) {
+            FeedMedia playable = (FeedMedia) getPlayable();
+            if (playable.getItem().getFeed().getId() == event.getFeedId()) {
                 if (event.getSkipEnding() != 0) {
-                    FeedPreferences feedPreferences
-                            = ((FeedMedia) getPlayable()).getItem().getFeed().getPreferences();
+                    FeedPreferences feedPreferences = playable.getItem().getFeed().getPreferences();
                     feedPreferences.setFeedSkipIntro(event.getSkipIntro());
                     feedPreferences.setFeedSkipEnding(event.getSkipEnding());
                 }
@@ -1684,18 +1683,11 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
     public void setSpeed(float speed) {
         PlaybackPreferences.setCurrentlyPlayingTemporaryPlaybackSpeed(speed);
-        if (currentMediaType == MediaType.VIDEO) {
-            UserPreferences.setVideoPlaybackSpeed(speed);
-        } else {
-            UserPreferences.setPlaybackSpeed(speed);
-        }
-
         mediaPlayer.setPlaybackParams(speed, getCurrentSkipSilence());
     }
 
     public void setSkipSilence(boolean skipSilence) {
         PlaybackPreferences.setCurrentlyPlayingTemporarySkipSilence(skipSilence);
-        UserPreferences.setSkipSilence(skipSilence);
         mediaPlayer.setPlaybackParams(getCurrentPlaybackSpeed(), skipSilence);
     }
 

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -33,7 +33,6 @@ import de.danoeh.antennapod.model.feed.FeedCounter;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.model.feed.SubscriptionsFilter;
-import de.danoeh.antennapod.model.playback.MediaType;
 
 /**
  * Provides access to preferences set by the user in the settings screen. A
@@ -118,7 +117,6 @@ public class UserPreferences {
 
     // Mediaplayer
     private static final String PREF_PLAYBACK_SPEED = "prefPlaybackSpeed";
-    private static final String PREF_VIDEO_PLAYBACK_SPEED = "prefVideoPlaybackSpeed";
     public static final String PREF_PLAYBACK_SKIP_SILENCE = "prefSkipSilence";
     private static final String PREF_FAST_FORWARD_SECS = "prefFastForwardSecs";
     private static final String PREF_REWIND_SECS = "prefRewindSecs";
@@ -131,8 +129,6 @@ public class UserPreferences {
     public static final int EPISODE_CLEANUP_DEFAULT = 0;
 
     // Constants
-    public static final int NOTIFICATION_BUTTON_REWIND = 0;
-    public static final int NOTIFICATION_BUTTON_FAST_FORWARD = 1;
     public static final int NOTIFICATION_BUTTON_SKIP = 2;
     public static final int NOTIFICATION_BUTTON_NEXT_CHAPTER = 3;
     public static final int NOTIFICATION_BUTTON_PLAYBACK_SPEED = 4;
@@ -406,30 +402,12 @@ public class UserPreferences {
         return prefs.getBoolean(PREF_DELETE_REMOVES_FROM_QUEUE, false);
     }
 
-    public static float getPlaybackSpeed(MediaType mediaType) {
-        if (mediaType == MediaType.VIDEO) {
-            return getVideoPlaybackSpeed();
-        } else {
-            return getAudioPlaybackSpeed();
-        }
-    }
-
-    private static float getAudioPlaybackSpeed() {
+    public static float getPlaybackSpeed() {
         try {
             return Float.parseFloat(prefs.getString(PREF_PLAYBACK_SPEED, "1.00"));
         } catch (NumberFormatException e) {
             Log.e(TAG, Log.getStackTraceString(e));
             UserPreferences.setPlaybackSpeed(1.0f);
-            return 1.0f;
-        }
-    }
-
-    private static float getVideoPlaybackSpeed() {
-        try {
-            return Float.parseFloat(prefs.getString(PREF_VIDEO_PLAYBACK_SPEED, "1.00"));
-        } catch (NumberFormatException e) {
-            Log.e(TAG, Log.getStackTraceString(e));
-            UserPreferences.setVideoPlaybackSpeed(1.0f);
             return 1.0f;
         }
     }
@@ -610,10 +588,6 @@ public class UserPreferences {
 
     public static void setPlaybackSpeed(float speed) {
         prefs.edit().putString(PREF_PLAYBACK_SPEED, String.valueOf(speed)).apply();
-    }
-
-    public static void setVideoPlaybackSpeed(float speed) {
-        prefs.edit().putString(PREF_VIDEO_PLAYBACK_SPEED, String.valueOf(speed)).apply();
     }
 
     public static void setSkipSilence(boolean skipSilence) {


### PR DESCRIPTION
### Description

- Remove video-specific playback speed (no longer needed now that we have per-podcast speed)
- Respect changed speed setting on settings page even if the service is not running
- Do not change global speed when feed setting is updated

Closes #6916

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
