### PR TITLE
Fix useless refresh on welcome home screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
@@ -184,6 +184,10 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
                 .subscribe(numEpisodes -> {
                     viewBinding.welcomeContainer.setVisibility(numEpisodes == 0 ? View.VISIBLE : View.GONE);
                     viewBinding.homeContainer.setVisibility(numEpisodes == 0 ? View.GONE : View.VISIBLE);
+                    viewBinding.swipeRefresh.setVisibility(numEpisodes == 0 ? View.GONE : View.VISIBLE);
+                    if (numEpisodes == 0) {
+                        viewBinding.homeScrollView.setScrollY(0);
+                    }
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 


### PR DESCRIPTION
### Description
If the user hasn't subscribed to any podcasts a welcome segment is shown on the homescreen. However, the scrollview with a refresh below was still there which was not only useless but could trigger an refresh at the wrong position and also tint the app bar.

**Screencast of the old behaivor:**

https://github.com/AntennaPod/AntennaPod/assets/21206831/d6aeaf4f-29d0-472c-8eb5-0a1a42e7cb42



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
