### PR TITLE
Fix autodownload tests sometimes crashing because sync service is not initialized

### DIFF
--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbCleanupTests.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbCleanupTests.java
@@ -16,6 +16,8 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.download.serviceinterface.AutoDownloadManager;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueueStub;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
@@ -83,6 +85,7 @@ public class DbCleanupTests {
         PlaybackPreferences.init(context);
         SynchronizationSettings.init(context);
         AutoDownloadManager.setInstance(new AutoDownloadManagerImpl());
+        SynchronizationQueue.setInstance(new SynchronizationQueueStub());
     }
 
     @After

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbQueueCleanupAlgorithmTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbQueueCleanupAlgorithmTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.net.download.serviceinterface.AutoDownloadManager;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueueStub;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 
 import org.junit.Test;
@@ -26,6 +28,7 @@ public class DbQueueCleanupAlgorithmTest extends DbCleanupTests {
     public DbQueueCleanupAlgorithmTest() {
         setCleanupAlgorithm(UserPreferences.EPISODE_CLEANUP_QUEUE);
         AutoDownloadManager.setInstance(new AutoDownloadManagerImpl());
+        SynchronizationQueue.setInstance(new SynchronizationQueueStub());
     }
 
     /**


### PR DESCRIPTION
### Description

Fix autodownload tests not initializing sync service

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
