### PR TITLE
Limit "check your classics" to the last 3 years

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
@@ -94,10 +94,7 @@ public class SubscriptionsSection extends HomeSection {
         SharedPreferences prefs = getContext().getSharedPreferences(StatisticsFragment.PREF_NAME, Context.MODE_PRIVATE);
         boolean includeMarkedAsPlayed = prefs.getBoolean(StatisticsFragment.PREF_INCLUDE_MARKED_PLAYED, false);
 
-        // Calculate timestamp for 3 years ago based on current time
-        long now = System.currentTimeMillis();
-        long threeYearsAgo = now - (3L * 365L * 24L * 60L * 60L * 1000L);
-
+        long threeYearsAgo = System.currentTimeMillis() - 3L * 365L * 24L * 60L * 60L * 1000L;
         disposable = Observable.fromCallable(() ->
                         DBReader.getStatistics(includeMarkedAsPlayed, threeYearsAgo, Long.MAX_VALUE).feedTime)
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
@@ -93,8 +93,13 @@ public class SubscriptionsSection extends HomeSection {
         }
         SharedPreferences prefs = getContext().getSharedPreferences(StatisticsFragment.PREF_NAME, Context.MODE_PRIVATE);
         boolean includeMarkedAsPlayed = prefs.getBoolean(StatisticsFragment.PREF_INCLUDE_MARKED_PLAYED, false);
+
+        // Calculate timestamp for 3 years ago based on current time
+        long now = System.currentTimeMillis();
+        long threeYearsAgo = now - (3L * 365L * 24L * 60L * 60L * 1000L);
+
         disposable = Observable.fromCallable(() ->
-                        DBReader.getStatistics(includeMarkedAsPlayed, 0, Long.MAX_VALUE).feedTime)
+                        DBReader.getStatistics(includeMarkedAsPlayed, threeYearsAgo, Long.MAX_VALUE).feedTime)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(statisticsData -> {


### PR DESCRIPTION
### Description

Closes #7469 

There is still an issue with this PR. I think I've found the right spot, but somehow it still doesn't filter anything out. I even used "empty" time frames (filter between `now + 1` and `now +2`), but I still always get all podcasts.

Can someone please tell me if I made an issue, or if I have to debug the SQL-Statement a bit more? Thank you so much!

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
