### PR TITLE
Change default drawer order to better fit bottom navigation

### DIFF
--- a/storage/preferences/src/main/res/values/arrays.xml
+++ b/storage/preferences/src/main/res/values/arrays.xml
@@ -4,8 +4,8 @@
         <item>HomeFragment</item>
         <item>QueueFragment</item>
         <item>NewEpisodesFragment</item>
-        <item>EpisodesFragment</item>
         <item>SubscriptionFragment</item>
+        <item>EpisodesFragment</item>
         <item>DownloadsFragment</item>
         <item>PlaybackHistoryFragment</item>
         <item>AddFeedFragment</item>


### PR DESCRIPTION
### Description

Change default drawer order to better fit bottom navigation.

As discussed in the community call yesterday, this should be mentioned in the changelog. The changelog should also mention that one can re-order the drawer.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
