### PR TITLE
Speed up feed parsing

### DIFF
--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -171,6 +171,13 @@ public final class DBTasks {
      * This is to work around podcasters breaking their GUIDs.
      */
     private static FeedItem searchFeedItemGuessDuplicate(List<FeedItem> items, FeedItem searchItem) {
+        // First, see if it is a well-behaving feed that contains an item with the same identifier
+        for (FeedItem item : items) {
+            if (FeedItemDuplicateGuesser.sameAndNotEmpty(item.getItemIdentifier(), searchItem.getItemIdentifier())) {
+                return item;
+            }
+        }
+        // Not found yet, start more expensive guessing
         for (FeedItem item : items) {
             if (FeedItemDuplicateGuesser.seemDuplicates(item, searchItem)) {
                 return item;

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/FeedItemDuplicateGuesser.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/FeedItemDuplicateGuesser.java
@@ -31,7 +31,7 @@ public class FeedItemDuplicateGuesser {
                 && mimeTypeLooksSimilar(media1, media2);
     }
 
-    private static boolean sameAndNotEmpty(String string1, String string2) {
+    public static boolean sameAndNotEmpty(String string1, String string2) {
         if (TextUtils.isEmpty(string1) || TextUtils.isEmpty(string2)) {
             return false;
         }

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Itunes.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Itunes.java
@@ -51,12 +51,12 @@ public class Itunes extends Namespace {
         }
 
         String content = state.getContentBuf().toString();
-        String contentFromHtml = HtmlCompat.fromHtml(content, HtmlCompat.FROM_HTML_MODE_COMPACT).toString();
         if (TextUtils.isEmpty(content)) {
             return;
         }
 
         if (AUTHOR.equals(localName) && state.getFeed() != null && state.getTagstack().size() <= 3) {
+            String contentFromHtml = HtmlCompat.fromHtml(content, HtmlCompat.FROM_HTML_MODE_COMPACT).toString();
             state.getFeed().setAuthor(contentFromHtml);
         } else if (DURATION.equals(localName)) {
             try {

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Media.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Media.java
@@ -73,10 +73,12 @@ public class Media extends Namespace {
                     && url != null && validTypeMedia) {
                 long size = 0;
                 String sizeStr = attributes.getValue(SIZE);
-                try {
-                    size = Long.parseLong(sizeStr);
-                } catch (NumberFormatException e) {
-                    Log.e(TAG, "Size \"" + sizeStr + "\" could not be parsed.");
+                if (!TextUtils.isEmpty(sizeStr)) {
+                    try {
+                        size = Long.parseLong(sizeStr);
+                    } catch (NumberFormatException e) {
+                        Log.e(TAG, "Size \"" + sizeStr + "\" could not be parsed.");
+                    }
                 }
 
                 int durationMs = 0;

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Rss20.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Rss20.java
@@ -92,7 +92,6 @@ public class Rss20 extends Namespace {
         } else if (state.getTagstack().size() >= 2 && state.getContentBuf() != null) {
             String contentRaw = state.getContentBuf().toString();
             String content = SyndStringUtils.trimAllWhitespace(contentRaw);
-            String contentFromHtml = HtmlCompat.fromHtml(content, HtmlCompat.FROM_HTML_MODE_COMPACT).toString();
             SyndElement topElement = state.getTagstack().peek();
             String top = topElement.getName();
             SyndElement secondElement = state.getSecondTag();
@@ -108,6 +107,8 @@ public class Rss20 extends Namespace {
                     state.getCurrentItem().setItemIdentifier(contentRaw);
                 }
             } else if (TITLE.equals(top)) {
+                // Calling fromHtml only if needed because it is slow for huge feeds
+                String contentFromHtml = HtmlCompat.fromHtml(content, HtmlCompat.FROM_HTML_MODE_COMPACT).toString();
                 if (ITEM.equals(second) && state.getCurrentItem() != null) {
                     state.getCurrentItem().setTitle(contentFromHtml);
                 } else if (CHANNEL.equals(second) && state.getFeed() != null) {
@@ -128,6 +129,8 @@ public class Rss20 extends Namespace {
                 }
             } else if (DESCR.equals(localName)) {
                 if (CHANNEL.equals(second) && state.getFeed() != null) {
+                    // Calling fromHtml only if needed because it is slow for huge feeds
+                    String contentFromHtml = HtmlCompat.fromHtml(content, HtmlCompat.FROM_HTML_MODE_COMPACT).toString();
                     state.getFeed().setDescription(contentFromHtml);
                 } else if (ITEM.equals(second) && state.getCurrentItem() != null) {
                     state.getCurrentItem().setDescriptionIfLonger(content); // fromHtml here breaks \n when not html


### PR DESCRIPTION
### Description

Speed up feed parsing. AntennaPod is quite slow with huge feeds. The reason is that we have a bunch of workarounds for misbehaving feeds that also make it slower to work with feeds that do not misbehave.

Changes:

- Only start guessing duplicate episodes when no "proper" match is found
- Only parse non-html as HTML for attributes that really need it
- Do not log failed Long parsing when size is not specified
- Try to parse dates with RFC822 first before falling back to workarounds for other formats

I ran a benchmark with "Stuff you should know" (for which the workarounds are not needed) containing 2k episodes. Includes download of 8MB of feed XML (~5 seconds), debug build.
Before: 44 seconds, after: 13 seconds ==> **3.4 times faster feed refresh**

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
