### PR TITLE
Remove headings on add podcast page

### DIFF
--- a/app/src/main/res/layout/addfeed.xml
+++ b/app/src/main/res/layout/addfeed.xml
@@ -87,17 +87,8 @@
                 android:id="@+id/quickFeedDiscovery"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
                 android:name="de.danoeh.antennapod.ui.discovery.QuickFeedDiscoveryFragment" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/advanced"
-                android:textSize="18sp"
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="8dp"
-                android:accessibilityHeading="true"
-                android:textColor="?android:attr/textColorPrimary" />
 
             <TextView
                 android:id="@+id/addViaUrlButton"

--- a/app/src/main/res/layout/home_section.xml
+++ b/app/src/main/res/layout/home_section.xml
@@ -83,7 +83,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/barrier"
-        tools:text="@string/discover_more"
+        tools:text="more »"
         style="@style/Widget.MaterialComponents.Button.TextButton" />
 
     <androidx.constraintlayout.widget.Barrier

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -305,7 +305,7 @@
         <item name="elevation">0dp</item>
     </style>
 
-    <style name="AddPodcastTextView">
+    <style name="AddPodcastTextView" parent="@style/TextAppearance.Material3.BodyMedium">
         <item name="android:drawablePadding">8dp</item>
         <item name="android:paddingTop">8dp</item>
         <item name="android:paddingBottom">8dp</item>

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/QuickFeedDiscoveryFragment.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/QuickFeedDiscoveryFragment.java
@@ -10,10 +10,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
-import android.widget.Button;
-import android.widget.GridView;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 import androidx.fragment.app.Fragment;
 import de.danoeh.antennapod.net.discovery.BuildConfig;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -22,6 +18,7 @@ import de.danoeh.antennapod.net.discovery.ItunesTopListLoader;
 import de.danoeh.antennapod.net.discovery.PodcastSearchResult;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
+import de.danoeh.antennapod.ui.discovery.databinding.QuickFeedDiscoveryBinding;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -36,45 +33,33 @@ import java.util.Locale;
 
 import static android.content.Context.MODE_PRIVATE;
 
-
 public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.OnItemClickListener {
     private static final String TAG = "FeedDiscoveryFragment";
     private static final int NUM_SUGGESTIONS = 12;
 
     private Disposable disposable;
     private FeedDiscoverAdapter adapter;
-    private GridView discoverGridLayout;
-    private TextView errorTextView;
-    private TextView poweredByTextView;
-    private LinearLayout errorView;
-    private Button errorRetry;
+    private QuickFeedDiscoveryBinding viewBinding;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
-        View root = inflater.inflate(R.layout.quick_feed_discovery, container, false);
-        View discoverMore = root.findViewById(R.id.discover_more);
-        discoverMore.setOnClickListener(v -> startActivity(new MainActivityStarter(getContext())
+        viewBinding = QuickFeedDiscoveryBinding.inflate(inflater);
+        viewBinding.discoverMore.setOnClickListener(v -> startActivity(new MainActivityStarter(getContext())
                 .withFragmentLoaded(DiscoveryFragment.TAG)
                 .withAddToBackStack()
                 .getIntent()));
 
-        discoverGridLayout = root.findViewById(R.id.discover_grid);
-        errorView = root.findViewById(R.id.discover_error);
-        errorTextView = root.findViewById(R.id.discover_error_txtV);
-        errorRetry = root.findViewById(R.id.discover_error_retry_btn);
-        poweredByTextView = root.findViewById(R.id.discover_powered_by_itunes);
-
         adapter = new FeedDiscoverAdapter(getActivity());
-        discoverGridLayout.setAdapter(adapter);
-        discoverGridLayout.setOnItemClickListener(this);
+        viewBinding.discoverGrid.setAdapter(adapter);
+        viewBinding.discoverGrid.setOnItemClickListener(this);
 
         DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
         float screenWidthDp = displayMetrics.widthPixels / displayMetrics.density;
         if (screenWidthDp > 600) {
-            discoverGridLayout.setNumColumns(6);
+            viewBinding.discoverGrid.setNumColumns(6);
         } else {
-            discoverGridLayout.setNumColumns(4);
+            viewBinding.discoverGrid.setNumColumns(4);
         }
 
         // Fill with dummy elements to have a fixed height and
@@ -88,7 +73,13 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
         loadToplist();
 
         EventBus.getDefault().register(this);
-        return root;
+        return viewBinding.getRoot();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        viewBinding = null;
     }
 
     @Override
@@ -107,32 +98,32 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
     }
 
     private void loadToplist() {
-        errorView.setVisibility(View.GONE);
-        errorRetry.setVisibility(View.INVISIBLE);
-        errorRetry.setText(R.string.retry_label);
-        poweredByTextView.setVisibility(View.VISIBLE);
+        viewBinding.errorContainer.setVisibility(View.GONE);
+        viewBinding.errorRetryButton.setVisibility(View.INVISIBLE);
+        viewBinding.errorRetryButton.setText(R.string.retry_label);
+        viewBinding.poweredByLabel.setVisibility(View.VISIBLE);
 
         ItunesTopListLoader loader = new ItunesTopListLoader(getContext());
         SharedPreferences prefs = getActivity().getSharedPreferences(ItunesTopListLoader.PREFS, MODE_PRIVATE);
         String countryCode = prefs.getString(ItunesTopListLoader.PREF_KEY_COUNTRY_CODE,
                 Locale.getDefault().getCountry());
         if (prefs.getBoolean(ItunesTopListLoader.PREF_KEY_HIDDEN_DISCOVERY_COUNTRY, false)) {
-            errorTextView.setText(R.string.discover_is_hidden);
-            errorView.setVisibility(View.VISIBLE);
-            discoverGridLayout.setVisibility(View.GONE);
-            errorRetry.setVisibility(View.GONE);
-            poweredByTextView.setVisibility(View.GONE);
+            viewBinding.errorLabel.setText(R.string.discover_is_hidden);
+            viewBinding.errorContainer.setVisibility(View.VISIBLE);
+            viewBinding.discoverGrid.setVisibility(View.GONE);
+            viewBinding.errorRetryButton.setVisibility(View.GONE);
+            viewBinding.poweredByLabel.setVisibility(View.GONE);
             return;
         }
         //noinspection ConstantConditions
         if (BuildConfig.FLAVOR.equals("free") && prefs.getBoolean(ItunesTopListLoader.PREF_KEY_NEEDS_CONFIRM, true)) {
-            errorTextView.setText("");
-            errorView.setVisibility(View.VISIBLE);
-            discoverGridLayout.setVisibility(View.VISIBLE);
-            errorRetry.setVisibility(View.VISIBLE);
-            errorRetry.setText(R.string.discover_confirm);
-            poweredByTextView.setVisibility(View.VISIBLE);
-            errorRetry.setOnClickListener(v -> {
+            viewBinding.errorLabel.setText("");
+            viewBinding.errorContainer.setVisibility(View.VISIBLE);
+            viewBinding.discoverGrid.setVisibility(View.VISIBLE);
+            viewBinding.errorRetryButton.setVisibility(View.VISIBLE);
+            viewBinding.errorRetryButton.setText(R.string.discover_confirm);
+            viewBinding.poweredByLabel.setVisibility(View.VISIBLE);
+            viewBinding.errorRetryButton.setOnClickListener(v -> {
                 prefs.edit().putBoolean(ItunesTopListLoader.PREF_KEY_NEEDS_CONFIRM, false).apply();
                 loadToplist();
             });
@@ -145,22 +136,22 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     podcasts -> {
-                        errorView.setVisibility(View.GONE);
-                        if (podcasts.size() == 0) {
-                            errorTextView.setText(getResources().getText(R.string.search_status_no_results));
-                            errorView.setVisibility(View.VISIBLE);
-                            discoverGridLayout.setVisibility(View.INVISIBLE);
+                        viewBinding.errorContainer.setVisibility(View.GONE);
+                        if (podcasts.isEmpty()) {
+                            viewBinding.errorLabel.setText(getResources().getText(R.string.search_status_no_results));
+                            viewBinding.errorContainer.setVisibility(View.VISIBLE);
+                            viewBinding.discoverGrid.setVisibility(View.INVISIBLE);
                         } else {
-                            discoverGridLayout.setVisibility(View.VISIBLE);
+                            viewBinding.discoverGrid.setVisibility(View.VISIBLE);
                             adapter.updateData(podcasts);
                         }
                     }, error -> {
                         Log.e(TAG, Log.getStackTraceString(error));
-                        errorTextView.setText(error.getLocalizedMessage());
-                        errorView.setVisibility(View.VISIBLE);
-                        discoverGridLayout.setVisibility(View.INVISIBLE);
-                        errorRetry.setVisibility(View.VISIBLE);
-                        errorRetry.setOnClickListener(v -> loadToplist());
+                        viewBinding.errorLabel.setText(error.getLocalizedMessage());
+                        viewBinding.errorContainer.setVisibility(View.VISIBLE);
+                        viewBinding.discoverGrid.setVisibility(View.INVISIBLE);
+                        viewBinding.errorRetryButton.setVisibility(View.VISIBLE);
+                        viewBinding.errorRetryButton.setOnClickListener(v -> loadToplist());
                     });
     }
 

--- a/ui/discovery/src/main/res/layout/quick_feed_discovery.xml
+++ b/ui/discovery/src/main/res/layout/quick_feed_discovery.xml
@@ -6,32 +6,6 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <TextView
-            android:layout_width="0dip"
-            android:layout_height="wrap_content"
-            android:text="@string/discover"
-            android:textSize="18sp"
-            android:layout_marginBottom="8dp"
-            android:layout_weight="1"
-            android:accessibilityHeading="true"
-            android:textColor="?android:attr/textColorPrimary" />
-
-        <Button
-            android:id="@+id/discover_more"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minHeight="48dp"
-            android:minWidth="0dp"
-            android:text="@string/discover_more"
-            style="@style/Widget.MaterialComponents.Button.TextButton" />
-
-    </LinearLayout>
-
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -49,7 +23,7 @@
             android:layout_rowWeight="1" />
 
         <LinearLayout
-            android:id="@+id/discover_error"
+            android:id="@+id/errorContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
@@ -57,7 +31,7 @@
             android:orientation="vertical">
 
             <TextView
-                android:id="@+id/discover_error_txtV"
+                android:id="@+id/errorLabel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
@@ -67,7 +41,7 @@
                 tools:background="@android:color/holo_red_light" />
 
             <Button
-                android:id="@+id/discover_error_retry_btn"
+                android:id="@+id/errorRetryButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="16dp"
@@ -78,15 +52,30 @@
 
     </RelativeLayout>
 
-    <TextView
-        android:id="@+id/discover_powered_by_itunes"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="?android:attr/textColorTertiary"
-        android:text="@string/discover_powered_by_itunes"
-        android:textSize="12sp"
-        android:layout_gravity="right|end"
-        android:paddingHorizontal="4dp"
-        android:textAlignment="textEnd" />
+        android:layout_gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/poweredByLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/discover_powered_by_itunes"
+            android:paddingHorizontal="4dp"
+            style="@style/TextAppearance.Material3.BodySmall" />
+
+        <Button
+            android:id="@+id/discover_more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="40dp"
+            android:minWidth="0dp"
+            android:text="@string/discover_more"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -773,13 +773,12 @@
     <string name="search_itunes_label">Search Apple Podcasts</string>
     <string name="search_podcastindex_label">Search Podcast Index</string>
     <string name="search_fyyd_label">Search fyyd</string>
-    <string name="advanced">Advanced</string>
     <string name="add_podcast_by_url">Add podcast by RSS address</string>
     <string name="add_podcast_by_url_hint" translatable="false">www.example.com/feed</string>
     <string name="discover">Discover</string>
     <string name="discover_hide">Hide</string>
     <string name="discover_is_hidden">You selected to hide suggestions.</string>
-    <string name="discover_more">more »</string>
+    <string name="discover_more">Discover more »</string>
     <string name="discover_powered_by_itunes">Suggestions by Apple Podcasts</string>
     <string name="discover_confirm">Show suggestions</string>
     <string name="search_powered_by">Results by %1$s</string>


### PR DESCRIPTION
### Description

Use Material3 font styles on add podcast page. Subtle difference, but I think it looks a bit more modern.

Before/After:
<img width="250" src="https://github.com/user-attachments/assets/e66b2c86-eae8-4ce6-a1a4-293b47ca6c93" /> <img width="250" src="https://github.com/user-attachments/assets/6570bae0-28c8-4843-953a-c2e5bb2541ea" />

ToDo:

- Move more button below
- Change label to "discover more"
- Remove headings
- Same line with "suggestions by", breaking "suggestions by"

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
