### PR TITLE
Make Media Controls work better after battery eviction

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -305,6 +305,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (mediaPlayer == null) {
             mediaPlayer = new LocalPSMP(this, mediaPlayerCallback); // Cast not supported or not connected
         }
+        if (media == null) { // Media is null here if app is restarted from ACTION_MEDIA_BUTTON
+            media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+        }
         if (media != null) {
             mediaPlayer.playMediaObject(media, !media.localFileAvailable(), wasPlaying, true);
         }


### PR DESCRIPTION
The patch allows to restart AntennaPod after being removed by the battery saver from the Media Control. It doesn't start the media, but restores the interface in Media Control to then to start playing.

### Description

This improves #7134 and issue #6576. It doesn't really fix the underlying issue that AntennaPod is quickly evicted from memory and can't resume playing from Media Controls.

This patch enables that pressing the play button from Media Controls for an evicted AntennaPod will start AntennaPod again and shows the play controls. The user can then press play again to start the podcast.

I hope this is helpful.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
