### PR TITLE
Sync service rework

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -24,6 +24,7 @@ import de.danoeh.antennapod.net.download.service.feed.remote.Downloader;
 import de.danoeh.antennapod.net.download.service.feed.remote.FeedParserTask;
 import de.danoeh.antennapod.net.download.serviceinterface.AutoDownloadManager;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadRequestCreator;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
 import de.danoeh.antennapod.storage.database.DBWriter;
@@ -103,6 +104,7 @@ public class FeedUpdateWorker extends Worker {
         NonSubscribedFeedsCleaner.deleteOldNonSubscribedFeeds(getApplicationContext());
         AutoDownloadManager.getInstance().autodownloadUndownloadedItems(getApplicationContext());
         notificationManager.cancel(R.id.notification_updating_feeds);
+        SynchronizationQueue.getInstance().syncImmediately();
         return Result.success();
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -571,7 +571,7 @@
     <string name="sync_status_episodes_download">Downloading episode changes…</string>
     <string name="sync_status_upload_played">Uploading played status…</string>
     <string name="sync_status_subscriptions">Synchronizing subscriptions…</string>
-    <string name="sync_status_wait_for_downloads">Waiting for downloads to complete…</string>
+    <string name="sync_status_wait_for_downloads">Waiting for subscriptions refresh…</string>
     <string name="sync_status_success">Synchronization successful</string>
     <string name="sync_status_error">Synchronization failed</string>
 


### PR DESCRIPTION
### Description

- Enables users to manually trigger sync
- Makes sure that we actually refresh when a new feed arrives:
Previously, we might request the feed to be refreshed but then don't
actually wait for it to be completed because the refresh service
wouldn't start up quickly enough.

This makes sure that we do not try to sync again before the refresh
actually went through, even if the sync service is called multiple times.

Closes: #7184

ToDo later:

- When coming across an episode action that we cannot find, make sure that feeds were refreshed after that action 
- Do not upload copy of actions on full sync. This just floods servers unnecessarily and might mess up "last played" statistics 

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
