### PR TITLE
Rename FeedMedia methods to no longer have underscores

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/download/HttpDownloaderTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/download/HttpDownloaderTest.java
@@ -67,7 +67,7 @@ public class HttpDownloaderTest {
         if (deleteExisting) {
             Log.d(TAG, "Deleting file: " + file.delete());
         }
-        feedfile.setFile_url(fileUrl);
+        feedfile.setLocalFileUrl(fileUrl);
         return feedfile;
     }
 
@@ -78,7 +78,7 @@ public class HttpDownloaderTest {
     private Downloader download(String url, String title, boolean expectedResult, boolean deleteExisting,
                                 String username, String password) {
         Feed feedFile = setupFeedFile(url, title, deleteExisting);
-        DownloadRequest request = new DownloadRequest(feedFile.getFile_url(), url, title, 0, Feed.FEEDFILETYPE_FEED,
+        DownloadRequest request = new DownloadRequest(feedFile.getLocalFileUrl(), url, title, 0, Feed.FEEDFILETYPE_FEED,
                 username, password, null, false);
         Downloader downloader = new HttpDownloader(request);
         downloader.call();
@@ -86,7 +86,7 @@ public class HttpDownloaderTest {
         assertNotNull(status);
         assertEquals(expectedResult, status.isSuccessful());
         // the file should not exist if the download has failed and deleteExisting was true
-        assertTrue(!deleteExisting || new File(feedFile.getFile_url()).exists() == expectedResult);
+        assertTrue(!deleteExisting || new File(feedFile.getLocalFileUrl()).exists() == expectedResult);
         return downloader;
     }
 
@@ -114,8 +114,8 @@ public class HttpDownloaderTest {
     public void testCancel() {
         final String url = httpServer.getBaseUrl() + "/delay/3";
         Feed feedFile = setupFeedFile(url, "delay", true);
-        final Downloader downloader = new HttpDownloader(new DownloadRequest(feedFile.getFile_url(), url, "delay", 0,
-                Feed.FEEDFILETYPE_FEED, null, null, null, false));
+        final Downloader downloader = new HttpDownloader(new DownloadRequest(feedFile.getLocalFileUrl(),
+                url, "delay", 0, Feed.FEEDFILETYPE_FEED, null, null, null, false));
         Thread t = new Thread() {
             @Override
             public void run() {

--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -63,7 +63,7 @@ public class MainActivityTest {
         openNavDrawer();
         onView(withText(R.string.add_feed_label)).perform(click());
         onView(withId(R.id.addViaUrlButton)).perform(scrollTo(), click());
-        onView(withId(R.id.urlEditText)).perform(replaceText(feed.getDownload_url()));
+        onView(withId(R.id.urlEditText)).perform(replaceText(feed.getDownloadUrl()));
         onView(withText(R.string.confirm_label)).perform(scrollTo(), click());
 
         // subscribe podcast

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -138,7 +138,7 @@ public class UITestUtils {
                 }
             }
             feed.setItems(items);
-            feed.setDownload_url(hostFeed(feed));
+            feed.setDownloadUrl(hostFeed(feed));
             hostedFeeds.add(feed);
         }
         feedDataHosted = true;
@@ -174,8 +174,8 @@ public class UITestUtils {
                 for (FeedItem item : feed.getItems()) {
                     if (item.hasMedia()) {
                         FeedMedia media = item.getMedia();
-                        int fileId = Integer.parseInt(StringUtils.substringAfter(media.getDownload_url(), "files/"));
-                        media.setFile_url(server.accessFile(fileId).getAbsolutePath());
+                        int fileId = Integer.parseInt(StringUtils.substringAfter(media.getDownloadUrl(), "files/"));
+                        media.setLocalFileUrl(server.accessFile(fileId).getAbsolutePath());
                         media.setDownloaded(true);
                     }
                 }

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtilsTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtilsTest.java
@@ -45,10 +45,10 @@ public class UITestUtilsTest {
         assertFalse(feeds.isEmpty());
 
         for (Feed feed : feeds) {
-            testUrlReachable(feed.getDownload_url());
+            testUrlReachable(feed.getDownloadUrl());
             for (FeedItem item : feed.getItems()) {
                 if (item.hasMedia()) {
-                    testUrlReachable(item.getMedia().getDownload_url());
+                    testUrlReachable(item.getMedia().getDownloadUrl());
                 }
             }
         }
@@ -77,8 +77,8 @@ public class UITestUtilsTest {
                     assertTrue(item.getMedia().getId() != 0);
                     if (downloadEpisodes) {
                         assertTrue(item.getMedia().isDownloaded());
-                        assertNotNull(item.getMedia().getFile_url());
-                        File file = new File(item.getMedia().getFile_url());
+                        assertNotNull(item.getMedia().getLocalFileUrl());
+                        File file = new File(item.getMedia().getLocalFileUrl());
                         assertTrue(file.exists());
                     }
                 }

--- a/app/src/androidTest/java/de/test/antennapod/util/syndication/feedgenerator/Rss2Generator.java
+++ b/app/src/androidTest/java/de/test/antennapod/util/syndication/feedgenerator/Rss2Generator.java
@@ -110,9 +110,9 @@ public class Rss2Generator implements FeedGenerator {
                 }
                 if (item.getMedia() != null) {
                     xml.startTag(null, "enclosure");
-                    xml.attribute(null, "url", item.getMedia().getDownload_url());
+                    xml.attribute(null, "url", item.getMedia().getDownloadUrl());
                     xml.attribute(null, "length", String.valueOf(item.getMedia().getSize()));
-                    xml.attribute(null, "type", item.getMedia().getMime_type());
+                    xml.attribute(null, "type", item.getMedia().getMimeType());
                     xml.endTag(null, "enclosure");
                 }
                 if (fundingList != null) {

--- a/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OnlineFeedViewActivity.java
@@ -382,7 +382,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
     private FeedHandlerResult doParseFeed(String destination) throws Exception {
         FeedHandler handler = new FeedHandler();
         Feed feed = new Feed(selectedDownloadUrl, null);
-        feed.setFile_url(destination);
+        feed.setLocalFileUrl(destination);
         File destinationFile = new File(destination);
         try {
             return handler.parseFeed(feed);
@@ -485,7 +485,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             final List<String> alternateUrlsList = new ArrayList<>();
             final List<String> alternateUrlsTitleList = new ArrayList<>();
 
-            alternateUrlsList.add(feed.getDownload_url());
+            alternateUrlsList.add(feed.getDownloadUrl());
             alternateUrlsTitleList.add(feed.getTitle());
 
 
@@ -577,7 +577,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             return 0;
         }
         for (Feed f : feeds) {
-            if (f.getDownload_url().equals(selectedDownloadUrl)) {
+            if (f.getDownloadUrl().equals(selectedDownloadUrl)) {
                 return f.getId();
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/VideoplayerActivity.java
@@ -553,7 +553,7 @@ public class VideoplayerActivity extends CastEnabledActivity implements SeekBar.
         menu.findItem(R.id.visit_website_item).setVisible(hasWebsiteLink);
 
         boolean isItemAndHasLink = isFeedMedia && ShareUtils.hasLinkToShare(((FeedMedia) media).getItem());
-        boolean isItemHasDownloadLink = isFeedMedia && ((FeedMedia) media).getDownload_url() != null;
+        boolean isItemHasDownloadLink = isFeedMedia && ((FeedMedia) media).getDownloadUrl() != null;
         menu.findItem(R.id.share_item).setVisible(hasWebsiteLink || isItemAndHasLink || isItemHasDownloadLink);
 
         menu.findItem(R.id.add_to_favorites_item).setVisible(false);

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DownloadActionButton.java
@@ -68,7 +68,7 @@ public class DownloadActionButton extends ItemActionButton {
     }
 
     private boolean shouldNotDownload(@NonNull FeedMedia media) {
-        boolean isDownloading = DownloadServiceInterface.get().isDownloadingEpisode(media.getDownload_url());
+        boolean isDownloading = DownloadServiceInterface.get().isDownloadingEpisode(media.getDownloadUrl());
         return isDownloading || media.isDownloaded();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/ItemActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/ItemActionButton.java
@@ -39,7 +39,7 @@ public abstract class ItemActionButton {
             return new MarkAsPlayedActionButton(item);
         }
 
-        final boolean isDownloadingMedia = DownloadServiceInterface.get().isDownloadingEpisode(media.getDownload_url());
+        final boolean isDownloadingMedia = DownloadServiceInterface.get().isDownloadingEpisode(media.getDownloadUrl());
         if (PlaybackStatus.isCurrentlyPlaying(media)) {
             return new PauseActionButton(item);
         } else if (item.getFeed().isLocalFeed()) {

--- a/app/src/main/java/de/danoeh/antennapod/dialog/DownloadLogDetailsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/DownloadLogDetailsDialog.java
@@ -26,12 +26,12 @@ public class DownloadLogDetailsDialog extends MaterialAlertDialogBuilder {
         if (status.getFeedfileType() == FeedMedia.FEEDFILETYPE_FEEDMEDIA) {
             FeedMedia media = DBReader.getFeedMedia(status.getFeedfileId());
             if (media != null) {
-                url = media.getDownload_url();
+                url = media.getDownloadUrl();
             }
         } else if (status.getFeedfileType() == Feed.FEEDFILETYPE_FEED) {
             Feed feed = DBReader.getFeed(status.getFeedfileId());
             if (feed != null) {
-                url = feed.getDownload_url();
+                url = feed.getDownloadUrl();
             }
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EditUrlSettingsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EditUrlSettingsDialog.java
@@ -33,7 +33,7 @@ public abstract class EditUrlSettingsDialog {
 
         final EditTextDialogBinding binding = EditTextDialogBinding.inflate(LayoutInflater.from(activity));
 
-        binding.urlEditText.setText(feed.getDownload_url());
+        binding.urlEditText.setText(feed.getDownloadUrl());
 
         new MaterialAlertDialogBuilder(activity)
                 .setView(binding.getRoot())
@@ -47,7 +47,7 @@ public abstract class EditUrlSettingsDialog {
     private void onConfirmed(String original, String updated) {
         try {
             DBWriter.updateFeedDownloadURL(original, updated).get();
-            feed.setDownload_url(updated);
+            feed.setDownloadUrl(updated);
             FeedUpdateManager.runOnce(activityRef.get(), feed);
         } catch (ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
@@ -61,7 +61,7 @@ public abstract class EditUrlSettingsDialog {
                 .setTitle(R.string.edit_url_menu)
                 .setMessage(R.string.edit_url_confirmation_msg)
                 .setPositiveButton(android.R.string.ok, (d, input) -> {
-                    onConfirmed(feed.getDownload_url(), url);
+                    onConfirmed(feed.getDownloadUrl(), url);
                     setUrl(url);
                 })
                 .setNegativeButton(R.string.cancel_label, null)

--- a/app/src/main/java/de/danoeh/antennapod/dialog/ShareDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/ShareDialog.java
@@ -82,7 +82,7 @@ public class ShareDialog extends BottomSheetDialogFragment {
         boolean downloaded = hasMedia && item.getMedia().isDownloaded();
         viewBinding.shareMediaFileRadio.setVisibility(downloaded ? View.VISIBLE : View.GONE);
 
-        boolean hasDownloadUrl = hasMedia && item.getMedia().getDownload_url() != null;
+        boolean hasDownloadUrl = hasMedia && item.getMedia().getDownloadUrl() != null;
         if (!hasDownloadUrl) {
             viewBinding.shareMediaReceiverRadio.setVisibility(View.GONE);
         }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedInfoFragment.java
@@ -92,8 +92,8 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
     private final View.OnClickListener copyUrlToClipboard = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-            if (feed != null && feed.getDownload_url() != null) {
-                String url = feed.getDownload_url();
+            if (feed != null && feed.getDownloadUrl() != null) {
+                String url = feed.getDownloadUrl();
                 ClipData clipData = ClipData.newPlainText(url, url);
                 android.content.ClipboardManager cm = (android.content.ClipboardManager) getContext()
                         .getSystemService(Context.CLIPBOARD_SERVICE);
@@ -198,7 +198,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
     private void showFeed() {
         Log.d(TAG, "Language is " + feed.getLanguage());
         Log.d(TAG, "Author is " + feed.getAuthor());
-        Log.d(TAG, "URL is " + feed.getDownload_url());
+        Log.d(TAG, "URL is " + feed.getDownloadUrl());
         Glide.with(this)
                 .load(feed.getImageUrl())
                 .apply(new RequestOptions()
@@ -227,7 +227,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
             txtvAuthorHeader.setText(feed.getAuthor());
         }
 
-        txtvUrl.setText(feed.getDownload_url());
+        txtvUrl.setText(feed.getDownloadUrl());
         txtvUrl.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_paperclip, 0);
 
         if (feed.getPaymentLinks() == null || feed.getPaymentLinks().size() == 0) {
@@ -309,8 +309,8 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
             new EditUrlSettingsDialog(getActivity(), feed) {
                 @Override
                 protected void setUrl(String url) {
-                    feed.setDownload_url(url);
-                    txtvUrl.setText(feed.getDownload_url());
+                    feed.setDownloadUrl(url);
+                    txtvUrl.setText(feed.getDownloadUrl());
                     txtvUrl.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_paperclip, 0);
                 }
             }.show();
@@ -339,7 +339,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
             if (documentFile == null) {
                 throw new IllegalArgumentException("Unable to retrieve document tree");
             }
-            feed.setDownload_url(Feed.PREFIX_LOCAL_FOLDER + uri.toString());
+            feed.setDownloadUrl(Feed.PREFIX_LOCAL_FOLDER + uri.toString());
             DBTasks.updateFeed(getContext(), feed, true);
         })
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -276,7 +276,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             FeedUpdateManager.runOnceOrAsk(getContext(), feed);
         } else if (item.getItemId() == R.id.refresh_complete_item) {
             new Thread(() -> {
-                feed.setNextPageLink(feed.getDownload_url());
+                feed.setNextPageLink(feed.getDownloadUrl());
                 feed.setPageNr(0);
                 try {
                     DBWriter.resetPagedFeedPage(feed).get();

--- a/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/ItemFragment.java
@@ -304,12 +304,12 @@ public class ItemFragment extends Fragment {
     private void updateButtons() {
         progbarDownload.setVisibility(View.GONE);
         if (item.hasMedia()) {
-            if (DownloadServiceInterface.get().isDownloadingEpisode(item.getMedia().getDownload_url())) {
+            if (DownloadServiceInterface.get().isDownloadingEpisode(item.getMedia().getDownloadUrl())) {
                 progbarDownload.setVisibility(View.VISIBLE);
                 progbarDownload.setPercentage(0.01f * Math.max(1,
-                        DownloadServiceInterface.get().getProgress(item.getMedia().getDownload_url())), item);
+                        DownloadServiceInterface.get().getProgress(item.getMedia().getDownloadUrl())), item);
                 progbarDownload.setIndeterminate(
-                        DownloadServiceInterface.get().isEpisodeQueued(item.getMedia().getDownload_url()));
+                        DownloadServiceInterface.get().isEpisodeQueued(item.getMedia().getDownloadUrl()));
             }
         }
 
@@ -334,7 +334,7 @@ public class ItemFragment extends Fragment {
             } else {
                 actionButton1 = new StreamActionButton(item);
             }
-            if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownload_url())) {
+            if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownloadUrl())) {
                 actionButton2 = new CancelDownloadActionButton(item);
             } else if (!media.isDownloaded()) {
                 actionButton2 = new DownloadActionButton(item);
@@ -383,7 +383,7 @@ public class ItemFragment extends Fragment {
         if (item == null || item.getMedia() == null) {
             return;
         }
-        if (!event.getUrls().contains(item.getMedia().getDownload_url())) {
+        if (!event.getUrls().contains(item.getMedia().getDownloadUrl())) {
             return;
         }
         if (itemsLoaded && getActivity() != null) {

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/EpisodeItemViewHolder.java
@@ -148,11 +148,11 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
             itemView.setBackgroundResource(ThemeUtils.getDrawableFromAttr(activity, R.attr.selectableItemBackground));
         }
 
-        if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownload_url())) {
-            float percent = 0.01f * DownloadServiceInterface.get().getProgress(media.getDownload_url());
+        if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownloadUrl())) {
+            float percent = 0.01f * DownloadServiceInterface.get().getProgress(media.getDownloadUrl());
             secondaryActionProgress.setPercentage(Math.max(percent, 0.01f), item);
             secondaryActionProgress.setIndeterminate(
-                    DownloadServiceInterface.get().isEpisodeQueued(media.getDownload_url()));
+                    DownloadServiceInterface.get().isEpisodeQueued(media.getDownloadUrl()));
         } else if (media.isDownloaded()) {
             secondaryActionProgress.setPercentage(1, item); // Do not animate 100% -> 0%
             secondaryActionProgress.setIndeterminate(false);

--- a/app/src/main/java/de/danoeh/antennapod/view/viewholder/HorizontalItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/view/viewholder/HorizontalItemViewHolder.java
@@ -85,11 +85,11 @@ public class HorizontalItemViewHolder extends RecyclerView.ViewHolder {
                 setProgressBar(false, 0);
             }
 
-            if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownload_url())) {
-                float percent = 0.01f * DownloadServiceInterface.get().getProgress(media.getDownload_url());
+            if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownloadUrl())) {
+                float percent = 0.01f * DownloadServiceInterface.get().getProgress(media.getDownloadUrl());
                 circularProgressBar.setPercentage(Math.max(percent, 0.01f), item);
                 circularProgressBar.setIndeterminate(
-                        DownloadServiceInterface.get().isEpisodeQueued(media.getDownload_url()));
+                        DownloadServiceInterface.get().isEpisodeQueued(media.getDownloadUrl()));
             } else if (media.isDownloaded()) {
                 circularProgressBar.setPercentage(1, item); // Do not animate 100% -> 0%
                 circularProgressBar.setIndeterminate(false);

--- a/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/feed/LocalFeedUpdater.java
@@ -54,7 +54,7 @@ public class LocalFeedUpdater {
     public static void updateFeed(Feed feed, Context context,
                                   @Nullable UpdaterProgressListener updaterProgressListener) {
         try {
-            String uriString = feed.getDownload_url().replace(Feed.PREFIX_LOCAL_FOLDER, "");
+            String uriString = feed.getDownloadUrl().replace(Feed.PREFIX_LOCAL_FOLDER, "");
             DocumentFile documentFolder = DocumentFile.fromTreeUri(context, Uri.parse(uriString));
             if (documentFolder == null) {
                 throw new IOException("Unable to retrieve document tree. "
@@ -178,7 +178,7 @@ public class LocalFeedUpdater {
 
         for (FeedItem existingItem : feed.getItems()) {
             if (existingItem.getMedia() != null
-                    && existingItem.getMedia().getDownload_url().equals(file.getUri().toString())
+                    && existingItem.getMedia().getDownloadUrl().equals(file.getUri().toString())
                     && file.getLength() == existingItem.getMedia().getSize()) {
                 // We found an old file that we already scanned. Re-use metadata.
                 item.updateFromOther(existingItem);

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadRequestCreator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadRequestCreator.java
@@ -24,7 +24,7 @@ public class DownloadRequestCreator {
         if (dest.exists()) {
             dest.delete();
         }
-        Log.d(TAG, "Requesting download of url " + feed.getDownload_url());
+        Log.d(TAG, "Requesting download of url " + feed.getDownloadUrl());
 
         String username = (feed.getPreferences() != null) ? feed.getPreferences().getUsername() : null;
         String password = (feed.getPreferences() != null) ? feed.getPreferences().getPassword() : null;
@@ -36,10 +36,10 @@ public class DownloadRequestCreator {
 
     public static DownloadRequestBuilder create(FeedMedia media) {
         final boolean partiallyDownloadedFileExists =
-                media.getFile_url() != null && new File(media.getFile_url()).exists();
+                media.getLocalFileUrl() != null && new File(media.getLocalFileUrl()).exists();
         File dest;
         if (partiallyDownloadedFileExists) {
-            dest = new File(media.getFile_url());
+            dest = new File(media.getLocalFileUrl());
         } else {
             dest = new File(getMediafilePath(media), getMediafilename(media));
         }
@@ -47,7 +47,7 @@ public class DownloadRequestCreator {
         if (dest.exists() && !partiallyDownloadedFileExists) {
             dest = findUnusedFile(dest);
         }
-        Log.d(TAG, "Requesting download of url " + media.getDownload_url());
+        Log.d(TAG, "Requesting download of url " + media.getDownloadUrl());
 
         String username = (media.getItem().getFeed().getPreferences() != null)
                 ? media.getItem().getFeed().getPreferences().getUsername() : null;
@@ -83,7 +83,7 @@ public class DownloadRequestCreator {
     }
 
     private static String getFeedfileName(Feed feed) {
-        String filename = feed.getDownload_url();
+        String filename = feed.getDownloadUrl();
         if (feed.getTitle() != null && !feed.getTitle().isEmpty()) {
             filename = feed.getTitle();
         }
@@ -105,7 +105,7 @@ public class DownloadRequestCreator {
             titleBaseFilename = FileNameGenerator.generateFileName(title);
         }
 
-        String urlBaseFilename = URLUtil.guessFileName(media.getDownload_url(), null, media.getMime_type());
+        String urlBaseFilename = URLUtil.guessFileName(media.getDownloadUrl(), null, media.getMimeType());
 
         String baseFilename;
         if (!titleBaseFilename.equals("")) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceInterfaceImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceInterfaceImpl.java
@@ -30,14 +30,14 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
         } else {
             workRequest.setConstraints(getConstraints());
         }
-        WorkManager.getInstance(context).enqueueUniqueWork(item.getMedia().getDownload_url(),
+        WorkManager.getInstance(context).enqueueUniqueWork(item.getMedia().getDownloadUrl(),
                 ExistingWorkPolicy.KEEP, workRequest.build());
     }
 
     public void download(Context context, FeedItem item) {
         OneTimeWorkRequest.Builder workRequest = getRequest(context, item);
         workRequest.setConstraints(getConstraints());
-        WorkManager.getInstance(context).enqueueUniqueWork(item.getMedia().getDownload_url(),
+        WorkManager.getInstance(context).enqueueUniqueWork(item.getMedia().getDownloadUrl(),
                 ExistingWorkPolicy.KEEP, workRequest.build());
     }
 
@@ -45,7 +45,7 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
         OneTimeWorkRequest.Builder workRequest = new OneTimeWorkRequest.Builder(EpisodeDownloadWorker.class)
                 .setInitialDelay(0L, TimeUnit.MILLISECONDS)
                 .addTag(DownloadServiceInterface.WORK_TAG)
-                .addTag(DownloadServiceInterface.WORK_TAG_EPISODE_URL + item.getMedia().getDownload_url());
+                .addTag(DownloadServiceInterface.WORK_TAG_EPISODE_URL + item.getMedia().getDownloadUrl());
         if (!item.isTagged(FeedItem.TAG_QUEUE) && UserPreferences.enqueueDownloadedEpisodes()) {
             DBWriter.addQueueItem(context, false, item.getId());
             workRequest.addTag(DownloadServiceInterface.WORK_DATA_WAS_QUEUED);
@@ -68,7 +68,7 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
     public void cancel(Context context, FeedMedia media) {
         // This needs to be done here, not in the worker. Reason: The worker might or might not be running.
         DBWriter.deleteFeedMediaOfItem(context, media.getId()); // Remove partially downloaded file
-        String tag = WORK_TAG_EPISODE_URL + media.getDownload_url();
+        String tag = WORK_TAG_EPISODE_URL + media.getDownloadUrl();
         Future<List<WorkInfo>> future = WorkManager.getInstance(context).getWorkInfosByTag(tag);
         Observable.fromFuture(future)
                 .subscribeOn(Schedulers.io())

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/EpisodeDownloadWorker.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/EpisodeDownloadWorker.java
@@ -116,7 +116,7 @@ public class EpisodeDownloadWorker extends Worker {
                 nm.cancel(R.id.notification_downloading);
             }
         }
-        Log.d(TAG, "Worker for " + media.getDownload_url() + " returned.");
+        Log.d(TAG, "Worker for " + media.getDownloadUrl() + " returned.");
         return result;
     }
 
@@ -146,7 +146,7 @@ public class EpisodeDownloadWorker extends Worker {
         }
 
         if (dest.exists()) {
-            media.setFile_url(request.getDestination());
+            media.setLocalFileUrl(request.getDestination());
             try {
                 DBWriter.setFeedMedia(media).get();
             } catch (Exception e) {

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedParserTask.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/FeedParserTask.java
@@ -39,7 +39,7 @@ public class FeedParserTask implements Callable<FeedHandlerResult> {
     @Override
     public FeedHandlerResult call() {
         Feed feed = new Feed(request.getSource(), request.getLastModified());
-        feed.setFile_url(request.getDestination());
+        feed.setLocalFileUrl(request.getDestination());
         feed.setId(request.getFeedfileId());
         feed.setDownloaded(true);
         feed.setPreferences(new FeedPreferences(0, true, FeedPreferences.AutoDeleteAction.GLOBAL,
@@ -57,7 +57,7 @@ public class FeedParserTask implements Callable<FeedHandlerResult> {
             Log.d(TAG, feed.getTitle() + " parsed");
             checkFeedData(feed);
             if (TextUtils.isEmpty(feed.getImageUrl())) {
-                feed.setImageUrl(Feed.PREFIX_GENERATIVE_COVER + feed.getDownload_url());
+                feed.setImageUrl(Feed.PREFIX_GENERATIVE_COVER + feed.getDownloadUrl());
             }
         } catch (SAXException | IOException | ParserConfigurationException e) {
             successful = false;

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/MediaDownloadedHandler.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/handler/MediaDownloadedHandler.java
@@ -51,7 +51,7 @@ public class MediaDownloadedHandler implements Runnable {
         // media.setDownloaded modifies played state
         boolean broadcastUnreadStateUpdate = media.getItem() != null && media.getItem().isNew();
         media.setDownloaded(true);
-        media.setFile_url(request.getDestination());
+        media.setLocalFileUrl(request.getDestination());
         media.setSize(new File(request.getDestination()).length());
         media.checkEmbeddedPicture(); // enforce check
 
@@ -70,7 +70,7 @@ public class MediaDownloadedHandler implements Runnable {
         // Get duration
         String durationStr = null;
         try (MediaMetadataRetrieverCompat mmr = new MediaMetadataRetrieverCompat()) {
-            mmr.setDataSource(media.getFile_url());
+            mmr.setDataSource(media.getLocalFileUrl());
             durationStr = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
             media.setDuration(Integer.parseInt(durationStr));
             Log.d(TAG, "Duration of file is " + media.getDuration());

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/LocalPSMP.java
@@ -175,10 +175,10 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 } else {
                     mediaPlayer.setDataSource(media.getStreamUrl());
                 }
-            } else if (media.getLocalMediaUrl() != null && new File(media.getLocalMediaUrl()).canRead()) {
-                mediaPlayer.setDataSource(media.getLocalMediaUrl());
+            } else if (media.getLocalFileUrl() != null && new File(media.getLocalFileUrl()).canRead()) {
+                mediaPlayer.setDataSource(media.getLocalFileUrl());
             } else {
-                throw new IOException("Unable to read local file " + media.getLocalMediaUrl());
+                throw new IOException("Unable to read local file " + media.getLocalFileUrl());
             }
             UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
             if (uiModeManager.getCurrentModeType() != Configuration.UI_MODE_TYPE_CAR) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -98,7 +98,7 @@ public final class DBTasks {
     public static void notifyMissingFeedMediaFile(final Context context, final FeedMedia media) {
         Log.i(TAG, "The feedmanager was notified about a missing episode. It will update its database now.");
         media.setDownloaded(false);
-        media.setFile_url(null);
+        media.setLocalFileUrl(null);
         DBWriter.setFeedMedia(media);
         EventBus.getDefault().post(FeedItemEvent.updated(media.getItem()));
         EventBus.getDefault().post(new MessageEvent(context.getString(R.string.error_file_not_found)));
@@ -369,7 +369,7 @@ public final class DBTasks {
     private static String duplicateEpisodeDetails(FeedItem item) {
         return "Title: " + item.getTitle()
                 + "\nID: " + item.getItemIdentifier()
-                + ((item.getMedia() == null) ? "" : "\nURL: " + item.getMedia().getDownload_url());
+                + ((item.getMedia() == null) ? "" : "\nURL: " + item.getMedia().getDownloadUrl());
     }
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBWriter.java
@@ -116,25 +116,25 @@ public class DBWriter {
         Log.i(TAG, String.format(Locale.US, "Requested to delete FeedMedia [id=%d, title=%s, downloaded=%s",
                 media.getId(), media.getEpisodeTitle(), media.isDownloaded()));
         boolean localDelete = false;
-        if (media.getFile_url() != null && media.getFile_url().startsWith("content://")) {
+        if (media.getLocalFileUrl() != null && media.getLocalFileUrl().startsWith("content://")) {
             // Local feed
-            DocumentFile documentFile = DocumentFile.fromSingleUri(context, Uri.parse(media.getFile_url()));
+            DocumentFile documentFile = DocumentFile.fromSingleUri(context, Uri.parse(media.getLocalFileUrl()));
             if (documentFile == null || !documentFile.exists() || !documentFile.delete()) {
                 EventBus.getDefault().post(new MessageEvent(context.getString(R.string.delete_local_failed)));
                 return false;
             }
-            media.setFile_url(null);
+            media.setLocalFileUrl(null);
             localDelete = true;
-        } else if (media.getFile_url() != null) {
+        } else if (media.getLocalFileUrl() != null) {
             // delete downloaded media file
-            File mediaFile = new File(media.getFile_url());
+            File mediaFile = new File(media.getLocalFileUrl());
             if (mediaFile.exists() && !mediaFile.delete()) {
                 MessageEvent evt = new MessageEvent(context.getString(R.string.delete_failed));
                 EventBus.getDefault().post(evt);
                 return false;
             }
             media.setDownloaded(false);
-            media.setFile_url(null);
+            media.setLocalFileUrl(null);
             media.setHasEmbeddedPicture(false);
             PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
@@ -192,7 +192,7 @@ public class DBWriter {
             adapter.close();
 
             if (!feed.isLocalFeed()) {
-                SynchronizationQueueSink.enqueueFeedRemovedIfSynchronizationIsActive(context, feed.getDownload_url());
+                SynchronizationQueueSink.enqueueFeedRemovedIfSynchronizationIsActive(context, feed.getDownloadUrl());
             }
             EventBus.getDefault().post(new FeedListUpdateEvent(feed));
         });
@@ -802,7 +802,7 @@ public class DBWriter {
 
             for (Feed feed : feeds) {
                 if (!feed.isLocalFeed()) {
-                    SynchronizationQueueSink.enqueueFeedAddedIfSynchronizationIsActive(context, feed.getDownload_url());
+                    SynchronizationQueueSink.enqueueFeedAddedIfSynchronizationIsActive(context, feed.getDownloadUrl());
                 }
             }
 

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/FeedItemDuplicateGuesser.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/FeedItemDuplicateGuesser.java
@@ -53,8 +53,8 @@ public class FeedItemDuplicateGuesser {
     }
 
     private static boolean mimeTypeLooksSimilar(FeedMedia media1, FeedMedia media2) {
-        String mimeType1 = media1.getMime_type();
-        String mimeType2 = media2.getMime_type();
+        String mimeType1 = media1.getMimeType();
+        String mimeType2 = media2.getMimeType();
         if (mimeType1 == null || mimeType2 == null) {
             return true;
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/ItemEnqueuePositionCalculator.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/ItemEnqueuePositionCalculator.java
@@ -74,7 +74,7 @@ class ItemEnqueuePositionCalculator {
         }
         return curItem != null
                 && curItem.getMedia() != null
-                && DownloadServiceInterface.get().isDownloadingEpisode(curItem.getMedia().getDownload_url());
+                && DownloadServiceInterface.get().isDownloadingEpisode(curItem.getMedia().getDownloadUrl());
     }
 
     private static int getCurrentlyPlayingPosition(@NonNull List<FeedItem> curQueue,

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ChapterUtils.java
@@ -125,10 +125,10 @@ public class ChapterUtils {
 
     private static CountingInputStream openStream(Playable playable, Context context) throws IOException {
         if (playable.localFileAvailable()) {
-            if (playable.getLocalMediaUrl() == null) {
+            if (playable.getLocalFileUrl() == null) {
                 throw new IOException("No local url");
             }
-            File source = new File(playable.getLocalMediaUrl());
+            File source = new File(playable.getLocalFileUrl());
             if (!source.exists()) {
                 throw new IOException("Local file does not exist");
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/FeedItemUtil.java
@@ -27,7 +27,7 @@ public class FeedItemUtil {
     public static int indexOfItemWithDownloadUrl(List<FeedItem> items, String downloadUrl) {
         for (int i = 0; i < items.size(); i++) {
             FeedItem item = items.get(i);
-            if (item != null && item.getMedia() != null && item.getMedia().getDownload_url().equals(downloadUrl)) {
+            if (item != null && item.getMedia() != null && item.getMedia().getDownloadUrl().equals(downloadUrl)) {
                 return i;
             }
         }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/ShareUtils.java
@@ -38,7 +38,7 @@ public class ShareUtils {
         String text = feed.getTitle()
                 + "\n\n"
                 + "https://antennapod.org/deeplink/subscribe/?url="
-                + URLEncoder.encode(feed.getDownload_url())
+                + URLEncoder.encode(feed.getDownloadUrl())
                 + "&title="
                 + URLEncoder.encode(feed.getTitle());
         shareLink(context, text);
@@ -49,7 +49,7 @@ public class ShareUtils {
     }
 
     public static void shareMediaDownloadLink(Context context, FeedMedia media) {
-        shareLink(context, media.getDownload_url());
+        shareLink(context, media.getDownloadUrl());
     }
 
     public static void shareFeedItemLinkWithDownloadLink(Context context, FeedItem item, boolean withPosition) {
@@ -66,9 +66,9 @@ public class ShareUtils {
             text += FeedItemUtil.getLinkWithFallback(item);
         }
 
-        if (item.getMedia() != null && item.getMedia().getDownload_url() != null) {
+        if (item.getMedia() != null && item.getMedia().getDownloadUrl() != null) {
             text += "\n\n" + context.getResources().getString(R.string.share_dialog_media_file_label) + ": ";
-            text +=  item.getMedia().getDownload_url();
+            text +=  item.getMedia().getDownloadUrl();
             if (withPosition) {
                 text += "#t=" + pos / 1000;
             }
@@ -78,10 +78,10 @@ public class ShareUtils {
 
     public static void shareFeedItemFile(Context context, FeedMedia media) {
         Uri fileUri = FileProvider.getUriForFile(context, context.getString(R.string.provider_authority),
-                new File(media.getLocalMediaUrl()));
+                new File(media.getLocalFileUrl()));
 
         new ShareCompat.IntentBuilder(context)
-                .setType(media.getMime_type())
+                .setType(media.getMimeType())
                 .addStream(fileUri)
                 .setChooserTitle(R.string.share_file_label)
                 .startChooser();

--- a/core/src/main/java/de/danoeh/antennapod/core/util/download/MediaSizeLoader.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/download/MediaSizeLoader.java
@@ -28,14 +28,14 @@ public abstract class MediaSizeLoader {
             }
             long size = Integer.MIN_VALUE;
             if (media.isDownloaded()) {
-                File mediaFile = new File(media.getLocalMediaUrl());
+                File mediaFile = new File(media.getLocalFileUrl());
                 if (mediaFile.exists()) {
                     size = mediaFile.length();
                 }
             } else if (!media.checkedOnSizeButUnknown()) {
                 // only query the network if we haven't already checked
 
-                String url = media.getDownload_url();
+                String url = media.getDownloadUrl();
                 if (TextUtils.isEmpty(url)) {
                     emitter.onSuccess(0L);
                     return;

--- a/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/feed/LocalFeedUpdaterTest.java
@@ -112,7 +112,7 @@ public class LocalFeedUpdaterTest {
         // verify new feed in database
         verifySingleFeedInDatabaseAndItemCount(2);
         Feed feedAfter = verifySingleFeedInDatabase();
-        assertEquals(FEED_URL, feedAfter.getDownload_url());
+        assertEquals(FEED_URL, feedAfter.getDownloadUrl());
     }
 
     /**

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbCleanupTests.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbCleanupTests.java
@@ -211,7 +211,7 @@ public class DbCleanupTests {
         FeedMedia m = feeds.get(0).getItems().get(0).getMedia();
         //noinspection ConstantConditions
         m.setDownloaded(true);
-        m.setFile_url("file");
+        m.setLocalFileUrl("file");
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         adapter.setMedia(m);

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbReaderTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbReaderTest.java
@@ -112,7 +112,7 @@ public class DbReaderTest {
             assertNotNull(urls);
             assertEquals(feeds.size(), urls.size());
             for (int i = 0; i < urls.size(); i++) {
-                assertEquals(urls.get(i), feeds.get(i).getDownload_url());
+                assertEquals(urls.get(i), feeds.get(i).getDownloadUrl());
             }
         }
 
@@ -225,7 +225,7 @@ public class DbReaderTest {
                 if (!downloaded.contains(items.get(i))) {
                     FeedItem item = items.get(i);
                     item.getMedia().setDownloaded(true);
-                    item.getMedia().setFile_url("file" + i);
+                    item.getMedia().setLocalFileUrl("file" + i);
                     downloaded.add(item);
                 }
             }
@@ -247,7 +247,7 @@ public class DbReaderTest {
             for (FeedItem item : downloadedSaved) {
                 assertNotNull(item.getMedia());
                 assertTrue(item.getMedia().isDownloaded());
-                assertNotNull(item.getMedia().getDownload_url());
+                assertNotNull(item.getMedia().getDownloadUrl());
             }
         }
 
@@ -434,7 +434,7 @@ public class DbReaderTest {
             List<Feed> feeds = saveFeedlist(1, 1, true);
             FeedItem item1 = feeds.get(0).getItems().get(0);
             FeedItem feedItemByEpisodeUrl = DBReader.getFeedItemByGuidOrEpisodeUrl(null,
-                    item1.getMedia().getDownload_url());
+                    item1.getMedia().getDownloadUrl());
             assertEquals(item1.getItemIdentifier(), feedItemByEpisodeUrl.getItemIdentifier());
         }
 
@@ -444,7 +444,7 @@ public class DbReaderTest {
             FeedItem item1 = feeds.get(0).getItems().get(0);
 
             FeedItem feedItemByGuid = DBReader.getFeedItemByGuidOrEpisodeUrl(item1.getItemIdentifier(),
-                    item1.getMedia().getDownload_url());
+                    item1.getMedia().getDownloadUrl());
             assertEquals(item1.getItemIdentifier(), feedItemByGuid.getItemIdentifier());
         }
 

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
@@ -157,7 +157,7 @@ public class DbWriterTest {
         assertNotNull(media);
         assertFalse(dest.exists());
         assertFalse(media.isDownloaded());
-        assertNull(media.getFile_url());
+        assertNull(media.getLocalFileUrl());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class DbWriterTest {
         assertNotNull(media);
         assertFalse(dest.exists());
         assertFalse(media.isDownloaded());
-        assertNull(media.getFile_url());
+        assertNull(media.getLocalFileUrl());
         Awaitility.await().timeout(2, TimeUnit.SECONDS).until(() -> DBReader.getQueue().isEmpty());
     }
 

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/mapper/FeedCursorMapperTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/mapper/FeedCursorMapperTest.java
@@ -53,8 +53,8 @@ public class FeedCursorMapperTest {
             assertEquals("feed author", feed.getAuthor());
             assertEquals("feed language", feed.getLanguage());
             assertEquals("feed image url", feed.getImageUrl());
-            assertEquals("feed file url", feed.getFile_url());
-            assertEquals("feed download url", feed.getDownload_url());
+            assertEquals("feed file url", feed.getLocalFileUrl());
+            assertEquals("feed download url", feed.getDownloadUrl());
             assertTrue(feed.isDownloaded());
             assertEquals("feed last update", feed.getLastModified());
             assertEquals("feed type", feed.getType());

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
@@ -133,7 +133,7 @@ public class Feed {
         if (filter != null) {
             this.itemfilter = new FeedItemFilter(filter);
         } else {
-            this.itemfilter = new FeedItemFilter(new String[0]);
+            this.itemfilter = new FeedItemFilter();
         }
         setSortOrder(sortOrder);
         this.lastUpdateFailed = lastUpdateFailed;
@@ -455,22 +455,22 @@ public class Feed {
         return id;
     }
 
-    public String getFile_url() {
+    public String getLocalFileUrl() {
         return localFileUrl;
     }
 
-    public void setFile_url(String fileUrl) {
+    public void setLocalFileUrl(String fileUrl) {
         this.localFileUrl = fileUrl;
         if (fileUrl == null) {
             downloaded = false;
         }
     }
 
-    public String getDownload_url() {
+    public String getDownloadUrl() {
         return downloadUrl;
     }
 
-    public void setDownload_url(String downloadUrl) {
+    public void setDownloadUrl(String downloadUrl) {
         this.downloadUrl = downloadUrl;
     }
 
@@ -509,12 +509,6 @@ public class Feed {
     @Nullable
     public FeedItemFilter getItemFilter() {
         return itemfilter;
-    }
-
-    public void setItemFilter(String[] properties) {
-        if (properties != null) {
-            this.itemfilter = new FeedItemFilter(properties);
-        }
     }
 
     @Nullable

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -182,8 +182,8 @@ public class FeedItem implements Serializable {
             return itemIdentifier;
         } else if (title != null && !title.isEmpty()) {
             return title;
-        } else if (hasMedia() && media.getDownload_url() != null) {
-            return media.getDownload_url();
+        } else if (hasMedia() && media.getDownloadUrl() != null) {
+            return media.getDownloadUrl();
         } else {
             return link;
         }
@@ -325,7 +325,7 @@ public class FeedItem implements Serializable {
         if (imageUrl != null) {
             return imageUrl;
         } else if (media != null && media.hasEmbeddedPicture()) {
-            return FeedMedia.FILENAME_PREFIX_EMBEDDED_COVER + media.getLocalMediaUrl();
+            return FeedMedia.FILENAME_PREFIX_EMBEDDED_COVER + media.getLocalFileUrl();
         } else if (feed != null) {
             return feed.getImageUrl();
         } else {

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -239,7 +239,7 @@ public class FeedMedia implements Playable {
         return (CHECKED_ON_SIZE_BUT_UNKNOWN == this.size);
     }
 
-    public String getMime_type() {
+    public String getMimeType() {
         return mimeType;
     }
 
@@ -355,12 +355,16 @@ public class FeedMedia implements Playable {
     }
 
     @Override
-    public String getLocalMediaUrl() {
+    public String getLocalFileUrl() {
         return localFileUrl;
     }
 
     @Override
     public String getStreamUrl() {
+        return downloadUrl;
+    }
+
+    public String getDownloadUrl() {
         return downloadUrl;
     }
 
@@ -402,16 +406,8 @@ public class FeedMedia implements Playable {
         this.id = id;
     }
 
-    public String getFile_url() {
-        return localFileUrl;
-    }
-
     public boolean isDownloaded() {
         return downloaded;
-    }
-
-    public String getDownload_url() {
-        return downloadUrl;
     }
 
     public long getItemId() {
@@ -470,7 +466,7 @@ public class FeedMedia implements Playable {
         if (item != null) {
             return item.getImageLocation();
         } else if (hasEmbeddedPicture()) {
-            return FILENAME_PREFIX_EMBEDDED_COVER + getLocalMediaUrl();
+            return FILENAME_PREFIX_EMBEDDED_COVER + getLocalFileUrl();
         } else {
             return null;
         }
@@ -487,9 +483,9 @@ public class FeedMedia implements Playable {
         }
     }
 
-    public void setFile_url(String file_url) {
-        this.localFileUrl = file_url;
-        if (file_url == null) {
+    public void setLocalFileUrl(String fileUrl) {
+        this.localFileUrl = fileUrl;
+        if (fileUrl == null) {
             downloaded = false;
         }
     }
@@ -500,7 +496,7 @@ public class FeedMedia implements Playable {
             return;
         }
         try (MediaMetadataRetrieverCompat mmr = new MediaMetadataRetrieverCompat()) {
-            mmr.setDataSource(getLocalMediaUrl());
+            mmr.setDataSource(getLocalFileUrl());
             byte[] image = mmr.getEmbeddedPicture();
             if (image != null) {
                 hasEmbeddedPicture = Boolean.TRUE;

--- a/model/src/main/java/de/danoeh/antennapod/model/playback/Playable.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/playback/Playable.java
@@ -88,7 +88,7 @@ public interface Playable extends Parcelable, Serializable {
      * Returns an url to a local file that can be played or null if this file
      * does not exist.
      */
-    String getLocalMediaUrl();
+    String getLocalFileUrl();
 
     /**
      * Returns an url to a file that can be streamed by the player or null if

--- a/model/src/main/java/de/danoeh/antennapod/model/playback/RemoteMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/playback/RemoteMedia.java
@@ -62,9 +62,9 @@ public class RemoteMedia implements Playable {
     }
 
     public RemoteMedia(FeedItem item) {
-        this.downloadUrl = item.getMedia().getDownload_url();
+        this.downloadUrl = item.getMedia().getDownloadUrl();
         this.itemIdentifier = item.getItemIdentifier();
-        this.feedUrl = item.getFeed().getDownload_url();
+        this.feedUrl = item.getFeed().getDownloadUrl();
         this.feedTitle = item.getFeed().getTitle();
         this.episodeTitle = item.getTitle();
         this.episodeLink = item.getLink();
@@ -75,7 +75,7 @@ public class RemoteMedia implements Playable {
             this.imageUrl = item.getFeed().getImageUrl();
         }
         this.feedLink = item.getFeed().getLink();
-        this.mimeType = item.getMedia().getMime_type();
+        this.mimeType = item.getMedia().getMimeType();
         this.pubDate = item.getPubDate();
         this.notes = item.getDescription();
     }
@@ -175,7 +175,7 @@ public class RemoteMedia implements Playable {
     }
 
     @Override
-    public String getLocalMediaUrl() {
+    public String getLocalFileUrl() {
         return null;
     }
 
@@ -300,7 +300,7 @@ public class RemoteMedia implements Playable {
                 return false;
             }
             Feed feed = fi.getFeed();
-            return feed != null && TextUtils.equals(feedUrl, feed.getDownload_url());
+            return feed != null && TextUtils.equals(feedUrl, feed.getDownloadUrl());
         }
         return false;
     }

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadRequestBuilder.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadRequestBuilder.java
@@ -21,7 +21,7 @@ public class DownloadRequestBuilder {
 
     public DownloadRequestBuilder(@NonNull String destination, @NonNull FeedMedia media) {
         this.destination = destination;
-        this.source = UrlChecker.prepareUrl(media.getDownload_url());
+        this.source = UrlChecker.prepareUrl(media.getDownloadUrl());
         this.title = media.getHumanReadableIdentifier();
         this.feedfileId = media.getId();
         this.feedfileType = FeedMedia.FEEDFILETYPE_FEEDMEDIA;
@@ -29,7 +29,7 @@ public class DownloadRequestBuilder {
 
     public DownloadRequestBuilder(@NonNull String destination, @NonNull Feed feed) {
         this.destination = destination;
-        this.source = feed.isLocalFeed() ? feed.getDownload_url() : UrlChecker.prepareUrl(feed.getDownload_url());
+        this.source = feed.isLocalFeed() ? feed.getDownloadUrl() : UrlChecker.prepareUrl(feed.getDownloadUrl());
         this.title = feed.getHumanReadableIdentifier();
         this.feedfileId = feed.getId();
         this.feedfileType = Feed.FEEDFILETYPE_FEED;

--- a/net/sync/model/src/main/java/de/danoeh/antennapod/net/sync/model/EpisodeAction.java
+++ b/net/sync/model/src/main/java/de/danoeh/antennapod/net/sync/model/EpisodeAction.java
@@ -239,7 +239,7 @@ public class EpisodeAction {
         private String guid;
 
         public Builder(FeedItem item, Action action) {
-            this(item.getFeed().getDownload_url(), item.getMedia().getDownload_url(), action);
+            this(item.getFeed().getDownloadUrl(), item.getMedia().getDownloadUrl(), action);
             this.guid(item.getItemIdentifier());
         }
 

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/FeedHandler.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/FeedHandler.java
@@ -25,7 +25,7 @@ public class FeedHandler {
         SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
         SAXParser saxParser = factory.newSAXParser();
-        File file = new File(feed.getFile_url());
+        File file = new File(feed.getLocalFileUrl());
         Reader inputStreamReader = new XmlStreamReader(file);
         InputSource inputSource = new InputSource(inputStreamReader);
 

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/util/TypeGetter.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/util/TypeGetter.java
@@ -29,7 +29,7 @@ public class TypeGetter {
 
     public Type getType(Feed feed) throws UnsupportedFeedtypeException {
         XmlPullParserFactory factory;
-        if (feed.getFile_url() != null) {
+        if (feed.getLocalFileUrl() != null) {
             Reader reader = null;
             try {
                 factory = XmlPullParserFactory.newInstance();
@@ -86,7 +86,7 @@ public class TypeGetter {
                 // XML document might actually be a HTML document -> try to parse as HTML
                 String rootElement = null;
                 try {
-                    Jsoup.parse(new File(feed.getFile_url()));
+                    Jsoup.parse(new File(feed.getLocalFileUrl()));
                     rootElement = "html";
                 } catch (IOException e1) {
                     e1.printStackTrace();
@@ -112,7 +112,7 @@ public class TypeGetter {
     private Reader createReader(Feed feed) {
         Reader reader;
         try {
-            reader = new XmlStreamReader(new File(feed.getFile_url()));
+            reader = new XmlStreamReader(new File(feed.getLocalFileUrl()));
         } catch (FileNotFoundException e) {
             e.printStackTrace();
             return null;

--- a/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/AtomParserTest.java
+++ b/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/AtomParserTest.java
@@ -47,9 +47,9 @@ public class AtomParserTest {
             assertTrue(item.hasMedia());
             FeedMedia media = item.getMedia();
             //noinspection ConstantConditions
-            assertEquals("http://example.com/media-" + i, media.getDownload_url());
+            assertEquals("http://example.com/media-" + i, media.getDownloadUrl());
             assertEquals(1024 * 1024, media.getSize());
-            assertEquals("audio/mp3", media.getMime_type());
+            assertEquals("audio/mp3", media.getMimeType());
             // chapters
             assertNull(item.getChapters());
         }

--- a/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/FeedParserTestHelper.java
+++ b/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/FeedParserTestHelper.java
@@ -28,7 +28,7 @@ public abstract class FeedParserTestHelper {
     static Feed runFeedParser(@NonNull File feedFile) throws Exception {
         FeedHandler handler = new FeedHandler();
         Feed parsedFeed = new Feed("http://example.com/feed", null);
-        parsedFeed.setFile_url(feedFile.getAbsolutePath());
+        parsedFeed.setLocalFileUrl(feedFile.getAbsolutePath());
         parsedFeed.setDownloaded(true);
         handler.parseFeed(parsedFeed);
         return parsedFeed;

--- a/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
+++ b/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
@@ -48,9 +48,9 @@ public class RssParserTest {
             assertTrue(item.hasMedia());
             FeedMedia media = item.getMedia();
             //noinspection ConstantConditions
-            assertEquals("http://example.com/media-" + i, media.getDownload_url());
+            assertEquals("http://example.com/media-" + i, media.getDownloadUrl());
             assertEquals(1024 * 1024, media.getSize());
-            assertEquals("audio/mp3", media.getMime_type());
+            assertEquals("audio/mp3", media.getMimeType());
             // chapters
             assertNull(item.getChapters());
         }
@@ -81,7 +81,7 @@ public class RssParserTest {
         FeedItem feedItem = feed.getItems().get(0);
         //noinspection ConstantConditions
         assertEquals(MediaType.VIDEO, feedItem.getMedia().getMediaType());
-        assertEquals("https://www.example.com/file.mp4", feedItem.getMedia().getDownload_url());
+        assertEquals("https://www.example.com/file.mp4", feedItem.getMedia().getDownloadUrl());
     }
 
     @Test

--- a/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastUtils.java
+++ b/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastUtils.java
@@ -132,7 +132,7 @@ public class CastUtils {
             return false;
         }
         Feed feed = fi.getFeed();
-        return feed != null && TextUtils.equals(metadata.getString(KEY_FEED_URL), feed.getDownload_url());
+        return feed != null && TextUtils.equals(metadata.getString(KEY_FEED_URL), feed.getDownloadUrl());
     }
 
     /**

--- a/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/MediaInfoCreator.java
+++ b/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/MediaInfoCreator.java
@@ -97,8 +97,8 @@ public class MediaInfoCreator {
                 if (!TextUtils.isEmpty(feed.getAuthor())) {
                     metadata.putString(MediaMetadata.KEY_ARTIST, feed.getAuthor());
                 }
-                if (!TextUtils.isEmpty(feed.getDownload_url())) {
-                    metadata.putString(CastUtils.KEY_FEED_URL, feed.getDownload_url());
+                if (!TextUtils.isEmpty(feed.getDownloadUrl())) {
+                    metadata.putString(CastUtils.KEY_FEED_URL, feed.getDownloadUrl());
                 }
                 if (!TextUtils.isEmpty(feed.getLink())) {
                     metadata.putString(CastUtils.KEY_FEED_WEBSITE, feed.getLink());
@@ -124,7 +124,7 @@ public class MediaInfoCreator {
         metadata.putString(CastUtils.KEY_STREAM_URL, media.getStreamUrl());
 
         MediaInfo.Builder builder = new MediaInfo.Builder(media.getStreamUrl())
-                .setContentType(media.getMime_type())
+                .setContentType(media.getMimeType())
                 .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
                 .setMetadata(metadata);
         if (media.getDuration() > 0) {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -416,8 +416,8 @@ public class PodDBAdapter {
         values.put(KEY_LANGUAGE, feed.getLanguage());
         values.put(KEY_IMAGE_URL, feed.getImageUrl());
 
-        values.put(KEY_FILE_URL, feed.getFile_url());
-        values.put(KEY_DOWNLOAD_URL, feed.getDownload_url());
+        values.put(KEY_FILE_URL, feed.getLocalFileUrl());
+        values.put(KEY_DOWNLOAD_URL, feed.getDownloadUrl());
         values.put(KEY_DOWNLOADED, feed.isDownloaded());
         values.put(KEY_LASTUPDATE, feed.getLastModified());
         values.put(KEY_TYPE, feed.getType());
@@ -493,10 +493,10 @@ public class PodDBAdapter {
         values.put(KEY_DURATION, media.getDuration());
         values.put(KEY_POSITION, media.getPosition());
         values.put(KEY_SIZE, media.getSize());
-        values.put(KEY_MIME_TYPE, media.getMime_type());
-        values.put(KEY_DOWNLOAD_URL, media.getDownload_url());
+        values.put(KEY_MIME_TYPE, media.getMimeType());
+        values.put(KEY_DOWNLOAD_URL, media.getDownloadUrl());
         values.put(KEY_DOWNLOADED, media.isDownloaded());
-        values.put(KEY_FILE_URL, media.getFile_url());
+        values.put(KEY_FILE_URL, media.getLocalFileUrl());
         values.put(KEY_HAS_EMBEDDED_PICTURE, media.hasEmbeddedPicture());
         values.put(KEY_LAST_PLAYED_TIME, media.getLastPlayedTime());
 

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/FavoritesWriter.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/FavoritesWriter.java
@@ -87,7 +87,7 @@ public class FavoritesWriter {
                 .replace("{FEED_IMG}", feed.getImageUrl())
                 .replace("{FEED_TITLE}", feed.getTitle())
                 .replace("{FEED_LINK}", feed.getLink())
-                .replace("{FEED_WEBSITE}", feed.getDownload_url());
+                .replace("{FEED_WEBSITE}", feed.getDownloadUrl());
 
         writer.append(feedInfo);
     }
@@ -99,8 +99,8 @@ public class FavoritesWriter {
         } else {
             favItem = favItem.replace("{FAV_WEBSITE}", "");
         }
-        if (item.getMedia() != null && item.getMedia().getDownload_url() != null) {
-            favItem = favItem.replace("{FAV_MEDIA}", item.getMedia().getDownload_url());
+        if (item.getMedia() != null && item.getMedia().getDownloadUrl() != null) {
+            favItem = favItem.replace("{FAV_MEDIA}", item.getMedia().getDownloadUrl());
         } else {
             favItem = favItem.replace("{FAV_MEDIA}", "");
         }

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/HtmlWriter.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/HtmlWriter.java
@@ -35,7 +35,7 @@ public class HtmlWriter {
             writer.append(" <span><a href=\"");
             writer.append(feed.getLink());
             writer.append("\">Website</a> • <a href=\"");
-            writer.append(feed.getDownload_url());
+            writer.append(feed.getDownloadUrl());
             writer.append("\">Feed</a></span></p></div></li>\n");
         }
         writer.append(templateParts[1]);

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/OpmlWriter.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/OpmlWriter.java
@@ -54,7 +54,7 @@ public class OpmlWriter {
             if (feed.getType() != null) {
                 xs.attribute(null, OpmlSymbols.TYPE, feed.getType());
             }
-            xs.attribute(null, OpmlSymbols.XMLURL, feed.getDownload_url());
+            xs.attribute(null, OpmlSymbols.XMLURL, feed.getDownloadUrl());
             if (feed.getLink() != null) {
                 xs.attribute(null, OpmlSymbols.HTMLURL, feed.getLink());
             }

--- a/ui/glide/src/main/java/de/danoeh/antennapod/ui/glide/ChapterImageModelLoader.java
+++ b/ui/glide/src/main/java/de/danoeh/antennapod/ui/glide/ChapterImageModelLoader.java
@@ -81,7 +81,7 @@ public final class ChapterImageModelLoader implements ModelLoader<EmbeddedChapte
                         Uri uri = Uri.parse(image.getMedia().getStreamUrl());
                         stream = new BufferedInputStream(context.getContentResolver().openInputStream(uri));
                     } else {
-                        File localFile = new File(image.getMedia().getLocalMediaUrl());
+                        File localFile = new File(image.getMedia().getLocalFileUrl());
                         stream = new BufferedInputStream(new FileInputStream(localFile));
                     }
                     IOUtils.skip(stream, image.getPosition());


### PR DESCRIPTION
### Description

Rename FeedMedia methods to no longer have underscores.
I hate doing this PR with so many file changes messing up the git history, but that name ambiguous (file_url could be local or remote file) and looks weird with its underscore.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
