### PR TITLE
Support plurals for strings reported on Weblate

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
@@ -57,8 +57,8 @@ public class DownloadActionButton extends ItemActionButton {
         long timeSinceBypass = System.currentTimeMillis() / 1000 - bypassCellularNetworkWarningTimer;
         boolean shouldBypass = timeSinceBypass < TIMEOUT_NETWORK_WARN_SECONDS;
         if (shouldBypass && bypassCellularNetworkType == BYPASS_TYPE_NOW) {
-            Toast.makeText(context, context.getString(
-                    R.string.mobile_download_notice, TIMEOUT_NETWORK_WARN_SECONDS / 60), Toast.LENGTH_LONG).show();
+            Toast.makeText(context, context.getResources().getQuantityString(R.plurals.mobile_download_notice,
+                    TIMEOUT_NETWORK_WARN_SECONDS / 60, TIMEOUT_NETWORK_WARN_SECONDS / 60), Toast.LENGTH_LONG).show();
         }
         if (NetworkUtils.isEpisodeDownloadAllowed() || shouldBypass) {
             DownloadServiceInterface.get().downloadNow(context, item, bypassCellularNetworkType == BYPASS_TYPE_NOW);

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -321,7 +321,10 @@
     <string name="confirm_mobile_download_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Downloading over mobile data connection is disabled in the settings. If you want this problem to be fixed, contact the creators of your VPN app.</string>
     <string name="confirm_mobile_download_dialog_download_later">Download later</string>
     <string name="confirm_mobile_download_dialog_allow_this_time">Download anyway</string>
-    <string name="mobile_download_notice">Downloading over mobile data connection for the next %d minutes</string>
+    <plurals name="mobile_download_notice">
+        <item quantity="one">Downloading over mobile data connection for the next %d minute</item>
+        <item quantity="other">Downloading over mobile data connection for the next %d minutes</item>
+    </plurals>
     <string name="confirm_mobile_streaming_notification_title">Confirm mobile streaming</string>
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>
@@ -737,10 +740,20 @@
     <string name="keep_updated">Keep updated</string>
     <string name="keep_updated_summary">Include this podcast when (auto-)refreshing all podcasts</string>
     <string name="auto_download_disabled_globally">Auto download is disabled in the main AntennaPod settings</string>
-    <string name="statistics_episodes_started">started</string>
-    <string name="statistics_episodes_total">total</string>
-    <string name="statistics_episodes_played">played</string>
-    <string name="statistics_episodes_downloaded">downloaded</string>
+    <plurals name="statistics_episodes_started">
+        <item quantity="one">started</item>
+        <item quantity="other">started</item>
+    </plurals>
+    <plurals name="statistics_episodes_total">
+        <item quantity="one">total</item>
+        <item quantity="other">total</item>
+    </plurals>
+    <plurals name="statistics_episodes_downloaded">
+        <item quantity="one">downloaded</item>
+        <item quantity="other">downloaded</item>
+    </plurals>
+    <string name="statistics_time_total">total</string>
+    <string name="statistics_time_played">played</string>
     <string name="statistics_episodes_space">space taken</string>
     <string name="statistics_release_schedule">release schedule</string>
     <string name="statistics_release_next">next episode (estimate)</string>

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
@@ -153,21 +153,24 @@ public class FeedStatisticsFragment extends Fragment {
         StatisticsItem s = p.first;
         viewBinding.episodesStarted.mainLabel.setText(getResources()
                 .getQuantityString(R.plurals.num_episodes, (int) s.episodesStarted, s.episodesStarted));
-        viewBinding.episodesStarted.subtitleLabel.setText(R.string.statistics_episodes_started);
+        viewBinding.episodesStarted.subtitleLabel.setText(getResources()
+                .getQuantityString(R.plurals.statistics_episodes_started, (int) s.episodesStarted));
 
         viewBinding.episodesTotal.mainLabel.setText(getResources()
                 .getQuantityString(R.plurals.num_episodes, (int) s.episodes, s.episodes));
-        viewBinding.episodesTotal.subtitleLabel.setText(R.string.statistics_episodes_total);
+        viewBinding.episodesTotal.subtitleLabel.setText(getResources()
+                .getQuantityString(R.plurals.statistics_episodes_total, (int) s.episodes));
 
         viewBinding.playbackTime.mainLabel.setText(Converter.shortLocalizedDuration(getContext(), s.timePlayed));
-        viewBinding.playbackTime.subtitleLabel.setText(R.string.statistics_episodes_played);
+        viewBinding.playbackTime.subtitleLabel.setText(R.string.statistics_time_played);
 
         viewBinding.durationTotal.mainLabel.setText(Converter.shortLocalizedDuration(getContext(), s.time));
-        viewBinding.durationTotal.subtitleLabel.setText(R.string.statistics_episodes_total);
+        viewBinding.durationTotal.subtitleLabel.setText(R.string.statistics_time_total);
 
         viewBinding.episodesDownloaded.mainLabel.setText(getResources()
                 .getQuantityString(R.plurals.num_episodes, (int) s.episodesDownloadCount, s.episodesDownloadCount));
-        viewBinding.episodesDownloaded.subtitleLabel.setText(R.string.statistics_episodes_downloaded);
+        viewBinding.episodesDownloaded.subtitleLabel.setText(getResources()
+                .getQuantityString(R.plurals.statistics_episodes_downloaded, (int) s.episodesDownloadCount));
 
         viewBinding.spaceDownloaded.mainLabel.setText(Formatter.formatShortFileSize(getContext(), s.totalDownloadSize));
         viewBinding.spaceDownloaded.subtitleLabel.setText(R.string.statistics_episodes_space);


### PR DESCRIPTION
### Description

Support plurals for strings reported on Weblate

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
