### PR TITLE
Move auto-delete settings

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/FeedSettingsTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/FeedSettingsTest.java
@@ -70,7 +70,7 @@ public class FeedSettingsTest {
         clickPreference(R.string.pref_feed_skip);
         onView(withText(R.string.cancel_label)).perform(click());
 
-        clickPreference(R.string.auto_delete_label);
+        clickPreference(R.string.pref_auto_delete_playback_title);
         onView(withText(R.string.cancel_label)).perform(click());
 
         clickPreference(R.string.feed_volume_adapdation);

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -175,10 +175,10 @@ public class PreferencesTest {
         clickPreference(R.string.downloads_pref);
         onView(withText(R.string.pref_auto_delete_title)).perform(click());
         final boolean autoDelete = UserPreferences.isAutoDelete();
-        onView(withText(R.string.pref_auto_delete_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_playback_title)).perform(click());
         Awaitility.await().atMost(1000, MILLISECONDS)
                 .until(() -> autoDelete != UserPreferences.isAutoDelete());
-        onView(withText(R.string.pref_auto_delete_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_playback_title)).perform(click());
         Awaitility.await().atMost(1000, MILLISECONDS)
                 .until(() -> autoDelete == UserPreferences.isAutoDelete());
     }
@@ -187,7 +187,7 @@ public class PreferencesTest {
     public void testAutoDeleteLocal() {
         clickPreference(R.string.downloads_pref);
         onView(withText(R.string.pref_auto_delete_title)).perform(click());
-        onView(withText(R.string.pref_auto_delete_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_playback_title)).perform(click());
         assertTrue(UserPreferences.isAutoDelete());
         assertFalse(UserPreferences.isAutoDeleteLocal());
 

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -173,6 +173,7 @@ public class PreferencesTest {
     @Test
     public void testAutoDelete() {
         clickPreference(R.string.downloads_pref);
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
         final boolean autoDelete = UserPreferences.isAutoDelete();
         onView(withText(R.string.pref_auto_delete_title)).perform(click());
         Awaitility.await().atMost(1000, MILLISECONDS)
@@ -185,8 +186,10 @@ public class PreferencesTest {
     @Test
     public void testAutoDeleteLocal() {
         clickPreference(R.string.downloads_pref);
-        final boolean initialAutoDelete = UserPreferences.isAutoDeleteLocal();
-        assertFalse(initialAutoDelete);
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
+        assertTrue(UserPreferences.isAutoDelete());
+        assertFalse(UserPreferences.isAutoDeleteLocal());
 
         onView(withText(R.string.pref_auto_local_delete_title)).perform(click());
         onView(withText(R.string.yes)).perform(click());
@@ -289,7 +292,7 @@ public class PreferencesTest {
     @Test
     public void testEpisodeCleanupFavoriteOnly() {
         clickPreference(R.string.downloads_pref);
-        onView(withText(R.string.pref_automatic_download_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
         onView(withText(R.string.pref_episode_cleanup_title)).perform(click());
         onView(withId(R.id.select_dialog_listview)).perform(swipeDown());
         onView(withText(R.string.episode_cleanup_except_favorite_removal)).perform(click());
@@ -300,7 +303,7 @@ public class PreferencesTest {
     @Test
     public void testEpisodeCleanupQueueOnly() {
         clickPreference(R.string.downloads_pref);
-        onView(withText(R.string.pref_automatic_download_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
         onView(withText(R.string.pref_episode_cleanup_title)).perform(click());
         onView(withId(R.id.select_dialog_listview)).perform(swipeDown());
         onView(withText(R.string.episode_cleanup_queue_removal)).perform(click());
@@ -311,7 +314,7 @@ public class PreferencesTest {
     @Test
     public void testEpisodeCleanupNeverAlg() {
         clickPreference(R.string.downloads_pref);
-        onView(withText(R.string.pref_automatic_download_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
         onView(withText(R.string.pref_episode_cleanup_title)).perform(click());
         onView(withId(R.id.select_dialog_listview)).perform(swipeUp());
         onView(withText(R.string.episode_cleanup_never)).perform(click());
@@ -322,7 +325,7 @@ public class PreferencesTest {
     @Test
     public void testEpisodeCleanupClassic() {
         clickPreference(R.string.downloads_pref);
-        onView(withText(R.string.pref_automatic_download_title)).perform(click());
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
         onView(withText(R.string.pref_episode_cleanup_title)).perform(click());
         onView(withText(R.string.episode_cleanup_after_listening)).perform(click());
         Awaitility.await().atMost(1000, MILLISECONDS)
@@ -339,7 +342,7 @@ public class PreferencesTest {
     @Test
     public void testEpisodeCleanupNumDays() {
         clickPreference(R.string.downloads_pref);
-        clickPreference(R.string.pref_automatic_download_title);
+        onView(withText(R.string.pref_auto_delete_title)).perform(click());
         clickPreference(R.string.pref_episode_cleanup_title);
         String search = res.getQuantityString(R.plurals.episode_cleanup_days_after_listening, 3, 3);
         onView(withText(search)).perform(scrollTo());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/AutomaticDeletionPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/AutomaticDeletionPreferencesFragment.java
@@ -1,0 +1,96 @@
+package de.danoeh.antennapod.ui.screen.preferences;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import androidx.preference.ListPreference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.TwoStatePreference;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+
+
+public class AutomaticDeletionPreferencesFragment extends PreferenceFragmentCompat {
+    private static final String PREF_AUTO_DELETE_LOCAL = "prefAutoDeleteLocal";
+    private boolean blockAutoDeleteLocal = true;
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        addPreferencesFromResource(R.xml.preferences_auto_deletion);
+        setupScreen();
+        buildEpisodeCleanupPreference();
+        checkItemVisibility(UserPreferences.isAutoDelete());
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        ((PreferenceActivity) getActivity()).getSupportActionBar().setTitle(R.string.auto_delete_label);
+    }
+
+    private void checkItemVisibility(boolean autoDeleteEnabled) {
+        findPreference(UserPreferences.PREF_FAVORITE_KEEPS_EPISODE).setEnabled(autoDeleteEnabled);
+        findPreference(PREF_AUTO_DELETE_LOCAL).setEnabled(autoDeleteEnabled);
+    }
+
+    private void setupScreen() {
+        if (!UserPreferences.isEnableAutodownload()) {
+            findPreference(UserPreferences.PREF_EPISODE_CLEANUP).setEnabled(false);
+            findPreference(UserPreferences.PREF_EPISODE_CLEANUP).setSummary(R.string.auto_download_disabled_globally);
+        }
+        findPreference(PREF_AUTO_DELETE_LOCAL).setOnPreferenceChangeListener((preference, newValue) -> {
+            if (blockAutoDeleteLocal && newValue == Boolean.TRUE) {
+                showAutoDeleteEnableDialog();
+                return false;
+            } else {
+                return true;
+            }
+        });
+        findPreference(UserPreferences.PREF_AUTO_DELETE).setOnPreferenceChangeListener((preference, newValue) -> {
+            if (newValue instanceof Boolean) {
+                checkItemVisibility((Boolean) newValue);
+            }
+            return true;
+        });
+    }
+
+    private void showAutoDeleteEnableDialog() {
+        new MaterialAlertDialogBuilder(requireContext())
+                .setMessage(R.string.pref_auto_local_delete_dialog_body)
+                .setPositiveButton(R.string.yes, (dialog, which) -> {
+                    blockAutoDeleteLocal = false;
+                    ((TwoStatePreference) findPreference(PREF_AUTO_DELETE_LOCAL)).setChecked(true);
+                    blockAutoDeleteLocal = true;
+                })
+                .setNegativeButton(R.string.cancel_label, null)
+                .show();
+    }
+
+
+    private void buildEpisodeCleanupPreference() {
+        final Resources res = getActivity().getResources();
+
+        ListPreference pref = findPreference(UserPreferences.PREF_EPISODE_CLEANUP);
+        String[] values = res.getStringArray(
+                de.danoeh.antennapod.ui.preferences.R.array.episode_cleanup_values);
+        String[] entries = new String[values.length];
+        for (int x = 0; x < values.length; x++) {
+            int v = Integer.parseInt(values[x]);
+            if (v == UserPreferences.EPISODE_CLEANUP_EXCEPT_FAVORITE) {
+                entries[x] =  res.getString(R.string.episode_cleanup_except_favorite_removal);
+            } else if (v == UserPreferences.EPISODE_CLEANUP_QUEUE) {
+                entries[x] = res.getString(R.string.episode_cleanup_queue_removal);
+            } else if (v == UserPreferences.EPISODE_CLEANUP_NULL) {
+                entries[x] = res.getString(R.string.episode_cleanup_never);
+            } else if (v == 0) {
+                entries[x] = res.getString(R.string.episode_cleanup_after_listening);
+            } else if (v > 0 && v < 24) {
+                entries[x] = res.getQuantityString(R.plurals.episode_cleanup_hours_after_listening, v, v);
+            } else {
+                int numDays = v / 24; // assume underlying value will be NOT fraction of days, e.g., 36 (hours)
+                entries[x] = res.getQuantityString(R.plurals.episode_cleanup_days_after_listening, numDays, numDays);
+            }
+        }
+        pref.setEntries(entries);
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/AutomaticDeletionPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/AutomaticDeletionPreferencesFragment.java
@@ -25,7 +25,7 @@ public class AutomaticDeletionPreferencesFragment extends PreferenceFragmentComp
     @Override
     public void onStart() {
         super.onStart();
-        ((PreferenceActivity) getActivity()).getSupportActionBar().setTitle(R.string.auto_delete_label);
+        ((PreferenceActivity) getActivity()).getSupportActionBar().setTitle(R.string.pref_auto_delete_title);
     }
 
     private void checkItemVisibility(boolean autoDeleteEnabled) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
@@ -2,16 +2,12 @@ package de.danoeh.antennapod.ui.screen.preferences;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
-import androidx.preference.TwoStatePreference;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
-import de.danoeh.antennapod.ui.preferences.screen.downloads.ChooseDataFolderDialog;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.preferences.screen.downloads.ChooseDataFolderDialog;
 
 import java.io.File;
 
@@ -19,11 +15,9 @@ import java.io.File;
 public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
         implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String PREF_SCREEN_AUTODL = "prefAutoDownloadSettings";
-    private static final String PREF_AUTO_DELETE_LOCAL = "prefAutoDeleteLocal";
+    private static final String PREF_SCREEN_AUTO_DELETE = "prefAutoDeleteScreen";
     private static final String PREF_PROXY = "prefProxy";
     private static final String PREF_CHOOSE_DATA_DIR = "prefChooseDataDir";
-
-    private boolean blockAutoDeleteLocal = true;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -55,6 +49,10 @@ public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
             ((PreferenceActivity) getActivity()).openScreen(R.xml.preferences_autodownload);
             return true;
         });
+        findPreference(PREF_SCREEN_AUTO_DELETE).setOnPreferenceClickListener(preference -> {
+            ((PreferenceActivity) getActivity()).openScreen(R.xml.preferences_auto_deletion);
+            return true;
+        });
         // validate and set correct value: number of downloads between 1 and 50 (inclusive)
         findPreference(PREF_PROXY).setOnPreferenceClickListener(preference -> {
             ProxyDialog dialog = new ProxyDialog(getActivity());
@@ -67,14 +65,6 @@ public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
                 setDataFolderText();
             });
             return true;
-        });
-        findPreference(PREF_AUTO_DELETE_LOCAL).setOnPreferenceChangeListener((preference, newValue) -> {
-            if (blockAutoDeleteLocal && newValue == Boolean.TRUE) {
-                showAutoDeleteEnableDialog();
-                return false;
-            } else {
-                return true;
-            }
         });
     }
 
@@ -90,17 +80,5 @@ public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
         if (UserPreferences.PREF_UPDATE_INTERVAL.equals(key)) {
             FeedUpdateManager.getInstance().restartUpdateAlarm(getContext(), true);
         }
-    }
-
-    private void showAutoDeleteEnableDialog() {
-        new MaterialAlertDialogBuilder(requireContext())
-                .setMessage(R.string.pref_auto_local_delete_dialog_body)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
-                    blockAutoDeleteLocal = false;
-                    ((TwoStatePreference) findPreference(PREF_AUTO_DELETE_LOCAL)).setChecked(true);
-                    blockAutoDeleteLocal = true;
-                })
-                .setNegativeButton(R.string.cancel_label, null)
-                .show();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PreferenceActivity.java
@@ -109,7 +109,7 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
         } else if (preferences == R.xml.preferences_swipe) {
             return R.string.swipeactions_label;
         } else if (preferences == R.xml.preferences_auto_deletion) {
-            return R.string.auto_delete_label;
+            return R.string.pref_auto_delete_title;
         }
         return R.string.settings_label;
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PreferenceActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PreferenceActivity.java
@@ -83,6 +83,8 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             prefFragment = new NotificationPreferencesFragment();
         } else if (screen == R.xml.preferences_swipe) {
             prefFragment = new SwipePreferencesFragment();
+        } else if (screen == R.xml.preferences_auto_deletion) {
+            prefFragment = new AutomaticDeletionPreferencesFragment();
         }
         return prefFragment;
     }
@@ -106,6 +108,8 @@ public class PreferenceActivity extends AppCompatActivity implements SearchPrefe
             return R.string.feed_settings_label;
         } else if (preferences == R.xml.preferences_swipe) {
             return R.string.swipeactions_label;
+        } else if (preferences == R.xml.preferences_auto_deletion) {
+            return R.string.auto_delete_label;
         }
         return R.string.settings_label;
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
@@ -96,7 +96,7 @@ public class FeedMultiSelectActionHandler {
 
     private void autoDeleteEpisodesPrefHandler() {
         PreferenceListDialog preferenceListDialog = new PreferenceListDialog(activity,
-                activity.getString(R.string.auto_delete_label));
+                activity.getString(R.string.pref_auto_delete_playback_title));
         String[] items = activity.getResources().getStringArray(R.array.spnAutoDeleteItems);
         preferenceListDialog.openDialog(items);
         preferenceListDialog.setOnPreferenceChangedListener(which -> {

--- a/app/src/main/res/menu/nav_feed_action_speeddial.xml
+++ b/app/src/main/res/menu/nav_feed_action_speeddial.xml
@@ -23,7 +23,7 @@
     <item
         android:id="@+id/autoDeleteDownload"
         android:menuCategory="container"
-        android:title="@string/auto_delete_label"
+        android:title="@string/pref_auto_delete_playback_title"
         android:icon="@drawable/ic_delete_auto"/>
     <item
         android:id="@+id/playback_speed"

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -46,7 +46,7 @@
         android:icon="@drawable/ic_delete"
         android:key="autoDelete"
         android:summary="@string/global_default"
-        android:title="@string/auto_delete_label" />
+        android:title="@string/pref_auto_delete_playback_title" />
 
     <de.danoeh.antennapod.ui.screen.feed.preferences.VolumeAdaptationPreference
         android:defaultValue="off"

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -80,8 +80,8 @@ public abstract class UserPreferences {
     public static final String PREF_HARDWARE_PREVIOUS_BUTTON = "prefHardwarePreviousButton";
     public static final String PREF_FOLLOW_QUEUE = "prefFollowQueue";
     public static final String PREF_SKIP_KEEPS_EPISODE = "prefSkipKeepsEpisode";
-    private static final String PREF_FAVORITE_KEEPS_EPISODE = "prefFavoriteKeepsEpisode";
-    private static final String PREF_AUTO_DELETE = "prefAutoDelete";
+    public static final String PREF_FAVORITE_KEEPS_EPISODE = "prefFavoriteKeepsEpisode";
+    public static final String PREF_AUTO_DELETE = "prefAutoDelete";
     private static final String PREF_AUTO_DELETE_LOCAL = "prefAutoDeleteLocal";
     public static final String PREF_SMART_MARK_AS_PLAYED_SECS = "prefSmartMarkAsPlayedSecs";
     private static final String PREF_PLAYBACK_SPEED_ARRAY = "prefPlaybackSpeedArray";

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -385,7 +385,7 @@
     <string name="preference_search_hint">Search…</string>
     <string name="preference_search_no_results">No results</string>
     <string name="preference_search_clear_history">Clear history</string>
-    <string name="pref_episode_cleanup_title">Episode cleanup</string>
+    <string name="pref_episode_cleanup_title">Delete before auto download</string>
     <string name="pref_episode_cleanup_summary">Episodes that should be eligible for removal if Auto Download needs space for new episodes</string>
     <string name="pref_pauseOnDisconnect_sum">Pause playback when headphones or bluetooth are disconnected</string>
     <string name="pref_unpauseOnHeadsetReconnect_sum">Resume playback when the headphones are reconnected</string>
@@ -455,8 +455,8 @@
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>
     <string name="pref_automatic_download_on_battery_sum">Allow automatic download when the battery is not charging</string>
-    <string name="pref_episode_cache_title">Episode cache</string>
-    <string name="pref_episode_cache_summary">Total number of downloaded episodes cached on the device. Automatic download will be suspended if this number is reached.</string>
+    <string name="pref_episode_cache_title">Episode limit</string>
+    <string name="pref_episode_cache_summary">Automatic download is stopped if this number is reached</string>
     <string name="pref_episode_cover_title">Use episode cover</string>
     <string name="pref_episode_cover_summary">Use the episode specific cover in lists whenever available. If unchecked, the app will always use the podcast cover image.</string>
     <string name="pref_show_remain_time_title">Show remaining time</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -127,7 +127,6 @@
     <string name="close_label">Close</string>
     <string name="retry_label">Retry</string>
     <string name="auto_download_label">Include in auto downloads</string>
-    <string name="auto_delete_label">Auto delete episode</string>
     <string name="feed_volume_adapdation">Volume adaptation</string>
     <string name="feed_volume_adaptation_summary">Turn volume for episodes of this podcast up or down: %1$s</string>
     <string name="feed_volume_reduction_off">No adaption</string>
@@ -399,8 +398,10 @@
     <string name="button_action_skip_episode">Skip episode</string>
     <string name="button_action_restart_episode">Restart episode</string>
     <string name="pref_followQueue_sum">Jump to next queue item when playback completes</string>
-    <string name="pref_auto_delete_sum">Delete episode when playback completes</string>
-    <string name="pref_auto_delete_title">Auto delete</string>
+    <string name="pref_auto_delete_playback_sum">Delete episode when playback completes</string>
+    <string name="pref_auto_delete_playback_title">Delete after playing</string>
+    <string name="pref_auto_delete_title">Automatic deletion</string>
+    <string name="pref_auto_delete_sum">Delete episodes after playing or when automatic download needs space</string>
     <string name="pref_auto_local_delete_title">Auto delete from local folders</string>
     <string name="pref_auto_local_delete_sum">Include local folders in Auto delete functionality</string>
     <string name="pref_auto_local_delete_dialog_body">Note that for local folders this will remove episodes from AntennaPod and delete their media files from your device storage. They cannot be downloaded again through AntennaPod. Enable auto delete?</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
@@ -3,7 +3,6 @@ package de.danoeh.antennapod.ui.preferences.screen;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.content.res.Resources;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
 import android.os.Build;
@@ -11,7 +10,6 @@ import android.os.Bundle;
 import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.CheckBoxPreference;
-import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
@@ -35,7 +33,6 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
         setupAutoDownloadScreen();
         buildAutodownloadSelectedNetworksPreference();
         setSelectedNetworksEnabled(UserPreferences.isEnableAutodownloadWifiFilter());
-        buildEpisodeCleanupPreference();
     }
 
     @Override
@@ -78,7 +75,6 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
         findPreference(UserPreferences.PREF_EPISODE_CACHE_SIZE).setEnabled(autoDownload);
         findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled(autoDownload);
         findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled(autoDownload);
-        findPreference(UserPreferences.PREF_EPISODE_CLEANUP).setEnabled(autoDownload);
         setSelectedNetworksEnabled(autoDownload && UserPreferences.isEnableAutodownloadWifiFilter());
     }
 
@@ -163,33 +159,6 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
                 }
             }
         }
-    }
-
-    private void buildEpisodeCleanupPreference() {
-        final Resources res = getActivity().getResources();
-
-        ListPreference pref = findPreference(UserPreferences.PREF_EPISODE_CLEANUP);
-        String[] values = res.getStringArray(
-                R.array.episode_cleanup_values);
-        String[] entries = new String[values.length];
-        for (int x = 0; x < values.length; x++) {
-            int v = Integer.parseInt(values[x]);
-            if (v == UserPreferences.EPISODE_CLEANUP_EXCEPT_FAVORITE) {
-                entries[x] =  res.getString(R.string.episode_cleanup_except_favorite_removal);
-            } else if (v == UserPreferences.EPISODE_CLEANUP_QUEUE) {
-                entries[x] = res.getString(R.string.episode_cleanup_queue_removal);
-            } else if (v == UserPreferences.EPISODE_CLEANUP_NULL){
-                entries[x] = res.getString(R.string.episode_cleanup_never);
-            } else if (v == 0) {
-                entries[x] = res.getString(R.string.episode_cleanup_after_listening);
-            } else if (v > 0 && v < 24) {
-                entries[x] = res.getQuantityString(R.plurals.episode_cleanup_hours_after_listening, v, v);
-            } else {
-                int numDays = v / 24; // assume underlying value will be NOT fraction of days, e.g., 36 (hours)
-                entries[x] = res.getQuantityString(R.plurals.episode_cleanup_days_after_listening, numDays, numDays);
-            }
-        }
-        pref.setEntries(entries);
     }
 
     private void setSelectedNetworksEnabled(boolean b) {

--- a/ui/preferences/src/main/res/xml/preferences_auto_deletion.xml
+++ b/ui/preferences/src/main/res/xml/preferences_auto_deletion.xml
@@ -6,8 +6,8 @@
         android:defaultValue="false"
         android:enabled="true"
         android:key="prefAutoDelete"
-        android:summary="@string/pref_auto_delete_sum"
-        android:title="@string/pref_auto_delete_title"/>
+        android:summary="@string/pref_auto_delete_playback_sum"
+        android:title="@string/pref_auto_delete_playback_title"/>
     <SwitchPreferenceCompat
         android:defaultValue="false"
         android:enabled="true"

--- a/ui/preferences/src/main/res/xml/preferences_auto_deletion.xml
+++ b/ui/preferences/src/main/res/xml/preferences_auto_deletion.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen
+        xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:enabled="true"
+        android:key="prefAutoDelete"
+        android:summary="@string/pref_auto_delete_sum"
+        android:title="@string/pref_auto_delete_title"/>
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:enabled="true"
+        android:key="prefAutoDeleteLocal"
+        android:summary="@string/pref_auto_local_delete_sum"
+        android:title="@string/pref_auto_local_delete_title"/>
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:enabled="true"
+        android:key="prefFavoriteKeepsEpisode"
+        android:summary="@string/pref_favorite_keeps_episodes_sum"
+        android:title="@string/pref_favorite_keeps_episodes_title"/>
+    <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
+        android:defaultValue="-1"
+        android:entries="@array/episode_cleanup_entries"
+        android:key="prefEpisodeCleanup"
+        android:title="@string/pref_episode_cleanup_title"
+        android:summary="@string/pref_episode_cleanup_summary"
+        android:entryValues="@array/episode_cleanup_values"/>
+
+</PreferenceScreen>

--- a/ui/preferences/src/main/res/xml/preferences_autodownload.xml
+++ b/ui/preferences/src/main/res/xml/preferences_autodownload.xml
@@ -15,13 +15,6 @@
             android:title="@string/pref_episode_cache_title"
             android:summary="@string/pref_episode_cache_summary"
             android:entryValues="@array/episode_cache_size_values"/>
-    <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
-            android:defaultValue="-1"
-            android:entries="@array/episode_cleanup_entries"
-            android:key="prefEpisodeCleanup"
-            android:title="@string/pref_episode_cleanup_title"
-            android:summary="@string/pref_episode_cleanup_summary"
-            android:entryValues="@array/episode_cleanup_values"/>
     <SwitchPreferenceCompat
             android:key="prefEnableAutoDownloadOnBattery"
             android:title="@string/pref_automatic_download_on_battery_title"

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -27,24 +27,10 @@
             android:key="prefAutoDownloadSettings"
             android:title="@string/pref_automatic_download_title"
             search:ignore="true" />
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:enabled="true"
-            android:key="prefAutoDelete"
+        <Preference
+            android:key="prefAutoDeleteScreen"
             android:summary="@string/pref_auto_delete_sum"
             android:title="@string/pref_auto_delete_title"/>
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:enabled="true"
-            android:key="prefAutoDeleteLocal"
-            android:summary="@string/pref_auto_local_delete_sum"
-            android:title="@string/pref_auto_local_delete_title"/>
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:enabled="true"
-            android:key="prefFavoriteKeepsEpisode"
-            android:summary="@string/pref_favorite_keeps_episodes_sum"
-            android:title="@string/pref_favorite_keeps_episodes_title"/>
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:enabled="true"


### PR DESCRIPTION
### Description

Users had a hard time understanding that automatic deletion and episode cleanup are two different things. Maybe that is because in German, both got translated to the exact same string. Now both are next to each other and the titles are updated, so that it hopefully causes less confusion.

ToDo: Make strings a bit more consistent

Closes #4795

<img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/625cfa16-a110-4bea-aedc-5f690028942f" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/391140f1-bffe-4a57-a6a2-d702b3b5a543" /> <img width="250" src="https://github.com/AntennaPod/AntennaPod/assets/5811634/01ed47d5-3130-462d-b0fd-d076bfa7f7b6" />

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
