### PR TITLE
Do not show estimated episode release for local folder

### DIFF
--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
@@ -175,9 +175,12 @@ public class FeedStatisticsFragment extends Fragment {
         viewBinding.expectedNextEpisode.subtitleLabel.setText(R.string.statistics_release_next);
         viewBinding.episodeSchedule.subtitleLabel.setText(R.string.statistics_release_schedule);
         ReleaseScheduleGuesser.Guess guess = p.second;
-        if (!s.feed.getPreferences().getKeepUpdated()) {
-            viewBinding.expectedNextEpisode.subtitleLabel.setText(R.string.statistics_expected_next_episode_unknown);
-            viewBinding.episodeSchedule.subtitleLabel.setText(R.string.updates_disabled_label);
+        if (s.feed.isLocalFeed()) {
+            viewBinding.expectedNextEpisode.mainLabel.setText(R.string.local_folder);
+            viewBinding.episodeSchedule.mainLabel.setText(R.string.local_folder);
+        } else if (!s.feed.getPreferences().getKeepUpdated()) {
+            viewBinding.expectedNextEpisode.mainLabel.setText(R.string.updates_disabled_label);
+            viewBinding.episodeSchedule.mainLabel.setText(R.string.updates_disabled_label);
         } else if (guess == null || guess.nextExpectedDate.getTime() <= new Date().getTime() - 7 * 24 * 3600000L) {
             // More than 30 days delayed
             viewBinding.expectedNextEpisode.mainLabel.setText(R.string.statistics_expected_next_episode_unknown);


### PR DESCRIPTION
### Description

Do not show estimated episode release for local folder

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
