### PR TITLE
Hide info views in multi-select

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/SelectableAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/SelectableAdapter.java
@@ -33,14 +33,9 @@ public abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> exten
             endSelectMode();
         }
 
-        if (onSelectModeListener != null) {
-            onSelectModeListener.onStartSelectMode();
-        }
-
         shouldSelectLazyLoadedItems = false;
         selectedIds.clear();
         selectedIds.add(getItemId(pos));
-        notifyDataSetChanged();
 
         actionMode = activity.startActionMode(new ActionMode.Callback() {
             @Override
@@ -72,14 +67,19 @@ public abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> exten
 
             @Override
             public void onDestroyActionMode(ActionMode mode) {
-                callOnEndSelectMode();
                 actionMode = null;
                 shouldSelectLazyLoadedItems = false;
                 selectedIds.clear();
+                callOnEndSelectMode();
                 notifyDataSetChanged();
             }
         });
         updateTitle();
+
+        if (onSelectModeListener != null) {
+            onSelectModeListener.onStartSelectMode();
+        }
+        notifyDataSetChanged();
     }
 
     /**
@@ -87,8 +87,9 @@ public abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> exten
      */
     public void endSelectMode() {
         if (inActionMode()) {
-            callOnEndSelectMode();
             actionMode.finish();
+            actionMode = null;
+            callOnEndSelectMode();
         }
     }
 
@@ -130,7 +131,7 @@ public abstract class SelectableAdapter<T extends RecyclerView.ViewHolder> exten
         setSelected(pos, !isSelected(pos));
         notifyItemChanged(pos);
 
-        if (selectedIds.size() == 0) {
+        if (selectedIds.isEmpty()) {
             endSelectMode();
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
@@ -113,7 +113,9 @@ public class AllEpisodesFragment extends EpisodesListFragment {
 
     private void updateFilterUi() {
         swipeActions.setFilter(getFilter());
-        if (getFilter().getValues().length > 0) {
+        if (listAdapter.inActionMode()) {
+            txtvInformation.setVisibility(View.INVISIBLE);
+        } else if (getFilter().getValues().length > 0) {
             txtvInformation.setVisibility(View.VISIBLE);
             emptyView.setMessage(R.string.no_all_episodes_filtered_label);
         } else {
@@ -122,6 +124,18 @@ public class AllEpisodesFragment extends EpisodesListFragment {
         }
         toolbar.getMenu().findItem(R.id.action_favorites).setIcon(
                 getFilter().showIsFavorite ? R.drawable.ic_star : R.drawable.ic_star_border);
+    }
+
+    @Override
+    public void onStartSelectMode() {
+        super.onStartSelectMode();
+        updateFilterUi();
+    }
+
+    @Override
+    public void onEndSelectMode() {
+        super.onEndSelectMode();
+        updateFilterUi();
     }
 
     public static class AllEpisodesSortDialog extends ItemSortDialog {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -492,6 +492,14 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             info += Converter.getDurationStringLocalized(getResources(), timeLeft, false);
         }
         infoBar.setText(info);
+
+        if (recyclerAdapter.inActionMode()) {
+            infoBar.setVisibility(View.INVISIBLE);
+        } else if (UserPreferences.getSubscriptionsFilter().isEnabled()) {
+            infoBar.setVisibility(View.VISIBLE);
+        } else {
+            infoBar.setVisibility(View.GONE);
+        }
     }
 
     private void loadItems(final boolean restoreScrollPosition) {
@@ -522,15 +530,15 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         swipeActions.detach();
         speedDialView.setVisibility(View.VISIBLE);
         refreshToolbarState();
-        infoBar.setVisibility(View.GONE);
+        refreshInfoBar();
     }
 
     @Override
     public void onEndSelectMode() {
         speedDialView.close();
         speedDialView.setVisibility(View.GONE);
-        infoBar.setVisibility(View.VISIBLE);
         swipeActions.attachTo(recyclerView);
+        refreshInfoBar();
     }
 
     public static class QueueSortDialog extends ItemSortDialog {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -301,7 +301,13 @@ public class SubscriptionFragment extends Fragment
                         Log.e(TAG, Log.getStackTraceString(error));
                     });
 
-        if (UserPreferences.getSubscriptionsFilter().isEnabled()) {
+        updateFilterVisibility();
+    }
+
+    private void updateFilterVisibility() {
+        if (subscriptionAdapter.inActionMode()) {
+            feedsFilteredMsg.setVisibility(View.INVISIBLE);
+        } else if (UserPreferences.getSubscriptionsFilter().isEnabled()) {
             feedsFilteredMsg.setVisibility(View.VISIBLE);
         } else {
             feedsFilteredMsg.setVisibility(View.GONE);
@@ -347,6 +353,7 @@ public class SubscriptionFragment extends Fragment
         speedDialView.setVisibility(View.GONE);
         subscriptionAddButton.setVisibility(View.VISIBLE);
         subscriptionAdapter.setItems(listItems);
+        updateFilterVisibility();
     }
 
     @Override
@@ -360,5 +367,6 @@ public class SubscriptionFragment extends Fragment
         subscriptionAdapter.setItems(feedsOnly);
         speedDialView.setVisibility(View.VISIBLE);
         subscriptionAddButton.setVisibility(View.GONE);
+        updateFilterVisibility();
     }
 }


### PR DESCRIPTION
### Description

Still not perfect because the toolbar is visible behind the action menu. However, it fixes the jumping when entering multi-select mode.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
