### PR TITLE
Don't allow downloading already downloaded episdoes again

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -91,12 +91,14 @@ public class EpisodeMultiSelectActionHandler {
 
     private void downloadChecked(List<FeedItem> items) {
         // download the check episodes in the same order as they are currently displayed
+        int downloaded = 0;
         for (FeedItem episode : items) {
-            if (episode.hasMedia() && !episode.getFeed().isLocalFeed()) {
+            if (episode.hasMedia() && !episode.isDownloaded() && !episode.getFeed().isLocalFeed()) {
                 DownloadServiceInterface.get().download(activity, episode);
+                downloaded++;
             }
         }
-        showMessage(R.plurals.downloading_batch_label, items.size());
+        showMessage(R.plurals.downloading_batch_label, downloaded);
     }
 
     private void deleteChecked(List<FeedItem> items) {

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
@@ -36,6 +36,9 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
     }
 
     public void download(Context context, FeedItem item) {
+        if (item.isDownloaded()) {
+            return;
+        }
         OneTimeWorkRequest.Builder workRequest = getRequest(context, item);
         workRequest.setConstraints(getConstraints());
         WorkManager.getInstance(context).enqueueUniqueWork(item.getMedia().getDownloadUrl(),


### PR DESCRIPTION
### Description

Don't allow downloading already downloaded episdoes again
Closes #6974

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
