### PR TITLE
Directly enable notifications when permission was granted

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
@@ -107,14 +107,15 @@ public class FeedSettingsFragment extends Fragment {
     }
 
     public static class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
-        private static final CharSequence PREF_EPISODE_FILTER = "episodeFilter";
-        private static final CharSequence PREF_SCREEN = "feedSettingsScreen";
-        private static final CharSequence PREF_AUTHENTICATION = "authentication";
-        private static final CharSequence PREF_AUTO_DELETE = "autoDelete";
-        private static final CharSequence PREF_CATEGORY_AUTO_DOWNLOAD = "autoDownloadCategory";
-        private static final CharSequence PREF_NEW_EPISODES_ACTION = "feedNewEpisodesAction";
+        private static final String PREF_EPISODE_FILTER = "episodeFilter";
+        private static final String PREF_SCREEN = "feedSettingsScreen";
+        private static final String PREF_AUTHENTICATION = "authentication";
+        private static final String PREF_AUTO_DELETE = "autoDelete";
+        private static final String PREF_CATEGORY_AUTO_DOWNLOAD = "autoDownloadCategory";
+        private static final String PREF_NEW_EPISODES_ACTION = "feedNewEpisodesAction";
         private static final String PREF_FEED_PLAYBACK_SPEED = "feedPlaybackSpeed";
         private static final String PREF_AUTO_SKIP = "feedAutoSkip";
+        private static final String PREF_NOTIFICATION = "episodeNotification";
         private static final String PREF_TAGS = "tags";
 
         private Feed feed;
@@ -130,9 +131,12 @@ public class FeedSettingsFragment extends Fragment {
         }
 
         boolean notificationPermissionDenied = false;
-        private final ActivityResultLauncher<String> requestPermissionLauncher =
+        private final ActivityResultLauncher<String> enableNotificationsRequestPermissionLauncher =
                 registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                     if (isGranted) {
+                        SwitchPreferenceCompat pref = findPreference(PREF_NOTIFICATION);
+                        pref.setChecked(true);
+                        pref.callChangeListener(true);
                         return;
                     }
                     if (notificationPermissionDenied) {
@@ -506,16 +510,16 @@ public class FeedSettingsFragment extends Fragment {
         }
 
         private void setupEpisodeNotificationPreference() {
-            SwitchPreferenceCompat pref = findPreference("episodeNotification");
+            SwitchPreferenceCompat pref = findPreference(PREF_NOTIFICATION);
 
             pref.setChecked(feedPreferences.getShowEpisodeNotification());
             pref.setOnPreferenceChangeListener((preference, newValue) -> {
-                if (Build.VERSION.SDK_INT >= 33 && ContextCompat.checkSelfPermission(getContext(),
+                boolean checked = Boolean.TRUE.equals(newValue);
+                if (checked && Build.VERSION.SDK_INT >= 33 && ContextCompat.checkSelfPermission(getContext(),
                         Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+                    enableNotificationsRequestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
                     return false;
                 }
-                boolean checked = Boolean.TRUE.equals(newValue);
                 feedPreferences.setShowEpisodeNotification(checked);
                 DBWriter.setFeedPreferences(feedPreferences);
                 pref.setChecked(checked);


### PR DESCRIPTION
### Description

Directly enable notifications when permission was granted. Otherwise one needs to click the setting twice

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
