### PR TITLE
Get the app version name from BuildConfig instead of PackageManager for UserAgent

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ClientConfigurator.java
+++ b/app/src/main/java/de/danoeh/antennapod/ClientConfigurator.java
@@ -1,8 +1,6 @@
 package de.danoeh.antennapod;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import de.danoeh.antennapod.net.download.service.episode.autodownload.AutoDownloadManagerImpl;
 import de.danoeh.antennapod.net.download.service.feed.FeedUpdateManagerImpl;
 import de.danoeh.antennapod.net.download.serviceinterface.AutoDownloadManager;
@@ -33,12 +31,7 @@ public class ClientConfigurator {
         if (initialized) {
             return;
         }
-        try {
-            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            UserAgentInterceptor.USER_AGENT = "AntennaPod/" + packageInfo.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
-        }
+        UserAgentInterceptor.USER_AGENT = "AntennaPod/" + BuildConfig.VERSION_NAME;
         PodDBAdapter.init(context);
         UserPreferences.init(context);
         SynchronizationCredentials.init(context);


### PR DESCRIPTION
### Description
ClientConfigurator class is in the app module. It has access to BuildConfig which contains VERSION_NAME. No need to use PackageManager.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
