### PR TITLE
Fix detection of local-only refresh

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -68,6 +68,7 @@ public class FeedUpdateWorker extends Worker {
                 Feed feed = itr.next();
                 if (!feed.getPreferences().getKeepUpdated()) {
                     itr.remove();
+                    continue;
                 }
                 if (!feed.isLocalFeed()) {
                     allAreLocal = false;


### PR DESCRIPTION
### Description

Fix detection of local-only refresh. In the rare case that you have updates disabled for all feeds except local folders, AntennaPod would require a mobile data connection even though it doesn't actually need mobile data.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
