### PR TITLE
Add predictive back gestures to settings screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -131,6 +131,7 @@
             android:name=".ui.screen.preferences.PreferenceActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="false"
+            android:enableOnBackInvokedCallback="true"
             android:label="@string/settings_label">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -163,8 +164,9 @@
             </intent-filter>
         </activity>
         <activity
-                android:name=".ui.screen.preferences.BugReportActivity"
-                android:label="@string/bug_report_title">
+            android:name=".ui.screen.preferences.BugReportActivity"
+            android:enableOnBackInvokedCallback="true"
+            android:label="@string/bug_report_title">
             <meta-data
                     android:name="android.support.PARENT_ACTIVITY"
                     android:value="de.danoeh.antennapod.ui.screen.preferences.PreferenceActivity"/>

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/AutomaticDeletionPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/AutomaticDeletionPreferencesFragment.java
@@ -3,14 +3,14 @@ package de.danoeh.antennapod.ui.screen.preferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import androidx.preference.ListPreference;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.TwoStatePreference;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 
 
-public class AutomaticDeletionPreferencesFragment extends PreferenceFragmentCompat {
+public class AutomaticDeletionPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREF_AUTO_DELETE_LOCAL = "prefAutoDeleteLocal";
     private boolean blockAutoDeleteLocal = true;
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
@@ -2,17 +2,17 @@ package de.danoeh.antennapod.ui.screen.preferences;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.preferences.screen.downloads.ChooseDataFolderDialog;
 
 import java.io.File;
 
 
-public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
+public class DownloadsPreferencesFragment extends AnimatedPreferenceFragment
         implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String PREF_SCREEN_AUTODL = "prefAutoDownloadSettings";
     private static final String PREF_SCREEN_AUTO_DELETE = "prefAutoDeleteScreen";
@@ -66,6 +66,7 @@ public class DownloadsPreferencesFragment extends PreferenceFragmentCompat
             });
             return true;
         });
+        setDataFolderText();
     }
 
     private void setDataFolderText() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
@@ -23,7 +23,6 @@ import androidx.preference.SwitchPreferenceCompat;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.app.ShareCompat;
 import androidx.core.content.FileProvider;
-import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.OpmlImportActivity;
@@ -37,6 +36,7 @@ import de.danoeh.antennapod.storage.importexport.FavoritesWriter;
 import de.danoeh.antennapod.storage.importexport.HtmlWriter;
 import de.danoeh.antennapod.storage.importexport.OpmlWriter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -54,7 +54,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-public class ImportExportPreferencesFragment extends PreferenceFragmentCompat {
+public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String TAG = "ImportExPrefFragment";
     private static final String PREF_OPML_EXPORT = "prefOpmlExport";
     private static final String PREF_OPML_IMPORT = "prefOpmlImport";

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/MainPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/MainPreferencesFragment.java
@@ -7,16 +7,16 @@ import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import com.bytehamster.lib.preferencesearch.SearchConfiguration;
 import com.bytehamster.lib.preferencesearch.SearchPreference;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.ui.common.IntentUtils;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.preferences.screen.about.AboutFragment;
 
-public class MainPreferencesFragment extends PreferenceFragmentCompat {
+public class MainPreferencesFragment extends AnimatedPreferenceFragment {
 
     private static final String PREF_SCREEN_USER_INTERFACE = "prefScreenInterface";
     private static final String PREF_SCREEN_PLAYBACK = "prefScreenPlayback";

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PlaybackPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PlaybackPreferencesFragment.java
@@ -8,17 +8,17 @@ import androidx.annotation.NonNull;
 import androidx.collection.ArrayMap;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.storage.preferences.UsageStatistics;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.screen.feed.preferences.SkipPreferenceDialog;
 import de.danoeh.antennapod.ui.screen.playback.VariableSpeedDialog;
 import java.util.Map;
 import org.greenrobot.eventbus.EventBus;
 
-public class PlaybackPreferencesFragment extends PreferenceFragmentCompat {
+public class PlaybackPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREF_PLAYBACK_SPEED_LAUNCHER = "prefPlaybackSpeedLauncher";
     private static final String PREF_PLAYBACK_REWIND_DELTA_LAUNCHER = "prefPlaybackRewindDeltaLauncher";
     private static final String PREF_PLAYBACK_FAST_FORWARD_DELTA_LAUNCHER = "prefPlaybackFastForwardDeltaLauncher";

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/SwipePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/SwipePreferencesFragment.java
@@ -1,8 +1,8 @@
 package de.danoeh.antennapod.ui.screen.preferences;
 
 import android.os.Bundle;
-import androidx.preference.PreferenceFragmentCompat;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.swipeactions.SwipeActionsDialog;
 import de.danoeh.antennapod.ui.screen.AllEpisodesFragment;
 import de.danoeh.antennapod.ui.screen.download.CompletedDownloadsFragment;
@@ -11,7 +11,7 @@ import de.danoeh.antennapod.ui.screen.InboxFragment;
 import de.danoeh.antennapod.ui.screen.PlaybackHistoryFragment;
 import de.danoeh.antennapod.ui.screen.queue.QueueFragment;
 
-public class SwipePreferencesFragment extends PreferenceFragmentCompat {
+public class SwipePreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREF_SWIPE_QUEUE = "prefSwipeQueue";
     private static final String PREF_SWIPE_INBOX = "prefSwipeInbox";
     private static final String PREF_SWIPE_EPISODES = "prefSwipeEpisodes";

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
@@ -10,11 +10,11 @@ import android.widget.ListView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.screen.subscriptions.FeedSortDialog;
 import org.greenrobot.eventbus.EventBus;
 
@@ -27,7 +27,7 @@ import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 
-public class UserInterfacePreferencesFragment extends PreferenceFragmentCompat {
+public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREF_SWIPE = "prefSwipe";
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
 plugins {
     id 'com.android.application' version "$agpVersion" apply false
     id 'com.android.library' version "$agpVersion" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
     id 'com.github.spotbugs' version '4.8.0' apply false
     id 'checkstyle'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ project.ext {
     annotationVersion = "1.4.0"
     appcompatVersion = "1.5.1"
     coreVersion = "1.9.0"
-    fragmentVersion = "1.5.5"
+    fragmentVersion = "1.8.4"
     mediaVersion = "1.6.0"
     media3Version = "1.1.1"
     paletteVersion = "1.0.0"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
 plugins {
     id 'com.android.application' version "$agpVersion" apply false
     id 'com.android.library' version "$agpVersion" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
     id 'com.github.spotbugs' version '4.8.0' apply false
     id 'checkstyle'
 }

--- a/common.gradle
+++ b/common.gradle
@@ -56,6 +56,17 @@ android {
     }
 }
 
+dependencies {
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
+}
+
 tasks.withType(Test).configureEach {
     testLogging {
         exceptionFormat "full"

--- a/common.gradle
+++ b/common.gradle
@@ -56,6 +56,12 @@ android {
     }
 }
 
+dependencies {
+    // align all versions of kotlin transitive dependencies, see
+    // https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7
+    implementation platform("org.jetbrains.kotlin:kotlin-bom:1.9.24")
+}
+
 tasks.withType(Test).configureEach {
     testLogging {
         exceptionFormat "full"

--- a/common.gradle
+++ b/common.gradle
@@ -56,17 +56,6 @@ android {
     }
 }
 
-dependencies {
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
-            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
-        }
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
-            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
-        }
-    }
-}
-
 tasks.withType(Test).configureEach {
     testLogging {
         exceptionFormat "full"

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AnimatedPreferenceFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AnimatedPreferenceFragment.java
@@ -1,0 +1,27 @@
+package de.danoeh.antennapod.ui.preferences.screen;
+
+import android.os.Bundle;
+import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceFragmentCompat;
+import com.google.android.material.transition.MaterialSharedAxis;
+import de.danoeh.antennapod.ui.common.ThemeUtils;
+import de.danoeh.antennapod.ui.preferences.R;
+
+public abstract class AnimatedPreferenceFragment extends PreferenceFragmentCompat {
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setEnterTransition(new MaterialSharedAxis(MaterialSharedAxis.X, true));
+        setReturnTransition(new MaterialSharedAxis(MaterialSharedAxis.X, false));
+        setExitTransition(new MaterialSharedAxis(MaterialSharedAxis.X, true));
+        setReenterTransition(new MaterialSharedAxis(MaterialSharedAxis.X, false));
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        view.setBackgroundColor(ThemeUtils.getColorFromAttr(getContext(), R.attr.colorSurface));
+    }
+}

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/AutoDownloadPreferencesFragment.java
@@ -2,15 +2,15 @@ package de.danoeh.antennapod.ui.preferences.screen;
 
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.PreferenceFragmentCompat;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.R;
 
-public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
+public class AutoDownloadPreferencesFragment extends AnimatedPreferenceFragment {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.preferences_autodownload);
+        checkAutodownloadItemVisibility(UserPreferences.isEnableAutodownload());
 
         findPreference(UserPreferences.PREF_ENABLE_AUTODL).setOnPreferenceChangeListener(
                 (preference, newValue) -> {
@@ -25,12 +25,6 @@ public class AutoDownloadPreferencesFragment extends PreferenceFragmentCompat {
     public void onStart() {
         super.onStart();
         ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(R.string.pref_automatic_download_title);
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        checkAutodownloadItemVisibility(UserPreferences.isEnableAutodownload());
     }
 
     private void checkAutodownloadItemVisibility(boolean autoDownload) {

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/NotificationPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/NotificationPreferencesFragment.java
@@ -2,11 +2,10 @@ package de.danoeh.antennapod.ui.preferences.screen;
 
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.PreferenceFragmentCompat;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
 import de.danoeh.antennapod.ui.preferences.R;
 
-public class NotificationPreferencesFragment extends PreferenceFragmentCompat {
+public class NotificationPreferencesFragment extends AnimatedPreferenceFragment {
 
     private static final String PREF_GPODNET_NOTIFICATIONS = "pref_gpodnet_notifications";
 

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/AboutFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/AboutFragment.java
@@ -8,13 +8,13 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.ui.preferences.BuildConfig;
 import de.danoeh.antennapod.ui.preferences.R;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 
-public class AboutFragment extends PreferenceFragmentCompat {
+public class AboutFragment extends AnimatedPreferenceFragment {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/ContributorsPagerFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/ContributorsPagerFragment.java
@@ -5,12 +5,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
+import com.google.android.material.transition.MaterialSharedAxis;
 import de.danoeh.antennapod.ui.preferences.R;
 
 /**
@@ -21,6 +23,13 @@ public class ContributorsPagerFragment extends Fragment {
     private static final int POS_TRANSLATORS = 1;
     private static final int POS_SPECIAL_THANKS = 2;
     private static final int TOTAL_COUNT = 3;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setEnterTransition(new MaterialSharedAxis(MaterialSharedAxis.X, true));
+        setReturnTransition(new MaterialSharedAxis(MaterialSharedAxis.X, false));
+    }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/LicensesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/LicensesFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.fragment.app.ListFragment;
+import com.google.android.material.transition.MaterialSharedAxis;
 import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.ui.preferences.R;
 import io.reactivex.Single;
@@ -30,6 +31,13 @@ import java.util.ArrayList;
 public class LicensesFragment extends ListFragment {
     private Disposable licensesLoader;
     private final ArrayList<LicenseItem> licenses = new ArrayList<>();
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setEnterTransition(new MaterialSharedAxis(MaterialSharedAxis.X, true));
+        setReturnTransition(new MaterialSharedAxis(MaterialSharedAxis.X, false));
+    }
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
@@ -19,7 +19,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.text.HtmlCompat;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -27,6 +26,7 @@ import de.danoeh.antennapod.net.sync.service.SyncService;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationProvider;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueueSink;
 import de.danoeh.antennapod.ui.preferences.R;
+import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -35,7 +35,7 @@ import de.danoeh.antennapod.event.SyncServiceEvent;
 import de.danoeh.antennapod.storage.preferences.SynchronizationCredentials;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
 
-public class SynchronizationPreferencesFragment extends PreferenceFragmentCompat {
+public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREFERENCE_SYNCHRONIZATION_DESCRIPTION = "preference_synchronization_description";
     private static final String PREFERENCE_GPODNET_SETLOGIN_INFORMATION = "pref_gpodnet_setlogin_information";
     private static final String PREFERENCE_SYNC = "pref_synchronization_sync";


### PR DESCRIPTION
### Description

Add predictive back gestures to settings screen.

Based on #7257, but just the settings screen for now.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
