### PR TITLE
Fix inconsistent icons in the app toolbar.

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -157,7 +157,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         viewBinding.progressBar.setVisibility(View.VISIBLE);
 
         ToolbarIconTintManager iconTintManager = new ToolbarIconTintManager(
-                getContext(), viewBinding.toolbar, viewBinding.collapsingToolbar) {
+                viewBinding.toolbar.getContext(), viewBinding.toolbar, viewBinding.collapsingToolbar) {
             @Override
             protected void doTint(Context themedContext) {
                 viewBinding.toolbar.getMenu().findItem(R.id.refresh_item)

--- a/app/src/main/res/layout/addfeed.xml
+++ b/app/src/main/res/layout/addfeed.xml
@@ -18,7 +18,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
-            android:theme="?attr/actionBarTheme"
             app:title="@string/add_feed_label"
             app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="?homeAsUpIndicator" />

--- a/app/src/main/res/layout/audioplayer_fragment.xml
+++ b/app/src/main/res/layout/audioplayer_fragment.xml
@@ -26,7 +26,6 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:minHeight="?attr/actionBarSize"
-            android:theme="?attr/actionBarTheme"
             app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="@drawable/ic_arrow_down" />
 

--- a/app/src/main/res/layout/download_log_fragment.xml
+++ b/app/src/main/res/layout/download_log_fragment.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="?attr/actionBarTheme"
         android:layout_alignParentTop="true"
         app:title="@string/downloads_log_label" />
 

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -41,7 +41,6 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentTop="true"
                 android:minHeight="?attr/actionBarSize"
-                android:theme="?attr/actionBarTheme"
                 app:layout_collapseMode="pin"
                 app:navigationContentDescription="@string/toolbar_back_button_content_description"
                 app:navigationIcon="?homeAsUpIndicator" />

--- a/app/src/main/res/layout/feeditem_pager_fragment.xml
+++ b/app/src/main/res/layout/feeditem_pager_fragment.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="?attr/actionBarTheme"
         app:navigationContentDescription="@string/toolbar_back_button_content_description"
         app:navigationIcon="?homeAsUpIndicator" />
 

--- a/app/src/main/res/layout/feedsettings.xml
+++ b/app/src/main/res/layout/feedsettings.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="?attr/actionBarTheme"
         android:elevation="4dp"
         app:title="@string/feed_settings_label"
         app:navigationContentDescription="@string/toolbar_back_button_content_description"

--- a/app/src/main/res/layout/feedsettings.xml
+++ b/app/src/main/res/layout/feedsettings.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:elevation="4dp"
         app:title="@string/feed_settings_label"
         app:navigationContentDescription="@string/toolbar_back_button_content_description"
         app:navigationIcon="?homeAsUpIndicator" />

--- a/app/src/main/res/layout/search_fragment.xml
+++ b/app/src/main/res/layout/search_fragment.xml
@@ -17,7 +17,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
-            android:theme="?attr/actionBarTheme"
             app:title="@string/search_label"
             app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="?homeAsUpIndicator" />

--- a/app/src/main/res/layout/subscription_selection_activity.xml
+++ b/app/src/main/res/layout/subscription_selection_activity.xml
@@ -25,7 +25,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="?attr/actionBarSize"
-                android:theme="?attr/actionBarTheme"
                 android:layout_alignParentTop="true" />
 
             <View

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -234,7 +234,8 @@
     </style>
 
     <style name="Theme.AntennaPod.Toolbar" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
-        <item name="action_icon_color">@color/material_on_surface_emphasis_medium</item>
+         <item name="action_icon_color">?attr/colorOnSurface</item>
+        <item name="colorControlNormal">?attr/colorOnSurface</item>
     </style>
 
     <style name="Theme.AntennaPod.VideoPlayer" parent="@style/Theme.AntennaPod.Dark">

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="android:splitMotionEvents">false</item>
         <item name="android:fitsSystemWindows">false</item>
         <item name="android:windowContentTransitions">true</item>
+        <item name="toolbarStyle">@style/Style.AntennaPod.Toolbar</item>
         <item name="preferenceTheme">@style/AppPreferenceThemeOverlay</item>
     </style>
 
@@ -70,6 +71,7 @@
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="android:windowContentTransitions">true</item>
         <item name="android:navigationBarColor">@color/background_darktheme</item>
+        <item name="toolbarStyle">@style/Style.AntennaPod.Toolbar</item>
         <item name="preferenceTheme">@style/AppPreferenceThemeOverlay</item>
     </style>
 
@@ -225,6 +227,14 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/launcher_animate</item>
+    </style>
+
+    <style name="Style.AntennaPod.Toolbar" parent="Widget.Material3.Toolbar">
+        <item name="materialThemeOverlay">@style/Theme.AntennaPod.Toolbar</item>
+    </style>
+
+    <style name="Theme.AntennaPod.Toolbar" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
+        <item name="action_icon_color">@color/material_on_surface_emphasis_medium</item>
     </style>
 
     <style name="Theme.AntennaPod.VideoPlayer" parent="@style/Theme.AntennaPod.Dark">

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -12,7 +12,6 @@
     <style name="Theme.Base.AntennaPod.Dynamic.Light" parent="Theme.Material3.DynamicColors.Light">
         <item name="progressBarTheme">@style/ProgressBarLight</item>
         <item name="background_color">@color/background_light</item>
-        <item name="actionBarStyle">@style/Widget.AntennaPod.ActionBar</item>
         <item name="background_elevated">@color/background_elevated_light</item>
         <item name="action_icon_color">@color/black</item>
         <item name="android:textAllCaps">false</item>
@@ -53,7 +52,6 @@
     <style name="Theme.Base.AntennaPod.Dynamic.Dark" parent="Theme.Material3.DynamicColors.Dark">
         <item name="progressBarTheme">@style/ProgressBarDark</item>
         <item name="background_color">@color/background_darktheme</item>
-        <item name="actionBarStyle">@style/Widget.AntennaPod.ActionBar</item>
         <item name="background_elevated">@color/background_elevated_darktheme</item>
         <item name="action_icon_color">@color/white</item>
         <item name="android:textAllCaps">false</item>
@@ -234,7 +232,7 @@
     </style>
 
     <style name="Theme.AntennaPod.Toolbar" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
-         <item name="action_icon_color">?attr/colorOnSurface</item>
+        <item name="action_icon_color">?attr/colorOnSurface</item>
         <item name="colorControlNormal">?attr/colorOnSurface</item>
     </style>
 
@@ -289,11 +287,6 @@
         <item name="fastScrollHorizontalTrackDrawable">@drawable/scrollbar_track</item>
         <item name="fastScrollVerticalThumbDrawable">?attr/scrollbar_thumb</item>
         <item name="fastScrollVerticalTrackDrawable">@drawable/scrollbar_track</item>
-    </style>
-
-    <style name="Widget.AntennaPod.ActionBar" parent="Widget.Material3.Light.ActionBar.Solid">
-        <item name="background">?android:attr/colorBackground</item>
-        <item name="elevation">0dp</item>
     </style>
 
     <style name="AddPodcastTextView">

--- a/ui/discovery/src/main/res/layout/fragment_online_search.xml
+++ b/ui/discovery/src/main/res/layout/fragment_online_search.xml
@@ -19,7 +19,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
-            android:theme="?attr/actionBarTheme"
             app:title="@string/discover"
             app:navigationContentDescription="@string/toolbar_back_button_content_description"
             app:navigationIcon="?homeAsUpIndicator" />


### PR DESCRIPTION


### Description
**Closes:** #7128
The problem was that the icons have their own color they use (`attr/action_icon_color`) which is fine, except in the toolbar where they should use a different color.

The fix applies a style to all toolbars where in the style only adds a theme for the surface which remaps the `attr/action_icon_color` to the color the other icons in the toolbar use.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
