### PR TITLE
Better error message when nextcloud could not be reached

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -676,6 +676,7 @@
     <string name="gpodnetsync_pref_report_successful">Successful</string>
     <string name="gpodnetsync_pref_report_failed">Failed</string>
     <string name="gpodnetsync_username_characters_error">Usernames may only contain letters, digits, hyphens and underscores.</string>
+    <string name="nextcloud_login_error_generic"><![CDATA[Unable to log into your Nextcloud.\n\n- Check your network connection.\n- Confirm that you are using the correct server address.\n- Make sure that the gpoddersync Nextcloud plugin is installed.]]></string>
 
     <!-- Directory chooser -->
     <string name="choose_data_directory">Choose data folder</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/NextcloudAuthenticationFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/NextcloudAuthenticationFragment.java
@@ -3,6 +3,9 @@ package de.danoeh.antennapod.ui.preferences.screen.synchronization;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -55,7 +58,6 @@ public class NextcloudAuthenticationFragment extends DialogFragment
     }
 
     private void startLoginFlow() {
-        viewBinding.errorText.setVisibility(View.GONE);
         viewBinding.chooseHostButton.setVisibility(View.GONE);
         viewBinding.loginProgressContainer.setVisibility(View.VISIBLE);
         viewBinding.serverUrlText.setEnabled(false);
@@ -106,9 +108,17 @@ public class NextcloudAuthenticationFragment extends DialogFragment
     @Override
     public void onNextcloudAuthError(String errorMessage) {
         viewBinding.loginProgressContainer.setVisibility(View.GONE);
-        viewBinding.errorText.setVisibility(View.VISIBLE);
-        viewBinding.errorText.setText(errorMessage);
         viewBinding.chooseHostButton.setVisibility(View.VISIBLE);
         viewBinding.serverUrlText.setEnabled(true);
+
+        final MaterialAlertDialogBuilder errorDialog = new MaterialAlertDialogBuilder(getContext());
+        errorDialog.setTitle(R.string.error_label);
+        String genericMessage = getString(R.string.nextcloud_login_error_generic);
+        SpannableString combinedMessage = new SpannableString(genericMessage + "\n\n" + errorMessage);
+        combinedMessage.setSpan(new ForegroundColorSpan(0x88888888),
+                genericMessage.length(), combinedMessage.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        errorDialog.setMessage(combinedMessage);
+        errorDialog.setPositiveButton(android.R.string.ok, null);
+        errorDialog.show();
     }
 }

--- a/ui/preferences/src/main/res/layout/nextcloud_auth_dialog.xml
+++ b/ui/preferences/src/main/res/layout/nextcloud_auth_dialog.xml
@@ -56,14 +56,6 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/errorText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:textColor="?attr/icon_red"
-            android:layout_marginBottom="16dp" />
-
         <Button
             android:id="@+id/chooseHostButton"
             android:layout_width="match_parent"


### PR DESCRIPTION
### Description

Better error message when nextcloud could not be reached
Closes #7244

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
