### PR TITLE
Fix tests creating FeedItems just once because of duplicate IDs

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/TextOnlyFeedsTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/TextOnlyFeedsTest.java
@@ -66,7 +66,7 @@ public class TextOnlyFeedsTest {
         onDrawerItem(withText(feed.getTitle())).perform(click());
         onView(withText(feed.getItemAtIndex(0).getTitle())).perform(click());
         onView(isRoot()).perform(waitForView(withText(R.string.mark_read_no_media_label), 3000));
-        onView(withText(R.string.mark_read_no_media_label)).perform(click());
+        onView(allOf(withText(R.string.mark_read_no_media_label), isDisplayed())).perform(click());
         onView(isRoot()).perform(waitForView(allOf(withText(R.string.mark_read_no_media_label), not(isDisplayed())), 3000));
     }
 

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -128,13 +128,13 @@ public class UITestUtils {
             // create items
             List<FeedItem> items = new ArrayList<>();
             for (int j = 0; j < NUM_ITEMS_PER_FEED; j++) {
-                FeedItem item = new FeedItem(j, "Feed " + (i+1) + ": Item " + (j+1), "item" + j,
+                FeedItem item = new FeedItem(0, "Feed " + (i+1) + ": Item " + (j+1), "item" + j,
                         "http://example.com/feed" + i + "/item/" + j, new Date(), FeedItem.UNPLAYED, feed);
                 items.add(item);
 
                 if (!hostTextOnlyFeeds) {
                     File mediaFile = newMediaFile("feed-" + i + "-episode-" + j + ".mp3");
-                    item.setMedia(new FeedMedia(j, item, 0, 0, mediaFile.length(), "audio/mp3", null, hostFile(mediaFile), false, null, 0, 0));
+                    item.setMedia(new FeedMedia(0, item, 0, 0, mediaFile.length(), "audio/mp3", null, hostFile(mediaFile), false, null, 0, 0));
                 }
             }
             feed.setItems(items);


### PR DESCRIPTION
### Description

Fix tests creating FeedItems just once because of duplicate IDs
No idea why we only see the test failures now... Found them while implementing #7147 but they affect `master` as well

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
