### PR TITLE
Split notification channel of downloading and refreshing

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -123,7 +123,7 @@ public class FeedUpdateWorker extends Worker {
                 }
             }
         }
-        return new NotificationCompat.Builder(context, NotificationUtils.CHANNEL_ID_DOWNLOADING)
+        return new NotificationCompat.Builder(context, NotificationUtils.CHANNEL_ID_REFRESHING)
                 .setContentTitle(context.getString(R.string.download_notification_title_feeds))
                 .setContentText(contentText)
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(bigText))

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -862,6 +862,8 @@
     <string name="notification_channel_user_action_description">Shown if your action is required, for example if you need to enter a password.</string>
     <string name="notification_channel_downloading">Downloading</string>
     <string name="notification_channel_downloading_description">Shown while currently downloading.</string>
+    <string name="notification_channel_refreshing">Refreshing podcasts</string>
+    <string name="notification_channel_refreshing_description">Shown while checking for new episodes.</string>
     <string name="notification_channel_playing">Currently playing</string>
     <string name="notification_channel_playing_description">Allows to control playback. This is the main notification you see while playing a podcast.</string>
     <string name="notification_channel_download_error">Download failed</string>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -860,8 +860,8 @@
     <string name="notification_group_news">News</string>
     <string name="notification_channel_user_action">Action required</string>
     <string name="notification_channel_user_action_description">Shown if your action is required, for example if you need to enter a password.</string>
-    <string name="notification_channel_downloading">Downloading</string>
-    <string name="notification_channel_downloading_description">Shown while currently downloading.</string>
+    <string name="notification_channel_downloading">Downloading episodes</string>
+    <string name="notification_channel_downloading_description">Shown while currently downloading episodes.</string>
     <string name="notification_channel_refreshing">Refreshing podcasts</string>
     <string name="notification_channel_refreshing_description">Shown while checking for new episodes.</string>
     <string name="notification_channel_playing">Currently playing</string>

--- a/ui/notifications/src/main/java/de/danoeh/antennapod/ui/notifications/NotificationUtils.java
+++ b/ui/notifications/src/main/java/de/danoeh/antennapod/ui/notifications/NotificationUtils.java
@@ -14,6 +14,7 @@ import de.danoeh.antennapod.storage.preferences.UserPreferences;
 public class NotificationUtils {
     public static final String CHANNEL_ID_USER_ACTION = "user_action";
     public static final String CHANNEL_ID_DOWNLOADING = "downloading";
+    public static final String CHANNEL_ID_REFRESHING = "refreshing";
     public static final String CHANNEL_ID_PLAYING = "playing";
     public static final String CHANNEL_ID_DOWNLOAD_ERROR = "error";
     public static final String CHANNEL_ID_SYNC_ERROR = "sync_error";
@@ -33,6 +34,7 @@ public class NotificationUtils {
         final List<NotificationChannelCompat> channels = Arrays.asList(
                 createChannelUserAction(context),
                 createChannelDownloading(context),
+                createChannelRefreshing(context),
                 createChannelPlaying(context),
                 createChannelError(context),
                 createChannelSyncError(context),
@@ -54,6 +56,15 @@ public class NotificationUtils {
                         CHANNEL_ID_DOWNLOADING, NotificationManagerCompat.IMPORTANCE_LOW)
                 .setName(c.getString(R.string.notification_channel_downloading))
                 .setDescription(c.getString(R.string.notification_channel_downloading_description))
+                .setShowBadge(false)
+                .build();
+    }
+
+    private static NotificationChannelCompat createChannelRefreshing(final Context c) {
+        return new NotificationChannelCompat.Builder(
+                        CHANNEL_ID_REFRESHING, NotificationManagerCompat.IMPORTANCE_LOW)
+                .setName(c.getString(R.string.notification_channel_refreshing))
+                .setDescription(c.getString(R.string.notification_channel_refreshing_description))
                 .setShowBadge(false)
                 .build();
     }


### PR DESCRIPTION
### Description

Closes #7079 

That is, I created a seperate refresh notification channel and updated the wording of the download notification channel

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- ~[ ] If it is a core feature, I have added automated tests~
