### PR TITLE
Improve collapsing toolbar collapse state

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -105,7 +105,6 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
 
         ToolbarIconTintManager iconTintManager =
                 new ToolbarIconTintManager(viewBinding.toolbar, viewBinding.collapsingToolbar);
-        iconTintManager.updateTint();
         viewBinding.appBar.addOnOffsetChangedListener(iconTintManager);
 
         viewBinding.header.butShowInfo.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -51,6 +51,7 @@ import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.cleaner.HtmlToPlainText;
 import de.danoeh.antennapod.ui.common.IntentUtils;
+import de.danoeh.antennapod.ui.common.OnCollapseChangeListener;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemListAdapter;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemViewHolder;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeMultiSelectActionHandler;
@@ -161,8 +162,16 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
         ToolbarIconTintManager iconTintManager =
                 new ToolbarIconTintManager(viewBinding.toolbar, viewBinding.collapsingToolbar);
-        iconTintManager.updateTint();
         viewBinding.appBar.addOnOffsetChangedListener(iconTintManager);
+        viewBinding.appBar.addOnOffsetChangedListener(new OnCollapseChangeListener(viewBinding.collapsingToolbar) {
+            @Override
+            public void onCollapseChanged(boolean isCollapsed) {
+                if (feed == null) {
+                    return;
+                }
+                viewBinding.toolbar.setTitle(isCollapsed ? feed.getTitle() : "");
+            }
+        });
 
         nextPageLoader = new MoreContentListFooterUtil(viewBinding.moreContent.moreContentListFooter);
         nextPageLoader.setClickListener(() -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/ToolbarIconTintManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/ToolbarIconTintManager.java
@@ -5,38 +5,27 @@ import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.view.Menu;
 
-import com.google.android.material.appbar.MaterialToolbar;
-import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
+
+import de.danoeh.antennapod.ui.common.OnCollapseChangeListener;
 
 /**
  * A manager that automatically finds all icons in a collapsable toolbar and tints them according to the collapse state
  * of the toolbar.
  */
-public class ToolbarIconTintManager implements AppBarLayout.OnOffsetChangedListener {
-    private final CollapsingToolbarLayout collapsingToolbar;
+public class ToolbarIconTintManager extends OnCollapseChangeListener {
     private final MaterialToolbar toolbar;
-    private boolean isTinted = false;
 
     public ToolbarIconTintManager(MaterialToolbar toolbar, CollapsingToolbarLayout collapsingToolbar) {
-        this.collapsingToolbar = collapsingToolbar;
+        super(collapsingToolbar);
         this.toolbar = toolbar;
+        this.onCollapseChanged(false);
     }
 
     @Override
-    public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
-        boolean tint  = (collapsingToolbar.getHeight() + offset) > (2 * collapsingToolbar.getMinimumHeight());
-        if (isTinted != tint) {
-            isTinted = tint;
-            updateTint();
-        }
-    }
-
-    public void updateTint() {
-        PorterDuffColorFilter filter = null;
-        if (isTinted) {
-            filter = new PorterDuffColorFilter(0xffffffff, Mode.SRC_ATOP);
-        }
+    public void onCollapseChanged(boolean isCollapsed) {
+        PorterDuffColorFilter filter = isCollapsed ? null : new PorterDuffColorFilter(0xffffffff, Mode.SRC_ATOP);
 
         safeSetColorFilter(toolbar.getNavigationIcon(), filter);
         safeSetColorFilter(toolbar.getOverflowIcon(), filter);

--- a/app/src/main/res/layout/feed_item_list_fragment.xml
+++ b/app/src/main/res/layout/feed_item_list_fragment.xml
@@ -16,6 +16,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:scrimAnimationDuration="200"
+            app:titleEnabled="false"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
             <ImageView

--- a/ui/common/src/main/java/de/danoeh/antennapod/ui/common/OnCollapseChangeListener.java
+++ b/ui/common/src/main/java/de/danoeh/antennapod/ui/common/OnCollapseChangeListener.java
@@ -1,0 +1,25 @@
+package de.danoeh.antennapod.ui.common;
+
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+
+public abstract class OnCollapseChangeListener implements AppBarLayout.OnOffsetChangedListener {
+    private final CollapsingToolbarLayout collapsingToolbar;
+    private boolean wasCollapsed = false;
+
+    public OnCollapseChangeListener(CollapsingToolbarLayout collapsingToolbar) {
+        this.collapsingToolbar = collapsingToolbar;
+    }
+
+    @Override
+    public void onOffsetChanged(AppBarLayout appBarLayout, int offset) {
+        boolean isCollapsed = (collapsingToolbar.getHeight() + offset)
+                < collapsingToolbar.getScrimVisibleHeightTrigger();
+        if (wasCollapsed != isCollapsed) {
+            wasCollapsed = isCollapsed;
+            onCollapseChanged(isCollapsed);
+        }
+    }
+
+    public abstract void onCollapseChanged(boolean isCollapsed);
+}


### PR DESCRIPTION

### Description
First this commit improves the threshold at which the toolbar icon color is changed. We now ask the collapsing toolbar at which size it will be collapsed instead of guessing.

Second, this commit also sets the appbar title (when collapsed) to the podcast name in the podcast episode view.

I expect some pushback on this, since I implemented the updating title without asking for design first, but it was easy to implement and personally I quite like it.
I am excited to hear what you have to say about it. 😅 

### Screen Recordings

**Before:**

https://github.com/AntennaPod/AntennaPod/assets/21206831/10ba3a37-b3f3-420a-ae7d-ab4158af457f 

**After:**

https://github.com/AntennaPod/AntennaPod/assets/21206831/51892589-d64e-412d-82fa-06c7e671f720 

Since we now use the correct threshold you can see that the icon color now updates with the toolbar and too soon.
### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
