### PR TITLE
Faster feed deletion

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DeleteActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/adapter/actionbutton/DeleteActionButton.java
@@ -39,7 +39,7 @@ public class DeleteActionButton extends ItemActionButton {
         }
 
         LocalDeleteModal.showLocalFeedDeleteWarningIfNecessary(context, Collections.singletonList(item),
-                () -> DBWriter.deleteFeedMediaOfItem(context, media.getId()));
+                () -> DBWriter.deleteFeedMediaOfItem(context, media));
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/fragment/actions/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/actions/EpisodeMultiSelectActionHandler.java
@@ -104,7 +104,7 @@ public class EpisodeMultiSelectActionHandler {
         for (FeedItem feedItem : items) {
             if (feedItem.hasMedia() && feedItem.getMedia().isDownloaded()) {
                 countHasMedia++;
-                DBWriter.deleteFeedMediaOfItem(activity, feedItem.getMedia().getId());
+                DBWriter.deleteFeedMediaOfItem(activity, feedItem.getMedia());
             }
         }
         showMessage(R.plurals.deleted_multi_episode_batch_label, countHasMedia);

--- a/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/DeleteSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/swipeactions/DeleteSwipeAction.java
@@ -40,7 +40,7 @@ public class DeleteSwipeAction implements SwipeAction {
         }
         LocalDeleteModal.showLocalFeedDeleteWarningIfNecessary(
                 fragment.requireContext(), Collections.singletonList(item),
-                () -> DBWriter.deleteFeedMediaOfItem(fragment.requireContext(), item.getMedia().getId()));
+                () -> DBWriter.deleteFeedMediaOfItem(fragment.requireContext(), item.getMedia()));
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/menuhandler/FeedItemMenuHandler.java
@@ -153,7 +153,7 @@ public class FeedItemMenuHandler {
             context.sendBroadcast(MediaButtonStarter.createIntent(context, KeyEvent.KEYCODE_MEDIA_NEXT));
         } else if (menuItemId == R.id.remove_item) {
             LocalDeleteModal.showLocalFeedDeleteWarningIfNecessary(context, Arrays.asList(selectedItem),
-                    () -> DBWriter.deleteFeedMediaOfItem(context, selectedItem.getMedia().getId()));
+                    () -> DBWriter.deleteFeedMediaOfItem(context, selectedItem.getMedia()));
         } else if (menuItemId == R.id.remove_inbox_item) {
             removeNewFlagWithUndo(fragment, selectedItem);
         } else if (menuItemId == R.id.mark_read_item) {
@@ -232,7 +232,7 @@ public class FeedItemMenuHandler {
             FeedMedia media = item.getMedia();
             boolean shouldAutoDelete = FeedUtil.shouldAutoDeleteItemsOnThatFeed(item.getFeed());
             if (media != null && FeedItemUtil.hasAlmostEnded(media) && shouldAutoDelete) {
-                DBWriter.deleteFeedMediaOfItem(fragment.requireContext(), media.getId());
+                DBWriter.deleteFeedMediaOfItem(fragment.requireContext(), media);
             }
         };
 

--- a/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceInterfaceImpl.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/download/DownloadServiceInterfaceImpl.java
@@ -67,7 +67,9 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
     @Override
     public void cancel(Context context, FeedMedia media) {
         // This needs to be done here, not in the worker. Reason: The worker might or might not be running.
-        DBWriter.deleteFeedMediaOfItem(context, media.getId()); // Remove partially downloaded file
+        if (media.fileExists()) {
+            DBWriter.deleteFeedMediaOfItem(context, media); // Remove partially downloaded file
+        }
         String tag = WORK_TAG_EPISODE_URL + media.getDownloadUrl();
         Future<List<WorkInfo>> future = WorkManager.getInstance(context).getWorkInfosByTag(tag);
         Observable.fromFuture(future)

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -1150,7 +1150,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                                 && FeedUtil.shouldAutoDeleteItemsOnThatFeed(item.getFeed()));
                 if (shouldAutoDelete && (!item.isTagged(FeedItem.TAG_FAVORITE)
                         || !UserPreferences.shouldFavoriteKeepEpisode())) {
-                    DBWriter.deleteFeedMediaOfItem(PlaybackService.this, media.getId());
+                    DBWriter.deleteFeedMediaOfItem(PlaybackService.this, media);
                     Log.d(TAG, "Episode Deleted");
                 }
                 notifyChildrenChanged(getString(R.string.queue_label));

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APCleanupAlgorithm.java
@@ -66,7 +66,7 @@ public class APCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
         for (FeedItem item : delete) {
             try {
-                DBWriter.deleteFeedMediaOfItem(context, item.getMedia().getId()).get();
+                DBWriter.deleteFeedMediaOfItem(context, item.getMedia()).get();
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/APQueueCleanupAlgorithm.java
@@ -58,7 +58,7 @@ public class APQueueCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
         for (FeedItem item : delete) {
             try {
-                DBWriter.deleteFeedMediaOfItem(context, item.getMedia().getId()).get();
+                DBWriter.deleteFeedMediaOfItem(context, item.getMedia()).get();
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/ExceptFavoriteCleanupAlgorithm.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/ExceptFavoriteCleanupAlgorithm.java
@@ -59,7 +59,7 @@ public class ExceptFavoriteCleanupAlgorithm extends EpisodeCleanupAlgorithm {
 
         for (FeedItem item : delete) {
             try {
-                DBWriter.deleteFeedMediaOfItem(context, item.getMedia().getId()).get();
+                DBWriter.deleteFeedMediaOfItem(context, item.getMedia()).get();
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
@@ -151,7 +151,7 @@ public class DbWriterTest {
         assertTrue(media.getId() != 0);
         assertTrue(item.getId() != 0);
 
-        DBWriter.deleteFeedMediaOfItem(context, media.getId())
+        DBWriter.deleteFeedMediaOfItem(context, media)
                 .get(TIMEOUT, TimeUnit.SECONDS);
         media = DBReader.getFeedMedia(media.getId());
         assertNotNull(media);
@@ -189,9 +189,9 @@ public class DbWriterTest {
         assertTrue(media.getId() != 0);
         assertTrue(item.getId() != 0);
         queue = DBReader.getQueue();
-        assertTrue(queue.size() != 0);
+        assertFalse(queue.isEmpty());
 
-        DBWriter.deleteFeedMediaOfItem(context, media.getId());
+        DBWriter.deleteFeedMediaOfItem(context, media);
         Awaitility.await().timeout(2, TimeUnit.SECONDS).until(() -> !dest.exists());
         media = DBReader.getFeedMedia(media.getId());
         assertNotNull(media);

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -414,6 +414,10 @@ public class FeedMedia implements Playable {
         return itemID;
     }
 
+    public void setItemId(long id) {
+        itemID = id;
+    }
+
     @Override
     public void onPlaybackStart() {
         startPosition = Math.max(position, 0);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -667,6 +667,7 @@ public class PodDBAdapter {
         }
         if (item.getMedia() != null) {
             setMedia(item.getMedia());
+            item.getMedia().setItemId(item.getId());
         }
         if (item.getChapters() != null) {
             setChapters(item);


### PR DESCRIPTION
### Description

Deleting feeds is now about 10 times faster for large databases

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
