### PR TITLE
Fix missing delete item for local feeds

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -103,7 +103,8 @@ public class EpisodeMultiSelectActionHandler {
     private void deleteChecked(List<FeedItem> items) {
         int countHasMedia = 0;
         for (FeedItem feedItem : items) {
-            if (feedItem.hasMedia() && feedItem.getMedia().isDownloaded()) {
+            if ((feedItem.hasMedia() && feedItem.getMedia().isDownloaded())
+                    || feedItem.getFeed().isLocalFeed()) {
                 countHasMedia++;
                 DBWriter.deleteFeedMediaOfItem(activity, feedItem.getMedia());
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -83,7 +83,7 @@ public class FeedItemMenuHandler {
             canMarkPlayed |= !item.isPlayed();
             canMarkUnplayed |= item.isPlayed();
             canResetPosition |= hasMedia && item.getMedia().getPosition() != 0;
-            canDelete |= hasMedia && item.getMedia().isDownloaded();
+            canDelete |= (hasMedia && item.getMedia().isDownloaded()) || item.getFeed().isLocalFeed();
             canDownload |= hasMedia && !item.getMedia().isDownloaded() && !item.getFeed().isLocalFeed();
             canAddFavorite |= !item.isTagged(FeedItem.TAG_FAVORITE);
             canRemoveFavorite |= item.isTagged(FeedItem.TAG_FAVORITE);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -145,7 +145,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         floatingSelectMenu = layout.findViewById(R.id.floatingSelectMenu);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
         registerForContextMenu(recyclerView);
-        adapter = new EpisodeItemListAdapter((MainActivity) getActivity()) {
+        adapter = new EpisodeItemListAdapter(getActivity()) {
             @Override
             public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
                 super.onCreateContextMenu(menu, v, menuInfo);
@@ -153,6 +153,14 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
                     menu.findItem(R.id.multi_select).setVisible(true);
                 }
                 MenuItemUtils.setOnClickListeners(menu, SearchFragment.this::onContextItemSelected);
+            }
+
+            @Override
+            protected void onSelectedItemsUpdated() {
+                super.onSelectedItemsUpdated();
+                FeedItemMenuHandler.onPrepareMenu(floatingSelectMenu.getMenu(), getSelectedItems(),
+                        R.id.add_to_queue_item, R.id.remove_inbox_item);
+                floatingSelectMenu.updateItemVisibility();
             }
         };
         adapter.setOnSelectModeListener(this);


### PR DESCRIPTION
### Description

Fix missing delete item for local feeds.
Also fix search fragment always showing all multi-select options.
See https://forum.antennapod.org/t/deleting-episodes-from-a-local-directory-isnt-working-anymore/5896

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
