### PR TITLE
Check if media player is null before accessing tracks

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -31,6 +31,7 @@ import org.greenrobot.eventbus.EventBus;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -579,6 +580,9 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     }
 
     public List<String> getAudioTracks() {
+        if (mediaPlayer == null) {
+            return Collections.emptyList();
+        }
         return mediaPlayer.getAudioTracks();
     }
 
@@ -587,6 +591,9 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     }
 
     public int getSelectedAudioTrack() {
+        if (mediaPlayer == null) {
+            return -1;
+        }
         return mediaPlayer.getSelectedAudioTrack();
     }
 


### PR DESCRIPTION
### Description

Check if media player is null before accessing tracks
Closes #7205

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
