### PR TITLE
Limit share preview length

### DIFF
--- a/app/src/main/res/layout/share_episode_dialog.xml
+++ b/app/src/main/res/layout/share_episode_dialog.xml
@@ -55,6 +55,7 @@
                         android:id="@+id/socialMessageText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:maxLines="7"
                         android:text="@string/share_dialog_for_social"
                         style="@style/TextAppearance.Material3.BodyMedium" />
 


### PR DESCRIPTION
### Description

Otherwise devices with large font sizes would
push one of the items off the screen

Closes #7540

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
