### PR TITLE
Make swiping out easier

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/SwipeActions.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/SwipeActions.java
@@ -222,7 +222,7 @@ public class SwipeActions extends ItemTouchHelper.SimpleCallback implements Life
 
     @Override
     public float getSwipeThreshold(@NonNull RecyclerView.ViewHolder viewHolder) {
-        return swipeOutEnabled ? 0.6f : 1.0f;
+        return swipeOutEnabled ? super.getSwipeThreshold(viewHolder) : 1.0f;
     }
 
     @Override


### PR DESCRIPTION
### Description

Make swiping out easier. Going back to Google's default value for slow swipes. Partially reverts #5135
Closes #7000

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
