### PR TITLE
Fix crash when opening deeplink that does not have a url

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -102,15 +102,11 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             feedUrl = getIntent().getDataString();
         }
 
-        if (feedUrl == null) {
+        if (feedUrl == null || UrlChecker.isDeeplinkWithoutUrl(feedUrl)) {
             Log.e(TAG, "feedUrl is null.");
             showNoPodcastFoundError();
         } else {
             Log.d(TAG, "Activity was started with url " + feedUrl);
-            // Remove subscribeonandroid.com from feed URL in order to subscribe to the actual feed URL
-            if (feedUrl.contains("subscribeonandroid.com")) {
-                feedUrl = feedUrl.replaceFirst("((www.)?(subscribeonandroid.com/))", "");
-            }
             if (savedInstanceState != null) {
                 username = savedInstanceState.getString("username");
                 password = savedInstanceState.getString("password");

--- a/net/common/src/main/java/de/danoeh/antennapod/net/common/UrlChecker.java
+++ b/net/common/src/main/java/de/danoeh/antennapod/net/common/UrlChecker.java
@@ -62,12 +62,19 @@ public final class UrlChecker {
             } catch (UnsupportedEncodingException e) {
                 return prepareUrl(query);
             }
+        } else if (lowerCaseUrl.contains("subscribeonandroid.com")) {
+            return prepareUrl(url.replaceFirst("((www.)?(subscribeonandroid.com/))", ""));
         } else if (!(lowerCaseUrl.startsWith("http://") || lowerCaseUrl.startsWith("https://"))) {
             Log.d(TAG, "Adding http:// at the beginning of the URL");
             return "http://" + url;
         } else {
             return url;
         }
+    }
+
+    public static boolean isDeeplinkWithoutUrl(String url) {
+        return url.toLowerCase(Locale.ROOT).contains(AP_SUBSCRIBE_DEEPLINK)
+                && Uri.parse(url).getQueryParameter("url") == null;
     }
 
     /**

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="download_log_title_unknown">Unknown title</string>
     <string name="download_type_feed">Feed</string>
     <string name="download_type_media">Media file</string>
-    <string name="null_value_podcast_error">No podcast was provided that could be shown.</string>
+    <string name="null_value_podcast_error">The link you tapped does not contain a valid podcast URL. Please verify the link and try again, or search for the podcast manually.</string>
     <string name="no_feed_url_podcast_found_by_search">The suggested podcast did not have an RSS link, AntennaPod found a podcast that could match</string>
     <string name="authentication_notification_title">Authentication required</string>
     <string name="confirm_mobile_download_dialog_title">Confirm mobile download</string>


### PR DESCRIPTION
### Description

Closes #7451

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
