### PR TITLE
Make skip silence configurable

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
@@ -243,16 +243,25 @@ public class FeedSettingsFragment extends Fragment {
                     viewBinding.seekBar.setAlpha(isChecked ? 0.4f : 1f);
                     viewBinding.currentSpeedLabel.setAlpha(isChecked ? 0.4f : 1f);
 
-                    viewBinding.skipSilenceFeed.setEnabled(!isChecked);
-                    viewBinding.skipSilenceFeed.setAlpha(isChecked ? 0.4f : 1f);
+                    viewBinding.skipSilence.setEnabled(!isChecked);
+                    viewBinding.skipSilence.setAlpha(isChecked ? 0.4f : 1f);
                 });
                 float speed = feedPreferences.getFeedPlaybackSpeed();
                 FeedPreferences.SkipSilence skipSilence = feedPreferences.getFeedSkipSilence();
                 boolean isGlobal = speed == FeedPreferences.SPEED_USE_GLOBAL;
                 viewBinding.useGlobalCheckbox.setChecked(isGlobal);
                 viewBinding.seekBar.updateSpeed(isGlobal ? 1 : speed);
-                viewBinding.skipSilenceFeed.setChecked(!isGlobal
-                        && skipSilence == FeedPreferences.SkipSilence.AGGRESSIVE);
+                    if (isGlobal) {
+                        viewBinding.skipSilence.clearChecked();
+                    } else {
+                        int id = View.NO_ID;
+                        switch (skipSilence) {
+                            case OFF: id = R.id.skipSilenceOff; break;
+                            case MEDIUM: id = R.id.skipSilenceMedium; break;
+                            case AGGRESSIVE: id = R.id.skipSilenceAggressive; break;
+                        }
+                        viewBinding.skipSilence.check(id);
+                    }
                 new MaterialAlertDialogBuilder(getContext())
                         .setTitle(R.string.playback_speed)
                         .setView(viewBinding.getRoot())
@@ -263,10 +272,12 @@ public class FeedSettingsFragment extends Fragment {
                             FeedPreferences.SkipSilence newSkipSilence;
                             if (viewBinding.useGlobalCheckbox.isChecked()) {
                                 newSkipSilence = FeedPreferences.SkipSilence.GLOBAL;
-                            } else if (viewBinding.skipSilenceFeed.isChecked()) {
-                                newSkipSilence = FeedPreferences.SkipSilence.AGGRESSIVE;
                             } else {
-                                newSkipSilence = FeedPreferences.SkipSilence.OFF;
+                                final int id = viewBinding.skipSilence.getCheckedButtonId();
+                                if (id == R.id.skipSilenceOff) newSkipSilence = FeedPreferences.SkipSilence.OFF;
+                                else if (id == R.id.skipSilenceMedium) newSkipSilence = FeedPreferences.SkipSilence.MEDIUM;
+                                else if (id == R.id.skipSilenceAggressive) newSkipSilence = FeedPreferences.SkipSilence.AGGRESSIVE;
+                                else newSkipSilence = FeedPreferences.SkipSilence.GLOBAL;
                             }
                             feedPreferences.setFeedSkipSilence(newSkipSilence);
                             DBWriter.setFeedPreferences(feedPreferences);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/VariableSpeedDialog.java
@@ -7,16 +7,19 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.view.ItemOffsetDecoration;
@@ -36,7 +39,7 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
     private final List<Float> selectedSpeeds;
     private PlaybackSpeedSeekBar speedSeekBar;
     private Chip addCurrentSpeedChip;
-    private CheckBox skipSilenceCheckbox;
+    private MaterialButtonToggleGroup skipSilenceToggleGroup;
 
     public VariableSpeedDialog() {
         DecimalFormatSymbols format = new DecimalFormatSymbols(Locale.US);
@@ -74,8 +77,28 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
         addCurrentSpeedChip.setText(String.format(Locale.getDefault(), "%1$.2f", event.getNewSpeed()));
     }
 
-    public void updateSkipSilence(boolean skipSilence) {
-        skipSilenceCheckbox.setChecked(skipSilence);
+    public void updateSkipSilence(FeedPreferences.SkipSilence skipSilence) {
+        int id = View.NO_ID;
+        switch (skipSilence) {
+            case OFF: id = R.id.skipSilenceOff; break;
+            case MEDIUM: id = R.id.skipSilenceMedium; break;
+            case AGGRESSIVE: id = R.id.skipSilenceAggressive; break;
+        }
+        skipSilenceToggleGroup.check(id);
+    }
+
+    private void onSkipSilenceChanged(MaterialButtonToggleGroup group, int checkedId, boolean isChecked) {
+        FeedPreferences.SkipSilence opt;
+        final int id = group.getCheckedButtonId();
+        if (id == R.id.skipSilenceOff) opt = FeedPreferences.SkipSilence.OFF;
+        else if (id == R.id.skipSilenceMedium) opt = FeedPreferences.SkipSilence.MEDIUM;
+        else if (id == R.id.skipSilenceAggressive) opt = FeedPreferences.SkipSilence.AGGRESSIVE;
+        else opt = FeedPreferences.SkipSilence.GLOBAL;
+        if (UserPreferences.getSkipSilence() != opt)
+            UserPreferences.setSkipSilence(opt);
+        if (controller != null) {
+            controller.setSkipSilence(opt);
+        }
     }
 
     @Nullable
@@ -104,12 +127,10 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
         addCurrentSpeedChip.setCloseIconContentDescription(getString(R.string.add_preset));
         addCurrentSpeedChip.setOnClickListener(v -> addCurrentSpeed());
 
-        skipSilenceCheckbox = root.findViewById(R.id.skipSilence);
-        skipSilenceCheckbox.setChecked(UserPreferences.isSkipSilence());
-        skipSilenceCheckbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            UserPreferences.setSkipSilence(isChecked);
-            controller.setSkipSilence(isChecked);
-        });
+        skipSilenceToggleGroup = root.findViewById(R.id.skipSilence);
+        skipSilenceToggleGroup.addOnButtonCheckedListener(
+            (group, checkedId, isChecked) -> onSkipSilenceChanged(group, checkedId, isChecked));
+        updateSkipSilence(UserPreferences.getSkipSilence());
         return root;
     }
 

--- a/app/src/main/res/layout/playback_speed_feed_setting_dialog.xml
+++ b/app/src/main/res/layout/playback_speed_feed_setting_dialog.xml
@@ -34,10 +34,38 @@
 
     </LinearLayout>
 
-    <CheckBox
-        android:id="@+id/skipSilenceFeed"
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/skipSilence"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/pref_skip_silence_title" />
+        android:weightSum="3"
+        app:singleSelection="true">
+
+        <Button
+            android:id="@+id/skipSilenceOff"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Off"
+            style="@style/OutlinedButtonBetterContrast" />
+
+        <Button
+            android:id="@+id/skipSilenceMedium"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Medium"
+            style="@style/OutlinedButtonBetterContrast" />
+
+        <Button
+            android:id="@+id/skipSilenceAggressive"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Aggressive"
+            style="@style/OutlinedButtonBetterContrast" />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
 
 </LinearLayout>

--- a/app/src/main/res/layout/speed_select_dialog.xml
+++ b/app/src/main/res/layout/speed_select_dialog.xml
@@ -42,10 +42,45 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <CheckBox
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/pref_skip_silence_title"
+        style="@style/AntennaPod.TextView.ListItemPrimaryTitle" />
+
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/skipSilence"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/pref_skip_silence_title" />
+        android:weightSum="3"
+        app:singleSelection="true">
+
+        <Button
+            android:id="@+id/skipSilenceOff"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Off"
+            style="@style/OutlinedButtonBetterContrast" />
+
+        <Button
+            android:id="@+id/skipSilenceMedium"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Medium"
+            style="@style/OutlinedButtonBetterContrast" />
+
+        <Button
+            android:id="@+id/skipSilenceAggressive"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Aggressive"
+            style="@style/OutlinedButtonBetterContrast" />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
 
 </LinearLayout>

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
@@ -60,7 +60,7 @@ public class FeedPreferences implements Serializable {
     }
 
     public enum SkipSilence {
-        OFF(0), GLOBAL(1), AGGRESSIVE(2);
+        GLOBAL(0), OFF(1), MEDIUM(2), AGGRESSIVE(3);
 
         public final int code;
 

--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/PlaybackServiceMediaPlayer.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/PlaybackServiceMediaPlayer.java
@@ -13,6 +13,7 @@ import java.util.List;
 import androidx.annotation.Nullable;
 import de.danoeh.antennapod.model.playback.MediaType;
 import de.danoeh.antennapod.model.playback.Playable;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
 
 
 /*
@@ -144,14 +145,14 @@ public abstract class PlaybackServiceMediaPlayer {
      * - SkipSilence (ExoPlayer only)
      * This method is executed on an internal executor service.
      */
-    public abstract void  setPlaybackParams(final float speed, final boolean skipSilence);
+    public abstract void  setPlaybackParams(final float speed, final FeedPreferences.SkipSilence skipSilence);
 
     /**
      * Returns the current playback speed. If the playback speed could not be retrieved, 1 is returned.
      */
     public abstract float getPlaybackSpeed();
 
-    public abstract boolean getSkipSilence();
+    public abstract FeedPreferences.SkipSilence getSkipSilence();
 
     /**
      * Sets the playback volume.

--- a/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastPsmp.java
+++ b/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastPsmp.java
@@ -26,6 +26,7 @@ import com.google.android.gms.common.GoogleApiAvailability;
 import de.danoeh.antennapod.event.PlayerErrorEvent;
 import de.danoeh.antennapod.event.playback.BufferUpdateEvent;
 import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.model.playback.MediaType;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.model.playback.RemoteMedia;
@@ -415,7 +416,7 @@ public class CastPsmp extends PlaybackServiceMediaPlayer {
     }
 
     @Override
-    public void setPlaybackParams(float speed, boolean skipSilence) {
+    public void setPlaybackParams(float speed, FeedPreferences.SkipSilence skipSilenceDurationUs) {
         double playbackRate = (float) Math.max(MediaLoadOptions.PLAYBACK_RATE_MIN,
                 Math.min(MediaLoadOptions.PLAYBACK_RATE_MAX, speed));
         remoteMediaClient.setPlaybackRate(playbackRate);
@@ -428,9 +429,9 @@ public class CastPsmp extends PlaybackServiceMediaPlayer {
     }
 
     @Override
-    public boolean getSkipSilence() {
+    public FeedPreferences.SkipSilence getSkipSilence() {
         // Don't think this is supported
-        return false;
+        return FeedPreferences.SkipSilence.OFF;
     }
 
     @Override

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
@@ -407,7 +407,7 @@ public abstract class PlaybackController {
         }
     }
 
-    public void setSkipSilence(boolean skipSilence) {
+    public void setSkipSilence(FeedPreferences.SkipSilence skipSilence) {
         if (playbackService != null) {
             playbackService.setSkipSilence(skipSilence);
         }
@@ -421,12 +421,11 @@ public abstract class PlaybackController {
         }
     }
 
-    public boolean getCurrentPlaybackSkipSilence() {
+    public FeedPreferences.SkipSilence getCurrentPlaybackSkipSilence() {
         if (playbackService != null) {
             return playbackService.getCurrentSkipSilence();
         } else {
-            return PlaybackSpeedUtils.getCurrentSkipSilencePreference(getMedia())
-                    == FeedPreferences.SkipSilence.AGGRESSIVE;
+            return PlaybackSpeedUtils.getCurrentSkipSilencePreference(getMedia());
         }
     }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1641,9 +1641,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     setSpeed(event.getSpeed());
                 }
                 if (event.getSkipSilence() == FeedPreferences.SkipSilence.GLOBAL) {
-                    setSkipSilence(UserPreferences.isSkipSilence());
+                    setSkipSilence(UserPreferences.getSkipSilence());
                 } else {
-                    setSkipSilence(event.getSkipSilence() == FeedPreferences.SkipSilence.AGGRESSIVE);
+                    setSkipSilence(event.getSkipSilence());
                 }
             }
         }
@@ -1703,7 +1703,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         mediaPlayer.setPlaybackParams(speed, getCurrentSkipSilence());
     }
 
-    public void setSkipSilence(boolean skipSilence) {
+    public void setSkipSilence(FeedPreferences.SkipSilence skipSilence) {
         PlaybackPreferences.setCurrentlyPlayingTemporarySkipSilence(skipSilence);
         mediaPlayer.setPlaybackParams(getCurrentPlaybackSpeed(), skipSilence);
     }
@@ -1715,9 +1715,9 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         return mediaPlayer.getPlaybackSpeed();
     }
 
-    public boolean getCurrentSkipSilence() {
+    public FeedPreferences.SkipSilence getCurrentSkipSilence() {
         if (mediaPlayer == null) {
-            return false;
+            return FeedPreferences.SkipSilence.OFF;
         }
         return mediaPlayer.getSkipSilence();
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -163,8 +163,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             callback.ensureMediaInfoLoaded(media);
             callback.onMediaChanged(false);
             setPlaybackParams(PlaybackSpeedUtils.getCurrentPlaybackSpeed(media),
-                    PlaybackSpeedUtils.getCurrentSkipSilencePreference(media)
-                            == FeedPreferences.SkipSilence.AGGRESSIVE);
+                    PlaybackSpeedUtils.getCurrentSkipSilencePreference(media));
             if (stream) {
                 if (playable instanceof FeedMedia) {
                     FeedMedia feedMedia = (FeedMedia) playable;
@@ -216,8 +215,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 acquireWifiLockIfNecessary();
 
                 setPlaybackParams(PlaybackSpeedUtils.getCurrentPlaybackSpeed(media),
-                        PlaybackSpeedUtils.getCurrentSkipSilencePreference(media)
-                                == FeedPreferences.SkipSilence.AGGRESSIVE);
+                        PlaybackSpeedUtils.getCurrentSkipSilencePreference(media));
                 setVolume(1.0f, 1.0f);
 
                 if (playerStatus == PlayerStatus.PREPARED && media.getPosition() > 0) {
@@ -444,7 +442,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
      * This method is executed on an internal executor service.
      */
     @Override
-    public void setPlaybackParams(final float speed, final boolean skipSilence) {
+    public void setPlaybackParams(final float speed, final FeedPreferences.SkipSilence skipSilence) {
         Log.d(TAG, "Playback speed was set to " + speed);
         EventBus.getDefault().post(new SpeedChangedEvent(speed));
         mediaPlayer.setPlaybackParams(speed, skipSilence);
@@ -466,15 +464,14 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     }
 
     @Override
-    public boolean getSkipSilence() {
-        boolean retVal = false;
+    public FeedPreferences.SkipSilence getSkipSilence() {
         if ((playerStatus == PlayerStatus.PLAYING
                 || playerStatus == PlayerStatus.PAUSED
                 || playerStatus == PlayerStatus.INITIALIZED
                 || playerStatus == PlayerStatus.PREPARED)) {
-            retVal = mediaPlayer.getCurrentSkipSilence();
+            return mediaPlayer.getCurrentSkipSilence();
         }
-        return retVal;
+        return FeedPreferences.SkipSilence.OFF;
     }
 
     /**

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/PlaybackPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/PlaybackPreferences.java
@@ -158,10 +158,9 @@ public abstract class PlaybackPreferences {
         editor.apply();
     }
 
-    public static void setCurrentlyPlayingTemporarySkipSilence(boolean skipSilence) {
+    public static void setCurrentlyPlayingTemporarySkipSilence(FeedPreferences.SkipSilence skipSilence) {
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putInt(PREF_CURRENTLY_PLAYING_TEMPORARY_SKIP_SILENCE, skipSilence
-                ? FeedPreferences.SkipSilence.AGGRESSIVE.code : FeedPreferences.SkipSilence.OFF.code);
+        editor.putInt(PREF_CURRENTLY_PLAYING_TEMPORARY_SKIP_SILENCE, skipSilence.code);
         editor.apply();
     }
 

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -406,8 +406,16 @@ public abstract class UserPreferences {
         }
     }
 
-    public static boolean isSkipSilence() {
-        return prefs.getBoolean(PREF_PLAYBACK_SKIP_SILENCE, false);
+    public static FeedPreferences.SkipSilence getSkipSilence() {
+        try {
+            return FeedPreferences.SkipSilence.fromCode(prefs.getInt(
+                PREF_PLAYBACK_SKIP_SILENCE, FeedPreferences.SkipSilence.OFF.code));
+        } catch (ClassCastException e) {
+            // migrate old binary preference
+            FeedPreferences.SkipSilence skipSilence = prefs.getBoolean(PREF_PLAYBACK_SKIP_SILENCE, false) ? FeedPreferences.SkipSilence.AGGRESSIVE : FeedPreferences.SkipSilence.OFF;
+            setSkipSilence(skipSilence);
+            return skipSilence;
+        }
     }
 
     public static List<Float> getPlaybackSpeedArray() {
@@ -584,8 +592,8 @@ public abstract class UserPreferences {
         prefs.edit().putString(PREF_PLAYBACK_SPEED, String.valueOf(speed)).apply();
     }
 
-    public static void setSkipSilence(boolean skipSilence) {
-        prefs.edit().putBoolean(PREF_PLAYBACK_SKIP_SILENCE, skipSilence).apply();
+    public static void setSkipSilence(FeedPreferences.SkipSilence skipSilence) {
+        prefs.edit().putInt(PREF_PLAYBACK_SKIP_SILENCE, skipSilence.code).apply();
     }
 
     public static void setPlaybackSpeedArray(List<Float> speeds) {

--- a/ui/episodes/src/main/java/de/danoeh/antennapod/ui/episodes/PlaybackSpeedUtils.java
+++ b/ui/episodes/src/main/java/de/danoeh/antennapod/ui/episodes/PlaybackSpeedUtils.java
@@ -52,8 +52,7 @@ public abstract class PlaybackSpeedUtils {
             }
         }
         if (skipSilence == FeedPreferences.SkipSilence.GLOBAL) {
-            skipSilence = UserPreferences.isSkipSilence()
-                    ? FeedPreferences.SkipSilence.AGGRESSIVE : FeedPreferences.SkipSilence.OFF;
+            skipSilence = UserPreferences.getSkipSilence();
         }
         return skipSilence;
     }


### PR DESCRIPTION
- followup feed-specific skip silence config (#6910) and #6903
- toggle buttons to configure
- medium 300ms gap
- aggressive 50ms gap
- recreate player when switching between those

fixes #4229

### Description


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ ] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ ] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
