### PR TITLE
Refactor ToolbarIconTintManager to a simpler API

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -20,7 +20,6 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.content.res.AppCompatResources;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.Fragment;
 import com.bumptech.glide.Glide;
@@ -104,16 +103,8 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
         viewBinding.toolbar.setOnMenuItemClickListener(this);
         refreshToolbarState();
 
-        ToolbarIconTintManager iconTintManager = new ToolbarIconTintManager(getContext(),
-                viewBinding.toolbar, viewBinding.collapsingToolbar) {
-            @Override
-            protected void doTint(Context themedContext) {
-                viewBinding.toolbar.getMenu().findItem(R.id.visit_website_item)
-                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_web));
-                viewBinding.toolbar.getMenu().findItem(R.id.share_item)
-                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_share));
-            }
-        };
+        ToolbarIconTintManager iconTintManager =
+                new ToolbarIconTintManager(viewBinding.toolbar, viewBinding.collapsingToolbar);
         iconTintManager.updateTint();
         viewBinding.appBar.addOnOffsetChangedListener(iconTintManager);
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.ui.screen.feed;
 
-import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.LightingColorFilter;
 import android.os.Bundle;
@@ -14,7 +13,6 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -159,16 +157,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         swipeActions = new SwipeActions(this, TAG).attachTo(viewBinding.recyclerView);
         viewBinding.progressBar.setVisibility(View.VISIBLE);
 
-        ToolbarIconTintManager iconTintManager = new ToolbarIconTintManager(
-                viewBinding.toolbar.getContext(), viewBinding.toolbar, viewBinding.collapsingToolbar) {
-            @Override
-            protected void doTint(Context themedContext) {
-                viewBinding.toolbar.getMenu().findItem(R.id.refresh_item)
-                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_refresh));
-                viewBinding.toolbar.getMenu().findItem(R.id.action_search)
-                        .setIcon(AppCompatResources.getDrawable(themedContext, R.drawable.ic_search));
-            }
-        };
+        ToolbarIconTintManager iconTintManager =
+                new ToolbarIconTintManager(viewBinding.toolbar, viewBinding.collapsingToolbar);
         iconTintManager.updateTint();
         viewBinding.appBar.addOnOffsetChangedListener(iconTintManager);
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/ToolbarIconTintManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/ToolbarIconTintManager.java
@@ -1,23 +1,24 @@
 package de.danoeh.antennapod.ui.screen.feed;
 
-import android.content.Context;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
-import android.view.ContextThemeWrapper;
+import android.view.Menu;
+
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
-import de.danoeh.antennapod.R;
 
-public abstract class ToolbarIconTintManager implements AppBarLayout.OnOffsetChangedListener {
-    private final Context context;
+/**
+ * A manager that automatically finds all icons in a collapsable toolbar and tints them according to the collapse state
+ * of the toolbar.
+ */
+public class ToolbarIconTintManager implements AppBarLayout.OnOffsetChangedListener {
     private final CollapsingToolbarLayout collapsingToolbar;
     private final MaterialToolbar toolbar;
     private boolean isTinted = false;
 
-    public ToolbarIconTintManager(Context context, MaterialToolbar toolbar, CollapsingToolbarLayout collapsingToolbar) {
-        this.context = context;
+    public ToolbarIconTintManager(MaterialToolbar toolbar, CollapsingToolbarLayout collapsingToolbar) {
         this.collapsingToolbar = collapsingToolbar;
         this.toolbar = toolbar;
     }
@@ -32,16 +33,20 @@ public abstract class ToolbarIconTintManager implements AppBarLayout.OnOffsetCha
     }
 
     public void updateTint() {
+        PorterDuffColorFilter filter = null;
         if (isTinted) {
-            doTint(new ContextThemeWrapper(context, R.style.Theme_AntennaPod_Dark));
-            safeSetColorFilter(toolbar.getNavigationIcon(), new PorterDuffColorFilter(0xffffffff, Mode.SRC_ATOP));
-            safeSetColorFilter(toolbar.getOverflowIcon(), new PorterDuffColorFilter(0xffffffff, Mode.SRC_ATOP));
-            safeSetColorFilter(toolbar.getCollapseIcon(), new PorterDuffColorFilter(0xffffffff, Mode.SRC_ATOP));
-        } else {
-            doTint(context);
-            safeSetColorFilter(toolbar.getNavigationIcon(), null);
-            safeSetColorFilter(toolbar.getOverflowIcon(), null);
-            safeSetColorFilter(toolbar.getCollapseIcon(), null);
+            filter = new PorterDuffColorFilter(0xffffffff, Mode.SRC_ATOP);
+        }
+
+        safeSetColorFilter(toolbar.getNavigationIcon(), filter);
+        safeSetColorFilter(toolbar.getOverflowIcon(), filter);
+        safeSetColorFilter(toolbar.getCollapseIcon(), filter);
+
+        Menu menu = toolbar.getMenu();
+        for (int i = 0; i < menu.size(); i++) {
+            Drawable icon = menu.getItem(i).getIcon();
+            safeSetColorFilter(icon, filter);
+            menu.getItem(i).setIcon(icon);
         }
     }
 
@@ -50,10 +55,4 @@ public abstract class ToolbarIconTintManager implements AppBarLayout.OnOffsetCha
             icon.setColorFilter(filter);
         }
     }
-
-    /**
-     * View expansion was changed. Icons need to be tinted
-     * @param themedContext ContextThemeWrapper with dark theme while expanded
-     */
-    protected abstract void doTint(Context themedContext);
 }


### PR DESCRIPTION
### Description

The original API used a callback where the caller needed to specify the icons of the menu items. However, the manager can find them on it's own.

Since the callback was never used for anything else, I also removed it, which now means the ToolbarIconTintManager can be used on it's own instead of instantiating an anonymous class that only overwrites the callback.

I originally stumbled upon this code when I fixed the app bar icon colors in #7163 and since then wanted to tidy it up a bit.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
