### PR TITLE
Fix marked played reset position

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/MarkAsPlayedActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/MarkAsPlayedActionButton.java
@@ -30,7 +30,7 @@ public class MarkAsPlayedActionButton extends ItemActionButton {
     @Override
     public void onClick(Context context) {
         if (!item.isPlayed()) {
-            DBWriter.markItemPlayed(item, FeedItem.PLAYED, true);
+            DBWriter.markItemPlayed(FeedItem.PLAYED, item);
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -6,6 +6,7 @@ import androidx.annotation.PluralsRes;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
@@ -67,26 +68,24 @@ public class EpisodeMultiSelectActionHandler {
     }
 
     private void removeFromInboxChecked(List<FeedItem> items) {
-        LongList markUnplayed = new LongList();
+        List<FeedItem> markUnplayed = new ArrayList<>();
         for (FeedItem episode : items) {
             if (episode.isNew()) {
-                markUnplayed.add(episode.getId());
+                markUnplayed.add(episode);
             }
         }
-        DBWriter.markItemPlayed(FeedItem.UNPLAYED, markUnplayed.toArray());
+        DBWriter.markItemPlayed(FeedItem.UNPLAYED, markUnplayed);
         showMessage(R.plurals.removed_from_inbox_batch_label, markUnplayed.size());
     }
 
     private void markedCheckedPlayed(List<FeedItem> items) {
-        long[] checkedIds = getSelectedIds(items);
-        DBWriter.markItemPlayed(FeedItem.PLAYED, checkedIds);
-        showMessage(R.plurals.marked_read_batch_label, checkedIds.length);
+        DBWriter.markItemPlayed(FeedItem.PLAYED, items);
+        showMessage(R.plurals.marked_read_batch_label, items.size());
     }
 
     private void markedCheckedUnplayed(List<FeedItem> items) {
-        long[] checkedIds = getSelectedIds(items);
-        DBWriter.markItemPlayed(FeedItem.UNPLAYED, checkedIds);
-        showMessage(R.plurals.marked_unread_batch_label, checkedIds.length);
+        DBWriter.markItemPlayed(FeedItem.UNPLAYED, items);
+        showMessage(R.plurals.marked_unread_batch_label, items.size());
     }
 
     private void downloadChecked(List<FeedItem> items) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -157,7 +157,7 @@ public class FeedItemMenuHandler {
             removeNewFlagWithUndo(fragment, selectedItem);
         } else if (menuItemId == R.id.mark_read_item) {
             selectedItem.setPlayed(true);
-            DBWriter.markItemPlayed(selectedItem, FeedItem.PLAYED, true);
+            DBWriter.markItemPlayed(FeedItem.PLAYED, selectedItem);
             if (!selectedItem.getFeed().isLocalFeed() && SynchronizationSettings.isProviderConnected()) {
                 FeedMedia media = selectedItem.getMedia();
                 // not all items have media, Gpodder only cares about those that do
@@ -173,7 +173,7 @@ public class FeedItemMenuHandler {
             }
         } else if (menuItemId == R.id.mark_unread_item) {
             selectedItem.setPlayed(false);
-            DBWriter.markItemPlayed(selectedItem, FeedItem.UNPLAYED, false);
+            DBWriter.markItemPlayed(FeedItem.UNPLAYED, selectedItem);
             if (!selectedItem.getFeed().isLocalFeed() && selectedItem.getMedia() != null) {
                 EpisodeAction actionNew = new EpisodeAction.Builder(selectedItem, EpisodeAction.NEW)
                         .currentTimestamp()
@@ -194,7 +194,7 @@ public class FeedItemMenuHandler {
                 PlaybackPreferences.writeNoMediaPlaying();
                 IntentUtils.sendLocalBroadcast(context, PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
             }
-            DBWriter.markItemPlayed(selectedItem, FeedItem.UNPLAYED, true);
+            DBWriter.markItemPlayed(FeedItem.UNPLAYED, selectedItem);
         } else if (menuItemId == R.id.visit_website_item) {
             IntentUtils.openInBrowser(context, selectedItem.getLinkWithFallback());
         } else if (menuItemId == R.id.share_item) {
@@ -224,7 +224,7 @@ public class FeedItemMenuHandler {
         Log.d(TAG, "markReadWithUndo(" + item.getId() + ")");
         // we're marking it as unplayed since the user didn't actually play it
         // but they don't want it considered 'NEW' anymore
-        DBWriter.markItemPlayed(playState, item.getId());
+        DBWriter.markItemPlayed(playState, item);
 
         final Handler h = new Handler(fragment.requireContext().getMainLooper());
         final Runnable r = () -> {
@@ -265,7 +265,7 @@ public class FeedItemMenuHandler {
             ((MainActivity) fragment.getActivity()).showSnackbarAbovePlayer(
                     playStateStringRes, duration)
                     .setAction(fragment.getString(R.string.undo), v -> {
-                        DBWriter.markItemPlayed(item.getPlayState(), item.getId());
+                        DBWriter.markItemPlayed(item.getPlayState(), item);
                         // don't forget to cancel the thing that's going to remove the media
                         h.removeCallbacks(r);
                     });

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1151,7 +1151,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     || autoSkipped
                     || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
                 // only mark the item as played if we're not keeping it anyways
-                DBWriter.markItemPlayed(item, FeedItem.PLAYED, ended || (skipped && almostEnded));
+                DBWriter.markItemPlayed(FeedItem.PLAYED, item);
                 // don't know if it actually matters to not autodownload when smart mark as played is triggered
                 DBWriter.removeQueueItem(PlaybackService.this, ended, item);
                 // Delete episode if enabled

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlayableUtils.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlayableUtils.java
@@ -23,7 +23,7 @@ public abstract class PlayableUtils {
             FeedMedia media = (FeedMedia) playable;
             FeedItem item = media.getItem();
             if (item != null && item.isNew()) {
-                DBWriter.markItemPlayed(FeedItem.UNPLAYED, item.getId());
+                DBWriter.markItemPlayed(FeedItem.UNPLAYED, item);
             }
             if (media.getStartPosition() >= 0 && playable.getPosition() > media.getStartPosition()) {
                 media.setPlayedDuration(media.getPlayedDurationWhenStarted()

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -693,28 +693,12 @@ public class DBWriter {
      * @param itemIds IDs of the FeedItems.
      */
     public static Future<?> markItemPlayed(final int played, final long... itemIds) {
-        return markItemPlayed(played, true, itemIds);
-    }
-
-    /*
-     * Sets the 'read'-attribute of all specified FeedItems
-     *
-     * @param played  New value of the 'read'-attribute, one of FeedItem.PLAYED, FeedItem.NEW,
-     *                FeedItem.UNPLAYED
-     * @param broadcastUpdate true if this operation should trigger a UnreadItemsUpdate broadcast.
-     *        This option is usually set to true
-     * @param itemIds IDs of the FeedItems.
-     */
-    public static Future<?> markItemPlayed(final int played, final boolean broadcastUpdate,
-                                           final long... itemIds) {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
             adapter.setFeedItemRead(played, itemIds);
             adapter.close();
-            if (broadcastUpdate) {
-                EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-            }
+            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
         });
     }
 


### PR DESCRIPTION
### Description
**Closes: #7144**

Remove duplicated marked as played implementation

There were two implementations, one for single items and one for
multiple items. Now we always use the code for multiple items.

I also made API a lot more simpler and the PodDBAdapter now decides if
a the playback position should be reset. Which it will now do if the
we set it to PLAYED but not for NEW or UNPLAYED.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests

### Question for the Reviewer
There is currently a bug in this Implementation. If an episode is currently playing the playback position will be reset but since the player is still running it will reset the position within the next second.
If the playback is currently stopped the playback will be reset but reset to the previous position as soon as the user plays the episode again.

What is the best way to solve that? Cause checking for the currenlty playing item it feels wrong to do in PodDBAdapter and also I get a circular dependency warning if I try to include the Playbackservice.


