### PR TITLE
Revert ExoPlayer back to default http backend

### DIFF
--- a/playback/service/build.gradle
+++ b/playback/service/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation "androidx.core:core:$coreVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "androidx.media:media:$mediaVersion"
-    implementation "androidx.media3:media3-datasource-okhttp:$media3Version"
     implementation "androidx.media3:media3-exoplayer:$media3Version"
     implementation "androidx.media3:media3-ui:$media3Version"
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
@@ -18,11 +18,11 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.database.StandaloneDatabaseProvider;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.datasource.HttpDataSource;
 import androidx.media3.datasource.cache.CacheDataSource;
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor;
 import androidx.media3.datasource.cache.SimpleCache;
-import androidx.media3.datasource.okhttp.OkHttpDataSource;
 import androidx.media3.exoplayer.DefaultLoadControl;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.common.Format;
@@ -48,14 +48,12 @@ import de.danoeh.antennapod.net.common.UserAgentInterceptor;
 import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
 import de.danoeh.antennapod.playback.service.R;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
-import de.danoeh.antennapod.net.common.AntennapodHttpClient;
 import de.danoeh.antennapod.net.common.HttpCredentialEncoder;
 import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.model.playback.Playable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
-import okhttp3.Call;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -235,16 +233,14 @@ public class ExoPlayerWrapper {
     public void setDataSource(String s, String user, String password)
             throws IllegalArgumentException, IllegalStateException {
         Log.d(TAG, "setDataSource: " + s);
-        final OkHttpDataSource.Factory httpDataSourceFactory =
-                new OkHttpDataSource.Factory((Call.Factory) AntennapodHttpClient.getHttpClient())
-                        .setUserAgent(UserAgentInterceptor.USER_AGENT);
+        final DefaultHttpDataSource.Factory httpDataSourceFactory = new DefaultHttpDataSource.Factory();
+        httpDataSourceFactory.setUserAgent(UserAgentInterceptor.USER_AGENT);
+        httpDataSourceFactory.setAllowCrossProtocolRedirects(true);
+        httpDataSourceFactory.setKeepPostFor302Redirects(true);
 
         if (!TextUtils.isEmpty(user) && !TextUtils.isEmpty(password)) {
             final HashMap<String, String> requestProperties = new HashMap<>();
-            requestProperties.put(
-                    "Authorization",
-                    HttpCredentialEncoder.encode(user, password, "ISO-8859-1")
-            );
+            requestProperties.put("Authorization", HttpCredentialEncoder.encode(user, password, "ISO-8859-1"));
             httpDataSourceFactory.setDefaultRequestProperties(requestProperties);
         }
         DataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, httpDataSourceFactory);


### PR DESCRIPTION
### Description

Related PR: #5510

Basically reverts 186de76d95631bbdcd3cc4a2057321855b5a69aa
The OkHttp backend sometimes causes issues when servers cut the connection.
We had this happen after 1000s (about 17 minutes) for many users after upgrading OkHttp.
Removes proxy support for streaming.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
