### PR TITLE
Added caption below bar chart for years statistics diagram #7217

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -871,4 +871,5 @@
     <string name="shortcut_subscription_label">Subscription shortcut</string>
     <string name="shortcut_select_subscription">Select subscription</string>
     <string name="add_shortcut">Add shortcut</string>
+    <string name="statistics_years_barchart_description">Time played per month</string>
 </resources>

--- a/ui/statistics/src/main/res/layout/statistics_listitem_barchart.xml
+++ b/ui/statistics/src/main/res/layout/statistics_listitem_barchart.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
+<RelativeLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
 
     <de.danoeh.antennapod.ui.statistics.years.BarChartView
-        android:id="@+id/barChart"
-        android:layout_width="match_parent"
-        android:layout_height="200dp" />
+            android:id="@+id/barChart"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_centerInParent="true" />
+
+    <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:id="@+id/barchart_description"
+            android:textAlignment="center"
+            android:text="@string/statistics_years_barchart_description"
+            android:layout_below="@id/barChart"
+            android:layout_marginTop="8dp"/>
 
     <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginTop="16dp"
-        android:background="?android:attr/dividerVertical" />
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:background="?android:attr/dividerVertical"
+            android:layout_below="@id/barchart_description" />
 
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
### Description
Closes #7217 

### Tasks
[x] Introduce a chart title/explanation: "Time played per month" (we do have something similar on the other chart tabs) 
[ ] We display the first year if the total timespan is < 2 or 3 years.

Detailed implementation:
1. changed the linear layout of `statistics_listitem_barchart.xml` to relative layout
2. added textView `barchart_description` relative below the bar chart
3. added `strings.xml` for storing the value of description named as `statistics_years_barchart__description`

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
