### PR TITLE
Do not crash if an event comes in before the media is loaded

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/chapter/ChaptersFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/chapter/ChaptersFragment.java
@@ -127,7 +127,7 @@ public class ChaptersFragment extends AppCompatDialogFragment {
     }
 
     private int getCurrentChapter(Playable media) {
-        if (controller == null) {
+        if (controller == null || media == null) {
             return -1;
         }
         return Chapter.getAfterPosition(media.getChapters(), controller.getPosition());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
@@ -261,6 +261,9 @@ public class CoverFragment extends Fragment {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PlaybackPositionEvent event) {
+        if (media == null) {
+            return;
+        }
         int newChapterIndex = Chapter.getAfterPosition(media.getChapters(), event.getPosition());
         if (newChapterIndex > -1 && newChapterIndex != displayedChapterIndex) {
             refreshChapterData(newChapterIndex);


### PR DESCRIPTION
### Description

Do not crash if an event comes in before the media is loaded.
Was introduced during the restructuring

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
