### PR TITLE
Implement queue autodownload

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -28,7 +28,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
-import de.danoeh.antennapod.net.download.service.feed.DownloadServiceInterfaceImpl;
+import de.danoeh.antennapod.net.download.serviceinterface.AutoDownloadManager;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.ui.episodes.PlaybackSpeedUtils;
@@ -138,15 +138,13 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(items -> {
-                    // this will fail with less than 5 items.
                     int maxItems = Math.min(items.size(), 5);
 
                     for (int i = 0; i < items.size(); i++) {
-
                         // Filter items when they are played.
                         FeedItem fitem = items.get(i);
                         if (!fitem.isPlayed()) {
-                            (new DownloadServiceInterfaceImpl()).download(this.getContext(), fitem);
+                            DBWriter.markItemForAutodownload(fitem);
                             maxItems--;
                         }
 
@@ -154,6 +152,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                             break;
                         }
                     }
+                    AutoDownloadManager.getInstance().autodownloadUndownloadedItems(this.getContext());
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -1,5 +1,7 @@
 package de.danoeh.antennapod.ui.screen.queue;
 
+import static de.danoeh.antennapod.storage.preferences.UserPreferences.CONST_AUTODL_QUEUE_ITEMS;
+
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
@@ -138,7 +140,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(items -> {
-                    int maxItems = Math.min(items.size(), 5);
+                    int maxItems = Math.min(items.size(), CONST_AUTODL_QUEUE_ITEMS);
 
                     for (int i = 0; i < items.size(); i++) {
                         // Filter items when they are played.

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -131,7 +131,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     }
 
     private void updateQueueDownloads() {
-        if(!UserPreferences.shouldAutodownloadQueue()) {
+        if (!UserPreferences.shouldAutodownloadQueue()) {
             return;
         }
         Observable.fromCallable(DBReader::getQueue)
@@ -141,16 +141,16 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                     // this will fail with less than 5 items.
                     int maxItems = Math.min(items.size(), 5);
 
-                    for(int i = 0; i < items.size(); i++) {
+                    for (int i = 0; i < items.size(); i++) {
 
                         // Filter items when they are played.
                         FeedItem fitem = items.get(i);
-                        if(!fitem.isPlayed()) {
+                        if (!fitem.isPlayed()) {
                             (new DownloadServiceInterfaceImpl()).download(this.getContext(), fitem);
                             maxItems--;
                         }
 
-                        if(maxItems == 0) {
+                        if (maxItems == 0) {
                             break;
                         }
                     }
@@ -167,7 +167,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             return;
             }
 
-            updateQueueDownloads();
+        updateQueueDownloads();
 
         switch(event.action) {
             case ADDED:

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -165,7 +165,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         } else if (recyclerAdapter == null) {
             loadItems(true);
             return;
-            }
+        }
 
         updateQueueDownloads();
 

--- a/playback/service/build.gradle
+++ b/playback/service/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation project(':ui:notifications')
     implementation project(':ui:widget')
     implementation project(':ui:chapters')
+    implementation project(':net:download:service')
+    implementation project(':net:download:service-interface')
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.car.app:app:1.4.0-rc02"

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.playback.service;
 
 import static de.danoeh.antennapod.model.feed.FeedPreferences.SPEED_USE_GLOBAL;
+import static de.danoeh.antennapod.storage.preferences.UserPreferences.CONST_AUTODL_QUEUE_ITEMS;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
@@ -1176,7 +1177,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 if (UserPreferences.shouldAutodownloadQueue()) {
                     // First, get items and assign the maximum. Either 5, or the listsize, the smaller one.
                     List<FeedItem> items = DBReader.getQueue();
-                    int maxItems = Math.min(items.size(), 5);
+                    int maxItems = Math.min(items.size(), CONST_AUTODL_QUEUE_ITEMS);
 
                     for (int i = 0; i < items.size(); i++) {
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1173,21 +1173,21 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     Log.d(TAG, "Episode Deleted");
                 }
 
-                if(UserPreferences.shouldAutodownloadQueue()) {
+                if (UserPreferences.shouldAutodownloadQueue()) {
                     // First, get items and assign the maximum. Either 5, or the listsize, the smaller one.
                     List<FeedItem> items = DBReader.getQueue();
                     int maxItems = Math.min(items.size(), 5);
 
-                    for(int i = 0; i < items.size(); i++) {
+                    for (int i = 0; i < items.size(); i++) {
 
                         // Filter items when they are played.
                         FeedItem fitem = items.get(i);
-                        if(!fitem.isPlayed()) {
+                        if (!fitem.isPlayed()) {
                             (new DownloadServiceInterfaceImpl()).download(getApplicationContext(), fitem);
                             maxItems--;
                         }
 
-                        if(maxItems == 0) {
+                        if (maxItems == 0) {
                             break;
                         }
                     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -54,7 +54,7 @@ import androidx.lifecycle.Observer;
 import androidx.media.MediaBrowserServiceCompat;
 
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.net.download.service.feed.DownloadServiceInterfaceImpl;
+import de.danoeh.antennapod.net.download.serviceinterface.AutoDownloadManager;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueueSink;
 import de.danoeh.antennapod.playback.service.internal.LocalPSMP;
 import de.danoeh.antennapod.playback.service.internal.PlayableUtils;
@@ -1183,7 +1183,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                         // Filter items when they are played.
                         FeedItem fitem = items.get(i);
                         if (!fitem.isPlayed()) {
-                            (new DownloadServiceInterfaceImpl()).download(getApplicationContext(), fitem);
+                            DBWriter.markItemForAutodownload(fitem);
                             maxItems--;
                         }
 
@@ -1191,6 +1191,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                             break;
                         }
                     }
+                    AutoDownloadManager.getInstance().autodownloadUndownloadedItems(getApplicationContext());
                 }
                 notifyChildrenChanged(getString(R.string.queue_label));
             }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -740,6 +740,27 @@ public class DBWriter {
         });
     }
 
+
+    /**
+     * Sets the 'autodownload'-attribute of a FeedItem to true.
+     *
+     * @param item               The FeedItem object
+     */
+    @NonNull
+    public static Future<?> markItemForAutodownload(FeedItem item) {
+        return runOnDbThread(() -> {
+            final PodDBAdapter adapter = PodDBAdapter.getInstance();
+            adapter.open();
+            adapter.setFeedItemAutoDownload(item.getId());
+            adapter.close();
+
+            EventBus.getDefault().post(FeedItemEvent.updated(item));
+        });
+    }
+
+
+
+
     /**
      * Sets the 'read'-attribute of all NEW FeedItems of a specific Feed to UNPLAYED.
      *

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -505,6 +505,14 @@ public class PodDBAdapter {
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(feedId)});
     }
 
+    public void setFeedItemAutoDownload(long feedItemId) {
+        Log.d(TAG, String.format(Locale.US,
+                "setFeedItemAutoDownload() called with: feedId = [%d]", feedItemId));
+        ContentValues values = new ContentValues();
+        values.put(KEY_AUTO_DOWNLOAD_ENABLED, true);
+        db.update(TABLE_NAME_FEED_ITEMS, values, KEY_ID + "=?", new String[]{String.valueOf(feedItemId)});
+    }
+
     /**
      * Inserts or updates a media entry
      *

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -101,6 +101,7 @@ public abstract class UserPreferences {
     public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
     public static final String PREF_ENABLE_AUTODL_WIFI_FILTER = "prefEnableAutoDownloadWifiFilter";
     public static final String PREF_ENABLE_AUTODL_QUEUE = "prefKeepQueueDownloaded";
+    public static final int CONST_AUTODL_QUEUE_ITEMS = 5;
     private static final String PREF_AUTODL_SELECTED_NETWORKS = "prefAutodownloadSelectedNetworks";
     private static final String PREF_PROXY_TYPE = "prefProxyType";
     private static final String PREF_PROXY_HOST = "prefProxyHost";

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -96,6 +96,7 @@ public abstract class UserPreferences {
     private static final String PREF_MOBILE_UPDATE = "prefMobileUpdateTypes";
     public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
+    public static final String PREF_AUTODOWNLOAD_QUEUE = "prefKeepQueueDownloaded";
     public static final String PREF_ENABLE_AUTODL = "prefEnableAutoDl";
     public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
     public static final String PREF_ENABLE_AUTODL_WIFI_FILTER = "prefEnableAutoDownloadWifiFilter";
@@ -395,6 +396,11 @@ public abstract class UserPreferences {
     public static boolean shouldDeleteRemoveFromQueue() {
         return prefs.getBoolean(PREF_DELETE_REMOVES_FROM_QUEUE, false);
     }
+
+    public static boolean shouldAutodownloadQueue() {
+        return prefs.getBoolean(PREF_AUTODOWNLOAD_QUEUE, false);
+    }
+
 
     public static float getPlaybackSpeed() {
         try {

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -100,6 +100,7 @@ public abstract class UserPreferences {
     public static final String PREF_ENABLE_AUTODL = "prefEnableAutoDl";
     public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
     public static final String PREF_ENABLE_AUTODL_WIFI_FILTER = "prefEnableAutoDownloadWifiFilter";
+    public static final String PREF_ENABLE_AUTODL_QUEUE = "prefKeepQueueDownloaded";
     private static final String PREF_AUTODL_SELECTED_NETWORKS = "prefAutodownloadSelectedNetworks";
     private static final String PREF_PROXY_TYPE = "prefProxyType";
     private static final String PREF_PROXY_HOST = "prefProxyHost";

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -456,6 +456,8 @@
     <string name="pref_nav_drawer_feed_counter_title">Set subscription counter</string>
     <string name="pref_nav_drawer_feed_counter_sum">Change the information displayed by the subscription counter. Also affects the sorting of subscriptions if \'Subscription Order\' is set to \'Counter\'.</string>
     <string name="pref_automatic_download_title">Automatic download</string>
+    <string name="pref_autodownload_queue_items">Automatically download the next 5 episodes in the queue</string>
+    <string name="pref_autodownload_queue_items_title">Keep Queue up to date</string>
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes</string>
     <string name="pref_autodl_wifi_filter_title">Enable Wi-Fi filter</string>
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
@@ -75,6 +75,8 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
         findPreference(UserPreferences.PREF_EPISODE_CACHE_SIZE).setEnabled(autoDownload);
         findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled(autoDownload);
         findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled(autoDownload);
+        findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled(autoDownload);
+        findPreference(UserPreferences.PREF_ENABLE_AUTODL_QUEUE).setEnabled(autoDownload);
         setSelectedNetworksEnabled(autoDownload && UserPreferences.isEnableAutodownloadWifiFilter());
     }
 

--- a/ui/preferences/src/main/res/xml/preferences_autodownload.xml
+++ b/ui/preferences/src/main/res/xml/preferences_autodownload.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch">
 
     <de.danoeh.antennapod.ui.preferences.preference.MasterSwitchPreference
@@ -15,6 +16,11 @@
             android:title="@string/pref_episode_cache_title"
             android:summary="@string/pref_episode_cache_summary"
             android:entryValues="@array/episode_cache_size_values"/>
+    <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="prefKeepQueueDownloaded"
+            android:summary="@string/pref_autodownload_queue_items"
+            android:title="@string/pref_autodownload_queue_items_title"/>
     <SwitchPreferenceCompat
             android:key="prefEnableAutoDownloadOnBattery"
             android:title="@string/pref_automatic_download_on_battery_title"

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -27,6 +27,13 @@
             android:key="prefAutoDownloadSettings"
             android:title="@string/pref_automatic_download_title"
             search:ignore="true" />
+
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:enabled="true"
+                android:key="prefKeepQueueDownloaded"
+                android:summary="@string/pref_autodownload_queue_items"
+                android:title="@string/pref_autodownload_queue_items_title"/>
         <Preference
             android:key="prefAutoDeleteScreen"
             android:summary="@string/pref_auto_delete_sum"

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -27,13 +27,6 @@
             android:key="prefAutoDownloadSettings"
             android:title="@string/pref_automatic_download_title"
             search:ignore="true" />
-
-        <SwitchPreferenceCompat
-                android:defaultValue="false"
-                android:enabled="true"
-                android:key="prefKeepQueueDownloaded"
-                android:summary="@string/pref_autodownload_queue_items"
-                android:title="@string/pref_autodownload_queue_items_title"/>
         <Preference
             android:key="prefAutoDeleteScreen"
             android:summary="@string/pref_auto_delete_sum"


### PR DESCRIPTION
### Description
This PR implements auto download of queued items. The first 5 items are always downloaded, if enabled.
After an episode is finished, this is checked, and if nessessary, a download is triggered.

This has the following benefits:
- The user can "entirely" prevent mobile data usage.
- Issues with stream-caching are prevented
- Content is available when internet is not, regardless of user interaction. (to be precise: regardless of user inaction, where they forgot to download the next episode)

Closes #7273
Closes #6829
Implements #7171
Implements #7172


### Todo: 

- [ ] Add setting to import/export (if applicable)
- [ ] Find good naming for setting
- [ ] Put the setting in the correct place
- [ ] Is the `DownloadServiceInterfaceImpl` the correct way to handle this?


P.S.:

I _really_ like the debug-app-icon. It is great!

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
