### PR TITLE
Implement missing equals and hashcode methods for feeditem

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/Chapter.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/Chapter.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.model.feed;
 
 import java.util.List;
+import java.util.Objects;
 
 public class Chapter {
     private long id;
@@ -87,5 +88,23 @@ public class Chapter {
             }
         }
         return chapters.size() - 1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Chapter chapter = (Chapter) o;
+        return id == chapter.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
@@ -5,6 +5,8 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -467,5 +469,23 @@ public class Feed {
 
     public boolean isLocalFeed() {
         return downloadUrl.startsWith(PREFIX_LOCAL_FOLDER);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Feed feed = (Feed) o;
+        return id == feed.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -417,5 +418,22 @@ public class FeedItem implements Serializable {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FeedItem feedItem = (FeedItem) o;
+        return id == feedItem.id && feedId == feedItem.feedId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, feedId);
     }
 }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -428,12 +428,13 @@ public class FeedItem implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
         FeedItem feedItem = (FeedItem) o;
-        return id == feedItem.id && feedId == feedItem.feedId;
+        return id == feedItem.id;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, feedId);
+        return Objects.hash(id);
     }
 }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -501,12 +501,21 @@ public class FeedMedia implements Playable {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o == null) {
             return false;
         }
         if (o instanceof RemoteMedia) {
             return o.equals(this);
         }
-        return super.equals(o);
+
+        if (getClass() != o.getClass()) {
+            return false;
+        }
+
+        FeedMedia feedMedia = (FeedMedia) o;
+        return id == feedMedia.id;
     }
 }


### PR DESCRIPTION
### Description
Closes: #7108 

The episodes were never removed from the Queue screen or the queue segment on the homescreen because no `QueueEvent`was emitted.

However, after closer inspection I found that there was already code in `DBWriter` to remove all such items:
https://github.com/AntennaPod/AntennaPod/blob/c56facd141a34d33ef38c0bdbee04a9944de8de7/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java#L197

With more debugging I discovered that the `queue.remove` always returned false and never removed any items even if they were structurally equal. Since `FeedItem` doesn't override equal the two identical items are only equal if they are the same instance which is here never the case and therefore this never finds the matching items in the queue.

By adding the equals method the bug is fixed as the code now works as intended.


**Questions:**
I implemented `equals` by just comparing the feedid and id of the item. This is mostly cause I don't want to cyclic equals where a feeditem defines equals with it's feed and the feed with all the items it holds. However, I am not sure if the assumption is save to make that two `FeedItems` are always equal if those two id's match so maybe someone with more experience can verify that.

Also while we're at it should we implement `equals` for more classes like the `Feed` and `FeedMedia` ?

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
