### PR TITLE
Fix show notes link color

### DIFF
--- a/app/src/main/assets/shownotes-style.css
+++ b/app/src/main/assets/shownotes-style.css
@@ -4,7 +4,6 @@
 }
 a {
      font-style: normal;
-     text-decoration: none;
      font-weight: normal;
      color: %s;
 }


### PR DESCRIPTION
### Description
The problem has been described at length in #7139, but the links are now easier to distinguish from the other text, especially on dynamic themes.

Now all links are underlined (what the webview does per default) to better distinguish them.

Closes: #7139

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
