### PR TITLE
Keep playback service in foreground when media is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This is the official repository of AntennaPod, the easy-to-use, flexible and ope
 
 <img src="https://raw.githubusercontent.com/AntennaPod/StoreMetadata/main/listings/en-US/graphics/phone-screenshots/00.png" alt="Screenshot 0" height="200"> <img src="https://raw.githubusercontent.com/AntennaPod/StoreMetadata/main/listings/en-US/graphics/phone-screenshots/01.png" alt="Screenshot 1" height="200"> <img src="https://raw.githubusercontent.com/AntennaPod/StoreMetadata/main/listings/en-US/graphics/phone-screenshots/02.png" alt="Screenshot 2" height="200"> <img src="https://raw.githubusercontent.com/AntennaPod/StoreMetadata/main/listings/en-US/graphics/phone-screenshots/03.png" alt="Screenshot 3" height="200"> <img src="https://raw.githubusercontent.com/AntennaPod/StoreMetadata/main/listings/en-US/graphics/phone-screenshots/04.png" alt="Screenshot 4" height="200"> <img src="https://raw.githubusercontent.com/AntennaPod/StoreMetadata/main/listings/en-US/graphics/phone-screenshots/05.png" alt="Screenshot 5" height="200">
 
-
 ## Feedback
 You can use the [AntennaPod Forum](https://forum.antennapod.org/) for discussions about the app or just podcasting in general.
 
@@ -36,7 +35,6 @@ AntennaPod is licensed under the GNU General Public License (GPL-3.0). You can f
 ## Translating AntennaPod
 
 If you want to translate AntennaPod into another language, you can visit our [Weblate page](https://hosted.weblate.org/projects/antennapod/).
-
 
 ## Building AntennaPod
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -495,7 +495,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         super.onStartCommand(intent, flags, startId);
-        Log.d(TAG, "OnStartCommand called");
+        Log.d(TAG, "onStartCommand called");
 
         stateManager.startForeground(R.id.notification_playing, notificationBuilder.build());
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
@@ -845,9 +845,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 case PAUSED:
                     updateNotificationAndMediaSession(newInfo.getPlayable());
                     PlaybackPreferences.setCurrentPlayerStatus(PlaybackPreferences.PLAYER_STATUS_PAUSED);
-                    if (!isCasting) {
-                        stateManager.stopForeground(!UserPreferences.isPersistNotify());
-                    }
                     cancelPositionObserver();
                     break;
                 case STOPPED:

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -327,7 +327,7 @@ public abstract class UserPreferences {
     /**
      * Returns true if notifications are persistent
      *
-     * @return {@code true} if notifications are persistent, {@code false}  otherwise
+     * @return {@code true} if notifications are persistent, {@code false} otherwise
      */
     public static boolean isPersistNotify() {
         return prefs.getBoolean(PREF_PERSISTENT_NOTIFICATION, true);


### PR DESCRIPTION
Fixes #6576

### Description

As reported, pausing media while the notification is visible removes the playback thread from the foreground state, allowing it to be destroyed when Android needs more memory.  Some brands of phones seem to reap the service about a minute after that.

It seems the "play" code behind the notification is not designed to deal with this removal of the playback service, as playback no longer resumes when the "play" button is pressed in the notification after the service has been destroyed.  Unfortunately no clear error appears from the Android system and all of the logic behind this notification appears to be abstracted and hidden by `androidx`'s `PlaybackStateCompat`.  After all, "compact" action buttons for the notification are created with `PendingIntent.getForegroundService()` which are supposed to (re)start the service if it went missing.

One solution [^media3], proposed here, is to **not** remove the service from the foreground state when media is simply paused; this allows the playback button to operate at all times, and is how foreground services are designed: when the notification is visible, you can be guaranteed that whatever it is showing/providing is operational.  Technically this keeps the service in memory longer, but should not cause any increase in CPU utilization as - if the app is well written... [^quality] - the service should be dormant and waiting for its next command (i.e. play) and *not* spin-looping.

[^media3]: Migrating to `media3` was proposed in #6608, but this did not seem to resolve the issue of the notification being unable to resume playback.
[^quality]: Multiple comments seem to point to the player code needing to be completely rewritten...

Note that quite a few calls to `stopForeground(false)` remain that could possibly remove the service from the foreground list *while keeping the notification visible*.  This seems unintended, but I did not test those patterns.

> [!TIP]
> Following https://github.com/AntennaPod/AntennaPod/pull/7141#issuecomment-2081667548, it is unclear if there would be any way to "fix" this on the `PlaybackStateCompat` side so that it would be able to restart the player service. After all, Android documentation describes this exact design of taking a service out of the foreground state whenever it is paused: 
https://developer.android.com/reference/kotlin/androidx/media/app/NotificationCompat.MediaStyle#setShowCancelButton(boolean).
>
> EDIT: Not sure if this would even be used, but hopefully it creates the media button intents with the correct foreground service pending intent: https://github.com/androidx/media/blob/76088cd6af7f263aba238b7a48d64bd4f060cb8b/libraries/session/src/main/java/androidx/media3/session/DefaultActionFactory.java#L111-L131


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
