### PR TITLE
Fix android:pathPattern not starting with a slash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -185,8 +185,7 @@
                 <data android:scheme="https"/>
 
                 <data android:host="*"/>
-                <data android:pathPattern=".*.xml" />
-                <data android:pathPattern=".*.opml" />
+                <data android:pathPattern="/.*.opml" />
             </intent-filter>
         </activity>
         <activity
@@ -232,9 +231,9 @@
                 <data android:scheme="http"/>
                 <data android:scheme="https"/>
                 <data android:host="*"/>
-                <data android:pathPattern=".*\\.xml"/>
-                <data android:pathPattern=".*\\.rss"/>
-                <data android:pathPattern=".*\\.atom"/>
+                <data android:pathPattern="/.*\\.xml"/>
+                <data android:pathPattern="/.*\\.rss"/>
+                <data android:pathPattern="/.*\\.atom"/>
             </intent-filter>
 
             <!-- Feedburner URLs -->
@@ -287,7 +286,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:pathPattern=".*\\..*/.*" />
+                <data android:pathPattern="/.*\\..*/.*" />
                 <data android:host="subscribeonandroid.com" />
                 <data android:host="www.subscribeonandroid.com" />
                 <data android:host="*subscribeonandroid.com" />


### PR DESCRIPTION
### Description

Fix android:pathPattern not starting with a slash.
Reported through Google Play Console.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
