### PR TITLE
Android 14 on Lenovo tablets does not intialize this AudioEffect.

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
@@ -274,14 +274,22 @@ public class ExoPlayerWrapper {
     public void setVolume(float v, float v1) {
         if (v > 1) {
             exoPlayer.setVolume(1f);
-            if (loudnessEnhancer != null) {
-                loudnessEnhancer.setEnabled(true);
-                loudnessEnhancer.setTargetGain((int) (1000 * (v - 1)));
+            try {
+                if (loudnessEnhancer != null) {
+                    loudnessEnhancer.setEnabled(true);
+                    loudnessEnhancer.setTargetGain((int) (1000 * (v - 1)));
+                }
+            } catch (Exception e) {
+                Log.d(TAG, e.toString());
             }
         } else {
             exoPlayer.setVolume(v);
-            if (loudnessEnhancer != null) {
-                loudnessEnhancer.setEnabled(false);
+            try {
+                if (loudnessEnhancer != null) {
+                    loudnessEnhancer.setEnabled(false);
+                }
+            } catch (Exception e) {
+                Log.d(TAG, e.toString());
             }
         }
     }


### PR DESCRIPTION
Android 14 on Lenovo tablets does not intialize this AudioEffect. Catch this exception and continue playback. Closes Issue #7256

### Description


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ ] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ ] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
