### PR TITLE
Move 'show subscription title' setting to subscription page

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -189,6 +189,9 @@ public class SubscriptionFragment extends Fragment
     private void refreshToolbarState() {
         int columns = prefs.getInt(PREF_NUM_COLUMNS, getDefaultNumOfColumns());
         toolbar.getMenu().findItem(COLUMN_CHECKBOX_IDS[columns - MIN_NUM_COLUMNS]).setChecked(true);
+        toolbar.getMenu().findItem(R.id.pref_show_subscription_title).setVisible(columns > 1);
+        toolbar.getMenu().findItem(R.id.pref_show_subscription_title)
+                .setChecked(UserPreferences.shouldShowSubscriptionTitle());
     }
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
@@ -229,6 +232,10 @@ public class SubscriptionFragment extends Fragment
         } else if (itemId == R.id.action_statistics) {
             ((MainActivity) getActivity()).loadChildFragment(new StatisticsFragment());
             return true;
+        } else if (itemId == R.id.pref_show_subscription_title) {
+            item.setChecked(!item.isChecked());
+            UserPreferences.setShouldShowSubscriptionTitle(item.isChecked());
+            subscriptionAdapter.notifyDataSetChanged();
         }
         return false;
     }

--- a/app/src/main/res/menu/subscriptions.xml
+++ b/app/src/main/res/menu/subscriptions.xml
@@ -49,4 +49,10 @@
             </group>
         </menu>
     </item>
+
+    <item
+        android:id="@+id/pref_show_subscription_title"
+        android:title="@string/pref_show_subscription_title"
+        android:checkable="true"
+        custom:showAsAction="never" />
 </menu>

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -831,6 +831,10 @@ public abstract class UserPreferences {
         return prefs.getBoolean(PREF_SUBSCRIPTION_TITLE, false);
     }
 
+    public static void setShouldShowSubscriptionTitle(boolean show) {
+        prefs.edit().putBoolean(PREF_SUBSCRIPTION_TITLE, show).apply();
+    }
+
     public static void setAllEpisodesSortOrder(SortOrder s) {
         prefs.edit().putString(PREF_SORT_ALL_EPISODES, "" + s.code).apply();
     }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -525,8 +525,7 @@
     <string name="new_episode_notification_disabled">Notification disabled</string>
     <string name="pref_feed_settings_dialog_msg">This setting is unique to each podcast. You can change it by opening the podcast page.</string>
     <string name="pref_contribute">Contribute</string>
-    <string name="pref_show_subscription_title">Show subscription title</string>
-    <string name="pref_show_subscription_title_summary">Display the subscription title below the cover image</string>
+    <string name="pref_show_subscription_title">Show titles</string>
     <string name="pref_new_episodes_action_title">New episodes action</string>
     <string name="pref_new_episodes_action_sum">Action to take for new episodes</string>
 

--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -49,11 +49,6 @@
             android:title="@string/pref_filter_feed_title"
             android:key="prefSubscriptionsFilter"
             android:summary="@string/pref_filter_feed_sum" />
-        <SwitchPreferenceCompat
-            android:title="@string/pref_show_subscription_title"
-            android:key="prefSubscriptionTitle"
-            android:summary="@string/pref_show_subscription_title_summary"
-            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/external_elements">
         <SwitchPreferenceCompat


### PR DESCRIPTION
### Description

Move 'show subscription title' setting to subscription page. Previously, the setting was buried on the settings page. To see what it actually does, one would need to leave the settings again and go back to the subscriptions page -- just to then navigate to the settings again if one does not like the setting.

Now the setting is directly on the page that it affects.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
