### PR TITLE
show the total num of episodes in stats screeng

### DIFF
--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/downloads/DownloadStatisticsListAdapter.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/downloads/DownloadStatisticsListAdapter.java
@@ -16,6 +16,7 @@ import java.util.List;
  */
 public class DownloadStatisticsListAdapter extends StatisticsListAdapter {
     private final Fragment fragment;
+    private int cacheEpisodes;
 
     public DownloadStatisticsListAdapter(Context context, Fragment fragment) {
         super(context);
@@ -29,15 +30,19 @@ public class DownloadStatisticsListAdapter extends StatisticsListAdapter {
 
     @Override
     protected String getHeaderValue() {
-        return Formatter.formatShortFileSize(context, (long) pieChartData.getSum());
+        return Formatter.formatShortFileSize(context, (long) pieChartData.getSum()) +
+        " • " + context.getResources().getQuantityString(R.plurals.num_episodes, cacheEpisodes, cacheEpisodes);
+
     }
 
     @Override
     protected PieChartView.PieChartData generateChartData(List<StatisticsItem> statisticsData) {
         float[] dataValues = new float[statisticsData.size()];
+        cacheEpisodes = 0;
         for (int i = 0; i < statisticsData.size(); i++) {
             StatisticsItem item = statisticsData.get(i);
             dataValues[i] = item.totalDownloadSize;
+            cacheEpisodes += item.episodesDownloadCount;
         }
         return new PieChartView.PieChartData(dataValues);
     }


### PR DESCRIPTION
close #5987 

### Description
- add the total number of cached episodes in the statistics screen

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests

## Screenshot
Here is what it looks like with 1 episode
![1 episode](https://github.com/user-attachments/assets/c8d38493-fc52-470f-add9-c7925335aa3f)

And 1,000 episodes
![1000 episode](https://github.com/user-attachments/assets/da88e6b9-7efa-4b2f-bc69-543dcbda69da)

