### PR TITLE
Small database efficiency tweaks

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
@@ -19,6 +19,7 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.ui.echo.EchoConfig;
 import de.danoeh.antennapod.ui.screen.home.sections.AllowNotificationsSection;
@@ -44,7 +45,6 @@ import de.danoeh.antennapod.databinding.HomeFragmentBinding;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
-import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.view.LiftOnScrollListener;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -193,14 +193,12 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
         if (disposable != null) {
             disposable.dispose();
         }
-        disposable = Observable.fromCallable(() ->
-                        DBReader.getNavDrawerData(UserPreferences.getSubscriptionsFilter(),
-                                UserPreferences.getFeedOrder(), UserPreferences.getFeedCounterSetting()).items.size())
+        disposable = Observable.fromCallable(() -> DBReader.getTotalEpisodeCount(FeedItemFilter.unfiltered()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(numSubscriptions -> {
-                    viewBinding.welcomeContainer.setVisibility(numSubscriptions == 0 ? View.VISIBLE : View.GONE);
-                    viewBinding.homeContainer.setVisibility(numSubscriptions == 0 ? View.GONE : View.VISIBLE);
+                .subscribe(numEpisodes -> {
+                    viewBinding.welcomeContainer.setVisibility(numEpisodes == 0 ? View.VISIBLE : View.GONE);
+                    viewBinding.homeContainer.setVisibility(numEpisodes == 0 ? View.GONE : View.VISIBLE);
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -124,14 +124,11 @@ public class DownloadsSection extends HomeSection {
             disposable.dispose();
         }
         SortOrder sortOrder = UserPreferences.getDownloadsSortedOrder();
-        disposable = Observable.fromCallable(() -> DBReader.getEpisodes(0, Integer.MAX_VALUE,
+        disposable = Observable.fromCallable(() -> DBReader.getEpisodes(0, NUM_EPISODES,
                         new FeedItemFilter(FeedItemFilter.DOWNLOADED), sortOrder))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(downloads -> {
-                    if (downloads.size() > NUM_EPISODES) {
-                        downloads = downloads.subList(0, NUM_EPISODES);
-                    }
                     items = downloads;
                     adapter.setDummyViews(0);
                     adapter.updateItems(items);

--- a/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
+++ b/core/src/test/java/de/danoeh/antennapod/core/storage/DbWriterTest.java
@@ -244,7 +244,7 @@ public class DbWriterTest {
             c = adapter.getFeedItemCursor(String.valueOf(item.getId()));
             assertEquals(0, c.getCount());
             c.close();
-            c = adapter.getSingleFeedMediaCursor(item.getMedia().getId());
+            c = adapter.getFeedItemFromMediaIdCursor(item.getMedia().getId());
             assertEquals(0, c.getCount());
             c.close();
         }
@@ -368,7 +368,7 @@ public class DbWriterTest {
             c = adapter.getFeedItemCursor(String.valueOf(item.getId()));
             assertEquals(0, c.getCount());
             c.close();
-            c = adapter.getSingleFeedMediaCursor(item.getMedia().getId());
+            c = adapter.getFeedItemFromMediaIdCursor(item.getMedia().getId());
             assertEquals(0, c.getCount());
             c.close();
         }
@@ -420,7 +420,7 @@ public class DbWriterTest {
             c = adapter.getFeedItemCursor(String.valueOf(item.getId()));
             assertEquals(0, c.getCount());
             c.close();
-            c = adapter.getSingleFeedMediaCursor(item.getMedia().getId());
+            c = adapter.getFeedItemFromMediaIdCursor(item.getMedia().getId());
             assertEquals(0, c.getCount());
             c.close();
         }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1041,14 +1041,9 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getFavoritesIdsCursor(int offset, int limit) {
-        // Way faster than selecting all columns
-        final String query = "SELECT " + TABLE_NAME_FEED_ITEMS + "." + KEY_ID
-                + " FROM " + TABLE_NAME_FEED_ITEMS
-                + " INNER JOIN " + TABLE_NAME_FAVORITES
-                + " ON " + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + " = " + TABLE_NAME_FAVORITES + "." + KEY_FEEDITEM
-                + " ORDER BY " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " DESC"
-                + " LIMIT " + offset + ", " + limit;
+    public final Cursor getFavoritesIdsCursor() {
+        final String query = "SELECT " + TABLE_NAME_FAVORITES + "." + KEY_FEEDITEM
+                + " FROM " + TABLE_NAME_FAVORITES;
         return db.rawQuery(query, null);
     }
 
@@ -1107,9 +1102,9 @@ public class PodDBAdapter {
         return "((" + SELECT_KEY_ITEM_ID + " * " + seed + ") % 46471)";
     }
 
-    public final Cursor getSingleFeedMediaCursor(long id) {
-        final String query = "SELECT " + KEYS_FEED_MEDIA + " FROM " + TABLE_NAME_FEED_MEDIA
-                + " WHERE " + KEY_ID + "=" + id;
+    public final Cursor getFeedItemFromMediaIdCursor(long mediaId) {
+        final String query = SELECT_FEED_ITEMS_AND_MEDIA
+                + " WHERE " + SELECT_KEY_MEDIA_ID + " = " + mediaId;
         return db.rawQuery(query, null);
     }
 


### PR DESCRIPTION
### Description

Small database efficiency tweaks

- When checking whether there is a subscription, there is no need to create feed objects (plus counters etc). Just the number of episodes is enough.
- Downloads section only needs to load the items it actually displays.
- No need to load FeedMedia, just to load FeedItem including the same FeedMedia afterwards.
- No need to convert columns to Strings and back to Longs.
- No need to join favorites when we are only interested in the list of IDs anyway.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
