### PR TITLE
Allow selecting external media dirs as data directory

### DIFF
--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -47,14 +47,14 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
         String freeSpace = Formatter.formatShortFileSize(context, storagePath.getAvailableSpace());
         String totalSpace = Formatter.formatShortFileSize(context, storagePath.getTotalSpace());
 
-        holder.path.setText(storagePath.getShortPath());
+        holder.path.setText(storagePath.getPath());
         holder.size.setText(String.format(freeSpaceString, freeSpace, totalSpace));
         holder.progressBar.setProgress(storagePath.getUsagePercentage());
-        View.OnClickListener selectListener = v -> selectionHandler.accept(storagePath.getFullPath());
+        View.OnClickListener selectListener = v -> selectionHandler.accept(storagePath.getPath());
         holder.root.setOnClickListener(selectListener);
         holder.radioButton.setOnClickListener(selectListener);
 
-        if (storagePath.getFullPath().equals(currentPath)) {
+        if (storagePath.getPath().equals(currentPath)) {
             holder.radioButton.toggle();
         }
     }
@@ -73,8 +73,10 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
     }
 
     private List<StoragePath> getStorageEntries(Context context) {
-        File[] mediaDirs = context.getExternalFilesDirs(null);
-        final List<StoragePath> entries = new ArrayList<>(mediaDirs.length);
+        final List<File> mediaDirs = new ArrayList<>();
+        mediaDirs.addAll(List.of(context.getExternalFilesDirs(null)));
+        mediaDirs.addAll(List.of(context.getExternalMediaDirs()));
+        final List<StoragePath> entries = new ArrayList<>(mediaDirs.size());
         for (File dir : mediaDirs) {
             if (!isWritable(dir)) {
                 continue;
@@ -115,12 +117,7 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
             this.path = path;
         }
 
-        String getShortPath() {
-            int prefixIndex = path.indexOf("Android");
-            return (prefixIndex > 0) ? path.substring(0, prefixIndex) : path;
-        }
-
-        String getFullPath() {
+        String getPath() {
             return this.path;
         }
 


### PR DESCRIPTION
### Description

Allow selecting external media dirs as data directory

In addition to `/sdcard/Android/data/de.danoeh.antennapod`, this now enables `/sdcard/Android/media/de.danoeh.antennapod`. The folder is readable by other applications that have the "read storage" permission. At the same time, AntennaPod does not need the permission to write the folder.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
