### PR TITLE
Show covers on podcast page

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemViewHolder.java
@@ -43,8 +43,8 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
 
     private final View container;
     public final ImageView dragHandle;
-    private final TextView placeholder;
-    private final ImageView cover;
+    public final TextView placeholder;
+    public final ImageView cover;
     private final TextView title;
     private final TextView pubDate;
     private final TextView position;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -26,6 +26,7 @@ import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.snackbar.Snackbar;
 import com.leinardi.android.speeddial.SpeedDialView;
 
+import de.danoeh.antennapod.ui.CoverLoader;
 import de.danoeh.antennapod.ui.screen.episode.ItemPagerFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.ui.TransitionEffect;
@@ -596,7 +597,18 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
         @Override
         protected void beforeBindViewHolder(EpisodeItemViewHolder holder, int pos) {
-            holder.coverHolder.setVisibility(View.GONE);
+            holder.coverHolder.setVisibility(View.GONE); // Load it ourselves
+        }
+
+        @Override
+        protected void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
+            holder.coverHolder.setVisibility(View.VISIBLE);
+            new CoverLoader()
+                    .withUri(holder.getFeedItem().getImageLocation()) // Ignore "Show episode cover" setting
+                    .withFallbackUri(holder.getFeedItem().getFeed().getImageUrl())
+                    .withPlaceholderView(holder.placeholder)
+                    .withCoverView(holder.cover)
+                    .load();
         }
 
         @Override


### PR DESCRIPTION
### Description

Currently the podcast page is the only page that does not show covers. This makes the read/unread state more visible. Also, it shows the episode covers if the podcast supports that. The screen ignores the "show episode covers in lists" setting and always shows them.

Disadvantage: For podcasts that do not support episode specific covers, it now shows the cover redundantly.

Before / After (podcast not supporting episode specific covers) / After (podcast supporting episode specific covers)
<img width="200" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/fb33c37c-5217-4d0a-a340-d9f688ff85be" /> <img width="200" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/6bf165d5-0258-45f2-a254-c491128a8973" /> <img width="200" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/43f315ee-6d52-4a57-8d8e-29358d6fda0e" />


Closes #7002
Closes #5148

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
