### PR TITLE
Always top-align blurred image

### DIFF
--- a/ui/glide/src/main/java/de/danoeh/antennapod/ui/glide/FastBlurTransformation.java
+++ b/ui/glide/src/main/java/de/danoeh/antennapod/ui/glide/FastBlurTransformation.java
@@ -1,7 +1,9 @@
 package de.danoeh.antennapod.ui.glide;
 
 import android.graphics.Bitmap;
-import android.media.ThumbnailUtils;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
 import androidx.annotation.NonNull;
 import android.util.Log;
 
@@ -27,9 +29,13 @@ public class FastBlurTransformation extends BitmapTransformation {
                                @NonNull Bitmap source,
                                int outWidth,
                                int outHeight) {
-        int targetWidth = outWidth / 3;
+        int targetWidth = outWidth / 2;
         int targetHeight = (int) (1.0 * outHeight * targetWidth / outWidth);
-        Bitmap resized = ThumbnailUtils.extractThumbnail(source, targetWidth, targetHeight);
+        Bitmap resized = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(resized);
+        c.drawBitmap(source,
+                new Rect(0, 0, source.getWidth(), source.getHeight()),
+                new Rect(0, 0, targetWidth, targetWidth * source.getWidth() / source.getHeight()), new Paint());
         Bitmap result = fastBlur(resized, STACK_BLUR_RADIUS);
         if (result == null) {
             Log.w(TAG, "result was null");


### PR DESCRIPTION
### Description

Always top-align blurred image
Closes (again) #7343

CC @loucasal 

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
