### PR TITLE
Fix sometimes not resetting media position

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -728,20 +728,10 @@ public class DBWriter {
      */
     @NonNull
     public static Future<?> markItemPlayed(FeedItem item, int played, boolean resetMediaPosition) {
-        long mediaId = (item.hasMedia()) ? item.getMedia().getId() : 0;
-        return markItemPlayed(item.getId(), played, mediaId, resetMediaPosition);
-    }
-
-    @NonNull
-    private static Future<?> markItemPlayed(final long itemId,
-                                            final int played,
-                                            final long mediaId,
-                                            final boolean resetMediaPosition) {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
-            adapter.setFeedItemRead(played, itemId, mediaId,
-                    resetMediaPosition);
+            adapter.setFeedItemRead(item, played, resetMediaPosition);
             adapter.close();
 
             EventBus.getDefault().post(new UnreadItemsUpdateEvent());

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -684,19 +684,21 @@ public class PodDBAdapter {
         return item.getId();
     }
 
-    public void setFeedItemRead(int played, long itemId, long mediaId,
-                                boolean resetMediaPosition) {
+    public void setFeedItemRead(FeedItem item, int played, boolean resetMediaPosition) {
         try {
             db.beginTransactionNonExclusive();
             ContentValues values = new ContentValues();
 
             values.put(KEY_READ, played);
-            db.update(TABLE_NAME_FEED_ITEMS, values, KEY_ID + "=?", new String[]{String.valueOf(itemId)});
+            db.update(TABLE_NAME_FEED_ITEMS, values, KEY_ID + "=?", new String[]{String.valueOf(item.getId())});
+            item.setPlayed(played == FeedItem.PLAYED);
 
             if (resetMediaPosition) {
                 values.clear();
                 values.put(KEY_POSITION, 0);
-                db.update(TABLE_NAME_FEED_MEDIA, values, KEY_ID + "=?", new String[]{String.valueOf(mediaId)});
+                db.update(TABLE_NAME_FEED_MEDIA, values, KEY_ID + "=?",
+                        new String[]{String.valueOf(item.getMedia().getId())});
+                item.getMedia().setPosition(0);
             }
 
             db.setTransactionSuccessful();


### PR DESCRIPTION
### Description

Before 5218e06904e489f77da4078de775dd0a63b94ef4, deleting an item loaded its state from the database again. Now it stores the state of that object. markItemPlayed() did not reset the object's playback position, so when auto-delete was enabled, the position was overwritten again.

Closes #7092

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
