### PR TITLE
Set show notes direction to auto

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/cleaner/ShownotesCleaner.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/cleaner/ShownotesCleaner.java
@@ -100,6 +100,7 @@ public class ShownotesCleaner {
         cleanCss(document);
         document.head().appendElement("style").attr("type", "text/css").text(webviewStyle);
         addTimecodes(document);
+        document.body().attr("dir", "auto");
         return document.toString();
     }
 


### PR DESCRIPTION
This matches what Android does automatically for most native text views. Not perfect but good enough.

### Description
Fixes partially #7497

<img width="258" alt="image" src="https://github.com/user-attachments/assets/093a2ded-7aa3-46dd-afec-6554a4ea80b3">

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
