### PR TITLE
Fix sharp corners on placeholders

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.ui.common.ImagePlaceholder;
 import de.danoeh.antennapod.ui.screen.preferences.PreferenceActivity;
 import de.danoeh.antennapod.ui.screen.AllEpisodesFragment;
 import de.danoeh.antennapod.ui.screen.download.CompletedDownloadsFragment;
@@ -314,13 +315,14 @@ public class NavListAdapter extends RecyclerView.Adapter<NavListAdapter.Holder>
             return;
         }
 
+        float radius = 4 * context.getResources().getDisplayMetrics().density;
         Glide.with(context)
                 .load(feed.getImageUrl())
                 .apply(new RequestOptions()
-                    .placeholder(R.color.light_gray)
-                    .error(R.color.light_gray)
+                    .placeholder(ImagePlaceholder.getDrawable(context, radius))
+                    .error(ImagePlaceholder.getDrawable(context, radius))
                     .transform(new FitCenter(),
-                            new RoundedCorners((int) (4 * context.getResources().getDisplayMetrics().density)))
+                            new RoundedCorners((int) radius))
                     .dontAnimate())
                 .into(holder.image);
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -52,6 +52,7 @@ import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.ui.common.Converter;
 import de.danoeh.antennapod.ui.common.DateFormatter;
 import de.danoeh.antennapod.ui.common.CircularProgressBar;
+import de.danoeh.antennapod.ui.common.ImagePlaceholder;
 import de.danoeh.antennapod.ui.common.ThemeUtils;
 import de.danoeh.antennapod.ui.cleaner.ShownotesCleaner;
 import de.danoeh.antennapod.ui.episodes.ImageResourceUtils;
@@ -286,10 +287,11 @@ public class ItemFragment extends Fragment {
             txtvPublished.setContentDescription(DateFormatter.formatForAccessibility(item.getPubDate()));
         }
 
+        float radius = 8 * getResources().getDisplayMetrics().density;
         RequestOptions options = new RequestOptions()
-                .error(R.color.light_gray)
+                .error(ImagePlaceholder.getDrawable(getContext(), radius))
                 .transform(new FitCenter(),
-                        new RoundedCorners((int) (8 * getResources().getDisplayMetrics().density)))
+                        new RoundedCorners((int) radius))
                 .dontAnimate();
 
         Glide.with(this)

--- a/ui/common/src/main/java/de/danoeh/antennapod/ui/common/ImagePlaceholder.java
+++ b/ui/common/src/main/java/de/danoeh/antennapod/ui/common/ImagePlaceholder.java
@@ -1,0 +1,19 @@
+package de.danoeh.antennapod.ui.common;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+
+import androidx.core.content.ContextCompat;
+
+
+public class ImagePlaceholder {
+    public static Drawable getDrawable(Context context, float cornerRadius) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setShape(GradientDrawable.RECTANGLE);
+        int color = ContextCompat.getColor(context, R.color.light_gray);
+        drawable.setColor(color);
+        drawable.setCornerRadius(cornerRadius);
+        return drawable;
+    }
+}

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/FeedDiscoverAdapter.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/FeedDiscoverAdapter.java
@@ -10,6 +10,7 @@ import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 import de.danoeh.antennapod.net.discovery.PodcastSearchResult;
+import de.danoeh.antennapod.ui.common.ImagePlaceholder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,12 +62,12 @@ public class FeedDiscoverAdapter extends BaseAdapter {
         final PodcastSearchResult podcast = getItem(position);
         holder.imageView.setContentDescription(podcast.title);
 
+        float radius = 8 * context.getResources().getDisplayMetrics().density;
         Glide.with(context)
                 .load(podcast.imageUrl)
                 .apply(new RequestOptions()
-                        .placeholder(R.color.light_gray)
-                        .transform(new FitCenter(), new RoundedCorners((int)
-                                (8 * context.getResources().getDisplayMetrics().density)))
+                        .placeholder(ImagePlaceholder.getDrawable(context, radius))
+                        .transform(new FitCenter(), new RoundedCorners((int) radius))
                         .dontAnimate())
                 .into(holder.imageView);
 

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/OnlineSearchAdapter.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/OnlineSearchAdapter.java
@@ -18,6 +18,7 @@ import com.bumptech.glide.request.RequestOptions;
 import java.util.List;
 
 import de.danoeh.antennapod.net.discovery.PodcastSearchResult;
+import de.danoeh.antennapod.ui.common.ImagePlaceholder;
 
 public class OnlineSearchAdapter extends ArrayAdapter<PodcastSearchResult> {
     /**
@@ -76,14 +77,14 @@ public class OnlineSearchAdapter extends ArrayAdapter<PodcastSearchResult> {
             viewHolder.authorView.setVisibility(View.GONE);
         }
 
-        //Update the empty imageView with the image from the feed
+        float radius = 4 * context.getResources().getDisplayMetrics().density;
         Glide.with(context)
                 .load(podcast.imageUrl)
                 .apply(new RequestOptions()
-                    .placeholder(R.color.light_gray)
+                    .placeholder(ImagePlaceholder.getDrawable(context, radius))
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
                     .transform(new FitCenter(),
-                            new RoundedCorners((int) (4 * context.getResources().getDisplayMetrics().density)))
+                            new RoundedCorners((int) radius))
                     .dontAnimate())
                 .into(viewHolder.coverView);
 

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/SimpleIconListAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/SimpleIconListAdapter.java
@@ -13,6 +13,7 @@ import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 
+import de.danoeh.antennapod.ui.common.ImagePlaceholder;
 import de.danoeh.antennapod.ui.preferences.R;
 
 import java.util.List;
@@ -43,12 +44,13 @@ public class SimpleIconListAdapter<T extends SimpleIconListAdapter.ListItem> ext
         if (item.imageUrl == null) {
             view.findViewById(R.id.icon).setVisibility(View.GONE);
         } else {
+            float radius = 4 * context.getResources().getDisplayMetrics().density;
             Glide.with(context)
                     .load(item.imageUrl)
                     .apply(new RequestOptions()
+                            .placeholder(ImagePlaceholder.getDrawable(context, radius))
                             .diskCacheStrategy(DiskCacheStrategy.NONE)
-                            .transform(new FitCenter(), new RoundedCorners((int)
-                                    (4 * context.getResources().getDisplayMetrics().density)))
+                            .transform(new FitCenter(), new RoundedCorners((int) radius))
                             .dontAnimate())
                     .into(((ImageView) view.findViewById(R.id.icon)));
         }


### PR DESCRIPTION
### Description
All placeholder now have round corners matching the corner radius of the image that will eventually load.

I also added placeholder to the avatars on the contributor screen.

**Screenshots (now/earlier):**
![image](https://github.com/AntennaPod/AntennaPod/assets/21206831/7bd08c41-3b08-4f4b-906f-24b15e03c0d6)


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests

### Notes
I am quite interested in hearing some feedback about my code here. Like, I know that the GradientDrawable I used here seems somewhat questionable since we don't need a gradient. However, I couldn't get ColorDrawable to round the cornors and the ShapeDrawable and PaintDrawable were always transparent :/ 

Also another question, I initially used quite a few type inference assignments with `var x = new SomeClass()`. However, after double checking I discovered that the rest of the codebase isn't written in that style so I removed them again. So I wanted to ask again if there is a special reason why they aren't used and would you be against introducing them?