### PR TITLE
Remember choice again in mobile download anyway prompt

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
@@ -54,10 +54,11 @@ public class DownloadActionButton extends ItemActionButton {
 
         UsageStatistics.logAction(UsageStatistics.ACTION_DOWNLOAD);
 
-        boolean shouldBypass = (System.currentTimeMillis() / 1000
-                - bypassCellularNetworkWarningTimer) < TIMEOUT_NETWORK_WARN_SECONDS;
+        long timeSinceBypass = System.currentTimeMillis() / 1000 - bypassCellularNetworkWarningTimer;
+        boolean shouldBypass = timeSinceBypass < TIMEOUT_NETWORK_WARN_SECONDS;
         if (shouldBypass && bypassCellularNetworkType == BYPASS_TYPE_NOW) {
-            Toast.makeText(context, context.getString(R.string.mobile_download_notice), Toast.LENGTH_LONG).show();
+            Toast.makeText(context, context.getString(
+                    R.string.mobile_download_notice, TIMEOUT_NETWORK_WARN_SECONDS / 60), Toast.LENGTH_LONG).show();
         }
         if (NetworkUtils.isEpisodeDownloadAllowed() || shouldBypass) {
             DownloadServiceInterface.get().downloadNow(context, item, bypassCellularNetworkType == BYPASS_TYPE_NOW);

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -320,6 +320,7 @@
     <string name="confirm_mobile_download_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Downloading over mobile data connection is disabled in the settings. If you want this problem to be fixed, contact the creators of your VPN app.</string>
     <string name="confirm_mobile_download_dialog_download_later">Download later</string>
     <string name="confirm_mobile_download_dialog_allow_this_time">Download anyway</string>
+    <string name="mobile_download_timeout">Enable download over mobile data for the next %d minutes</string>
     <string name="confirm_mobile_streaming_notification_title">Confirm mobile streaming</string>
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -320,7 +320,7 @@
     <string name="confirm_mobile_download_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Downloading over mobile data connection is disabled in the settings. If you want this problem to be fixed, contact the creators of your VPN app.</string>
     <string name="confirm_mobile_download_dialog_download_later">Download later</string>
     <string name="confirm_mobile_download_dialog_allow_this_time">Download anyway</string>
-    <string name="mobile_download_notice">Warning: downloading over mobile data connection</string>
+    <string name="mobile_download_notice">Downloading over mobile data connection for the next %d minutes</string>
     <string name="confirm_mobile_streaming_notification_title">Confirm mobile streaming</string>
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -320,7 +320,7 @@
     <string name="confirm_mobile_download_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Downloading over mobile data connection is disabled in the settings. If you want this problem to be fixed, contact the creators of your VPN app.</string>
     <string name="confirm_mobile_download_dialog_download_later">Download later</string>
     <string name="confirm_mobile_download_dialog_allow_this_time">Download anyway</string>
-    <string name="mobile_download_timeout">Enable download over mobile data for the next %d minutes</string>
+    <string name="mobile_download_notice">Warning: downloading over mobile data connection</string>
     <string name="confirm_mobile_streaming_notification_title">Confirm mobile streaming</string>
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>


### PR DESCRIPTION
Closes #6686

### Description
If a user clicks on Download Anyway, or Download Later 3 consecutive times, then remember that choice for 10 minutes and do not continue to ask the user.
- warn the user that Download over mobile is enabled for 30 minutes via a long Toast message

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
