### PR TITLE
Announce episode download start/end with Talkback

### DIFF
--- a/app/src/main/assets/shownotes-style.css
+++ b/app/src/main/assets/shownotes-style.css
@@ -4,7 +4,6 @@
 }
 a {
      font-style: normal;
-     text-decoration: none;
      font-weight: normal;
      color: %s;
 }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.net.download.service.episode;
 import android.content.Context;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
+import de.danoeh.antennapod.net.download.service.R;
 
 public class DownloadAnnouncer {
     private final Context context;
@@ -12,12 +13,15 @@ public class DownloadAnnouncer {
     }
 
     public void announceDownloadStart(String episodeTitle) {
-        String message = episodeTitle + " download started.";
+        String message = context.getString(R.string.download_started_talkback, episodeTitle);
         announceDownloadStatus(message);
     }
 
     public void announceDownloadEnd(String episodeTitle, boolean success) {
-        String message = episodeTitle + (success ? " download completed." : " download failed.");
+        String message = context.getString(
+                success ? R.string.download_completed_talkback : R.string.download_failed_talkback,
+                episodeTitle
+        );
         announceDownloadStatus(message);
     }
 

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
@@ -5,24 +5,17 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import de.danoeh.antennapod.net.download.service.R;
 
-public class DownloadAnnouncer {
-    private final Context context;
-
-    public DownloadAnnouncer(Context context) {
-        this.context = context;
+public abstract class DownloadAnnouncer {
+    public static void announceStart(Context context, String episodeTitle) {
+        announce(context, R.string.download_started_talkback, episodeTitle);
     }
 
-    public void announceDownloadStart(String episodeTitle) {
-        String message = context.getString(R.string.download_started_talkback, episodeTitle);
-        announceDownloadStatus(message);
+    public static void announceCompleted(Context context, String episodeTitle) {
+        announce(context, R.string.download_completed_talkback, episodeTitle);
     }
 
-    public void announceDownloadCompleted(String episodeTitle) {
-        String message = context.getString(R.string.download_completed_talkback, episodeTitle);
-        announceDownloadStatus(message);
-    }
-
-    private void announceDownloadStatus(String message) {
+    private static void announce(Context context, int messageTemplate, String episodeTitle) {
+        String message = context.getString(messageTemplate, episodeTitle);
         AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
         if (am != null && am.isEnabled()) {
             AccessibilityEvent event = AccessibilityEvent.obtain();

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
@@ -1,0 +1,32 @@
+package de.danoeh.antennapod.net.download.service.episode;
+
+import android.content.Context;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityManager;
+
+public class DownloadAnnouncer {
+    private final Context context;
+
+    public DownloadAnnouncer(Context context) {
+        this.context = context;
+    }
+
+    public void announceDownloadStart(String episodeTitle) {
+        String message = episodeTitle + " download started.";
+        announceDownloadStatus(message);
+    }
+
+    public void announceDownloadEnd(String episodeTitle, boolean success) {
+        String message = episodeTitle + (success ? " download completed." : " download failed.");
+        announceDownloadStatus(message);
+    }
+
+    private void announceDownloadStatus(String message) {
+        AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        if (am != null && am.isEnabled()) {
+            AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT);
+            event.getText().add(message);
+            am.sendAccessibilityEvent(event);
+        }
+    }
+}

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
@@ -24,7 +24,8 @@ public class DownloadAnnouncer {
     private void announceDownloadStatus(String message) {
         AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
         if (am != null && am.isEnabled()) {
-            AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT);
+            AccessibilityEvent event = AccessibilityEvent.obtain();
+            event.setEventType(AccessibilityEvent.TYPE_ANNOUNCEMENT);
             event.getText().add(message);
             am.sendAccessibilityEvent(event);
         }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
@@ -18,10 +18,9 @@ public class DownloadAnnouncer {
     }
 
     public void announceDownloadEnd(String episodeTitle, boolean success) {
-        String message = context.getString(
-                success ? R.string.download_completed_talkback : R.string.download_failed_talkback,
-                episodeTitle
-        );
+        String downloadCompletedMessage = context.getString(R.string.download_completed_talkback, episodeTitle);
+        String downloadFailedMessage = context.getString(R.string.download_failed_talkback, episodeTitle);
+        String message = success ? downloadCompletedMessage : downloadFailedMessage;
         announceDownloadStatus(message);
     }
 

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/DownloadAnnouncer.java
@@ -17,10 +17,8 @@ public class DownloadAnnouncer {
         announceDownloadStatus(message);
     }
 
-    public void announceDownloadEnd(String episodeTitle, boolean success) {
-        String downloadCompletedMessage = context.getString(R.string.download_completed_talkback, episodeTitle);
-        String downloadFailedMessage = context.getString(R.string.download_failed_talkback, episodeTitle);
-        String message = success ? downloadCompletedMessage : downloadFailedMessage;
+    public void announceDownloadCompleted(String episodeTitle) {
+        String message = context.getString(R.string.download_completed_talkback, episodeTitle);
         announceDownloadStatus(message);
     }
 

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
@@ -175,7 +175,6 @@ public class EpisodeDownloadWorker extends Worker {
         } catch (Exception e) {
             DBWriter.addDownloadStatus(downloader.getResult());
             sendErrorNotification(request.getTitle());
-            downloadAnnouncer.announceDownloadEnd(request.getTitle(), false);
             return Result.failure();
         } finally {
             if (wifiLock != null) {
@@ -214,7 +213,6 @@ public class EpisodeDownloadWorker extends Worker {
                 || status.getReason() == DownloadError.ERROR_IO_BLOCKED) {
             // Fail fast, these are probably unrecoverable
             sendErrorNotification(request.getTitle());
-            downloadAnnouncer.announceDownloadEnd(request.getTitle(), false);
             return Result.failure();
         }
         sendMessage(request.getTitle(), false);
@@ -224,7 +222,6 @@ public class EpisodeDownloadWorker extends Worker {
     private Result retry3times() {
         if (isLastRunAttempt()) {
             sendErrorNotification(downloader.getDownloadRequest().getTitle());
-            downloadAnnouncer.announceDownloadEnd(downloader.getDownloadRequest().getTitle(), false);
             return Result.failure();
         } else {
             return Result.retry();
@@ -260,6 +257,7 @@ public class EpisodeDownloadWorker extends Worker {
     }
 
     private void sendErrorNotification(String title) {
+        downloadAnnouncer.announceDownloadEnd(title, false);
         if (EventBus.getDefault().hasSubscriberForEvent(MessageEvent.class)) {
             sendMessage(title, false);
             return;

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
@@ -175,6 +175,7 @@ public class EpisodeDownloadWorker extends Worker {
         } catch (Exception e) {
             DBWriter.addDownloadStatus(downloader.getResult());
             sendErrorNotification(request.getTitle());
+            downloadAnnouncer.announceDownloadEnd(request.getTitle(), false);
             return Result.failure();
         } finally {
             if (wifiLock != null) {
@@ -213,6 +214,7 @@ public class EpisodeDownloadWorker extends Worker {
                 || status.getReason() == DownloadError.ERROR_IO_BLOCKED) {
             // Fail fast, these are probably unrecoverable
             sendErrorNotification(request.getTitle());
+            downloadAnnouncer.announceDownloadEnd(request.getTitle(), false);
             return Result.failure();
         }
         sendMessage(request.getTitle(), false);
@@ -222,6 +224,7 @@ public class EpisodeDownloadWorker extends Worker {
     private Result retry3times() {
         if (isLastRunAttempt()) {
             sendErrorNotification(downloader.getDownloadRequest().getTitle());
+            downloadAnnouncer.announceDownloadEnd(downloader.getDownloadRequest().getTitle(), false);
             return Result.failure();
         } else {
             return Result.retry();

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
@@ -193,7 +193,7 @@ public class EpisodeDownloadWorker extends Worker {
                     getApplicationContext(), downloader.getResult(), request);
             handler.run();
             DBWriter.addDownloadStatus(handler.getUpdatedStatus());
-            downloadAnnouncer.announceDownloadEnd(request.getTitle(), true);
+            downloadAnnouncer.announceDownloadCompleted(request.getTitle());
             return Result.success();
         }
 
@@ -257,7 +257,6 @@ public class EpisodeDownloadWorker extends Worker {
     }
 
     private void sendErrorNotification(String title) {
-        downloadAnnouncer.announceDownloadEnd(title, false);
         if (EventBus.getDefault().hasSubscriberForEvent(MessageEvent.class)) {
             sendMessage(title, false);
             return;

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/EpisodeDownloadWorker.java
@@ -46,13 +46,11 @@ import java.util.concurrent.ExecutionException;
 public class EpisodeDownloadWorker extends Worker {
     private static final String TAG = "EpisodeDownloadWorker";
     private static final Map<String, Integer> notificationProgress = new HashMap<>();
-    private final DownloadAnnouncer downloadAnnouncer;
 
     private Downloader downloader = null;
 
     public EpisodeDownloadWorker(@NonNull Context context, @NonNull WorkerParameters params) {
         super(context, params);
-        this.downloadAnnouncer = new DownloadAnnouncer(context);
     }
 
     @Override
@@ -156,6 +154,7 @@ public class EpisodeDownloadWorker extends Worker {
                 Log.e(TAG, "ExecutionException in writeFileUrl: " + e.getMessage());
             }
         }
+
         downloader = new DefaultDownloaderFactory().create(request);
         if (downloader == null) {
             Log.d(TAG, "Unable to create downloader");
@@ -169,7 +168,7 @@ public class EpisodeDownloadWorker extends Worker {
             wifiLock.acquire();
         }
 
-        downloadAnnouncer.announceDownloadStart(request.getTitle());
+        DownloadAnnouncer.announceStart(getApplicationContext(), request.getTitle());
         try {
             downloader.call();
         } catch (Exception e) {
@@ -193,7 +192,7 @@ public class EpisodeDownloadWorker extends Worker {
                     getApplicationContext(), downloader.getResult(), request);
             handler.run();
             DBWriter.addDownloadStatus(handler.getUpdatedStatus());
-            downloadAnnouncer.announceDownloadCompleted(request.getTitle());
+            DownloadAnnouncer.announceCompleted(getApplicationContext(), request.getTitle());
             return Result.success();
         }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -320,6 +320,10 @@
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>
     <string name="confirm_mobile_streaming_button_once">Once</string>
+    <string name="download_started_talkback">%1$s download started</string>
+    <string name="download_completed_talkback">%1$s download completed</string>
+    <string name="download_failed_talkback">%1$s download failed</string>
+
 
     <!-- Mediaplayer messages -->
     <string name="playback_error_generic"><![CDATA[The media file could not be played.\n\n- Try deleting and re-downloading the episode.\n- Check your network connection, and make sure no VPN or login page is blocking access.\n- Try long-pressing and sharing the \"Media address\" to your web browser to see if it can be played there. If not, contact the podcast creators.]]></string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -322,7 +322,6 @@
     <string name="confirm_mobile_streaming_button_once">Once</string>
     <string name="download_started_talkback">Download started for %1$s</string>
     <string name="download_completed_talkback">Download completed for %1$s</string>
-    <string name="download_failed_talkback">Download failed for %1$s</string>
 
 
     <!-- Mediaplayer messages -->

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -320,9 +320,9 @@
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>
     <string name="confirm_mobile_streaming_button_once">Once</string>
-    <string name="download_started_talkback">%1$s download started</string>
-    <string name="download_completed_talkback">%1$s download completed</string>
-    <string name="download_failed_talkback">%1$s download failed</string>
+    <string name="download_started_talkback">Download started for %1$s</string>
+    <string name="download_completed_talkback">Download completed for %1$s</string>
+    <string name="download_failed_talkback">Download failed for %1$s</string>
 
 
     <!-- Mediaplayer messages -->

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -320,9 +320,6 @@
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>
     <string name="confirm_mobile_streaming_button_once">Once</string>
-    <string name="download_started_talkback">Download started for %1$s</string>
-    <string name="download_completed_talkback">Download completed for %1$s</string>
-
 
     <!-- Mediaplayer messages -->
     <string name="playback_error_generic"><![CDATA[The media file could not be played.\n\n- Try deleting and re-downloading the episode.\n- Check your network connection, and make sure no VPN or login page is blocking access.\n- Try long-pressing and sharing the \"Media address\" to your web browser to see if it can be played there. If not, contact the podcast creators.]]></string>
@@ -713,6 +710,8 @@
     <string name="next_chapter">Next chapter</string>
     <string name="shuffle_suggestions">Shuffle suggestions</string>
     <string name="add_preset">Add preset</string>
+    <string name="download_started_talkback">Download started for %1$s</string>
+    <string name="download_completed_talkback">Download completed for %1$s</string>
 
     <!-- Feed settings/information screen -->
     <string name="authentication_label">Authentication</string>


### PR DESCRIPTION
### Description

resolves (partially) #7070 

I added Talkback announcements at the start and end of download of an episode.

I'm not confident about code organization here - as far as I was able to tell, that's the only ACCESSIBILITY_SERVICE-related code in the codebase. Given how limited it is, I just placed it nearby relevant episode download code, but it could just as well be part of some accessibility component, but then again accessibility as a whole is abstracted by Android itself. That choice feels to me somewhat arbitrary and I'm new to the project.

I made a choice to announce full episode name. From what I understand, announcement can happen in a moment not directly related to user expressing their intent to download given episode, and so it seems reasonable to provide minimal (no podcast title) relevant (I feel like it's podcast authors' fault if episode title doesn't make them identifiable) context.

I didn't add any automated tests, I'm honestly not sure how should they look like here. Deprecated AccessibilityEvent.obtain() is used, but I'm not sure what versions of API are targeted and if adding version check would be superior to having warning pop up until it can be updated for 30+.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests