### PR TITLE
Improve layout for missing chapter images

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/chapter/ChaptersListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/chapter/ChaptersListAdapter.java
@@ -19,6 +19,7 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.model.feed.Chapter;
 import de.danoeh.antennapod.ui.common.Converter;
 import de.danoeh.antennapod.model.feed.EmbeddedChapterImage;
+import de.danoeh.antennapod.ui.common.ImagePlaceholder;
 import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.ui.common.CircularProgressBar;
@@ -99,15 +100,27 @@ public class ChaptersListAdapter extends RecyclerView.Adapter<ChaptersListAdapte
 
         if (hasImages) {
             holder.image.setVisibility(View.VISIBLE);
+
+            float radius = 4 * context.getResources().getDisplayMetrics().density;
+            RequestOptions options = new RequestOptions()
+                    .placeholder(ImagePlaceholder.getDrawable(context, radius))
+                    .dontAnimate()
+                    .transform(new FitCenter(), new RoundedCorners((int) radius));
+
             if (TextUtils.isEmpty(sc.getImageUrl())) {
-                Glide.with(context).clear(holder.image);
+                if (media.getImageLocation() == null) {
+                    Glide.with(context).clear(holder.image);
+                    holder.image.setVisibility(View.GONE);
+                } else {
+                    Glide.with(context)
+                            .load(media.getImageLocation())
+                            .apply(options)
+                            .into(holder.image);
+                }
             } else {
                 Glide.with(context)
                         .load(EmbeddedChapterImage.getModelFor(media, position))
-                        .apply(new RequestOptions()
-                                .dontAnimate()
-                                .transform(new FitCenter(), new RoundedCorners((int)
-                                        (4 * context.getResources().getDisplayMetrics().density))))
+                        .apply(options)
                         .into(holder.image);
             }
         } else {


### PR DESCRIPTION


### Description
If only some chapters have images the other chapters don't display anything but reserve space for the image.

Now those chapters display the image of the episode. If no chapters have images no images will be displayed (just like before).

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests

**Alternative Implementation:**
We could also just remove the reserved space if the chapter has no image. This means that the items wouldn't be aligned but chapters without images would have more space to display information.
This is not my preferred solution but I am happy to hear your feedback.

**Screenshots:**
![image](https://github.com/AntennaPod/AntennaPod/assets/21206831/21e370d3-cee5-45d0-a0a7-5b13034e1a0e)
left: current, 
middle: preferred solution (this PR)
right: alternative implementation
