### PR TITLE
fix bug with transcript showing up for all episodes

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -60,8 +60,8 @@ public class FeedItemMenuHandler {
         boolean canSkip = false;
         boolean canRemoveFromQueue = false;
         boolean canAddToQueue = false;
-        boolean canVisitWebsite = selectedItems.size() == 1;
-        boolean canShare = selectedItems.size() == 1;
+        boolean canVisitWebsite = false;
+        boolean canShare = false;
         boolean canRemoveFromInbox = false;
         boolean canMarkPlayed = false;
         boolean canMarkUnplayed = false;

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -70,7 +70,7 @@ public class FeedItemMenuHandler {
         boolean canDownload = false;
         boolean canAddFavorite = false;
         boolean canRemoveFavorite = false;
-        boolean canShowTranscript = selectedItems.size() == 1;
+        boolean canShowTranscript = false;
 
         for (FeedItem item : selectedItems) {
             boolean hasMedia = item.getMedia() != null;


### PR DESCRIPTION
fix #7541

### Description
Do not display 'Show transcript' for episodes that do not have transcripts

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
