### PR TITLE
Closes #7269 - workaround to fast scroll crash

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -678,10 +678,14 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
         @Override
         protected void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
+            String fallbackImageUri = null;
+            if(holder.getFeedItem().getFeed() != null) {
+                fallbackImageUri = holder.getFeedItem().getFeed().getImageUrl();
+            }
             holder.coverHolder.setVisibility(View.VISIBLE);
             new CoverLoader()
                     .withUri(holder.getFeedItem().getImageLocation()) // Ignore "Show episode cover" setting
-                    .withFallbackUri(holder.getFeedItem().getFeed().getImageUrl())
+                    .withFallbackUri(fallbackImageUri)
                     .withPlaceholderView(holder.placeholder)
                     .withCoverView(holder.cover)
                     .load();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -679,7 +679,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         @Override
         protected void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
             String fallbackImageUri = null;
-            if(holder.getFeedItem().getFeed() != null) {
+            if (holder.getFeedItem().getFeed() != null) {
                 fallbackImageUri = holder.getFeedItem().getFeed().getImageUrl();
             }
             holder.coverHolder.setVisibility(View.VISIBLE);


### PR DESCRIPTION
On rapid scrolling of long lists, getFeedItem().getFeed() can be null, which causes a crash on getImageUrl(). CoverLoader appears to do the right thing if fallbackUri is null, so if we don't have a feed, pass in null as the fallbackUri.

Note: this is just a workaround that masks the symptom. I don't understand the way things are loaded enough to say it's the right fix for the problem - it probably isn't.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
