### PR TITLE
Catch crash when device does not support LoudnessEnhancer properly

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
@@ -399,11 +399,15 @@ public class ExoPlayerWrapper {
         LoudnessEnhancer newEnhancer = new LoudnessEnhancer(audioStreamId);
         LoudnessEnhancer oldEnhancer = this.loudnessEnhancer;
         if (oldEnhancer != null) {
-            newEnhancer.setEnabled(oldEnhancer.getEnabled());
-            if (oldEnhancer.getEnabled()) {
-                newEnhancer.setTargetGain((int) oldEnhancer.getTargetGain());
+            try {
+                newEnhancer.setEnabled(oldEnhancer.getEnabled());
+                if (oldEnhancer.getEnabled()) {
+                    newEnhancer.setTargetGain((int) oldEnhancer.getTargetGain());
+                }
+                oldEnhancer.release();
+            } catch (Exception e) {
+                Log.d(TAG, e.toString());
             }
-            oldEnhancer.release();
         }
 
         this.loudnessEnhancer = newEnhancer;


### PR DESCRIPTION
### Description

Catch crash when device does not support LoudnessEnhancer properly

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
