### PR TITLE
Fix non-subscribed feed cleaner removing feed even when episode is queued

### DIFF
--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/NonSubscribedFeedsCleanerTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/NonSubscribedFeedsCleanerTest.java
@@ -1,16 +1,24 @@
 package de.danoeh.antennapod.storage.database;
 
+import android.content.Context;
+import androidx.test.platform.app.InstrumentationRegistry;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
+import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterfaceStub;
+import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -104,6 +112,40 @@ public class NonSubscribedFeedsCleanerTest {
         queuedItem.getMedia().setDownloaded(true, System.currentTimeMillis());
         feed.getItems().add(queuedItem);
         assertFalse(NonSubscribedFeedsCleaner.shouldDelete(feed));
+    }
+
+    @Test
+    public void integrationTest() throws ExecutionException, InterruptedException {
+        final Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        final long longAgo = System.currentTimeMillis() - TimeUnit.MILLISECONDS.convert(200, TimeUnit.DAYS);
+
+        // Initialize database
+        PlaybackPreferences.init(context);
+        DownloadServiceInterface.setImpl(new DownloadServiceInterfaceStub());
+        PodDBAdapter.init(context);
+        PodDBAdapter.deleteDatabase();
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.close();
+
+        final Feed subscribedFeed = createFeed();
+        final Feed nonSubscribedFeed = createFeed();
+        nonSubscribedFeed.setState(Feed.STATE_NOT_SUBSCRIBED);
+        nonSubscribedFeed.setLastRefreshAttempt(longAgo);
+        final Feed nonSubscribedFeedFavorite = createFeed();
+        nonSubscribedFeedFavorite.setState(Feed.STATE_NOT_SUBSCRIBED);
+        nonSubscribedFeedFavorite.setLastRefreshAttempt(longAgo);
+        nonSubscribedFeedFavorite.getItems().add(createItem(nonSubscribedFeedFavorite));
+
+        DBWriter.setCompleteFeed(subscribedFeed, nonSubscribedFeedFavorite, nonSubscribedFeed).get();
+        DBWriter.addFavoriteItem(nonSubscribedFeedFavorite.getItems().get(0)).get();
+
+        NonSubscribedFeedsCleaner.deleteOldNonSubscribedFeeds(context);
+
+        List<Feed> feeds = DBReader.getFeedList();
+        assertEquals(2, feeds.size());
+        assertEquals(subscribedFeed.getId(), feeds.get(0).getId());
+        assertEquals(nonSubscribedFeedFavorite.getId(), feeds.get(1).getId());
     }
 
     private Feed createFeed() {


### PR DESCRIPTION
### Description

Fix non-subscribed feed cleaner removing feed even when episode is queued
See https://forum.antennapod.org/t/downloaded-podcasts-disappear/5881/5

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
