### PR TITLE
Add option to have Play/Pause button in Downloads

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -17,16 +17,11 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.actionbutton.ItemActionButton;
-import de.danoeh.antennapod.actionbutton.PauseActionButton;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
-import de.danoeh.antennapod.model.feed.FeedMedia;
-import de.danoeh.antennapod.playback.service.PlaybackStatus;
 import de.danoeh.antennapod.ui.common.ConfirmationDialog;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemListAdapter;
 import de.danoeh.antennapod.actionbutton.DeleteActionButton;
-import de.danoeh.antennapod.actionbutton.PlayActionButton;
 import de.danoeh.antennapod.event.DownloadLogEvent;
 import de.danoeh.antennapod.ui.MenuItemUtils;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
@@ -375,20 +370,10 @@ public class CompletedDownloadsFragment extends Fragment
         @Override
         public void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
             if (!inActionMode()) {
-                if (holder.getFeedItem().isDownloaded()) {
-                    ItemActionButton actionButton = null;
-                    FeedMedia media = getItem(pos).getMedia();
-                    if (!UserPreferences.shouldDownloadsButtonActionPlay()) {
-                        actionButton = new DeleteActionButton(getItem(pos));
-                        actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
-                    } else if (UserPreferences.shouldDownloadsButtonActionPlay()
-                                && PlaybackStatus.isCurrentlyPlaying(media)) {
-                        actionButton = new PauseActionButton(getItem(pos));
-                        actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
-                    } else if (UserPreferences.shouldDownloadsButtonActionPlay()) {
-                        actionButton = new PlayActionButton(getItem(pos));
-                        actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
-                    }
+                if (holder.getFeedItem().isDownloaded()
+                        && !UserPreferences.shouldDownloadsButtonActionPlay()) {
+                    DeleteActionButton actionButton = new DeleteActionButton(getItem(pos));
+                    actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
                 }
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -17,11 +17,16 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.actionbutton.ItemActionButton;
+import de.danoeh.antennapod.actionbutton.PauseActionButton;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.playback.service.PlaybackStatus;
 import de.danoeh.antennapod.ui.common.ConfirmationDialog;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemListAdapter;
 import de.danoeh.antennapod.actionbutton.DeleteActionButton;
+import de.danoeh.antennapod.actionbutton.PlayActionButton;
 import de.danoeh.antennapod.event.DownloadLogEvent;
 import de.danoeh.antennapod.ui.MenuItemUtils;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
@@ -371,8 +376,19 @@ public class CompletedDownloadsFragment extends Fragment
         public void afterBindViewHolder(EpisodeItemViewHolder holder, int pos) {
             if (!inActionMode()) {
                 if (holder.getFeedItem().isDownloaded()) {
-                    DeleteActionButton actionButton = new DeleteActionButton(getItem(pos));
-                    actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
+                    ItemActionButton actionButton = null;
+                    FeedMedia media = getItem(pos).getMedia();
+                    if (!UserPreferences.shouldDownloadsButtonActionPlay()) {
+                        actionButton = new DeleteActionButton(getItem(pos));
+                        actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
+                    } else if (UserPreferences.shouldDownloadsButtonActionPlay()
+                                && PlaybackStatus.isCurrentlyPlaying(media)) {
+                        actionButton = new PauseActionButton(getItem(pos));
+                        actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
+                    } else if (UserPreferences.shouldDownloadsButtonActionPlay()) {
+                        actionButton = new PlayActionButton(getItem(pos));
+                        actionButton.configure(holder.secondaryActionButton, holder.secondaryActionIcon, getActivity());
+                    }
                 }
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PlaybackPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/PlaybackPreferencesFragment.java
@@ -9,20 +9,17 @@ import androidx.collection.ArrayMap;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
-import de.danoeh.antennapod.storage.preferences.UsageStatistics;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.screen.feed.preferences.SkipPreferenceDialog;
 import de.danoeh.antennapod.ui.screen.playback.VariableSpeedDialog;
+
 import java.util.Map;
-import org.greenrobot.eventbus.EventBus;
 
 public class PlaybackPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREF_PLAYBACK_SPEED_LAUNCHER = "prefPlaybackSpeedLauncher";
     private static final String PREF_PLAYBACK_REWIND_DELTA_LAUNCHER = "prefPlaybackRewindDeltaLauncher";
     private static final String PREF_PLAYBACK_FAST_FORWARD_DELTA_LAUNCHER = "prefPlaybackFastForwardDeltaLauncher";
-    private static final String PREF_PLAYBACK_PREFER_STREAMING = "prefStreamOverDownload";
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -51,13 +48,6 @@ public class PlaybackPreferencesFragment extends AnimatedPreferenceFragment {
         });
         findPreference(PREF_PLAYBACK_FAST_FORWARD_DELTA_LAUNCHER).setOnPreferenceClickListener(preference -> {
             SkipPreferenceDialog.showSkipPreference(activity, SkipPreferenceDialog.SkipDirection.SKIP_FORWARD, null);
-            return true;
-        });
-        findPreference(PREF_PLAYBACK_PREFER_STREAMING).setOnPreferenceChangeListener((preference, newValue) -> {
-            // Update all visible lists to reflect new streaming action button
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-            // User consciously decided whether to prefer the streaming button, disable suggestion to change that
-            UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM);
             return true;
         });
         if (Build.VERSION.SDK_INT >= 31) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
@@ -14,6 +14,7 @@ import androidx.preference.Preference;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.storage.preferences.UsageStatistics;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import de.danoeh.antennapod.ui.screen.subscriptions.FeedSortDialog;
 import org.greenrobot.eventbus.EventBus;
@@ -88,6 +89,14 @@ public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment
         findPreference(PREF_SWIPE)
                 .setOnPreferenceClickListener(preference -> {
                     ((PreferenceActivity) getActivity()).openScreen(R.xml.preferences_swipe);
+                    return true;
+                });
+        findPreference(UserPreferences.PREF_STREAM_OVER_DOWNLOAD)
+                .setOnPreferenceChangeListener((preference, newValue) -> {
+                    // Update all visible lists to reflect new streaming action button
+                    EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+                    // User consciously decided whether to prefer the streaming button, disable suggestion
+                    UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM);
                     return true;
                 });
 

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -112,6 +112,7 @@ public abstract class UserPreferences {
     // Other
     private static final String PREF_DATA_FOLDER = "prefDataFolder";
     public static final String PREF_DELETE_REMOVES_FROM_QUEUE = "prefDeleteRemovesFromQueue";
+    public static final String PREF_DOWNLOADS_BUTTON_ACTION = "prefDownloadsButtonAction";
     private static final String PREF_AUTOMATIC_EXPORT_FOLDER = "prefAutomaticExportFolder";
 
     // Mediaplayer
@@ -421,6 +422,10 @@ public abstract class UserPreferences {
 
     public static boolean shouldDeleteRemoveFromQueue() {
         return prefs.getBoolean(PREF_DELETE_REMOVES_FROM_QUEUE, false);
+    }
+
+    public static boolean shouldDownloadsButtonActionPlay() {
+        return prefs.getBoolean(PREF_DOWNLOADS_BUTTON_ACTION, false);
     }
 
     public static float getPlaybackSpeed() {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -521,6 +521,7 @@
     <string name="pref_enqueue_downloaded_summary">Add downloaded episodes to the queue</string>
     <string name="pref_skip_silence_title">Skip silence in audio</string>
     <string name="behavior">Behavior</string>
+    <string name="episode_lists">Episode Lists</string>
     <string name="pref_default_page">Default page</string>
     <string name="pref_default_page_sum">Screen that is opened when starting AntennaPod</string>
     <string name="pref_back_button_opens_drawer">Back button opens drawer</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -528,6 +528,8 @@
     <string name="remember_last_page">Remember last page</string>
     <string name="pref_delete_removes_from_queue_title">Delete removes from queue</string>
     <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from the queue when it is deleted</string>
+    <string name="pref_downloads_button_action_title">Switch Delete button to Play/Pause</string>
+    <string name="pref_downloads_button_action_sum">Should Delete button be changed to Play/Pause in Downloads view</string>
     <string name="pref_filter_feed_title">Subscription filter</string>
     <string name="pref_filter_feed_sum">Filter your subscriptions in navigation drawer and subscriptions screen</string>
     <string name="subscriptions_counter_greater_zero">Counter greater than zero</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -529,8 +529,8 @@
     <string name="remember_last_page">Remember last page</string>
     <string name="pref_delete_removes_from_queue_title">Delete removes from queue</string>
     <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from the queue when it is deleted</string>
-    <string name="pref_downloads_button_action_title">Play/Pause button on Downloads screen</string>
-    <string name="pref_downloads_button_action_sum">Display a Play/Pause button instead of a Delete button</string>
+    <string name="pref_downloads_button_action_title">Play button on Downloads screen</string>
+    <string name="pref_downloads_button_action_sum">Display a Play button instead of a Delete button</string>
     <string name="pref_filter_feed_title">Subscription filter</string>
     <string name="pref_filter_feed_sum">Filter your subscriptions in navigation drawer and subscriptions screen</string>
     <string name="subscriptions_counter_greater_zero">Counter greater than zero</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -521,7 +521,7 @@
     <string name="pref_enqueue_downloaded_summary">Add downloaded episodes to the queue</string>
     <string name="pref_skip_silence_title">Skip silence in audio</string>
     <string name="behavior">Behavior</string>
-    <string name="episode_lists">Episode Lists</string>
+    <string name="episode_lists">Episode lists</string>
     <string name="pref_default_page">Default page</string>
     <string name="pref_default_page_sum">Screen that is opened when starting AntennaPod</string>
     <string name="pref_back_button_opens_drawer">Back button opens drawer</string>
@@ -529,8 +529,8 @@
     <string name="remember_last_page">Remember last page</string>
     <string name="pref_delete_removes_from_queue_title">Delete removes from queue</string>
     <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from the queue when it is deleted</string>
-    <string name="pref_downloads_button_action_title">Switch Delete button to Play/Pause</string>
-    <string name="pref_downloads_button_action_sum">Should Delete button be changed to Play/Pause in Downloads view</string>
+    <string name="pref_downloads_button_action_title">Play/Pause button on Downloads screen</string>
+    <string name="pref_downloads_button_action_sum">Display a Play/Pause button instead of a Delete button</string>
     <string name="pref_filter_feed_title">Subscription filter</string>
     <string name="pref_filter_feed_sum">Filter your subscriptions in navigation drawer and subscriptions screen</string>
     <string name="subscriptions_counter_greater_zero">Counter greater than zero</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -529,8 +529,8 @@
     <string name="remember_last_page">Remember last page</string>
     <string name="pref_delete_removes_from_queue_title">Delete removes from queue</string>
     <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from the queue when it is deleted</string>
-    <string name="pref_downloads_button_action_title">Play button on Downloads screen</string>
-    <string name="pref_downloads_button_action_sum">Display a Play button instead of a Delete button</string>
+    <string name="pref_downloads_button_action_title">Play from downloads screen</string>
+    <string name="pref_downloads_button_action_sum">Display play button instead of delete button on downloads screen</string>
     <string name="pref_filter_feed_title">Subscription filter</string>
     <string name="pref_filter_feed_sum">Filter your subscriptions in navigation drawer and subscriptions screen</string>
     <string name="subscriptions_counter_greater_zero">Counter greater than zero</string>

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -37,12 +37,6 @@
             android:key="prefDeleteRemovesFromQueue"
             android:summary="@string/pref_delete_removes_from_queue_sum"
             android:title="@string/pref_delete_removes_from_queue_title"/>
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:enabled="true"
-            android:key="prefDownloadsButtonAction"
-            android:summary="@string/pref_downloads_button_action_sum"
-            android:title="@string/pref_downloads_button_action_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/download_pref_details">

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -37,6 +37,12 @@
             android:key="prefDeleteRemovesFromQueue"
             android:summary="@string/pref_delete_removes_from_queue_sum"
             android:title="@string/pref_delete_removes_from_queue_title"/>
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefDownloadsButtonAction"
+            android:summary="@string/pref_downloads_button_action_sum"
+            android:title="@string/pref_downloads_button_action_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/download_pref_details">

--- a/ui/preferences/src/main/res/xml/preferences_playback.xml
+++ b/ui/preferences/src/main/res/xml/preferences_playback.xml
@@ -43,6 +43,11 @@
                 android:key="prefPlaybackSpeedLauncher"
                 android:summary="@string/pref_playback_speed_sum"
                 android:title="@string/playback_speed"/>
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:key="prefStreamOverDownload"
+                android:summary="@string/pref_stream_over_download_sum"
+                android:title="@string/pref_stream_over_download_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/reassign_hardware_buttons">

--- a/ui/preferences/src/main/res/xml/preferences_playback.xml
+++ b/ui/preferences/src/main/res/xml/preferences_playback.xml
@@ -43,11 +43,6 @@
                 android:key="prefPlaybackSpeedLauncher"
                 android:summary="@string/pref_playback_speed_sum"
                 android:title="@string/playback_speed"/>
-        <SwitchPreferenceCompat
-                android:defaultValue="false"
-                android:key="prefStreamOverDownload"
-                android:summary="@string/pref_stream_over_download_sum"
-                android:title="@string/pref_stream_over_download_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/reassign_hardware_buttons">

--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -93,9 +93,22 @@
                 android:title="@string/pref_back_button_opens_drawer"
                 android:summary="@string/pref_back_button_opens_drawer_summary"
                 android:defaultValue="false"/>
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/episode_lists">
         <Preference
                 android:key="prefSwipe"
                 android:summary="@string/swipeactions_summary"
                 android:title="@string/swipeactions_label"/>
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:key="prefStreamOverDownload"
+                android:summary="@string/pref_stream_over_download_sum"
+                android:title="@string/pref_stream_over_download_title"/>
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefDownloadsButtonAction"
+            android:summary="@string/pref_downloads_button_action_sum"
+            android:title="@string/pref_downloads_button_action_title"/>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -105,10 +105,10 @@
                 android:summary="@string/pref_stream_over_download_sum"
                 android:title="@string/pref_stream_over_download_title"/>
         <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:enabled="true"
-            android:key="prefDownloadsButtonAction"
-            android:summary="@string/pref_downloads_button_action_sum"
-            android:title="@string/pref_downloads_button_action_title"/>
+                android:defaultValue="false"
+                android:enabled="true"
+                android:key="prefDownloadsButtonAction"
+                android:summary="@string/pref_downloads_button_action_sum"
+                android:title="@string/pref_downloads_button_action_title"/>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -101,6 +101,11 @@
                 android:title="@string/swipeactions_label"/>
         <SwitchPreferenceCompat
                 android:defaultValue="false"
+                android:key="prefStreamOverDownload"
+                android:summary="@string/pref_stream_over_download_sum"
+                android:title="@string/pref_stream_over_download_title"/>
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefDownloadsButtonAction"
                 android:summary="@string/pref_downloads_button_action_sum"

--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -101,11 +101,6 @@
                 android:title="@string/swipeactions_label"/>
         <SwitchPreferenceCompat
                 android:defaultValue="false"
-                android:key="prefStreamOverDownload"
-                android:summary="@string/pref_stream_over_download_sum"
-                android:title="@string/pref_stream_over_download_title"/>
-        <SwitchPreferenceCompat
-                android:defaultValue="false"
                 android:enabled="true"
                 android:key="prefDownloadsButtonAction"
                 android:summary="@string/pref_downloads_button_action_sum"


### PR DESCRIPTION
### Description
resolves #7012

This PR adds a setting to configure Delete button action.
Allows switching Delete button to Play/Pause.

Created Episode Lists group in User Interface settings
moved Swipe actions, Prefer Streaming and the Play/Pause button in Downloads list.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
