### PR TITLE
Update empty_view_layout.xml

### DIFF
--- a/app/src/main/res/layout/empty_view_layout.xml
+++ b/app/src/main/res/layout/empty_view_layout.xml
@@ -23,6 +23,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="16sp"
+        android:textAlignment="center"
         android:textColor="?android:attr/textColorPrimary"
         tools:text="Title" />
 


### PR DESCRIPTION
### Description
I think I may take action to fix #7300. The fix is relatively simple by adding the attribute android:textAlignment="center", so that the title of the empty view layout can be centered even in the large text scale.

Before change:

<img width="254" alt="image" src="https://github.com/user-attachments/assets/7e80fa44-7f00-48b3-ad4d-7408a789be52">


After change:

<img width="247" alt="image" src="https://github.com/user-attachments/assets/821145fe-0a16-4e28-aa58-ca10d615c791">

<img width="238" alt="image" src="https://github.com/user-attachments/assets/c33cef47-da6c-4174-83ad-5e1cd5b1012e">


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x ] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ x] I have performed a self-review of my code
- [x ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] If it is a core feature, I have added automated tests
