### PR TITLE
Remove methods from DbReader that just call a private method

### DIFF
--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbReaderTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbReaderTest.java
@@ -153,7 +153,8 @@ public class DbReaderTest {
             Feed feed = saveFeedlist(numFeeds, numItems, false).get(0);
             List<FeedItem> items = feed.getItems();
             feed.setItems(null);
-            List<FeedItem> savedItems = DBReader.getFeedItemList(feed);
+            List<FeedItem> savedItems = DBReader.getFeedItemList(feed,
+                    FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD);
             assertNotNull(savedItems);
             assertEquals(items.size(), savedItems.size());
             for (int i = 0; i < savedItems.size(); i++) {

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
@@ -9,6 +9,8 @@ import androidx.core.util.Consumer;
 import androidx.preference.PreferenceManager;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterfaceStub;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -774,7 +776,8 @@ public class DbWriterTest {
         }
 
         DBWriter.removeAllNewFlags().get();
-        List<FeedItem> loadedItems = DBReader.getFeedItemList(feed);
+        List<FeedItem> loadedItems = DBReader.getFeedItemList(feed,
+                FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD);
         for (FeedItem item : loadedItems) {
             assertFalse(item.isNew());
         }

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/feed/local/LocalFeedUpdaterTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/feed/local/LocalFeedUpdaterTest.java
@@ -8,6 +8,8 @@ import android.webkit.MimeTypeMap;
 import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterfaceStub;
@@ -167,7 +169,7 @@ public class LocalFeedUpdaterTest {
         callUpdateFeed(LOCAL_FEED_DIR1);
 
         Feed feed = verifySingleFeedInDatabase();
-        List<FeedItem> feedItems = DBReader.getFeedItemList(feed);
+        List<FeedItem> feedItems = DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD);
         assertEquals("track1.mp3", feedItems.get(0).getTitle());
     }
 
@@ -281,7 +283,7 @@ public class LocalFeedUpdaterTest {
      */
     private static void verifySingleFeedInDatabaseAndItemCount(int expectedItemCount) {
         Feed feed = verifySingleFeedInDatabase();
-        List<FeedItem> feedItems = DBReader.getFeedItemList(feed);
+        List<FeedItem> feedItems = DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD);
         assertEquals(expectedItemCount, feedItems.size());
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -337,7 +337,7 @@ public class DBWriter {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
-            final List<FeedItem> queue = DBReader.getQueue(adapter);
+            final List<FeedItem> queue = DBReader.getQueue();
             FeedItem item;
 
             if (queue != null) {
@@ -412,7 +412,7 @@ public class DBWriter {
 
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
-            final List<FeedItem> queue = DBReader.getQueue(adapter);
+            final List<FeedItem> queue = DBReader.getQueue();
 
             boolean queueModified = false;
             LongList markAsUnplayedIds = new LongList();
@@ -523,7 +523,7 @@ public class DBWriter {
         }
         final PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        final List<FeedItem> queue = DBReader.getQueue(adapter);
+        final List<FeedItem> queue = DBReader.getQueue();
 
         if (queue != null) {
             boolean queueModified = false;
@@ -662,7 +662,7 @@ public class DBWriter {
                                             final int to, final boolean broadcastUpdate) {
         final PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        final List<FeedItem> queue = DBReader.getQueue(adapter);
+        final List<FeedItem> queue = DBReader.getQueue();
 
         if (queue != null) {
             if (from >= 0 && from < queue.size() && to >= 0 && to < queue.size()) {
@@ -948,7 +948,7 @@ public class DBWriter {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
-            final List<FeedItem> queue = DBReader.getQueue(adapter);
+            final List<FeedItem> queue = DBReader.getQueue();
 
             if (queue != null) {
                 permutor.reorder(queue);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriter.java
@@ -8,7 +8,9 @@ import de.danoeh.antennapod.model.download.DownloadError;
 import de.danoeh.antennapod.model.download.DownloadResult;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
+import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.net.sync.model.EpisodeAction;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueueSink;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
@@ -34,7 +36,7 @@ public abstract class FeedDatabaseWriter {
             List<Feed> feeds = DBReader.getFeedList();
             for (Feed f : feeds) {
                 if (f.getIdentifyingValue().equals(feed.getIdentifyingValue())) {
-                    f.setItems(DBReader.getFeedItemList(f));
+                    f.setItems(DBReader.getFeedItemList(f, FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD));
                     return f;
                 }
             }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -954,12 +954,14 @@ public class PodDBAdapter {
      * @param feed The feed you want to get the FeedItems from.
      * @return The cursor of the query
      */
-    public final Cursor getItemsOfFeedCursor(final Feed feed, FeedItemFilter filter) {
+    public final Cursor getItemsOfFeedCursor(final Feed feed, FeedItemFilter filter, SortOrder sortOrder) {
+        String orderByQuery = FeedItemSortQuery.generateFrom(sortOrder);
         String filterQuery = FeedItemFilterQuery.generateFrom(filter);
         String whereClauseAnd = "".equals(filterQuery) ? "" : " AND " + filterQuery;
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
                 + " WHERE " + TABLE_NAME_FEED_ITEMS + "." + KEY_FEED + "=" + feed.getId()
-                + whereClauseAnd;
+                + whereClauseAnd
+                + " ORDER BY " + orderByQuery;
         return db.rawQuery(query, null);
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemSortQuery.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemSortQuery.java
@@ -5,40 +5,30 @@ import de.danoeh.antennapod.storage.database.PodDBAdapter;
 
 public class FeedItemSortQuery {
     public static String generateFrom(SortOrder sortOrder) {
-        String sortQuery = "";
+        if (sortOrder == null) {
+            sortOrder = SortOrder.DATE_NEW_OLD;
+        }
         switch (sortOrder) {
             case EPISODE_TITLE_A_Z:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_TITLE + " " + "ASC";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_TITLE + " " + "ASC";
             case EPISODE_TITLE_Z_A:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_TITLE + " " + "DESC";
-                break;
-            case DATE_OLD_NEW:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_PUBDATE + " " + "ASC";
-                break;
-            case DATE_NEW_OLD:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_PUBDATE + " " + "DESC";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_TITLE + " " + "DESC";
             case DURATION_SHORT_LONG:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DURATION + " " + "ASC";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DURATION + " " + "ASC";
             case DURATION_LONG_SHORT:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DURATION + " " + "DESC";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DURATION + " " + "DESC";
             case SIZE_SMALL_LARGE:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_SIZE + " " + "ASC";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_SIZE + " " + "ASC";
             case SIZE_LARGE_SMALL:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_SIZE + " " + "DESC";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_SIZE + " " + "DESC";
             case COMPLETION_DATE_NEW_OLD:
-                sortQuery = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "."
+                return PodDBAdapter.TABLE_NAME_FEED_MEDIA + "."
                         + PodDBAdapter.KEY_PLAYBACK_COMPLETION_DATE + " " + "DESC";
-                break;
+            case DATE_OLD_NEW:
+                return PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_PUBDATE + " " + "ASC";
+            case DATE_NEW_OLD:
             default:
-                sortQuery = "";
-                break;
+                return PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_PUBDATE + " " + "DESC";
         }
-        return sortQuery;
     }
 }


### PR DESCRIPTION
### Description

Remove unneeded methods from DbReader that just relay to a private method

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
