### PR TITLE
Fix deleting downloaded episode removes from queue

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -171,6 +171,9 @@ public class FeedItem implements Serializable {
 
     public void setId(long id) {
         this.id = id;
+        if (this.media != null) {
+            media.setItemId(id);
+        }
     }
 
     /**

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -58,6 +58,7 @@ public class FeedMedia implements Playable {
         this.downloadUrl = downloadUrl;
         this.downloaded = false;
         this.item = i;
+        this.itemID = i != null ? i.getId() : 0;
         this.size = size;
         this.mimeType = mimeType;
     }
@@ -71,6 +72,7 @@ public class FeedMedia implements Playable {
         this.downloaded = downloaded;
         this.id = id;
         this.item = item;
+        this.itemID = item != null ? item.getId() : 0;
         this.duration = duration;
         this.position = position;
         this.playedDuration = playedDuration;
@@ -251,6 +253,7 @@ public class FeedMedia implements Playable {
      */
     public void setItem(FeedItem item) {
         this.item = item;
+        this.itemID = item != null ? item.getId() : 0;
         if (item != null && item.getMedia() != this) {
             item.setMedia(this);
         }


### PR DESCRIPTION
### Description
Closes: #7150 

The problem was that `FeedMedia.item.id` and `FeedMedia.itemID` were able to get out of sync.

This PR now forces them to stay in sync. However, this begs the question why the `FeedMedia` class even stores the item id itself and not simply calls the item itself?

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
