### PR TITLE
Store download date in database

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -138,7 +138,8 @@ public class PlaybackServiceMediaPlayerTest {
         f.setItems(new ArrayList<>());
         FeedItem i = new FeedItem(0, "t", "i", "l", new Date(), FeedItem.UNPLAYED, f);
         f.getItems().add(i);
-        FeedMedia media = new FeedMedia(0, i, 0, 0, 0, "audio/wav", fileUrl, downloadUrl, fileUrl != null, null, 0, 0);
+        FeedMedia media = new FeedMedia(0, i, 0, 0, 0, "audio/wav", fileUrl, downloadUrl,
+                fileUrl == null ? 0 : System.currentTimeMillis(), null, 0, 0);
         i.setMedia(media);
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -134,7 +134,8 @@ public class UITestUtils {
 
                 if (!hostTextOnlyFeeds) {
                     File mediaFile = newMediaFile("feed-" + i + "-episode-" + j + ".mp3");
-                    item.setMedia(new FeedMedia(j, item, 0, 0, mediaFile.length(), "audio/mp3", null, hostFile(mediaFile), false, null, 0, 0));
+                    item.setMedia(new FeedMedia(j, item, 0, 0, mediaFile.length(), "audio/mp3",
+                            null, hostFile(mediaFile), 0, null, 0, 0));
                 }
             }
             feed.setItems(items);
@@ -175,7 +176,7 @@ public class UITestUtils {
                         FeedMedia media = item.getMedia();
                         int fileId = Integer.parseInt(StringUtils.substringAfter(media.getDownloadUrl(), "files/"));
                         media.setLocalFileUrl(server.accessFile(fileId).getAbsolutePath());
-                        media.setDownloaded(true);
+                        media.setDownloaded(true, System.currentTimeMillis());
                     }
                 }
             }

--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/PlayActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/PlayActionButton.java
@@ -42,7 +42,7 @@ public class PlayActionButton extends ItemActionButton {
         }
         if (!media.fileExists()) {
             Log.i(TAG, "Missing episode. Will update the database now.");
-            media.setDownloaded(false);
+            media.setDownloaded(false, 0);
             media.setLocalFileUrl(null);
             DBWriter.setFeedMedia(media);
             EventBus.getDefault().post(FeedItemEvent.updated(media.getItem()));

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -34,7 +34,7 @@ public class FeedMedia implements Playable {
     private long id;
     private String localFileUrl;
     private String downloadUrl;
-    private boolean downloaded;
+    private long downloadDate;
     private int duration;
     private int position; // Current position in file
     private long lastPlayedTime; // Last time this media was played (in ms)
@@ -56,7 +56,7 @@ public class FeedMedia implements Playable {
                      String mimeType) {
         this.localFileUrl = null;
         this.downloadUrl = downloadUrl;
-        this.downloaded = false;
+        this.downloadDate = 0;
         this.item = i;
         this.size = size;
         this.mimeType = mimeType;
@@ -64,11 +64,11 @@ public class FeedMedia implements Playable {
 
     public FeedMedia(long id, FeedItem item, int duration, int position,
                      long size, String mimeType, String localFileUrl, String downloadUrl,
-                     boolean downloaded, Date playbackCompletionDate, int playedDuration,
+                     long downloadDate, Date playbackCompletionDate, int playedDuration,
                      long lastPlayedTime) {
         this.localFileUrl = localFileUrl;
         this.downloadUrl = downloadUrl;
-        this.downloaded = downloaded;
+        this.downloadDate = downloadDate;
         this.id = id;
         this.item = item;
         this.duration = duration;
@@ -84,9 +84,9 @@ public class FeedMedia implements Playable {
 
     public FeedMedia(long id, FeedItem item, int duration, int position,
                      long size, String mimeType, String localFileUrl, String downloadUrl,
-                     boolean downloaded, Date playbackCompletionDate, int playedDuration,
+                     long downloadDate, Date playbackCompletionDate, int playedDuration,
                      Boolean hasEmbeddedPicture, long lastPlayedTime) {
-        this(id, item, duration, position, size, mimeType, localFileUrl, downloadUrl, downloaded,
+        this(id, item, duration, position, size, mimeType, localFileUrl, downloadUrl, downloadDate,
                 playbackCompletionDate, playedDuration, lastPlayedTime);
         this.hasEmbeddedPicture = hasEmbeddedPicture;
     }
@@ -293,7 +293,7 @@ public class FeedMedia implements Playable {
         dest.writeString(mimeType);
         dest.writeString(localFileUrl);
         dest.writeString(downloadUrl);
-        dest.writeByte((byte) ((downloaded) ? 1 : 0));
+        dest.writeLong(downloadDate);
         dest.writeLong((playbackCompletionDate != null) ? playbackCompletionDate.getTime() : 0);
         dest.writeInt(playedDuration);
         dest.writeLong(lastPlayedTime);
@@ -393,7 +393,7 @@ public class FeedMedia implements Playable {
     }
 
     public boolean isDownloaded() {
-        return downloaded;
+        return downloadDate > 0;
     }
 
     public long getItemId() {
@@ -441,7 +441,7 @@ public class FeedMedia implements Playable {
             final long id = in.readLong();
             final long itemID = in.readLong();
             FeedMedia result = new FeedMedia(id, null, in.readInt(), in.readInt(), in.readLong(), in.readString(), in.readString(),
-                    in.readString(), in.readByte() != 0, new Date(in.readLong()), in.readInt(), in.readLong());
+                    in.readString(), in.readLong(), new Date(in.readLong()), in.readInt(), in.readLong());
             result.itemID = itemID;
             return result;
         }
@@ -466,17 +466,21 @@ public class FeedMedia implements Playable {
         this.hasEmbeddedPicture = hasEmbeddedPicture;
     }
 
-    public void setDownloaded(boolean downloaded) {
-        this.downloaded = downloaded;
+    public void setDownloaded(boolean downloaded, long when) {
+        this.downloadDate = downloaded ? when : 0;
         if (item != null && downloaded && item.isNew()) {
             item.setPlayed(false);
         }
     }
 
+    public long getDownloadDate() {
+        return downloadDate;
+    }
+
     public void setLocalFileUrl(String fileUrl) {
         this.localFileUrl = fileUrl;
         if (fileUrl == null) {
-            downloaded = false;
+            downloadDate = 0;
         }
     }
 

--- a/model/src/test/java/de/danoeh/antennapod/model/feed/FeedMediaTest.java
+++ b/model/src/test/java/de/danoeh/antennapod/model/feed/FeedMediaTest.java
@@ -28,7 +28,7 @@ public class FeedMediaTest {
         when(item.isPlayed()).thenReturn(false);
 
         media.setItem(item);
-        media.setDownloaded(true);
+        media.setDownloaded(true, System.currentTimeMillis());
 
         verify(item, never()).setNew();
         verify(item, never()).setPlayed(true);
@@ -45,7 +45,7 @@ public class FeedMediaTest {
         when(item.isPlayed()).thenReturn(true);
 
         media.setItem(item);
-        media.setDownloaded(true);
+        media.setDownloaded(true, System.currentTimeMillis());
 
         verify(item, never()).setNew();
         verify(item, never()).setPlayed(true);
@@ -62,7 +62,7 @@ public class FeedMediaTest {
         when(item.isPlayed()).thenReturn(false);
 
         media.setItem(item);
-        media.setDownloaded(true);
+        media.setDownloaded(true, System.currentTimeMillis());
 
         verify(item).setPlayed(false);
         verify(item, never()).setNew();

--- a/net/download/service-interface/src/test/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadRequestBuilderTest.java
+++ b/net/download/service-interface/src/test/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadRequestBuilderTest.java
@@ -117,6 +117,6 @@ public class DownloadRequestBuilderTest {
 
     private FeedMedia createFeedItem(final int id) {
         // Use mockito would be less verbose, but it'll take extra 1 second for this tiny test
-        return new FeedMedia(id, null, 0, 0, 0, "", "", "http://example.com/episode" + id, false, null, 0, 0);
+        return new FeedMedia(id, null, 0, 0, 0, "", "", "http://example.com/episode" + id, 0, null, 0, 0);
     }
 }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/MediaDownloadedHandler.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/MediaDownloadedHandler.java
@@ -50,7 +50,7 @@ public class MediaDownloadedHandler implements Runnable {
         }
         // media.setDownloaded modifies played state
         boolean broadcastUnreadStateUpdate = media.getItem() != null && media.getItem().isNew();
-        media.setDownloaded(true);
+        media.setDownloaded(true, System.currentTimeMillis());
         media.setLocalFileUrl(request.getDestination());
         media.setSize(new File(request.getDestination()).length());
         media.checkEmbeddedPicture(); // enforce check

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/local/LocalFeedUpdater.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/local/LocalFeedUpdater.java
@@ -172,7 +172,7 @@ public class LocalFeedUpdater {
 
         long size = file.getLength();
         FeedMedia media = new FeedMedia(0, item, 0, 0, size, file.getType(),
-                file.getUri().toString(), file.getUri().toString(), false, null, 0, 0);
+                file.getUri().toString(), file.getUri().toString(), 0, null, 0, 0);
         item.setMedia(media);
 
         for (FeedItem existingItem : feed.getItems()) {

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbCleanupTests.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbCleanupTests.java
@@ -137,7 +137,7 @@ public class DbCleanupTests {
             assertTrue(f.createNewFile());
             files.add(f);
             item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m",
-                    f.getAbsolutePath(), "url", true, playbackCompletionDate, 0, 0));
+                    f.getAbsolutePath(), "url", System.currentTimeMillis(), playbackCompletionDate, 0, 0));
             items.add(item);
         }
 
@@ -206,7 +206,7 @@ public class DbCleanupTests {
         List<Feed> feeds = saveFeedlist(1, 1, true);
         FeedMedia m = feeds.get(0).getItems().get(0).getMedia();
         //noinspection ConstantConditions
-        m.setDownloaded(true);
+        m.setDownloaded(true, System.currentTimeMillis());
         m.setLocalFileUrl("file");
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbNullCleanupAlgorithmTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbNullCleanupAlgorithmTest.java
@@ -101,7 +101,7 @@ public class DbNullCleanupAlgorithmTest {
             File f = new File(destFolder, "file " + i);
             assertTrue(f.createNewFile());
             files.add(f);
-            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", true,
+            item.setMedia(new FeedMedia(0, item, 1, 0, 1L, "m", f.getAbsolutePath(), "url", System.currentTimeMillis(),
                     new Date(numItems - i), 0, 0));
             items.add(item);
         }

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -231,7 +231,7 @@ public class DbReaderTest {
                 int i = random.nextInt(numItems);
                 if (!downloaded.contains(items.get(i))) {
                     FeedItem item = items.get(i);
-                    item.getMedia().setDownloaded(true);
+                    item.getMedia().setDownloaded(true, System.currentTimeMillis());
                     item.getMedia().setLocalFileUrl("file" + i);
                     downloaded.add(item);
                 }

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbWriterTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbWriterTest.java
@@ -101,7 +101,7 @@ public class DbWriterTest {
         FeedItem item = new FeedItem(0, "Item", "Item", "url", new Date(), FeedItem.PLAYED, feed);
         items.add(item);
         FeedMedia media = new FeedMedia(0, item, duration, 1, 1, "mime_type",
-                "dummy path", "download_url", true, null, 0, 0);
+                "dummy path", "download_url", System.currentTimeMillis(), null, 0, 0);
         item.setMedia(media);
 
         DBWriter.setFeedItem(item).get(TIMEOUT, TimeUnit.SECONDS);
@@ -133,7 +133,7 @@ public class DbWriterTest {
         FeedItem item = new FeedItem(0, "Item", "Item", "url", new Date(), FeedItem.PLAYED, feed);
 
         FeedMedia media = new FeedMedia(0, item, 1, 1, 1, "mime_type",
-                dest.getAbsolutePath(), "download_url", true, null, 0, 0);
+                dest.getAbsolutePath(), "download_url", System.currentTimeMillis(), null, 0, 0);
         item.setMedia(media);
 
         items.add(item);
@@ -168,7 +168,7 @@ public class DbWriterTest {
         FeedItem item = new FeedItem(0, "Item", "Item", "url", new Date(), FeedItem.UNPLAYED, feed);
 
         FeedMedia media = new FeedMedia(0, item, 1, 1, 1, "mime_type",
-                dest.getAbsolutePath(), "download_url", true, null, 0, 0);
+                dest.getAbsolutePath(), "download_url", System.currentTimeMillis(), null, 0, 0);
         item.setMedia(media);
 
         items.add(item);
@@ -214,7 +214,7 @@ public class DbWriterTest {
 
             itemFiles.add(enc);
             FeedMedia media = new FeedMedia(0, item, 1, 1, 1, "mime_type",
-                    enc.getAbsolutePath(), "download_url", true, null, 0, 0);
+                    enc.getAbsolutePath(), "download_url", System.currentTimeMillis(), null, 0, 0);
             item.setMedia(media);
         }
 
@@ -335,7 +335,7 @@ public class DbWriterTest {
             feed.getItems().add(item);
             File enc = new File(destFolder, "file " + i);
             FeedMedia media = new FeedMedia(0, item, 1, 1, 1, "mime_type",
-                    enc.getAbsolutePath(), "download_url", false, null, 0, 0);
+                    enc.getAbsolutePath(), "download_url", 0, null, 0, 0);
             item.setMedia(media);
         }
 
@@ -395,7 +395,7 @@ public class DbWriterTest {
             feed.getItems().add(item);
             File enc = new File(destFolder, "file " + i);
             FeedMedia media = new FeedMedia(0, item, 1, 1, 1, "mime_type",
-                    enc.getAbsolutePath(), "download_url", false, null, 0, 0);
+                    enc.getAbsolutePath(), "download_url", 0, null, 0, 0);
             item.setMedia(media);
         }
 
@@ -469,7 +469,7 @@ public class DbWriterTest {
         feed.setItems(new ArrayList<>());
         FeedItem item = new FeedItem(0, "title", "id", "link", new Date(), FeedItem.PLAYED, feed);
         FeedMedia media = new FeedMedia(0, item, 10, 0, 1, "mime", null,
-                "url", false, playbackCompletionDate, 0, 0);
+                "url", 0, playbackCompletionDate, 0, 0);
         feed.getItems().add(item);
         item.setMedia(media);
         PodDBAdapter adapter = PodDBAdapter.getInstance();

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -146,10 +146,10 @@ class DBUpgrader {
                     + " ADD COLUMN " + PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE + " INTEGER DEFAULT -1");
             db.execSQL("UPDATE " + PodDBAdapter.TABLE_NAME_FEED_MEDIA
                     + " SET " + PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE + "=0"
-                    + " WHERE " + PodDBAdapter.KEY_DOWNLOADED + "=0");
+                    + " WHERE " + PodDBAdapter.KEY_DOWNLOAD_DATE + "=0");
             Cursor c = db.rawQuery("SELECT " + PodDBAdapter.KEY_FILE_URL
                     + " FROM " + PodDBAdapter.TABLE_NAME_FEED_MEDIA
-                    + " WHERE " + PodDBAdapter.KEY_DOWNLOADED + "=1 "
+                    + " WHERE " + PodDBAdapter.KEY_DOWNLOAD_DATE + "=1 "
                     + " AND " + PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE + "=-1", null);
             if (c.moveToFirst()) {
                 MediaMetadataRetriever mmr = new MediaMetadataRetriever();
@@ -185,7 +185,7 @@ class DBUpgrader {
                     + PodDBAdapter.TABLE_NAME_QUEUE + "." + PodDBAdapter.KEY_FEEDITEM
                     + " WHERE "
                     + PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_READ + " = 0 AND " // unplayed
-                    + PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DOWNLOADED + " = 0 AND " // undownloaded
+                    + PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DOWNLOAD_DATE + " = 0 AND " // undownloaded
                     + PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_POSITION + " = 0 AND " // not partially played
                     + PodDBAdapter.TABLE_NAME_QUEUE + "." + PodDBAdapter.KEY_ID + " IS NULL"; // not in queue
             String sql = "UPDATE " + PodDBAdapter.TABLE_NAME_FEED_ITEMS

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -123,7 +123,7 @@ public class DBWriter {
             if (mediaFile.exists() && !mediaFile.delete()) {
                 Log.d(TAG, "Deletion of downloaded file failed.");
             }
-            media.setDownloaded(false);
+            media.setDownloaded(false, 0);
             media.setLocalFileUrl(null);
             media.setHasEmbeddedPicture(false);
             PodDBAdapter adapter = PodDBAdapter.getInstance();

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -76,7 +76,7 @@ public class PodDBAdapter {
     public static final String KEY_IMAGE_URL = "image_url";
     public static final String KEY_FEED = "feed";
     public static final String KEY_MEDIA = "media";
-    public static final String KEY_DOWNLOADED = "downloaded";
+    public static final String KEY_DOWNLOAD_DATE = "downloaded";
     public static final String KEY_LAST_REFRESH_ATTEMPT = "downloaded";
     public static final String KEY_LASTUPDATE = "last_update";
     public static final String KEY_FEEDFILE = "feedfile";
@@ -187,7 +187,7 @@ public class PodDBAdapter {
     private static final String CREATE_TABLE_FEED_MEDIA = "CREATE TABLE "
             + TABLE_NAME_FEED_MEDIA + " (" + TABLE_PRIMARY_KEY + KEY_DURATION
             + " INTEGER," + KEY_FILE_URL + " TEXT," + KEY_DOWNLOAD_URL
-            + " TEXT," + KEY_DOWNLOADED + " INTEGER," + KEY_POSITION
+            + " TEXT," + KEY_DOWNLOAD_DATE + " INTEGER," + KEY_POSITION
             + " INTEGER," + KEY_SIZE + " INTEGER," + KEY_MIME_TYPE + " TEXT,"
             + KEY_PLAYBACK_COMPLETION_DATE + " INTEGER,"
             + KEY_FEEDITEM + " INTEGER,"
@@ -277,7 +277,7 @@ public class PodDBAdapter {
             + TABLE_NAME_FEED_MEDIA + "." + KEY_DURATION + ", "
             + TABLE_NAME_FEED_MEDIA + "." + KEY_FILE_URL + ", "
             + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_URL + ", "
-            + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOADED + ", "
+            + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + ", "
             + TABLE_NAME_FEED_MEDIA + "." + KEY_POSITION + ", "
             + TABLE_NAME_FEED_MEDIA + "." + KEY_SIZE + ", "
             + TABLE_NAME_FEED_MEDIA + "." + KEY_MIME_TYPE + ", "
@@ -504,7 +504,7 @@ public class PodDBAdapter {
         values.put(KEY_SIZE, media.getSize());
         values.put(KEY_MIME_TYPE, media.getMimeType());
         values.put(KEY_DOWNLOAD_URL, media.getDownloadUrl());
-        values.put(KEY_DOWNLOADED, media.isDownloaded());
+        values.put(KEY_DOWNLOAD_DATE, media.getDownloadDate());
         values.put(KEY_FILE_URL, media.getLocalFileUrl());
         values.put(KEY_HAS_EMBEDDED_PICTURE, media.hasEmbeddedPicture());
         values.put(KEY_LAST_PLAYED_TIME, media.getLastPlayedTime());
@@ -1202,9 +1202,9 @@ public class PodDBAdapter {
                         + "IFNULL(SUM(CASE WHEN (" + timeFilter + ")"
                                 + " THEN (" + playedTime + ") ELSE 0 END), 0) AS played_time, "
                         + "IFNULL(SUM(" + TABLE_NAME_FEED_MEDIA + "." + KEY_DURATION + "), 0) AS total_time, "
-                        + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOADED + " > 0"
+                        + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + " > 0"
                                 + " THEN 1 ELSE 0 END) AS num_downloaded, "
-                        + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOADED + " > 0"
+                        + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + " > 0"
                                 + " THEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_SIZE + " ELSE 0 END) AS download_size"
                 + " FROM " + TABLE_NAME_FEED_ITEMS
                 + JOIN_FEED_ITEM_AND_MEDIA
@@ -1251,12 +1251,12 @@ public class PodDBAdapter {
                         + " OR " + KEY_READ + "=" + FeedItem.UNPLAYED + ")";
                 break;
             case SHOW_DOWNLOADED:
-                whereRead = KEY_DOWNLOADED + "=1";
+                whereRead = KEY_DOWNLOAD_DATE + ">0";
                 break;
             case SHOW_DOWNLOADED_UNPLAYED:
                 whereRead = "(" + KEY_READ + "=" + FeedItem.NEW
                         + " OR " + KEY_READ + "=" + FeedItem.UNPLAYED + ")"
-                        + " AND " + KEY_DOWNLOADED + "=1";
+                        + " AND " + KEY_DOWNLOAD_DATE + ">0";
                 break;
             case SHOW_NONE:
                 // deliberate fall-through

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
@@ -23,7 +23,7 @@ public class FeedItemFilterQuery {
         String keyRead = PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_READ;
         String keyPosition = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_POSITION;
         String keyCompletionDate = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_PLAYBACK_COMPLETION_DATE;
-        String keyDownloaded = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DOWNLOADED;
+        String keyDownloaded = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_DOWNLOAD_DATE;
         String keyMediaId = PodDBAdapter.TABLE_NAME_FEED_MEDIA + "." + PodDBAdapter.KEY_ID;
         String keyItemId = PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_ID;
         String keyFeedItem = PodDBAdapter.KEY_FEEDITEM;
@@ -49,7 +49,7 @@ public class FeedItemFilterQuery {
             statements.add(keyItemId + " NOT IN (SELECT " + keyFeedItem + " FROM " + tableQueue + ") ");
         }
         if (filter.showDownloaded) {
-            statements.add(keyDownloaded + " = 1 ");
+            statements.add(keyDownloaded + " > 0 ");
         } else if (filter.showNotDownloaded) {
             statements.add(keyDownloaded + " = 0 ");
         }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedMediaCursor.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedMediaCursor.java
@@ -20,7 +20,7 @@ public class FeedMediaCursor extends CursorWrapper {
     private final int indexMimeType;
     private final int indexFileUrl;
     private final int indexDownloadUrl;
-    private final int indexDownloaded;
+    private final int indexDownloadDate;
     private final int indexPlayedDuration;
     private final int indexLastPlayedTime;
     private final int indexHasEmbeddedPicture;
@@ -35,7 +35,7 @@ public class FeedMediaCursor extends CursorWrapper {
         indexMimeType = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_MIME_TYPE);
         indexFileUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FILE_URL);
         indexDownloadUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_DOWNLOAD_URL);
-        indexDownloaded = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_DOWNLOADED);
+        indexDownloadDate = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_DOWNLOAD_DATE);
         indexPlayedDuration = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PLAYED_DURATION);
         indexLastPlayedTime = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_LAST_PLAYED_TIME);
         indexHasEmbeddedPicture = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_HAS_EMBEDDED_PICTURE);
@@ -71,7 +71,7 @@ public class FeedMediaCursor extends CursorWrapper {
                 getString(indexMimeType),
                 getString(indexFileUrl),
                 getString(indexDownloadUrl),
-                getInt(indexDownloaded) > 0,
+                getLong(indexDownloadDate),
                 playbackCompletionDate,
                 getInt(indexPlayedDuration),
                 hasEmbeddedPicture,

--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedItemPermutorsTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedItemPermutorsTest.java
@@ -1,8 +1,6 @@
 package de.danoeh.antennapod.storage.database;
 
 import de.danoeh.antennapod.model.feed.SortOrder;
-import de.danoeh.antennapod.storage.database.FeedItemPermutors;
-import de.danoeh.antennapod.storage.database.Permutor;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -188,21 +186,24 @@ public class FeedItemPermutorsTest {
         calendar.set(2019, 0, 1);  // January 1st
         Feed feed1 = new Feed(null, null, "Feed title 1");
         FeedItem feedItem1 = new FeedItem(1, "Title 1", null, null, calendar.getTime(), 0, feed1);
-        FeedMedia feedMedia1 = new FeedMedia(0, feedItem1, 1000, 0, 100, null, null, null, true, null, 0, 0);
+        FeedMedia feedMedia1 = new FeedMedia(0, feedItem1, 1000, 0, 100, null, null, null,
+                System.currentTimeMillis(), null, 0, 0);
         feedItem1.setMedia(feedMedia1);
         itemList.add(feedItem1);
 
         calendar.set(2019, 2, 1);  // March 1st
         Feed feed2 = new Feed(null, null, "Feed title 3");
         FeedItem feedItem2 = new FeedItem(3, "Title 3", null, null, calendar.getTime(), 0, feed2);
-        FeedMedia feedMedia2 = new FeedMedia(0, feedItem2, 3000, 0, 300, null, null, null, true, null, 0, 0);
+        FeedMedia feedMedia2 = new FeedMedia(0, feedItem2, 3000, 0, 300, null, null, null,
+                System.currentTimeMillis(), null, 0, 0);
         feedItem2.setMedia(feedMedia2);
         itemList.add(feedItem2);
 
         calendar.set(2019, 1, 1);  // February 1st
         Feed feed3 = new Feed(null, null, "Feed title 2");
         FeedItem feedItem3 = new FeedItem(2, "Title 2", null, null, calendar.getTime(), 0, feed3);
-        FeedMedia feedMedia3 = new FeedMedia(0, feedItem3, 2000, 0, 200, null, null, null, true, null, 0, 0);
+        FeedMedia feedMedia3 = new FeedMedia(0, feedItem3, 2000, 0, 200, null, null, null,
+                System.currentTimeMillis(), null, 0, 0);
         feedItem3.setMedia(feedMedia3);
         itemList.add(feedItem3);
 


### PR DESCRIPTION
### Description

Store download date database. It re-purposes the "is downloaded" column of the database to store a date instead of just 0/1, so it does not need new database columns :)

Prepares for #6716 and for automatic deletion X days after downloading, even if not played.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
