### PR TITLE
Perform toplist discovery using PodcastIndex

### DIFF
--- a/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/PodcastIndexApi.java
+++ b/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/PodcastIndexApi.java
@@ -1,0 +1,49 @@
+package de.danoeh.antennapod.net.discovery;
+
+import de.danoeh.antennapod.net.common.UserAgentInterceptor;
+import okhttp3.Request;
+
+import java.security.MessageDigest;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public abstract class PodcastIndexApi {
+    public static Request.Builder buildAuthenticatedRequest(String url) {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.clear();
+        Date now = new Date();
+        calendar.setTime(now);
+        long secondsSinceEpoch = calendar.getTimeInMillis() / 1000L;
+        String apiHeaderTime = String.valueOf(secondsSinceEpoch);
+        String data4Hash = BuildConfig.PODCASTINDEX_API_KEY + BuildConfig.PODCASTINDEX_API_SECRET + apiHeaderTime;
+        String hashString = sha1(data4Hash);
+
+        return new Request.Builder()
+                .addHeader("X-Auth-Date", apiHeaderTime)
+                .addHeader("X-Auth-Key", BuildConfig.PODCASTINDEX_API_KEY)
+                .addHeader("Authorization", hashString)
+                .addHeader("User-Agent", UserAgentInterceptor.USER_AGENT)
+                .url(url);
+    }
+
+    private static String sha1(String clearString) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+            messageDigest.update(clearString.getBytes("UTF-8"));
+            return toHex(messageDigest.digest());
+        } catch (Exception ignored) {
+            ignored.printStackTrace();
+            return null;
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder buffer = new StringBuilder();
+        for (byte b : bytes) {
+            buffer.append(String.format(Locale.getDefault(), "%02x", b));
+        }
+        return buffer.toString();
+    }
+}

--- a/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/PodcastIndexPodcastSearcher.java
+++ b/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/PodcastIndexPodcastSearcher.java
@@ -1,22 +1,6 @@
 package de.danoeh.antennapod.net.discovery;
 
 import de.danoeh.antennapod.net.common.AntennapodHttpClient;
-import de.danoeh.antennapod.net.common.UserAgentInterceptor;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.security.MessageDigest;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
-
 import io.reactivex.Single;
 import io.reactivex.SingleOnSubscribe;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -24,6 +8,15 @@ import io.reactivex.schedulers.Schedulers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PodcastIndexPodcastSearcher implements PodcastSearcher {
     private static final String SEARCH_API_URL = "https://api.podcastindex.org/api/1.0/search/byterm?q=%s";
@@ -45,7 +38,8 @@ public class PodcastIndexPodcastSearcher implements PodcastSearcher {
             List<PodcastSearchResult> podcasts = new ArrayList<>();
             try {
                 OkHttpClient client = AntennapodHttpClient.getHttpClient();
-                Response response = client.newCall(buildAuthenticatedRequest(formattedUrl)).execute();
+                Request.Builder builder = PodcastIndexApi.buildAuthenticatedRequest(formattedUrl);
+                Response response = client.newCall(builder.build()).execute();
 
                 if (response.isSuccessful()) {
                     String resultString = response.body().string();
@@ -84,43 +78,5 @@ public class PodcastIndexPodcastSearcher implements PodcastSearcher {
     @Override
     public String getName() {
         return "Podcast Index";
-    }
-
-    private Request buildAuthenticatedRequest(String url) {
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.clear();
-        Date now = new Date();
-        calendar.setTime(now);
-        long secondsSinceEpoch = calendar.getTimeInMillis() / 1000L;
-        String apiHeaderTime = String.valueOf(secondsSinceEpoch);
-        String data4Hash = BuildConfig.PODCASTINDEX_API_KEY + BuildConfig.PODCASTINDEX_API_SECRET + apiHeaderTime;
-        String hashString = sha1(data4Hash);
-
-        Request.Builder httpReq = new Request.Builder()
-                .addHeader("X-Auth-Date", apiHeaderTime)
-                .addHeader("X-Auth-Key", BuildConfig.PODCASTINDEX_API_KEY)
-                .addHeader("Authorization", hashString)
-                .addHeader("User-Agent", UserAgentInterceptor.USER_AGENT)
-                .url(url);
-        return httpReq.build();
-    }
-
-    private static String sha1(String clearString) {
-        try {
-            MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
-            messageDigest.update(clearString.getBytes("UTF-8"));
-            return toHex(messageDigest.digest());
-        } catch (Exception ignored) {
-            ignored.printStackTrace();
-            return null;
-        }
-    }
-
-    private static String toHex(byte[] bytes) {
-        StringBuilder buffer = new StringBuilder();
-        for (byte b : bytes) {
-            buffer.append(String.format(Locale.getDefault(), "%02x", b));
-        }
-        return buffer.toString();
     }
 }

--- a/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/PodcastIndexTrendingLoader.java
+++ b/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/PodcastIndexTrendingLoader.java
@@ -1,0 +1,66 @@
+package de.danoeh.antennapod.net.discovery;
+
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.net.common.AntennapodHttpClient;
+import okhttp3.CacheControl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public abstract class PodcastIndexTrendingLoader {
+    private static final String API_URL = "https://api.podcastindex.org/api/1.0/podcasts/trending?max=%d&lang=%s";
+    private static final int NUM_LOADED = 25;
+
+    public static List<PodcastSearchResult> loadTrending(String country, int limit, List<Feed> subscribed)
+            throws JSONException, IOException {
+        String formattedUrl = String.format(Locale.ROOT, API_URL, NUM_LOADED, "de");
+
+        List<PodcastSearchResult> podcasts = new ArrayList<>();
+        OkHttpClient client = AntennapodHttpClient.getHttpClient();
+        Request.Builder builder = PodcastIndexApi.buildAuthenticatedRequest(formattedUrl);
+        builder.cacheControl(new CacheControl.Builder().maxStale(1, TimeUnit.DAYS).build());
+        Response response = client.newCall(builder.build()).execute();
+
+        if (!response.isSuccessful()) {
+            throw new IOException(response.toString());
+        }
+
+        String resultString = response.body().string();
+        JSONObject result = new JSONObject(resultString);
+        JSONArray j = result.getJSONArray("feeds");
+
+        for (int i = 0; i < j.length(); i++) {
+            JSONObject podcastJson = j.getJSONObject(i);
+            PodcastSearchResult podcast = PodcastSearchResult.fromPodcastIndex(podcastJson);
+            if (podcast.feedUrl == null) {
+                continue;
+            }
+            boolean alreadySubscribed = false;
+            for (Feed f : subscribed) {
+                if (f.getState() != Feed.STATE_SUBSCRIBED) {
+                    continue;
+                }
+                if (f.getDownloadUrl().equals(podcast.feedUrl) || f.getTitle().equals(podcast.title)) {
+                    alreadySubscribed = true;
+                    break;
+                }
+            }
+            if (!alreadySubscribed) {
+                podcasts.add(podcast);
+                if (podcasts.size() == limit) {
+                    return podcasts;
+                }
+            }
+        }
+        return podcasts;
+    }
+}

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/DiscoveryFragment.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/DiscoveryFragment.java
@@ -20,11 +20,12 @@ import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.google.android.material.textfield.TextInputLayout;
-import de.danoeh.antennapod.net.discovery.BuildConfig;
-import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.event.DiscoveryDefaultUpdateEvent;
+import de.danoeh.antennapod.net.discovery.BuildConfig;
 import de.danoeh.antennapod.net.discovery.ItunesTopListLoader;
+import de.danoeh.antennapod.net.discovery.PodcastIndexTrendingLoader;
 import de.danoeh.antennapod.net.discovery.PodcastSearchResult;
+import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -182,9 +183,8 @@ public class DiscoveryFragment extends Fragment implements Toolbar.OnMenuItemCli
             return;
         }
 
-        ItunesTopListLoader loader = new ItunesTopListLoader(getContext());
         disposable = Observable.fromCallable(() ->
-                        loader.loadToplist(country, NUM_OF_TOP_PODCASTS, DBReader.getFeedList()))
+                        PodcastIndexTrendingLoader.loadTrending(country, NUM_OF_TOP_PODCASTS, DBReader.getFeedList()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/QuickFeedDiscoveryFragment.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/QuickFeedDiscoveryFragment.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import androidx.fragment.app.Fragment;
 import de.danoeh.antennapod.net.discovery.BuildConfig;
+import de.danoeh.antennapod.net.discovery.PodcastIndexTrendingLoader;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.event.DiscoveryDefaultUpdateEvent;
 import de.danoeh.antennapod.net.discovery.ItunesTopListLoader;
@@ -103,7 +104,6 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
         viewBinding.errorRetryButton.setText(R.string.retry_label);
         viewBinding.poweredByLabel.setVisibility(View.VISIBLE);
 
-        ItunesTopListLoader loader = new ItunesTopListLoader(getContext());
         SharedPreferences prefs = getActivity().getSharedPreferences(ItunesTopListLoader.PREFS, MODE_PRIVATE);
         String countryCode = prefs.getString(ItunesTopListLoader.PREF_KEY_COUNTRY_CODE,
                 Locale.getDefault().getCountry());
@@ -131,7 +131,7 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
         }
 
         disposable = Observable.fromCallable(() ->
-                        loader.loadToplist(countryCode, NUM_SUGGESTIONS, DBReader.getFeedList()))
+                        PodcastIndexTrendingLoader.loadTrending(countryCode, NUM_SUGGESTIONS, DBReader.getFeedList()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(

--- a/ui/discovery/src/main/res/layout/fragment_online_search.xml
+++ b/ui/discovery/src/main/res/layout/fragment_online_search.xml
@@ -89,7 +89,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textColor="?android:attr/textColorTertiary"
-        android:text="@string/discover_powered_by_itunes"
+        android:text="@string/discover_powered_by_podcast_index"
         android:textSize="12sp"
         android:padding="4dp"
         android:background="?android:attr/colorBackground"

--- a/ui/discovery/src/main/res/layout/quick_feed_discovery.xml
+++ b/ui/discovery/src/main/res/layout/quick_feed_discovery.xml
@@ -63,7 +63,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/discover_powered_by_itunes"
+            android:text="@string/discover_powered_by_podcast_index"
             android:paddingHorizontal="4dp"
             style="@style/TextAppearance.Material3.BodySmall" />
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -784,7 +784,7 @@
     <string name="discover_hide">Hide</string>
     <string name="discover_is_hidden">You selected to hide suggestions.</string>
     <string name="discover_more">Discover more »</string>
-    <string name="discover_powered_by_itunes">Suggestions by Apple Podcasts</string>
+    <string name="discover_powered_by_podcast_index">Suggestions by Podcast Index</string>
     <string name="discover_confirm">Show suggestions</string>
     <string name="search_powered_by">Results by %1$s</string>
     <string name="select_country">Select country</string>


### PR DESCRIPTION
### Description

iTunes no longer returns the toplist, so we (rather quickly) have to find an alternative. This PR performs toplist discovery using PodcastIndex.

ToDo:
- [ ] Country selection not supported yet
- [ ] Caching should be more aggressive
- [ ] Remove iTunes variant

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
