### PR TITLE
Remove WiFi filter setting

### DIFF
--- a/net/common/src/main/java/de/danoeh/antennapod/net/common/NetworkUtils.java
+++ b/net/common/src/main/java/de/danoeh/antennapod/net/common/NetworkUtils.java
@@ -5,10 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
-import android.net.wifi.WifiManager;
 import android.os.Build;
-import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,11 +27,7 @@ public abstract class NetworkUtils {
             return false;
         }
         if (networkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
-            if (UserPreferences.isEnableAutodownloadWifiFilter()) {
-                return isInAllowedWifiNetwork();
-            } else {
-                return !isNetworkMetered();
-            }
+            return !isNetworkMetered();
         } else if (networkInfo.getType() == ConnectivityManager.TYPE_ETHERNET) {
             return true;
         } else {
@@ -116,12 +109,6 @@ public abstract class NetworkUtils {
             //noinspection deprecation
             return info.getType() == ConnectivityManager.TYPE_MOBILE;
         }
-    }
-
-    private static boolean isInAllowedWifiNetwork() {
-        WifiManager wm = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        List<String> selectedNetworks = Arrays.asList(UserPreferences.getAutodownloadSelectedNetworks());
-        return selectedNetworks.contains(Integer.toString(wm.getConnectionInfo().getNetworkId()));
     }
 
     public static boolean wasDownloadBlocked(Throwable throwable) {

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -100,8 +100,6 @@ public abstract class UserPreferences {
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
     public static final String PREF_ENABLE_AUTODL = "prefEnableAutoDl";
     public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
-    public static final String PREF_ENABLE_AUTODL_WIFI_FILTER = "prefEnableAutoDownloadWifiFilter";
-    private static final String PREF_AUTODL_SELECTED_NETWORKS = "prefAutodownloadSelectedNetworks";
     private static final String PREF_PROXY_TYPE = "prefProxyType";
     private static final String PREF_PROXY_HOST = "prefProxyHost";
     private static final String PREF_PROXY_PORT = "prefProxyPort";
@@ -536,17 +534,8 @@ public abstract class UserPreferences {
         return prefs.getBoolean(PREF_ENABLE_AUTODL, false);
     }
 
-    @VisibleForTesting
-    public static void setEnableAutodownload(boolean enabled) {
-        prefs.edit().putBoolean(PREF_ENABLE_AUTODL, enabled).apply();
-    }
-
     public static boolean isEnableAutodownloadOnBattery() {
         return prefs.getBoolean(PREF_ENABLE_AUTODL_ON_BATTERY, true);
-    }
-
-    public static boolean isEnableAutodownloadWifiFilter() {
-        return Build.VERSION.SDK_INT < 29 && prefs.getBoolean(PREF_ENABLE_AUTODL_WIFI_FILTER, false);
     }
 
     public static int getFastForwardSecs() {
@@ -555,11 +544,6 @@ public abstract class UserPreferences {
 
     public static int getRewindSecs() {
         return prefs.getInt(PREF_REWIND_SECS, 10);
-    }
-
-    public static String[] getAutodownloadSelectedNetworks() {
-        String selectedNetWorks = prefs.getString(PREF_AUTODL_SELECTED_NETWORKS, "");
-        return TextUtils.split(selectedNetWorks, ",");
     }
 
     public static void setProxyConfig(ProxyConfig config) {
@@ -626,10 +610,6 @@ public abstract class UserPreferences {
             jsonArray.put(speedFormat.format(speed));
         }
         prefs.edit().putString(PREF_PLAYBACK_SPEED_ARRAY, jsonArray.toString()).apply();
-    }
-
-    public static void setAutodownloadSelectedNetworks(String[] value) {
-        prefs.edit().putString(PREF_AUTODL_SELECTED_NETWORKS, TextUtils.join(",", value)).apply();
     }
 
     public static boolean gpodnetNotificationsEnabled() {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -464,8 +464,6 @@
     <string name="pref_nav_drawer_feed_counter_sum">Change the information displayed by the subscription counter. Also affects the sorting of subscriptions if \'Subscription Order\' is set to \'Counter\'.</string>
     <string name="pref_automatic_download_title">Automatic download</string>
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes</string>
-    <string name="pref_autodl_wifi_filter_title">Enable Wi-Fi filter</string>
-    <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>
     <string name="pref_automatic_download_on_battery_sum">Allow automatic download when the battery is not charging</string>
     <string name="pref_episode_cache_title">Episode limit</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
@@ -1,38 +1,24 @@
 package de.danoeh.antennapod.ui.preferences.screen;
 
-import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.content.Context;
-import android.net.wifi.WifiConfiguration;
-import android.net.wifi.WifiManager;
-import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.CheckBoxPreference;
-import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.PreferenceScreen;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.R;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
-    private static final String TAG = "AutoDnldPrefFragment";
-
-    private CheckBoxPreference[] selectedNetworks;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.preferences_autodownload);
 
-        setupAutoDownloadScreen();
-        buildAutodownloadSelectedNetworksPreference();
-        setSelectedNetworksEnabled(UserPreferences.isEnableAutodownloadWifiFilter());
+        findPreference(UserPreferences.PREF_ENABLE_AUTODL).setOnPreferenceChangeListener(
+                (preference, newValue) -> {
+                    if (newValue instanceof Boolean) {
+                        checkAutodownloadItemVisibility((Boolean) newValue);
+                    }
+                    return true;
+                });
     }
 
     @Override
@@ -47,125 +33,8 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
         checkAutodownloadItemVisibility(UserPreferences.isEnableAutodownload());
     }
 
-    private void setupAutoDownloadScreen() {
-        findPreference(UserPreferences.PREF_ENABLE_AUTODL).setOnPreferenceChangeListener(
-                (preference, newValue) -> {
-                    if (newValue instanceof Boolean) {
-                        checkAutodownloadItemVisibility((Boolean) newValue);
-                    }
-                    return true;
-                });
-        if (Build.VERSION.SDK_INT >= 29) {
-            findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setVisible(false);
-        }
-        findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER)
-                .setOnPreferenceChangeListener(
-                        (preference, newValue) -> {
-                            if (newValue instanceof Boolean) {
-                                setSelectedNetworksEnabled((Boolean) newValue);
-                                return true;
-                            } else {
-                                return false;
-                            }
-                        }
-                );
-    }
-
     private void checkAutodownloadItemVisibility(boolean autoDownload) {
         findPreference(UserPreferences.PREF_EPISODE_CACHE_SIZE).setEnabled(autoDownload);
         findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled(autoDownload);
-        findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled(autoDownload);
-        setSelectedNetworksEnabled(autoDownload && UserPreferences.isEnableAutodownloadWifiFilter());
-    }
-
-    private static String blankIfNull(String val) {
-        return val == null ? "" : val;
-    }
-
-    @SuppressLint("MissingPermission") // getConfiguredNetworks needs location permission starting with API 29
-    private void buildAutodownloadSelectedNetworksPreference() {
-        if (Build.VERSION.SDK_INT >= 29) {
-            return;
-        }
-
-        final Activity activity = getActivity();
-
-        if (selectedNetworks != null) {
-            clearAutodownloadSelectedNetworsPreference();
-        }
-        // get configured networks
-        WifiManager wifiservice = (WifiManager) activity.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        List<WifiConfiguration> networks = wifiservice.getConfiguredNetworks();
-
-        if (networks == null) {
-            Log.e(TAG, "Couldn't get list of configure Wi-Fi networks");
-            return;
-        }
-        Collections.sort(networks, (x, y) ->
-                blankIfNull(x.SSID).compareToIgnoreCase(blankIfNull(y.SSID)));
-        selectedNetworks = new CheckBoxPreference[networks.size()];
-        List<String> prefValues = Arrays.asList(UserPreferences
-                .getAutodownloadSelectedNetworks());
-        PreferenceScreen prefScreen = getPreferenceScreen();
-        Preference.OnPreferenceClickListener clickListener = preference -> {
-            if (preference instanceof CheckBoxPreference) {
-                String key = preference.getKey();
-                List<String> prefValuesList = new ArrayList<>(
-                        Arrays.asList(UserPreferences
-                                .getAutodownloadSelectedNetworks())
-                );
-                boolean newValue = ((CheckBoxPreference) preference)
-                        .isChecked();
-                Log.d(TAG, "Selected network " + key + ". New state: " + newValue);
-
-                int index = prefValuesList.indexOf(key);
-                if (index >= 0 && !newValue) {
-                    // remove network
-                    prefValuesList.remove(index);
-                } else if (index < 0 && newValue) {
-                    prefValuesList.add(key);
-                }
-
-                UserPreferences.setAutodownloadSelectedNetworks(prefValuesList.toArray(new String[0]));
-                return true;
-            } else {
-                return false;
-            }
-        };
-        // create preference for each known network. attach listener and set
-        // value
-        for (int i = 0; i < networks.size(); i++) {
-            WifiConfiguration config = networks.get(i);
-
-            CheckBoxPreference pref = new CheckBoxPreference(activity);
-            String key = Integer.toString(config.networkId);
-            pref.setTitle(config.SSID);
-            pref.setKey(key);
-            pref.setOnPreferenceClickListener(clickListener);
-            pref.setPersistent(false);
-            pref.setChecked(prefValues.contains(key));
-            selectedNetworks[i] = pref;
-            prefScreen.addPreference(pref);
-        }
-    }
-
-    private void clearAutodownloadSelectedNetworsPreference() {
-        if (selectedNetworks != null) {
-            PreferenceScreen prefScreen = getPreferenceScreen();
-
-            for (CheckBoxPreference network : selectedNetworks) {
-                if (network != null) {
-                    prefScreen.removePreference(network);
-                }
-            }
-        }
-    }
-
-    private void setSelectedNetworksEnabled(boolean b) {
-        if (selectedNetworks != null) {
-            for (Preference p : selectedNetworks) {
-                p.setEnabled(b);
-            }
-        }
     }
 }

--- a/ui/preferences/src/main/res/xml/preferences_autodownload.xml
+++ b/ui/preferences/src/main/res/xml/preferences_autodownload.xml
@@ -20,8 +20,4 @@
             android:title="@string/pref_automatic_download_on_battery_title"
             android:summary="@string/pref_automatic_download_on_battery_sum"
             android:defaultValue="true"/>
-    <SwitchPreferenceCompat
-            android:key="prefEnableAutoDownloadWifiFilter"
-            android:title="@string/pref_autodl_wifi_filter_title"
-            android:summary="@string/pref_autodl_wifi_filter_sum"/>
 </PreferenceScreen>


### PR DESCRIPTION
### Description

Remove WiFi filter setting. 93% of our users have an Android version modern enough that the setting is not available there anyway. From the remaining 7%, probably only a tiny percentage use that setting. Removing simplifies our code and makes it easier to maintain.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
