### PR TITLE
Fix arrow direction of home more links on RTL languages

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeSection.java
@@ -21,8 +21,6 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import org.greenrobot.eventbus.EventBus;
 
-import java.util.Locale;
-
 /**
  * Section on the HomeFragment
  */
@@ -36,11 +34,7 @@ public abstract class HomeSection extends Fragment implements View.OnCreateConte
                              @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         viewBinding = HomeSectionBinding.inflate(inflater);
         viewBinding.titleLabel.setText(getSectionTitle());
-        if (TextUtils.getLayoutDirectionFromLocale(Locale.getDefault()) == View.LAYOUT_DIRECTION_LTR) {
-            viewBinding.moreButton.setText(getMoreLinkTitle() + "\u00A0»");
-        } else {
-            viewBinding.moreButton.setText("«\u00A0" + getMoreLinkTitle());
-        }
+        viewBinding.moreButton.setText(getMoreLinkTitle());
         viewBinding.moreButton.setOnClickListener((view) -> handleMoreClick());
         if (TextUtils.isEmpty(getMoreLinkTitle())) {
             viewBinding.moreButton.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -125,7 +125,7 @@ public class DownloadsSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.downloads_label);
+        return getString(R.string.downloads_label_more);
     }
 
     private void loadItems() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EpisodesSurpriseSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EpisodesSurpriseSection.java
@@ -92,7 +92,7 @@ public class EpisodesSurpriseSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.episodes_label);
+        return getString(R.string.episodes_label_more);
     }
 
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
@@ -116,7 +116,7 @@ public class InboxSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.inbox_label);
+        return getString(R.string.inbox_label_more);
     }
 
     private void loadItems() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/QueueSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/QueueSection.java
@@ -143,7 +143,7 @@ public class QueueSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.queue_label);
+        return getString(R.string.queue_label_more);
     }
 
     private void loadItems() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
@@ -84,7 +84,7 @@ public class SubscriptionsSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.subscriptions_label);
+        return getString(R.string.subscriptions_label_more);
     }
 
     private void loadItems() {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -71,6 +71,11 @@
     <string name="configure_home">Configure Home Screen</string>
     <string name="section_hidden">Hidden</string>
     <string name="section_shown">Shown</string>
+    <string name="episodes_label_more">Episodes »</string>
+    <string name="queue_label_more">Queue »</string>
+    <string name="inbox_label_more">Inbox »</string>
+    <string name="downloads_label_more">Downloads »</string>
+    <string name="subscriptions_label_more">Subscriptions »</string>
 
     <!-- Download Statistics fragment -->
     <plurals name="total_size_downloaded_podcasts">


### PR DESCRIPTION
### Description

Concatenation does not work with real translations because Android reverses the arrow symbol automatically.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
