### PR TITLE
Item separator labels

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListAdapter.java
@@ -71,6 +71,7 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
     @Override
     public final void onBindViewHolder(EpisodeItemViewHolder holder, int pos) {
         if (pos >= episodes.size()) {
+            holder.separatorLabel.setVisibility(View.GONE);
             beforeBindViewHolder(holder, pos);
             holder.bindDummy();
             afterBindViewHolder(holder, pos);
@@ -81,6 +82,7 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
         // Reset state of recycled views
         holder.coverHolder.setVisibility(View.VISIBLE);
         holder.dragHandle.setVisibility(View.GONE);
+        holder.separatorLabel.setVisibility(View.GONE);
 
         beforeBindViewHolder(holder, pos);
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemViewHolder.java
@@ -55,6 +55,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
     public final ImageView isInQueue;
     private final ImageView isVideo;
     public final ImageView isFavorite;
+    public final TextView separatorLabel;
     private final ProgressBar progressBar;
     public final View secondaryActionButton;
     public final ImageView secondaryActionIcon;
@@ -92,6 +93,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
         secondaryActionIcon = itemView.findViewById(R.id.secondaryActionIcon);
         coverHolder = itemView.findViewById(R.id.coverHolder);
         leftPadding = itemView.findViewById(R.id.left_padding);
+        separatorLabel = itemView.findViewById(R.id.separatorLabel);
         itemView.setTag(this);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -177,23 +177,7 @@ public abstract class EpisodesListFragment extends Fragment
         swipeRefreshLayout.setDistanceToTriggerSync(getResources().getInteger(R.integer.swipe_refresh_distance));
         swipeRefreshLayout.setOnRefreshListener(() -> FeedUpdateManager.getInstance().runOnceOrAsk(requireContext()));
 
-        listAdapter = new EpisodeItemListAdapter(getActivity()) {
-            @Override
-            public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
-                super.onCreateContextMenu(menu, v, menuInfo);
-                if (!inActionMode()) {
-                    menu.findItem(R.id.multi_select).setVisible(true);
-                }
-                MenuItemUtils.setOnClickListeners(menu, EpisodesListFragment.this::onContextItemSelected);
-            }
-
-            @Override
-            protected void onSelectedItemsUpdated() {
-                super.onSelectedItemsUpdated();
-                FeedItemMenuHandler.onPrepareMenu(floatingSelectMenu.getMenu(), getSelectedItems());
-                floatingSelectMenu.updateItemVisibility();
-            }
-        };
+        listAdapter = createAdapter();
         listAdapter.setOnSelectModeListener(this);
         recyclerView.setAdapter(listAdapter);
         progressBar = root.findViewById(R.id.progressBar);
@@ -238,6 +222,26 @@ public abstract class EpisodesListFragment extends Fragment
         });
 
         return root;
+    }
+
+    protected EpisodeItemListAdapter createAdapter() {
+        return new EpisodeItemListAdapter(getActivity()) {
+            @Override
+            public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
+                super.onCreateContextMenu(menu, v, menuInfo);
+                if (!inActionMode()) {
+                    menu.findItem(R.id.multi_select).setVisible(true);
+                }
+                MenuItemUtils.setOnClickListeners(menu, EpisodesListFragment.this::onContextItemSelected);
+            }
+
+            @Override
+            protected void onSelectedItemsUpdated() {
+                super.onSelectedItemsUpdated();
+                FeedItemMenuHandler.onPrepareMenu(floatingSelectMenu.getMenu(), getSelectedItems());
+                floatingSelectMenu.updateItemVisibility();
+            }
+        };
     }
 
     private void performMultiSelectAction(int actionItemId) {

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:ignore="MergeRootFrame">
+    android:orientation="vertical">
 
-    <!--
-    This parent FrameLayout is necessary because RecyclerView's ItemAnimator changes alpha values,
-    which conflicts with our played state indicator.
-    -->
+    <TextView
+        android:id="@+id/separatorLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="4dp"
+        android:background="?attr/colorSurface"
+        android:visibility="gone"
+        style="@style/TextAppearance.Material3.TitleMedium" />
+
     <LinearLayout
         android:id="@+id/container"
         android:layout_width="match_parent"
@@ -216,4 +223,4 @@
 
     </LinearLayout>
 
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
### Description

Proof of concept: Item separator labels.

Like it is implemented now, the swipe actions affect the headers as well. Any other implementation that I can come up that doesn't do this would be significantly more complex and probably not something I could tackle in the near future.

See #6784
Re-requested in #7567

<img width="250" src="https://github.com/user-attachments/assets/6e4e2051-bd45-4d7d-afb2-37c04175aea5" />

[app-free-debug.apk.zip](https://github.com/user-attachments/files/18774000/app-free-debug.apk.zip)

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
