### PR TITLE
Upgrade AGP and Gradle for Java 23 support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -178,7 +178,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize"
             android:supportsPictureInPicture="true"
             android:screenOrientation="sensorLandscape"
-            android:exported="false">
+            android:exported="false"
+            tools:ignore="DiscouragedApi">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="de.danoeh.antennapod.activity.MainActivity"/>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.2"
 }
 plugins {
     id 'com.android.application' version "$agpVersion" apply false

--- a/common.gradle
+++ b/common.gradle
@@ -54,6 +54,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ui/i18n/src/main/res/values-ja/strings.xml
+++ b/ui/i18n/src/main/res/values-ja/strings.xml
@@ -217,8 +217,6 @@
     <string name="download_running">ダウンロード実行中</string>
     <string name="download_error_details">詳細</string>
     <string name="download_log_details_message">%1$s \n\n技術的な理由: \n%2$s \n\nファイル URL:\n%3$s</string>
-    <string name="download_error_retrying">\\%1$s\\ のダウンロードに失敗しました。後ほど再度ダウンロードを試みます。</string>
-    <string name="download_error_not_retrying">\\%1$s\\ のダウンロードに失敗しました。</string>
     <string name="download_error_tap_for_details">タップして詳細を表示します。</string>
     <string name="download_error_device_not_found">ストレージ デバイスが見つかりません</string>
     <string name="download_error_insufficient_space">デバイスに十分な空きスペースがありません。</string>
@@ -465,7 +463,6 @@
   <string name="search_status_no_results">見つかりませんでした</string>
     <string name="type_to_search">検索ワードを入力してください</string>
     <string name="search_label">検索</string>
-    <string name="no_results_for_query">\\%1$s\\ の結果は見つかりませんでした</string>
     <string name="search_online">オンラインで検索</string>
     <!--Synchronization-->
   <string name="sync_status_started">同期開始</string>


### PR DESCRIPTION
### Description

Upgrade AGP and Gradle for Java 23 support. Tested to still support Java 17. AGP is upgraded as well but not to the latest version to keep support for IntelliJ Idea 2024.2.

Closes #7499

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
