### PR TITLE
new way to detect car mode to fix skip to next episode

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -1,8 +1,6 @@
 package de.danoeh.antennapod.playback.service.internal;
 
-import android.app.UiModeManager;
 import android.content.Context;
-import android.content.res.Configuration;
 import android.media.AudioManager;
 import android.os.Handler;
 import android.os.Looper;

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -195,7 +195,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             }
             androidAutoConnectionState.removeObserver(androidAutoConnectionObserver);
 
-            if (! androidAutoConnected) {
+            if (!androidAutoConnected) {
                 setPlayerStatus(PlayerStatus.INITIALIZED, media);
             }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -75,7 +75,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
         mediaType = MediaType.UNKNOWN;
         videoSize = null;
 
-
         androidAutoConnectionState = new CarConnection(context).getType();
         androidAutoConnectionObserver = connectionState -> {
             androidAutoConnected = connectionState == CarConnection.CONNECTION_TYPE_PROJECTION;
@@ -194,7 +193,7 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
                 throw new IOException("Unable to read local file " + media.getLocalFileUrl());
             }
             
-            if (! androidAutoConnected) {
+            if (!androidAutoConnected) {
                 setPlayerStatus(PlayerStatus.INITIALIZED, media);
             }
 
@@ -536,7 +535,6 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             mediaPlayer = null;
             playerStatus = PlayerStatus.STOPPED;
         }
-
         androidAutoConnectionState.removeObserver(androidAutoConnectionObserver);
         isShutDown = true;
         abandonAudioFocus();

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -193,9 +193,8 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             } else {
                 throw new IOException("Unable to read local file " + media.getLocalFileUrl());
             }
-            androidAutoConnectionState.removeObserver(androidAutoConnectionObserver);
-
-            if (!androidAutoConnected) {
+            
+            if (! androidAutoConnected) {
                 setPlayerStatus(PlayerStatus.INITIALIZED, media);
             }
 
@@ -537,6 +536,8 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
             mediaPlayer = null;
             playerStatus = PlayerStatus.STOPPED;
         }
+
+        androidAutoConnectionState.removeObserver(androidAutoConnectionObserver);
         isShutDown = true;
         abandonAudioFocus();
         releaseWifiLockIfNecessary();


### PR DESCRIPTION
Closes #7441

### Description
Detect whether we are using Android Auto using the code from @hades [here](https://github.com/AntennaPod/AntennaPod/pull/7053/files) 
- this fixes showing the now playing screen when users skip to next or when a podcast finishes and move to the next episode automatically

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests


https://github.com/user-attachments/assets/f846448c-e4e6-407b-8f6b-e86686340ef6

