### PR TITLE
Wait in SyncService before enqueueing subscriptions refresh

### DIFF
--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.util.Pair;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
+import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.SyncServiceEvent;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -77,6 +78,7 @@ public class SyncService extends Worker {
         try {
             activeSyncProvider.login();
             syncSubscriptions(activeSyncProvider);
+            waitForDownloadServiceCompleted();
             if (someFeedWasNotRefreshedYet()) {
                 // Note that this service might get called several times before the FeedUpdate completes
                 Log.d(TAG, "Found new subscriptions. Need to refresh them before syncing episode actions");
@@ -107,6 +109,22 @@ public class SyncService extends Worker {
             }
         } finally {
             currentlyActive = false;
+        }
+    }
+
+    private void waitForDownloadServiceCompleted() {
+        EventBus.getDefault().postSticky(new SyncServiceEvent(R.string.sync_status_wait_for_downloads));
+        try {
+            while (true) {
+                FeedUpdateRunningEvent event = EventBus.getDefault().getStickyEvent(FeedUpdateRunningEvent.class);
+                if (event == null || !event.isFeedUpdateRunning) {
+                    return;
+                }
+                //noinspection BusyWait
+                Thread.sleep(1000);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
### Description

Apparently requesting to run the manager cancels the already running one on some devices. This leads to an endless loop trying to refresh over and over again.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
