### PR TITLE
Make choose_data_directory_available_space a plural-form string

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -684,7 +684,10 @@
     <!-- Directory chooser -->
     <string name="choose_data_directory">Choose data folder</string>
     <string name="choose_data_directory_message">Please choose the base of your data folder. AntennaPod will create the appropriate subdirectories.</string>
-    <string name="choose_data_directory_available_space">%1$s of %2$s free</string>
+    <plurals name="choose_data_directory_available_space">
+        <item quantity="one">%1$s of %2$s free</item>
+        <item quantity="other">%1$s of %2$s free</item>
+    </plurals>
     <string name="pref_pausePlaybackForFocusLoss_sum">Pause playback instead of lowering volume when another app wants to play sounds</string>
     <string name="pref_pausePlaybackForFocusLoss_title">Pause for interruptions</string>
 

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -29,7 +29,8 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
         this.entries = getStorageEntries(context);
         this.currentPath = getCurrentPath();
         this.selectionHandler = selectionHandler;
-        this.freeSpaceString = context.getResources().getQuantityString(R.plurals.choose_data_directory_available_space);
+        this.freeSpaceString = context.getResources()
+            .getQuantityString(R.plurals.choose_data_directory_available_space);
     }
 
     @NonNull

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -49,10 +49,10 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
 
         holder.path.setText(storagePath.getPath());
         String sizeText = resources.getQuantityString(
-            R.plurals.choose_data_directory_available_space,
-            (int) (availableSpace / (1024 * 1024)),
-            freeSpace,
-            totalSpace
+                R.plurals.choose_data_directory_available_space,
+                (int) (availableSpace / (1024 * 1024)),
+                freeSpace,
+                totalSpace
         );
         holder.size.setText(sizeText);
         holder.progressBar.setProgress(storagePath.getUsagePercentage());

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.ui.preferences.screen.downloads;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.StatFs;
 import android.text.format.Formatter;
 import android.view.LayoutInflater;

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -23,14 +23,13 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
     private final Consumer<String> selectionHandler;
     private final String currentPath;
     private final List<StoragePath> entries;
-    private final String freeSpaceString;
+    private final Resources resources;
 
     public DataFolderAdapter(Context context, @NonNull Consumer<String> selectionHandler) {
         this.entries = getStorageEntries(context);
         this.currentPath = getCurrentPath();
         this.selectionHandler = selectionHandler;
-        this.freeSpaceString = context.getResources()
-            .getQuantityString(R.plurals.choose_data_directory_available_space);
+        this.resources = context.getResources();
     }
 
     @NonNull
@@ -49,7 +48,13 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
         String totalSpace = Formatter.formatShortFileSize(context, storagePath.getTotalSpace());
 
         holder.path.setText(storagePath.getPath());
-        holder.size.setText(String.format(freeSpaceString, freeSpace, totalSpace));
+        String sizeText = resources.getQuantityString(
+            R.plurals.choose_data_directory_available_space,
+            (int) (availableSpace / (1024 * 1024)),
+            freeSpace,
+            totalSpace
+        );
+        holder.size.setText(sizeText);
         holder.progressBar.setProgress(storagePath.getUsagePercentage());
         View.OnClickListener selectListener = v -> selectionHandler.accept(storagePath.getPath());
         holder.root.setOnClickListener(selectListener);

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -45,13 +45,15 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         StoragePath storagePath = entries.get(position);
         Context context = holder.root.getContext();
-        String freeSpace = Formatter.formatShortFileSize(context, storagePath.getAvailableSpace());
+        long availableSpace = storagePath.getAvailableSpace();
+        String freeSpace = Formatter.formatShortFileSize(context, availableSpace);
         String totalSpace = Formatter.formatShortFileSize(context, storagePath.getTotalSpace());
 
         holder.path.setText(storagePath.getPath());
+        int quantity = (int) (availableSpace / (1024L * 1024L));
         String sizeText = resources.getQuantityString(
                 R.plurals.choose_data_directory_available_space,
-                (int) (availableSpace / (1024 * 1024)),
+                quantity,
                 freeSpace,
                 totalSpace
         );

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -29,7 +29,7 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
         this.entries = getStorageEntries(context);
         this.currentPath = getCurrentPath();
         this.selectionHandler = selectionHandler;
-        this.freeSpaceString = context.getString(R.string.choose_data_directory_available_space);
+        this.freeSpaceString = context.getResources().getQuantityString(R.plurals.choose_data_directory_available_space);
     }
 
     @NonNull


### PR DESCRIPTION
### Description
Closes #7166.

Stepping beyond my usual area of activity, so feedback much appreciated!



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
