### PR TITLE
More human-readable error when feed is invalid

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogDetailsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogDetailsDialog.java
@@ -4,6 +4,9 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.os.Build;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -39,15 +42,19 @@ public class DownloadLogDetailsDialog extends MaterialAlertDialogBuilder {
             message = status.getReasonDetailed();
         }
 
-        String messageFull = context.getString(R.string.download_log_details_message,
-                context.getString(DownloadErrorLabel.from(status.getReason())), message, url);
+        String humanReadableReason = context.getString(DownloadErrorLabel.from(status.getReason()));
+        SpannableString errorMessage = new SpannableString(context.getString(R.string.download_log_details_message,
+                humanReadableReason, message, url));
+        errorMessage.setSpan(new ForegroundColorSpan(0x88888888),
+                humanReadableReason.length(), errorMessage.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+
         setTitle(R.string.download_error_details);
-        setMessage(messageFull);
+        setMessage(errorMessage);
         setPositiveButton(android.R.string.ok, null);
         setNeutralButton(R.string.copy_to_clipboard, (dialog, which) -> {
             ClipboardManager clipboard = (ClipboardManager) getContext()
                     .getSystemService(Context.CLIPBOARD_SERVICE);
-            ClipData clip = ClipData.newPlainText(context.getString(R.string.download_error_details), messageFull);
+            ClipData clip = ClipData.newPlainText(context.getString(R.string.download_error_details), errorMessage);
             clipboard.setPrimaryClip(clip);
             if (Build.VERSION.SDK_INT < 32) {
                 EventBus.getDefault().post(new MessageEvent(context.getString(R.string.copied_to_clipboard)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -12,6 +12,7 @@ import android.text.style.ForegroundColorSpan;
 import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
+import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -294,7 +295,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(this::showFeedFragment, error -> {
             error.printStackTrace();
-            showErrorDialog(error.getMessage(), "");
+            showErrorDialog(getString(R.string.download_error_parser_exception), error.getMessage());
         });
     }
 
@@ -363,10 +364,10 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this);
             builder.setTitle(R.string.error_label);
             if (errorMsg != null) {
-                String total = errorMsg + "\n\n" + details;
-                SpannableString errorMessage = new SpannableString(total);
+                SpannableString errorMessage = new SpannableString(getString(
+                        R.string.download_log_details_message, errorMsg, details, selectedDownloadUrl));
                 errorMessage.setSpan(new ForegroundColorSpan(0x88888888),
-                        errorMsg.length(), total.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                        errorMsg.length(), errorMessage.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                 builder.setMessage(errorMessage);
             } else {
                 builder.setMessage(R.string.download_error_error_unknown);
@@ -382,6 +383,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
                 dialog.dismiss();
             }
             dialog = builder.show();
+            ((TextView) dialog.findViewById(android.R.id.message)).setTextIsSelectable(true);
         }
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -286,7 +286,7 @@
     <string name="download_error_insufficient_space">There is not enough space left on your device.</string>
     <string name="download_error_http_data_error">HTTP data error</string>
     <string name="download_error_error_unknown">Unknown error</string>
-    <string name="download_error_parser_exception">The podcast host\'s server sent a broken podcast feed.</string>
+    <string name="download_error_parser_exception">The podcast host\'s server sent a broken podcast feed. We recommend checking with a podcast validator such as castfeedvalidator.com and contacting the podcast creator to let them know.</string>
     <string name="download_error_unsupported_type">Unsupported feed type</string>
     <string name="download_error_unsupported_type_html">The podcast host\'s server sent a website, not a podcast.</string>
     <string name="download_error_not_found">The podcast host\'s server does not know where to find the file. It may have been deleted.</string>


### PR DESCRIPTION
### Description

More human-readable error when feed is invalid

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
