### PR TITLE
Remove imports only used in JavaDoc

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -35,7 +35,9 @@
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="AvoidStarImport"/>
-        <module name="UnusedImports"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="false"/>
+        </module>
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>
         <module name="EmptyBlock">

--- a/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/gpoddernet/model/GpodnetUploadChangesResponse.java
+++ b/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/gpoddernet/model/GpodnetUploadChangesResponse.java
@@ -2,7 +2,6 @@ package de.danoeh.antennapod.net.sync.gpoddernet.model;
 
 import androidx.collection.ArrayMap;
 
-import de.danoeh.antennapod.net.sync.gpoddernet.GpodnetService;
 import de.danoeh.antennapod.net.sync.serviceinterface.UploadChangesResponse;
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/gpoddernet/model/GpodnetUploadChangesResponse.java
+++ b/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/gpoddernet/model/GpodnetUploadChangesResponse.java
@@ -10,7 +10,7 @@ import org.json.JSONObject;
 import java.util.Map;
 
 /**
- * Object returned by {@link GpodnetService} in uploadChanges method.
+ * Object returned by {@link de.danoeh.antennapod.net.sync.gpoddernet.GpodnetService} in uploadChanges method.
  */
 public class GpodnetUploadChangesResponse extends UploadChangesResponse {
     /**

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/ItemEnqueuePositionCalculator.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/ItemEnqueuePositionCalculator.java
@@ -13,7 +13,8 @@ import de.danoeh.antennapod.storage.preferences.UserPreferences.EnqueueLocation;
 import de.danoeh.antennapod.model.playback.Playable;
 
 /**
- * @see DBWriter#addQueueItem(Context, boolean, long...) it uses the class to determine
+ * @see de.danoeh.antennapod.storage.database.DBWriter#addQueueItem(android.content.Context, boolean, long...)
+ * it uses the class to determine
  * the positions of the {@link FeedItem} in the queue.
  */
 public class ItemEnqueuePositionCalculator {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/ItemEnqueuePositionCalculator.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/ItemEnqueuePositionCalculator.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.storage.database;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -11,7 +9,6 @@ import java.util.Random;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
-import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences.EnqueueLocation;
 import de.danoeh.antennapod.model.playback.Playable;
 


### PR DESCRIPTION
### Description

I noticed some unused imports. This PR removes them. I did not create an issue for such _small_ change, but obviously I will if really needed.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
