### PR TITLE
Fix marking as played when there is no media

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/EspressoTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/EspressoTestUtils.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -44,6 +45,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
 
 public class EspressoTestUtils {
     /**
@@ -143,6 +145,21 @@ public class EspressoTestUtils {
         };
     }
 
+    public static void waitForViewToDisappear(Matcher<? super View> matcher, long maxWaitingTimeMs) {
+        long endTime = System.currentTimeMillis() + maxWaitingTimeMs;
+        while (System.currentTimeMillis() <= endTime) {
+            try {
+                onView(allOf(matcher, isDisplayed())).check(matches(not(doesNotExist())));
+                Thread.sleep(100);
+            } catch (NoMatchingViewException ex) {
+                return; // view has disappeared
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("timeout exceeded"); // or whatever exception you want
+    }
+    
     /**
      * Clear all app databases.
      */

--- a/app/src/androidTest/java/de/test/antennapod/ui/TextOnlyFeedsTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/TextOnlyFeedsTest.java
@@ -27,7 +27,6 @@ import static de.test.antennapod.EspressoTestUtils.onDrawerItem;
 import static de.test.antennapod.EspressoTestUtils.openNavDrawer;
 import static de.test.antennapod.EspressoTestUtils.waitForView;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.not;
 
 /**
  * Test UI for feeds that do not have media files

--- a/app/src/androidTest/java/de/test/antennapod/ui/TextOnlyFeedsTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/TextOnlyFeedsTest.java
@@ -67,7 +67,7 @@ public class TextOnlyFeedsTest {
         onView(withText(feed.getItemAtIndex(0).getTitle())).perform(click());
         onView(isRoot()).perform(waitForView(withText(R.string.mark_read_no_media_label), 3000));
         onView(allOf(withText(R.string.mark_read_no_media_label), isDisplayed())).perform(click());
-        onView(isRoot()).perform(waitForView(allOf(withText(R.string.mark_read_no_media_label), not(isDisplayed())), 3000));
+        EspressoTestUtils.waitForViewToDisappear(withText(R.string.mark_read_no_media_label), 3000);
     }
 
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -693,7 +693,7 @@ public class PodDBAdapter {
             db.update(TABLE_NAME_FEED_ITEMS, values, KEY_ID + "=?", new String[]{String.valueOf(item.getId())});
             item.setPlayed(played == FeedItem.PLAYED);
 
-            if (resetMediaPosition) {
+            if (resetMediaPosition && item.hasMedia()) {
                 values.clear();
                 values.put(KEY_POSITION, 0);
                 db.update(TABLE_NAME_FEED_MEDIA, values, KEY_ID + "=?",

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -693,7 +693,7 @@ public class PodDBAdapter {
             db.update(TABLE_NAME_FEED_ITEMS, values, KEY_ID + "=?", new String[]{String.valueOf(item.getId())});
             item.setPlayed(played == FeedItem.PLAYED);
 
-            if (resetMediaPosition && item.hasMedia()) {
+            if (resetMediaPosition) {
                 values.clear();
                 values.put(KEY_POSITION, 0);
                 db.update(TABLE_NAME_FEED_MEDIA, values, KEY_ID + "=?",


### PR DESCRIPTION
### Description

Closes #7188

Apparently our test for exactly this did not catch this 🤔 might need to update the test: https://stackoverflow.com/a/68528795

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
