### PR TITLE
Add workflows to ping about play reviews

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -1,0 +1,35 @@
+name: Release actions
+
+on:
+  release:
+    types: released
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Tag review replyers in closed issues with 'Needs: Review reply' label"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.issue.number;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              labels: ['Needs: Review reply']
+            });
+
+            if (issues.length > 0) {
+              for (const issue of issues) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: 'This feature or fix is now released! @AntennaPod/review-replyers, time to inform relevant reviews in Google Play console (please see links in one or more of the comments above).'
+                });
+              }
+            } else {
+              console.log('No closed issues with label "Needs: Review reply" found.');
+            }
+            

--- a/.github/workflows/review-link-label.yml
+++ b/.github/workflows/review-link-label.yml
@@ -1,0 +1,15 @@
+name: Label issues with comments containing review links
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  add_label:
+    name: Add label
+    if: ${{ contains(github.event.comment.body, 'https://play.google.com/apps/publish?account=8008695526664634386#ReviewDetailsPlace:p=de.danoeh.antennapod&reviewid=') || contains(github.event.comment.body, 'https://play.google.com/console/u/0/developers/8008695526664634386/app/4974638472012894302/user-feedback/review-details?reviewId=') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 'Needs: Review reply'


### PR DESCRIPTION
### Description
Set up two workflows to:
* Add the 'Needs: Review reply' to an issue in case an added or edited issue comment contains the old or the new links to Play store reviews in the Google Play Console.
* Add a comment tagging an organisation team on an issue when a new release is published if the issue a) is closed (assuming it's been implemented/addressed) and b) has the 'Needs: Review reply' label (assuming that there are links to Google Play reviews which need a reply.

Once replied, the user should remove the label in order to avoid being tagged again.
For this to work, I have also set up the 'review-replyers' team, which when tagged should ping all team members (currently only me).

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ ] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
