### PR TITLE
Fix crash when intent is redelivered

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -496,6 +496,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
         notificationManager.cancel(R.id.notification_streaming_confirmation);
 
+        if ((flags & Service.START_FLAG_REDELIVERY) != 0 || intent == null) {
+            Log.d(TAG, "onStartCommand is a redelivered intent, calling stopForeground now.");
+            stateManager.stopForeground(true);
+            return Service.START_NOT_STICKY;
+        }
+
         final int keycode = intent.getIntExtra(MediaButtonReceiver.EXTRA_KEYCODE, -1);
         final String customAction = intent.getStringExtra(MediaButtonReceiver.EXTRA_CUSTOM_ACTION);
         final boolean hardwareButton = intent.getBooleanExtra(MediaButtonReceiver.EXTRA_HARDWAREBUTTON, false);
@@ -506,55 +512,49 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             return Service.START_NOT_STICKY;
         }
 
-        if ((flags & Service.START_FLAG_REDELIVERY) != 0) {
-            Log.d(TAG, "onStartCommand is a redelivered intent, calling stopForeground now.");
-            stateManager.stopForeground(true);
-        } else {
-            if (keycode != -1) {
-                boolean notificationButton;
-                if (hardwareButton) {
-                    Log.d(TAG, "Received hardware button event");
-                    notificationButton = false;
-                } else {
-                    Log.d(TAG, "Received media button event");
-                    notificationButton = true;
-                }
-                boolean handled = handleKeycode(keycode, notificationButton);
-                if (!handled && !stateManager.hasReceivedValidStartCommand()) {
-                    stateManager.stopService();
-                    return Service.START_NOT_STICKY;
-                }
-            } else if (playable != null) {
-                stateManager.validStartCommandWasReceived();
-                boolean allowStreamThisTime = intent.getBooleanExtra(
-                        PlaybackServiceInterface.EXTRA_ALLOW_STREAM_THIS_TIME, false);
-                boolean allowStreamAlways = intent.getBooleanExtra(
-                        PlaybackServiceInterface.EXTRA_ALLOW_STREAM_ALWAYS, false);
-                sendNotificationBroadcast(PlaybackServiceInterface.NOTIFICATION_TYPE_RELOAD, 0);
-                if (allowStreamAlways) {
-                    UserPreferences.setAllowMobileStreaming(true);
-                }
-                Observable.fromCallable(
-                        () -> {
-                            if (playable instanceof FeedMedia) {
-                                return DBReader.getFeedMedia(((FeedMedia) playable).getId());
-                            } else {
-                                return playable;
-                            }
-                        })
-                        .subscribeOn(Schedulers.io())
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(
-                                loadedPlayable -> startPlaying(loadedPlayable, allowStreamThisTime),
-                                error -> {
-                                    Log.d(TAG, "Playable was not found. Stopping service.");
-                                    error.printStackTrace();
-                                    stateManager.stopService();
-                                });
-                return Service.START_NOT_STICKY;
+        if (keycode != -1) {
+            boolean notificationButton;
+            if (hardwareButton) {
+                Log.d(TAG, "Received hardware button event");
+                notificationButton = false;
             } else {
-                mediaSession.getController().getTransportControls().sendCustomAction(customAction, null);
+                Log.d(TAG, "Received media button event");
+                notificationButton = true;
             }
+            boolean handled = handleKeycode(keycode, notificationButton);
+            if (!handled && !stateManager.hasReceivedValidStartCommand()) {
+                stateManager.stopService();
+                return Service.START_NOT_STICKY;
+            }
+        } else if (playable != null) {
+            stateManager.validStartCommandWasReceived();
+            boolean allowStreamThisTime = intent.getBooleanExtra(
+                    PlaybackServiceInterface.EXTRA_ALLOW_STREAM_THIS_TIME, false);
+            boolean allowStreamAlways = intent.getBooleanExtra(
+                    PlaybackServiceInterface.EXTRA_ALLOW_STREAM_ALWAYS, false);
+            sendNotificationBroadcast(PlaybackServiceInterface.NOTIFICATION_TYPE_RELOAD, 0);
+            if (allowStreamAlways) {
+                UserPreferences.setAllowMobileStreaming(true);
+            }
+            Observable.fromCallable(
+                    () -> {
+                        if (playable instanceof FeedMedia) {
+                            return DBReader.getFeedMedia(((FeedMedia) playable).getId());
+                        } else {
+                            return playable;
+                        }
+                    })
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(
+                            loadedPlayable -> startPlaying(loadedPlayable, allowStreamThisTime),
+                            error -> {
+                                Log.d(TAG, "Playable was not found. Stopping service.");
+                                error.printStackTrace();
+                                stateManager.stopService();
+                            });
+        } else {
+            mediaSession.getController().getTransportControls().sendCustomAction(customAction, null);
         }
 
         return Service.START_NOT_STICKY;


### PR DESCRIPTION
### Description

Fix crash when intent is redelivered

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
