### PR TITLE
Fix downloads sometimes running in notification only

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -250,6 +250,9 @@ public class MainActivity extends CastEnabledActivity {
                             status = DownloadStatus.STATE_QUEUED;
                             progress = 0;
                         }
+                        if (updatedEpisodes.containsKey(downloadUrl) && status == DownloadStatus.STATE_COMPLETED) {
+                            continue; // In case of a duplicate, prefer running/queued over completed
+                        }
                         updatedEpisodes.put(downloadUrl, new DownloadStatus(status, progress));
                     }
                     DownloadServiceInterface.get().setCurrentDownloads(updatedEpisodes);


### PR DESCRIPTION
### Description

Fix downloads sometimes running in notification only

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
