### PR TITLE
Optionally display subscriptions as a simple list

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -14,7 +14,6 @@ import android.widget.ProgressBar;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -237,21 +236,20 @@ public class SubscriptionFragment extends Fragment
     private void setColumnNumber(int columns) {
         if (itemDecoration != null) {
             subscriptionRecycler.removeItemDecoration(itemDecoration);
+            itemDecoration = null;
         }
         RecyclerView.LayoutManager layoutManager;
         if (columns == 1 && getDefaultNumOfColumns() == 5) { // Tablet
             layoutManager = new GridLayoutManager(getContext(), 2, RecyclerView.VERTICAL, false);
-            itemDecoration = new DividerItemDecoration(getContext(), RecyclerView.VERTICAL);
         } else if (columns == 1) {
             layoutManager = new GridLayoutManager(getContext(), 1, RecyclerView.VERTICAL, false);
-            itemDecoration = new DividerItemDecoration(getContext(), RecyclerView.VERTICAL);
         } else {
             layoutManager = new GridLayoutManager(getContext(), columns, RecyclerView.VERTICAL, false);
             itemDecoration = new SubscriptionsRecyclerAdapter.GridDividerItemDecorator();
+            subscriptionRecycler.addItemDecoration(itemDecoration);
         }
         subscriptionAdapter.setColumnCount(columns);
         subscriptionRecycler.setLayoutManager(layoutManager);
-        subscriptionRecycler.addItemDecoration(itemDecoration);
         prefs.edit().putInt(PREF_NUM_COLUMNS, columns).apply();
         refreshToolbarState();
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionViewHolder.java
@@ -1,0 +1,106 @@
+package de.danoeh.antennapod.ui.screen.subscriptions;
+
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.cardview.widget.CardView;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.material.elevation.SurfaceColors;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.storage.database.NavDrawerData;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.CoverLoader;
+
+import java.lang.ref.WeakReference;
+import java.text.NumberFormat;
+
+public class SubscriptionViewHolder extends RecyclerView.ViewHolder {
+    public final TextView title;
+    public final ImageView coverImage;
+    public final TextView count;
+    public final TextView fallbackTitle;
+    public final FrameLayout selectView;
+    public final CheckBox selectCheckbox;
+    public final CardView card;
+    public final View errorIcon;
+    public final WeakReference<MainActivity> mainActivityRef;
+
+    public SubscriptionViewHolder(@NonNull View itemView, MainActivity mainActivity) {
+        super(itemView);
+        title = itemView.findViewById(R.id.titleLabel);
+        coverImage = itemView.findViewById(R.id.coverImage);
+        count = itemView.findViewById(R.id.countViewPill);
+        fallbackTitle = itemView.findViewById(R.id.fallbackTitleLabel);
+        selectView = itemView.findViewById(R.id.selectContainer);
+        selectCheckbox = itemView.findViewById(R.id.selectCheckBox);
+        card = itemView.findViewById(R.id.outerContainer);
+        errorIcon = itemView.findViewById(R.id.errorIcon);
+        this.mainActivityRef = new WeakReference<>(mainActivity);
+    }
+
+    public void bind(NavDrawerData.DrawerItem drawerItem, int columnCount) {
+        if (columnCount == 1) {
+            selectView.setBackgroundColor(0xBBFFFFFF);
+        } else {
+            Drawable drawable = AppCompatResources.getDrawable(selectView.getContext(),
+                    R.drawable.ic_checkbox_background);
+            selectView.setBackground(drawable); // Setting this in XML crashes API <= 21
+        }
+        title.setText(drawerItem.getTitle());
+        fallbackTitle.setText(drawerItem.getTitle());
+        coverImage.setContentDescription(drawerItem.getTitle());
+        if (drawerItem.getCounter() > 0) {
+            count.setText(NumberFormat.getInstance().format(drawerItem.getCounter()));
+            count.setVisibility(View.VISIBLE);
+        } else {
+            count.setVisibility(View.GONE);
+        }
+
+        CoverLoader coverLoader = new CoverLoader();
+        boolean textAndImageCombined;
+        if (drawerItem.type == NavDrawerData.DrawerItem.Type.FEED) {
+            Feed feed = ((NavDrawerData.FeedDrawerItem) drawerItem).feed;
+            textAndImageCombined = feed.isLocalFeed() && feed.getImageUrl() != null
+                    && feed.getImageUrl().startsWith(Feed.PREFIX_GENERATIVE_COVER);
+            coverLoader.withUri(feed.getImageUrl());
+            errorIcon.setVisibility(feed.hasLastUpdateFailed() ? View.VISIBLE : View.GONE);
+        } else {
+            textAndImageCombined = true;
+            coverLoader.withResource(R.drawable.ic_tag);
+            errorIcon.setVisibility(View.GONE);
+        }
+        if (UserPreferences.shouldShowSubscriptionTitle() || columnCount == 1) {
+            // No need for fallback title when already showing title
+            fallbackTitle.setVisibility(View.GONE);
+        } else {
+            coverLoader.withPlaceholderView(fallbackTitle, textAndImageCombined);
+        }
+        coverLoader.withCoverView(coverImage);
+        coverLoader.load();
+
+        if (card != null) {
+            float density = mainActivityRef.get().getResources().getDisplayMetrics().density;
+            card.setCardBackgroundColor(SurfaceColors.getColorForElevation(mainActivityRef.get(), 1 * density));
+        }
+
+        int textPadding = columnCount <= 3 ? 16 : 8;
+        title.setPadding(textPadding, textPadding, textPadding, textPadding);
+        fallbackTitle.setPadding(textPadding, textPadding, textPadding, textPadding);
+
+        int textSize = 14;
+        if (columnCount == 3) {
+            textSize = 15;
+        } else if (columnCount == 2) {
+            textSize = 16;
+        }
+        title.setTextSize(textSize);
+        fallbackTitle.setTextSize(textSize);
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionViewHolder.java
@@ -46,9 +46,7 @@ public class SubscriptionViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void bind(NavDrawerData.DrawerItem drawerItem, int columnCount) {
-        if (columnCount == 1) {
-            selectView.setBackgroundColor(0xBBFFFFFF);
-        } else {
+        if (selectView != null) {
             Drawable drawable = AppCompatResources.getDrawable(selectView.getContext(),
                     R.drawable.ic_checkbox_background);
             selectView.setBackground(drawable); // Setting this in XML crashes API <= 21

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
@@ -81,16 +81,21 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
         if (inActionMode()) {
             if (isFeed) {
                 holder.selectCheckbox.setVisibility(View.VISIBLE);
-                holder.selectView.setVisibility(View.VISIBLE);
+            }
+            if (holder.selectView != null) {
+                holder.selectView.setVisibility(isFeed ? View.VISIBLE : View.GONE);
+                holder.coverImage.setAlpha(0.6f);
             }
             holder.selectCheckbox.setChecked((isSelected(position)));
             holder.selectCheckbox.setOnCheckedChangeListener((buttonView, isChecked)
                     -> setSelected(holder.getBindingAdapterPosition(), isChecked));
-            holder.coverImage.setAlpha(0.6f);
             holder.count.setVisibility(View.GONE);
         } else {
-            holder.selectView.setVisibility(View.GONE);
-            holder.coverImage.setAlpha(1.0f);
+            holder.selectCheckbox.setVisibility(View.GONE);
+            if (holder.selectView != null) {
+                holder.selectView.setVisibility(View.GONE);
+                holder.coverImage.setAlpha(1.0f);
+            }
         }
 
         holder.itemView.setOnLongClickListener(v -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.ui.screen.subscriptions;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.view.ContextMenu;
 import android.view.InputDevice;
@@ -13,39 +12,26 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CheckBox;
-import android.widget.FrameLayout;
-import android.widget.ImageView;
-import android.widget.TextView;
-
 import androidx.annotation.NonNull;
-import androidx.appcompat.content.res.AppCompatResources;
-import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
-
-import com.google.android.material.elevation.SurfaceColors;
-import java.lang.ref.WeakReference;
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
-import de.danoeh.antennapod.ui.CoverLoader;
-import de.danoeh.antennapod.ui.SelectableAdapter;
-import de.danoeh.antennapod.storage.preferences.UserPreferences;
-import de.danoeh.antennapod.storage.database.NavDrawerData;
-import de.danoeh.antennapod.ui.screen.feed.FeedItemlistFragment;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.storage.database.NavDrawerData;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.SelectableAdapter;
+import de.danoeh.antennapod.ui.screen.feed.FeedItemlistFragment;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Adapter for subscriptions
  */
-public class SubscriptionsRecyclerAdapter extends SelectableAdapter<SubscriptionsRecyclerAdapter.SubscriptionViewHolder>
+public class SubscriptionsRecyclerAdapter extends SelectableAdapter<SubscriptionViewHolder>
         implements View.OnCreateContextMenuListener {
-    private static final int COVER_WITH_TITLE = 1;
-
     private final WeakReference<MainActivity> mainActivityRef;
     private List<NavDrawerData.DrawerItem> listItems;
     private NavDrawerData.DrawerItem selectedItem = null;
@@ -74,16 +60,23 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
     @NonNull
     @Override
     public SubscriptionViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View itemView = LayoutInflater.from(mainActivityRef.get()).inflate(R.layout.subscription_item, parent, false);
-        itemView.findViewById(R.id.titleLabel).setVisibility(viewType == COVER_WITH_TITLE ? View.VISIBLE : View.GONE);
-        return new SubscriptionViewHolder(itemView);
+        if (viewType == R.id.view_type_subscription_list) {
+            View itemView = LayoutInflater.from(mainActivityRef.get())
+                    .inflate(R.layout.subscription_list_item, parent, false);
+            return new SubscriptionViewHolder(itemView, mainActivityRef.get());
+        }
+        View itemView = LayoutInflater.from(mainActivityRef.get())
+                .inflate(R.layout.subscription_grid_item, parent, false);
+        itemView.findViewById(R.id.titleLabel).setVisibility(
+                viewType == R.id.view_type_subscription_grid_with_title ? View.VISIBLE : View.GONE);
+        return new SubscriptionViewHolder(itemView, mainActivityRef.get());
     }
 
     @Override
     public void onBindViewHolder(@NonNull SubscriptionViewHolder holder, int position) {
         NavDrawerData.DrawerItem drawerItem = listItems.get(position);
         boolean isFeed = drawerItem.type == NavDrawerData.DrawerItem.Type.FEED;
-        holder.bind(drawerItem);
+        holder.bind(drawerItem, columnCount);
         holder.itemView.setOnCreateContextMenuListener(this);
         if (inActionMode()) {
             if (isFeed) {
@@ -206,82 +199,12 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
 
     @Override
     public int getItemViewType(int position) {
-        return UserPreferences.shouldShowSubscriptionTitle() ? COVER_WITH_TITLE : 0;
-    }
-
-    public class SubscriptionViewHolder extends RecyclerView.ViewHolder {
-        private final TextView title;
-        private final ImageView coverImage;
-        private final TextView count;
-        private final TextView fallbackTitle;
-        private final FrameLayout selectView;
-        private final CheckBox selectCheckbox;
-        private final CardView card;
-        private final View errorIcon;
-
-        public SubscriptionViewHolder(@NonNull View itemView) {
-            super(itemView);
-            title = itemView.findViewById(R.id.titleLabel);
-            coverImage = itemView.findViewById(R.id.coverImage);
-            count = itemView.findViewById(R.id.countViewPill);
-            fallbackTitle = itemView.findViewById(R.id.fallbackTitleLabel);
-            selectView = itemView.findViewById(R.id.selectContainer);
-            selectCheckbox = itemView.findViewById(R.id.selectCheckBox);
-            card = itemView.findViewById(R.id.outerContainer);
-            errorIcon = itemView.findViewById(R.id.errorIcon);
-        }
-
-        public void bind(NavDrawerData.DrawerItem drawerItem) {
-            Drawable drawable = AppCompatResources.getDrawable(selectView.getContext(),
-                    R.drawable.ic_checkbox_background);
-            selectView.setBackground(drawable); // Setting this in XML crashes API <= 21
-            title.setText(drawerItem.getTitle());
-            fallbackTitle.setText(drawerItem.getTitle());
-            coverImage.setContentDescription(drawerItem.getTitle());
-            if (drawerItem.getCounter() > 0) {
-                count.setText(NumberFormat.getInstance().format(drawerItem.getCounter()));
-                count.setVisibility(View.VISIBLE);
-            } else {
-                count.setVisibility(View.GONE);
-            }
-
-            CoverLoader coverLoader = new CoverLoader();
-            boolean textAndImageCombined;
-            if (drawerItem.type == NavDrawerData.DrawerItem.Type.FEED) {
-                Feed feed = ((NavDrawerData.FeedDrawerItem) drawerItem).feed;
-                textAndImageCombined = feed.isLocalFeed() && feed.getImageUrl() != null
-                        && feed.getImageUrl().startsWith(Feed.PREFIX_GENERATIVE_COVER);
-                coverLoader.withUri(feed.getImageUrl());
-                errorIcon.setVisibility(feed.hasLastUpdateFailed() ? View.VISIBLE : View.GONE);
-            } else {
-                textAndImageCombined = true;
-                coverLoader.withResource(R.drawable.ic_tag);
-                errorIcon.setVisibility(View.GONE);
-            }
-            if (UserPreferences.shouldShowSubscriptionTitle()) {
-                // No need for fallback title when already showing title
-                fallbackTitle.setVisibility(View.GONE);
-            } else {
-                coverLoader.withPlaceholderView(fallbackTitle, textAndImageCombined);
-            }
-            coverLoader.withCoverView(coverImage);
-            coverLoader.load();
-
-            float density = mainActivityRef.get().getResources().getDisplayMetrics().density;
-            card.setCardBackgroundColor(SurfaceColors.getColorForElevation(mainActivityRef.get(), 1 * density));
-
-            int textPadding = columnCount <= 3 ? 16 : 8;
-            title.setPadding(textPadding, textPadding, textPadding, textPadding);
-            fallbackTitle.setPadding(textPadding, textPadding, textPadding, textPadding);
-
-            int textSize = 14;
-            if (columnCount == 3) {
-                textSize = 15;
-            } else if (columnCount == 2) {
-                textSize = 16;
-            }
-            title.setTextSize(textSize);
-            fallbackTitle.setTextSize(textSize);
+        if (columnCount == 1) {
+            return R.id.view_type_subscription_list;
+        } else if (UserPreferences.shouldShowSubscriptionTitle()) {
+            return R.id.view_type_subscription_grid_with_title;
+        } else {
+            return R.id.view_type_subscription_grid_without_title;
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
@@ -21,6 +21,7 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.storage.database.NavDrawerData;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.SelectableAdapter;
+import de.danoeh.antennapod.ui.common.ThemeUtils;
 import de.danoeh.antennapod.ui.screen.feed.FeedItemlistFragment;
 
 import java.lang.ref.WeakReference;
@@ -79,20 +80,27 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
         holder.bind(drawerItem, columnCount);
         holder.itemView.setOnCreateContextMenuListener(this);
         if (inActionMode()) {
-            if (isFeed) {
-                holder.selectCheckbox.setVisibility(View.VISIBLE);
-            }
             if (holder.selectView != null) {
+                if (isFeed) {
+                    holder.selectCheckbox.setVisibility(View.VISIBLE);
+                }
                 holder.selectView.setVisibility(isFeed ? View.VISIBLE : View.GONE);
                 holder.coverImage.setAlpha(0.6f);
+                holder.selectCheckbox.setChecked((isSelected(position)));
+                holder.selectCheckbox.setOnCheckedChangeListener((buttonView, isChecked)
+                        -> setSelected(holder.getBindingAdapterPosition(), isChecked));
+                holder.count.setVisibility(View.GONE);
+            } else {
+                holder.itemView.setBackgroundResource(android.R.color.transparent);
+                if (isSelected(position)) {
+                    holder.itemView.setBackgroundColor(0x88000000
+                            + (0xffffff & ThemeUtils.getColorFromAttr(mainActivityRef.get(), R.attr.colorAccent)));
+                }
             }
-            holder.selectCheckbox.setChecked((isSelected(position)));
-            holder.selectCheckbox.setOnCheckedChangeListener((buttonView, isChecked)
-                    -> setSelected(holder.getBindingAdapterPosition(), isChecked));
-            holder.count.setVisibility(View.GONE);
         } else {
-            holder.selectCheckbox.setVisibility(View.GONE);
+            holder.itemView.setBackgroundResource(android.R.color.transparent);
             if (holder.selectView != null) {
+                holder.selectCheckbox.setVisibility(View.GONE);
                 holder.selectView.setVisibility(View.GONE);
                 holder.coverImage.setAlpha(1.0f);
             }
@@ -125,7 +133,8 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
         holder.itemView.setOnClickListener(v -> {
             if (isFeed) {
                 if (inActionMode()) {
-                    holder.selectCheckbox.setChecked(!isSelected(holder.getBindingAdapterPosition()));
+                    setSelected(holder.getBindingAdapterPosition(), !isSelected(holder.getBindingAdapterPosition()));
+                    notifyItemChanged(holder.getBindingAdapterPosition());
                 } else {
                     Fragment fragment = FeedItemlistFragment
                             .newInstance(((NavDrawerData.FeedDrawerItem) drawerItem).feed.getId());

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -61,7 +61,7 @@
             android:layout_gravity="center_horizontal"
             android:paddingBottom="88dp"
             tools:itemCount="2"
-            tools:listitem="@layout/subscription_item" />
+            tools:listitem="@layout/subscription_grid_item" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/app/src/main/res/layout/subscription_grid_item.xml
+++ b/app/src/main/res/layout/subscription_grid_item.xml
@@ -26,7 +26,6 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_margin="1px"
                 android:clickable="false"
                 app:cardBackgroundColor="@color/non_square_icon_background"
                 app:cardCornerRadius="12dp"
@@ -34,7 +33,8 @@
 
                 <RelativeLayout
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_margin="1px">
 
                     <de.danoeh.antennapod.ui.common.SquareImageView
                         android:id="@+id/coverImage"

--- a/app/src/main/res/layout/subscription_list_item.xml
+++ b/app/src/main/res/layout/subscription_list_item.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:squareImageView="http://schemas.android.com/apk/de.danoeh.antennapod"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp"
+    android:foreground="?attr/selectableItemBackground"
+    android:orientation="horizontal">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:clickable="false"
+        app:cardBackgroundColor="@color/non_square_icon_background"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp">
+
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="1px">
+
+            <de.danoeh.antennapod.ui.common.SquareImageView
+                android:id="@+id/coverImage"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="fitCenter"
+                android:outlineProvider="background"
+                squareImageView:direction="width"
+                tools:src="@tools:sample/avatars" />
+
+            <TextView
+                android:id="@+id/fallbackTitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignStart="@+id/coverImage"
+                android:layout_alignLeft="@+id/coverImage"
+                android:layout_alignTop="@+id/coverImage"
+                android:layout_alignEnd="@+id/coverImage"
+                android:layout_alignRight="@+id/coverImage"
+                android:layout_alignBottom="@+id/coverImage"
+                android:background="@color/feed_text_bg"
+                android:gravity="center"
+                android:ellipsize="end"
+                android:padding="6dp"
+                android:textColor="#fff"
+                tools:text="@sample/episodes.json/data/title" />
+
+            <FrameLayout
+                android:id="@+id/selectContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clickable="false">
+
+                <CheckBox
+                    android:id="@+id/selectCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:minWidth="0dp"
+                    android:minHeight="0dp"
+                    android:layout_margin="8dp" />
+
+            </FrameLayout>
+
+        </RelativeLayout>
+
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/titleLabel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:gravity="start"
+        android:maxLines="2"
+        android:importantForAccessibility="no"
+        style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
+        tools:text="@sample/episodes.json/data/title" />
+
+    <TextView
+        android:id="@+id/countViewPill"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="8dp"
+        android:text="3"
+        android:textColor="?android:attr/textColorTertiary"
+        android:textSize="14sp" />
+
+    <ImageView
+        android:id="@+id/errorIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_margin="8dp"
+        android:visibility="gone"
+        android:layout_gravity="center_vertical"
+        android:contentDescription="@string/refresh_failed_msg"
+        app:srcCompat="@drawable/ic_error"
+        tools:visibility="visible" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/subscription_list_item.xml
+++ b/app/src/main/res/layout/subscription_list_item.xml
@@ -50,23 +50,6 @@
                 android:textColor="#fff"
                 tools:text="@sample/episodes.json/data/title" />
 
-            <FrameLayout
-                android:id="@+id/selectContainer"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clickable="false">
-
-                <CheckBox
-                    android:id="@+id/selectCheckBox"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:layout_margin="8dp" />
-
-            </FrameLayout>
-
         </RelativeLayout>
 
     </androidx.cardview.widget.CardView>
@@ -75,8 +58,7 @@
         android:id="@+id/titleLabel"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
+        android:layout_marginHorizontal="8dp"
         android:layout_gravity="center_vertical"
         android:layout_weight="1"
         android:ellipsize="end"
@@ -91,7 +73,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginStart="8dp"
         android:text="3"
         android:textColor="?android:attr/textColorTertiary"
         android:textSize="14sp" />
@@ -106,5 +87,12 @@
         android:contentDescription="@string/refresh_failed_msg"
         app:srcCompat="@drawable/ic_error"
         tools:visibility="visible" />
+
+    <CheckBox
+        android:id="@+id/selectCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_gravity="center_vertical" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/subscription_list_item.xml
+++ b/app/src/main/res/layout/subscription_list_item.xml
@@ -88,11 +88,4 @@
         app:srcCompat="@drawable/ic_error"
         tools:visibility="visible" />
 
-    <CheckBox
-        android:id="@+id/selectCheckBox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:layout_gravity="center_vertical" />
-
 </LinearLayout>

--- a/app/src/main/res/menu/subscriptions.xml
+++ b/app/src/main/res/menu/subscriptions.xml
@@ -32,6 +32,9 @@
             <group
                     android:checkableBehavior="single">
                 <item
+                        android:id="@+id/subscription_display_list"
+                        android:title="@string/subscription_display_list"/>
+                <item
                         android:id="@+id/subscription_num_columns_2"
                         android:title="2"/>
                 <item

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -14,4 +14,7 @@
 
     <!-- View types -->
     <item name="view_type_episode_item" type="id"/>
+    <item name="view_type_subscription_grid_with_title" type="id"/>
+    <item name="view_type_subscription_grid_without_title" type="id"/>
+    <item name="view_type_subscription_list" type="id"/>
 </resources>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -823,6 +823,7 @@
 
     <!-- Subscriptions fragment -->
     <string name="subscription_num_columns">Number of columns</string>
+    <string name="subscription_display_list">List</string>
 
     <!-- Notification channels -->
     <string name="notification_group_errors">Errors</string>


### PR DESCRIPTION
### Description

Optionally display subscriptions as a simple list. I was mainly thinking of giving a fallback for the navigation drawer when we switch to bottom navigation. However, I quite like the list myself now because it is very clean.

<img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/9ac39164-0685-42c8-83fe-1d838d0b3a5f" />

Users requesting this on the forum:
https://forum.antennapod.org/t/how-to-change-subscription-view-into-list/2189
https://forum.antennapod.org/t/text-only-view-for-subscriptions/1991
https://forum.antennapod.org/t/display-subscriptions-as-list-in-addition-to-tiles/2723

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
