### PR TITLE
Fix android auto resume on reconnect issues

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -238,8 +238,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         };
         androidAutoConnectionState.observeForever(androidAutoConnectionObserver);
 
-        ContextCompat.registerReceiver(this, autoStateUpdated,
-                new IntentFilter("com.google.android.gms.car.media.STATUS"), ContextCompat.RECEIVER_EXPORTED);
         ContextCompat.registerReceiver(this, shutdownReceiver,
                 new IntentFilter(PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE),
                 ContextCompat.RECEIVER_NOT_EXPORTED);
@@ -324,7 +322,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             mediaSession.release();
             mediaSession = null;
         }
-        unregisterReceiver(autoStateUpdated);
         unregisterReceiver(headsetDisconnected);
         unregisterReceiver(shutdownReceiver);
         unregisterReceiver(bluetoothStateUpdated);
@@ -1488,28 +1485,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             sendBroadcast(i);
         }
     }
-
-    private final BroadcastReceiver autoStateUpdated = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            String status = intent.getStringExtra("media_connection_status");
-            boolean isConnectedToCar = "media_connected".equals(status);
-            Log.d(TAG, "Received Auto Connection update: " + status);
-            if (!isConnectedToCar) {
-                Log.d(TAG, "Car was unplugged during playback.");
-            } else {
-                PlayerStatus playerStatus = mediaPlayer.getPlayerStatus();
-                if (playerStatus == PlayerStatus.PAUSED || playerStatus == PlayerStatus.PREPARED) {
-                    mediaPlayer.resume();
-                } else if (playerStatus == PlayerStatus.PREPARING) {
-                    mediaPlayer.setStartWhenPrepared(!mediaPlayer.isStartWhenPrepared());
-                } else if (playerStatus == PlayerStatus.INITIALIZED) {
-                    mediaPlayer.setStartWhenPrepared(true);
-                    mediaPlayer.prepare();
-                }
-            }
-        }
-    };
 
     /**
      * Pauses playback when the headset is disconnected and the preference is

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -272,11 +272,11 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 PendingIntent.FLAG_UPDATE_CURRENT | (Build.VERSION.SDK_INT >= 31 ? PendingIntent.FLAG_MUTABLE : 0));
 
         mediaSession = new MediaSessionCompat(getApplicationContext(), TAG, eventReceiver, buttonReceiverIntent);
-        setSessionToken(mediaSession.getSessionToken());
         mediaSession.setCallback(sessionCallback);
         mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
         recreateMediaPlayer();
         mediaSession.setActive(true);
+        setSessionToken(mediaSession.getSessionToken());
     }
 
     void recreateMediaPlayer() {
@@ -296,6 +296,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             mediaPlayer.playMediaObject(media, !media.localFileAvailable(), wasPlaying, true);
         }
         isCasting = mediaPlayer.isCasting();
+        updateMediaSession(mediaPlayer.getPlayerStatus());
     }
 
     @Override


### PR DESCRIPTION
Previously this was accomplished by manually subscribing to the Android Auto state. This was prone to failure, since it would only work as long as the service is running.

The correct way of handling this according to Android Auto docs[1] is to provide a valid PlaybackState when the service is bound. We accomplish this here by filling out the media session object whenever the media player is recreated.

Fixes #6698

[1] https://developer.android.com/training/cars/media/#initial-playback-state


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ ] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ ] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
