### PR TITLE
Remove support for deeplinking apple podcasts and SubscribeOnAndroid

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,9 +161,6 @@
                 <data android:scheme="content"/>
                 <data android:scheme="http"/>
                 <data android:scheme="https"/>
-
-                <data android:host="*"/>
-                <data android:pathPattern="/.*.opml" />
             </intent-filter>
         </activity>
         <activity
@@ -199,36 +196,6 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="de.danoeh.antennapod.activity.MainActivity"/>
 
-            <!-- URLs ending with '.xml' or '.rss' -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-
-                <data android:scheme="http"/>
-                <data android:scheme="https"/>
-                <data android:host="*"/>
-                <data android:pathPattern="/.*\\.xml"/>
-                <data android:pathPattern="/.*\\.rss"/>
-                <data android:pathPattern="/.*\\.atom"/>
-            </intent-filter>
-
-            <!-- Feedburner URLs -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-
-                <data android:scheme="http"/>
-                <data android:scheme="https"/>
-                <data android:host="feeds.feedburner.com"/>
-                <data android:host="feedproxy.google.com"/>
-                <data android:host="feeds2.feedburner.com"/>
-                <data android:host="feedsproxy.google.com"/>
-            </intent-filter>
-
             <!-- Files with mimeType rss/xml/atom -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
@@ -257,21 +224,6 @@
                 <data android:scheme="antennapod-subscribe"/>
             </intent-filter>
 
-            <!-- Support for subscribeonandroid.com URLS -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:pathPattern="/.*\\..*/.*" />
-                <data android:host="subscribeonandroid.com" />
-                <data android:host="www.subscribeonandroid.com" />
-                <data android:host="*subscribeonandroid.com" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-            </intent-filter>
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -279,20 +231,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:host="antennapod.org" />
-                <data android:host="www.antennapod.org" />
                 <data android:pathPrefix="/deeplink/subscribe" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:pathPattern="/.*/podcast/.*" />
-                <data android:host="podcasts.apple.com" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -224,7 +224,7 @@
                 <data android:scheme="antennapod-subscribe"/>
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
### Description

Remove support for deeplinking apple podcasts and SubscribeOnAndroid
See https://forum.antennapod.org/t/web-links-to-deeplink-search-and-deeplink-main-inside-the-app-dont-seem-to-be-working/5029

Google doesn't let us do that anymore if we can't verify that we own these domains.

Google Play Console:

antennapod.org: This domain passed ownership verification, but other domains in your app are failing. For users on Android 11 or older, one failing domain causes all other domains to fail. Once you have fixed or removed failing domains, users need to update their app before the links will work.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
