### PR TITLE
Fix infinite refresh indicator

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
@@ -14,6 +14,7 @@ import androidx.work.OutOfQuotaPolicy;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -90,6 +91,7 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
             runOnce(context, feed);
         } else if (!NetworkUtils.networkAvailable()) {
             EventBus.getDefault().post(new MessageEvent(context.getString(R.string.download_error_no_connection)));
+            EventBus.getDefault().postSticky(new FeedUpdateRunningEvent(false));
         } else if (NetworkUtils.isFeedRefreshAllowed()) {
             runOnce(context, feed);
         } else {
@@ -106,7 +108,9 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
                     UserPreferences.setAllowMobileFeedRefresh(true);
                     runOnce(context, feed);
                 })
-                .setNegativeButton(R.string.no, null);
+                .setNegativeButton(R.string.no, (dialog, which) -> {
+                    EventBus.getDefault().postSticky(new FeedUpdateRunningEvent(false));
+                });
         if (NetworkUtils.isNetworkRestricted() && NetworkUtils.isVpnOverWifi()) {
             builder.setMessage(R.string.confirm_mobile_feed_refresh_dialog_message_vpn);
         } else {


### PR DESCRIPTION


### Description
Closes: #7136

Before when refreshing any feed(s) without network the refresh indicator stayed indefinitely.

This was also the case if you were on mobile, trying to refresh a need and in the popup selected "don't update over mobile".

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests

### Notes
I am not completely sure if this is how the fix should be implemented, maybe there is a cleaner version.