### PR TITLE
Fix error icon in the drawer

### DIFF
--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -59,7 +59,6 @@
         android:visibility="gone"
         android:contentDescription="@string/refresh_failed_msg"
         app:srcCompat="@drawable/ic_error"
-        app:tint="?attr/icon_red"
         tools:text="!" />
 
     <TextView

--- a/ui/common/src/main/res/drawable/ic_error.xml
+++ b/ui/common/src/main/res/drawable/ic_error.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="16dp"
-    android:height="16dp"
+    android:height="24dp"
+    android:width="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path


### PR DESCRIPTION
### Description
**Screenshot (left: before, right: this PR)**
![image](https://github.com/AntennaPod/AntennaPod/assets/21206831/c3537ff6-f4cc-4c85-8ad8-311fa80228d4)

**Closes: #7109**

There has been some regression that the error icon in the drawer was just a circle instead of the the exclamation mark.

The error occurred because the icon was modified to have a background circle once it was added to the subscription screens. However, in the drawer a icon tint was applied which now also tinted the background and made now only the background show.

I also made the error icon larger, but I am not sure if that is better. Otherwise the exclamation mark is hard to read (even in the simulator) but that might be my bad eyesight 🙈

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
