### PR TITLE
Switch Emulator CI to Ubuntu

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,7 +102,7 @@ jobs:
   emulator-test:
     name: "Emulator Test"
     needs: static-analysis
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       api-level: 30
@@ -124,6 +124,11 @@ jobs:
         run: echo "org.gradle.parallel=true" >> local.properties
       - name: Build with Gradle
         run: ./gradlew assemblePlayDebugAndroidTest
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Android Emulator test
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -133,7 +138,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: zsh .github/workflows/runEmulatorTests.sh
+          script: bash .github/workflows/runEmulatorTests.sh
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/runEmulatorTests.sh
+++ b/.github/workflows/runEmulatorTests.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -o pipefail
 


### PR DESCRIPTION
### Description

Backport of #7140 to the master branch.

GitHub switched their MacOS runners to ARM, which makes the Android emulator fail to start. Since we introduced the CI workflow, GitHub upgraded the Ubuntu runners as well, now supporting hardware acceleration. This means we no longer need MacOS. The Ubuntu runner is also about 2 times faster.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
