### PR TITLE
Fix redundant hints on search screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -176,8 +176,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         emptyViewHandler = new EmptyViewHandler(getContext());
         emptyViewHandler.attachToRecyclerView(recyclerView);
         emptyViewHandler.setIcon(R.drawable.ic_search);
-        emptyViewHandler.setTitle(R.string.search_status_no_results);
-        emptyViewHandler.setMessage(R.string.type_to_search);
+        emptyViewHandler.setTitle(R.string.type_to_search);
         EventBus.getDefault().register(this);
 
         chip = layout.findViewById(R.id.feed_title_chip);
@@ -376,7 +375,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
 
         String query = searchView.getQuery().toString();
         if (query.isEmpty()) {
-            emptyViewHandler.setMessage(R.string.type_to_search);
+            emptyViewHandler.setTitle(R.string.type_to_search);
             return;
         }
         if (feed != 0) {
@@ -389,7 +388,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
                     .subscribe(results -> {
                         progressBar.setVisibility(View.GONE);
                         adapterFeeds.updateData(results);
-                        emptyViewHandler.setMessage(getString(R.string.no_results_for_query, query));
+                        emptyViewHandler.setTitle(getString(R.string.no_results_for_query, query));
                     }, error -> Log.e(TAG, Log.getStackTraceString(error)));
         }
         disposableEpisodes = Observable.fromCallable(() -> DBReader.searchFeedItems(feed, query))
@@ -399,7 +398,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
                     progressBar.setVisibility(View.GONE);
                     this.results = results;
                     adapter.updateItems(results);
-                    emptyViewHandler.setMessage(getString(R.string.no_results_for_query, searchView.getQuery()));
+                    emptyViewHandler.setTitle(getString(R.string.no_results_for_query, searchView.getQuery()));
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/view/EmptyViewHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/EmptyViewHandler.java
@@ -38,6 +38,10 @@ public class EmptyViewHandler {
         tvTitle.setText(title);
     }
 
+    public void setTitle(String title) {
+        tvTitle.setText(title);
+    }
+
     public void setMessage(int message) {
         tvMessage.setText(message);
     }


### PR DESCRIPTION


### Description
On the search screen there was always the message "no results found" even before anything was ever searched and the message was repeated beneath it if really nothing was found by the app.

**Screenshot (Left two Before, Right ones After):**
![aösldfkjaasddf](https://github.com/AntennaPod/AntennaPod/assets/21206831/b0f0e872-3a7e-45a1-9019-86e0f48939b9)

### Question for the Reviewer
In the `EmptyViewHandler.java` file many (but not all) private field names are prepended with the type they are of. Like the  TextView for the title is called `tvTitle`. I haven't seen such [Hungarian Notation](https://en.wikipedia.org/wiki/Hungarian_notation) in other parts of the app, so I assume they are a relict of the past. Should I also remove them since this PR already touches the file?

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
