### PR TITLE
Fix multiselect with lazy loading on podcast screen

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -641,20 +641,19 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         isLoadingMore = true;
         adapter.setDummyViews(1);
         adapter.notifyItemInserted(adapter.getItemCount() - 1);
-        disposable = Observable.fromCallable(() -> DBReader.getFeed(feedID, true,
-                        (page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE))
+        disposable = Observable.fromCallable(() -> loadMoreData(page))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        data -> {
-                            if (data.getItems().size() < EPISODES_PER_PAGE) {
+                        items -> {
+                            if (items.size() < EPISODES_PER_PAGE) {
                                 hasMoreItems = false;
                             }
-                            feed.getItems().addAll(data.getItems());
+                            feed.getItems().addAll(items);
                             adapter.setDummyViews(0);
                             adapter.updateItems(feed.getItems());
                             if (adapter.shouldSelectLazyLoadedItems()) {
-                                adapter.setSelected(feed.getItems().size() - data.getItems().size(),
+                                adapter.setSelected(feed.getItems().size() - items.size(),
                                         feed.getItems().size(), true);
                             }
                         }, error -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -204,19 +204,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             }
             EpisodeMultiSelectActionHandler handler
                     = new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId());
-            Completable.fromAction(
-                            () -> {
-                                handler.handleAction(adapter.getSelectedItems());
-                                if (adapter.shouldSelectLazyLoadedItems()) {
-                                    int applyPage = page + 1;
-                                    List<FeedItem> nextPage;
-                                    do {
-                                        nextPage = loadMoreData(applyPage);
-                                        handler.handleAction(nextPage);
-                                        applyPage++;
-                                    } while (nextPage.size() == EPISODES_PER_PAGE);
-                                }
-                            })
+            Completable.fromAction(() -> handleActionForAllSelectedItems(handler))
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(() -> adapter.endSelectMode(),
@@ -224,6 +212,19 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             return true;
         });
         return viewBinding.getRoot();
+    }
+
+    private void handleActionForAllSelectedItems(EpisodeMultiSelectActionHandler handler) {
+        handler.handleAction(adapter.getSelectedItems());
+        if (adapter.shouldSelectLazyLoadedItems()) {
+            int applyPage = page + 1;
+            List<FeedItem> nextPage;
+            do {
+                nextPage = loadMoreData(applyPage);
+                handler.handleAction(nextPage);
+                applyPage++;
+            } while (nextPage.size() == EPISODES_PER_PAGE);
+        }
     }
 
     private List<FeedItem> loadMoreData(int page) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -202,23 +202,25 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                         Snackbar.LENGTH_SHORT);
                 return false;
             }
-            EpisodeMultiSelectActionHandler handler = new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId());
-            Completable.fromAction(() -> {
-                handler.handleAction(adapter.getSelectedItems());
-                if (adapter.shouldSelectLazyLoadedItems()) {
-                    int applyPage = page + 1;
-                    List<FeedItem> nextPage;
-                    do {
-                        nextPage = loadMoreData(applyPage);
-                        handler.handleAction(nextPage);
-                        applyPage++;
-                    } while (nextPage.size() == EPISODES_PER_PAGE);
-                }
-            })
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(() -> adapter.endSelectMode(),
-                    error -> Log.e(TAG, Log.getStackTraceString(error)));
+            EpisodeMultiSelectActionHandler handler
+                    = new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId());
+            Completable.fromAction(
+                            () -> {
+                                handler.handleAction(adapter.getSelectedItems());
+                                if (adapter.shouldSelectLazyLoadedItems()) {
+                                    int applyPage = page + 1;
+                                    List<FeedItem> nextPage;
+                                    do {
+                                        nextPage = loadMoreData(applyPage);
+                                        handler.handleAction(nextPage);
+                                        applyPage++;
+                                    } while (nextPage.size() == EPISODES_PER_PAGE);
+                                }
+                            })
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(() -> adapter.endSelectMode(),
+                            error -> Log.e(TAG, Log.getStackTraceString(error)));
             return true;
         });
         return viewBinding.getRoot();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -412,7 +412,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     @Override
     public void onStartSelectMode() {
         if (feed != null) {
-            // Load all items when starting select mode to ensure multi-select works on all items
+            // Load all items when starting select mode to ensure multi-select works on all items, fixes #7461
             Feed f = DBReader.getFeed(feedID, true, 0, Integer.MAX_VALUE);
             feed.setItems(f.getItems());
             adapter.updateItems(feed.getItems());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -412,7 +412,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     @Override
     public void onStartSelectMode() {
         if (feed != null) {
-            // Load all items when starting select mode to ensure multi-select works on all items, fixes #7461
+            // Load all items when starting select mode to ensure multi-select works on all items
             Feed f = DBReader.getFeed(feedID, true, 0, Integer.MAX_VALUE);
             feed.setItems(f.getItems());
             adapter.updateItems(feed.getItems());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -411,6 +411,13 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
     @Override
     public void onStartSelectMode() {
+        if (feed != null) {
+            // Load all items when starting select mode to ensure multi-select works on all items
+            Feed f = DBReader.getFeed(feedID, true, 0, Integer.MAX_VALUE);
+            feed.setItems(f.getItems());
+            adapter.updateItems(feed.getItems());
+            hasMoreItems = false;
+        }
         viewBinding.floatingSelectMenu.setVisibility(View.VISIBLE);
         swipeActions.detach();
         updateRecyclerPadding();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -411,13 +411,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
     @Override
     public void onStartSelectMode() {
-        if (feed != null) {
-            // Load all items when starting select mode to ensure multi-select works on all items
-            Feed f = DBReader.getFeed(feedID, true, 0, Integer.MAX_VALUE);
-            feed.setItems(f.getItems());
-            adapter.updateItems(feed.getItems());
-            hasMoreItems = false;
-        }
         viewBinding.floatingSelectMenu.setVisibility(View.VISIBLE);
         swipeActions.detach();
         updateRecyclerPadding();


### PR DESCRIPTION
### Description

This branch loads all episodes before doing anything in multiselect.. This solves the issue #7461 where not all episodes are loaded.

Fixes #7461 


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- ~[ ] If it is a core feature, I have added automated tests~
