### PR TITLE
Add menu on statistics screen to bring back Echo

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
@@ -39,7 +39,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
-import java.util.Calendar;
 import java.util.List;
 
 /**
@@ -82,10 +81,7 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
         viewBinding.homeContainer.removeAllViews();
 
         SharedPreferences prefs = getContext().getSharedPreferences(HomeFragment.PREF_NAME, Context.MODE_PRIVATE);
-        if (Calendar.getInstance().get(Calendar.YEAR) == EchoConfig.RELEASE_YEAR
-                && Calendar.getInstance().get(Calendar.MONTH) == Calendar.DECEMBER
-                && Calendar.getInstance().get(Calendar.DAY_OF_MONTH) >= 10
-                && prefs.getInt(PREF_HIDE_ECHO, 0) != EchoConfig.RELEASE_YEAR) {
+        if (EchoConfig.isCurrentlyVisible() && prefs.getInt(PREF_HIDE_ECHO, 0) != EchoConfig.RELEASE_YEAR) {
             addSection(new EchoSection());
         }
 

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/EchoConfig.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/EchoConfig.java
@@ -16,4 +16,10 @@ public class EchoConfig {
         date.set(Calendar.YEAR, RELEASE_YEAR);
         return date.getTimeInMillis();
     }
+
+    public static boolean isCurrentlyVisible() {
+        return Calendar.getInstance().get(Calendar.YEAR) == RELEASE_YEAR
+                && Calendar.getInstance().get(Calendar.MONTH) == Calendar.DECEMBER
+                && Calendar.getInstance().get(Calendar.DAY_OF_MONTH) >= 10;
+    }
 }

--- a/ui/echo/src/main/res/values/echo-strings.xml
+++ b/ui/echo/src/main/res/values/echo-strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,PluralsCandidate">
-    <string name="debug_echo" translatable="false">[Debug] Echo</string>
     <string name="echo_home_header">Review the year</string>
     <string name="echo_home_subtitle">Your top podcasts and stats from the past year. Exclusively on your phone.</string>
 

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
@@ -23,6 +23,7 @@ import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.event.StatisticsEvent;
 import de.danoeh.antennapod.ui.common.PagedToolbarFragment;
 import de.danoeh.antennapod.ui.echo.EchoActivity;
+import de.danoeh.antennapod.ui.echo.EchoConfig;
 import de.danoeh.antennapod.ui.statistics.downloads.DownloadStatisticsFragment;
 import de.danoeh.antennapod.ui.statistics.subscriptions.SubscriptionStatisticsFragment;
 import de.danoeh.antennapod.ui.statistics.years.YearsStatisticsFragment;
@@ -63,8 +64,8 @@ public class StatisticsFragment extends PagedToolbarFragment {
         toolbar = rootView.findViewById(R.id.toolbar);
         toolbar.setTitle(getString(R.string.statistics_label));
         toolbar.inflateMenu(R.menu.statistics);
-        if (BuildConfig.DEBUG) {
-            toolbar.getMenu().findItem(R.id.debug_echo).setVisible(true);
+        if (BuildConfig.DEBUG || EchoConfig.isCurrentlyVisible()) {
+            toolbar.getMenu().findItem(R.id.show_echo).setVisible(true);
         }
         toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
         viewPager.setAdapter(new StatisticsPagerAdapter(this));
@@ -94,7 +95,7 @@ public class StatisticsFragment extends PagedToolbarFragment {
         if (item.getItemId() == R.id.statistics_reset) {
             confirmResetStatistics();
             return true;
-        } else if (item.getItemId() == R.id.debug_echo) {
+        } else if (item.getItemId() == R.id.show_echo) {
             startActivity(new Intent(getContext(), EchoActivity.class));
         }
         return super.onOptionsItemSelected(item);

--- a/ui/statistics/src/main/res/menu/statistics.xml
+++ b/ui/statistics/src/main/res/menu/statistics.xml
@@ -14,8 +14,8 @@
         custom:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/debug_echo"
-        android:title="@string/debug_echo"
+        android:id="@+id/show_echo"
+        android:title="@string/antennapod_echo"
         custom:showAsAction="never"
         android:visible="false" />
 


### PR DESCRIPTION
### Description

Add menu on statistics screen to bring back Echo
Closes #7543

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
