### PR TITLE
Hide play button on episode preview list

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/ItemActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/ItemActionButton.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import android.view.View;
 
-import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.playback.service.PlaybackStatus;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
@@ -49,8 +48,6 @@ public abstract class ItemActionButton {
             return new PlayActionButton(item);
         } else if (isDownloadingMedia) {
             return new CancelDownloadActionButton(item);
-        } else if (item.getFeed().getState() != Feed.STATE_SUBSCRIBED) {
-            return new StreamActionButton(item);
         } else if (UserPreferences.isStreamOverDownload()) {
             return new StreamActionButton(item);
         } else {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -696,6 +696,9 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                     .withPlaceholderView(holder.placeholder)
                     .withCoverView(holder.cover)
                     .load();
+            if (feed.getState() != Feed.STATE_SUBSCRIBED) {
+                holder.secondaryActionButton.setVisibility(View.GONE);
+            }
         }
 
         @Override


### PR DESCRIPTION
### Description

This makes it more clear that the podcast is not subscribed yet. It is still possible to stream or download by clicking the episodes.

Closes #7385

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
