### PR TITLE
SubscribeOnAndroid has a redirect to www subdomain

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -242,7 +242,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:pathPattern="/.*\\..*/.*" />
-                <data android:host="subscribeonandroid.com" />
+                <data android:host="www.subscribeonandroid.com" />
                 <data android:scheme="https" />
             </intent-filter>
 


### PR DESCRIPTION
### Description

Our domain is still not verified because SubscribeOnAndroid has a redirect to www subdomain...

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
