### PR TITLE
fix: fix android: foreground bug

### DIFF
--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -22,7 +22,7 @@
             android:layout_height="0dp"
             android:layout_gravity="center"
             android:layout_marginHorizontal="32dp"
-            android:foreground="?attr/selectableItemBackgroundBorderless"
+            android:background="?attr/selectableItemBackgroundBorderless"
             android:importantForAccessibility="no"
             android:scaleType="fitCenter"
             squareImageView:direction="minimum"

--- a/app/src/main/res/layout/feeditem_fragment.xml
+++ b/app/src/main/res/layout/feeditem_fragment.xml
@@ -28,7 +28,7 @@
                 android:layout_height="@dimen/thumbnail_length_queue_item"
                 android:layout_gravity="center_vertical"
                 android:contentDescription="@string/open_podcast"
-                android:foreground="?attr/selectableItemBackground"
+                android:background="?attr/selectableItemBackground"
                 tools:src="@tools:sample/avatars" />
 
             <LinearLayout

--- a/app/src/main/res/layout/horizontal_itemlist_item.xml
+++ b/app/src/main/res/layout/horizontal_itemlist_item.xml
@@ -72,7 +72,7 @@
                             android:layout_gravity="bottom|end"
                             android:layout_margin="4dp"
                             android:clickable="true"
-                            android:foreground="?attr/selectableItemBackgroundBorderless"
+                            android:background="?attr/selectableItemBackgroundBorderless"
                             android:padding="12dp"
                             app:srcCompat="@drawable/ic_play_24dp"
                             app:tint="?attr/colorOnPrimary"


### PR DESCRIPTION
### Description
We discovered a CC (Configuration Compatibility) Bug in your library. This issue is caused by the abnormal display of android:foreground in Android API levels below 23. As shown in the image below, when the software runs on API level 22, clicking the image does not trigger any response, whereas when running on API level 23, the click effect appears as expected.
![image](https://github.com/user-attachments/assets/4c1c1da4-0779-4c6c-9b32-56595fb55562)
Our repair tool replaced android:foreground with android:background to ensure it works correctly on lower API levels. I look forward to your reply.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
