### PR TITLE
Add option to automatically download queue

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
@@ -50,18 +50,24 @@ public class AutomaticDownloadAlgorithm {
 
                 Log.d(TAG, "Performing auto-dl of undownloaded episodes");
 
-                List<FeedItem> candidates;
-                final List<FeedItem> queue = DBReader.getQueue();
                 final List<FeedItem> newItems = DBReader.getEpisodes(0, Integer.MAX_VALUE,
                         new FeedItemFilter(FeedItemFilter.NEW), SortOrder.DATE_NEW_OLD);
-                candidates = new ArrayList<>(queue.size() + newItems.size());
-                candidates.addAll(queue);
+                final List<FeedItem> candidates = new ArrayList<>();
                 for (FeedItem newItem : newItems) {
                     FeedPreferences feedPrefs = newItem.getFeed().getPreferences();
                     if (feedPrefs.isAutoDownload(UserPreferences.isEnableAutodownloadGlobal())
                             && !candidates.contains(newItem)
                             && feedPrefs.getFilter().shouldAutoDownload(newItem)) {
                         candidates.add(newItem);
+                    }
+                }
+
+                if (UserPreferences.isEnableAutodownloadQueue()) {
+                    final List<FeedItem> queue = DBReader.getQueue();
+                    for (FeedItem item : queue) {
+                        if (!candidates.contains(item)) {
+                            candidates.add(item);
+                        }
                     }
                 }
 

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -99,6 +99,7 @@ public abstract class UserPreferences {
     public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
     public static final String PREF_AUTODL_GLOBAL = "prefEnableAutoDl";
+    public static final String PREF_AUTODL_QUEUE = "prefEnableAutoDlQueue";
     public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
     private static final String PREF_PROXY_TYPE = "prefProxyType";
     private static final String PREF_PROXY_HOST = "prefProxyHost";
@@ -537,6 +538,10 @@ public abstract class UserPreferences {
 
     public static boolean isEnableAutodownloadGlobal() {
         return prefs.getBoolean(PREF_AUTODL_GLOBAL, false);
+    }
+
+    public static boolean isEnableAutodownloadQueue() {
+        return prefs.getBoolean(PREF_AUTODL_QUEUE, false);
     }
 
     public static boolean isEnableAutodownloadOnBattery() {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -473,6 +473,8 @@
     <string name="pref_nav_drawer_feed_counter_sum">Change the information displayed by the subscription counter. Also affects the sorting of subscriptions if \'Subscription Order\' is set to \'Counter\'.</string>
     <string name="pref_automatic_download_title">Automatic download</string>
     <string name="pref_automatic_download_global_description">Automatically download new episodes. Can be overridden per podcast.</string>
+    <string name="pref_automatic_download_queue_title">Download queued</string>
+    <string name="pref_automatic_download_queue_description">Automatically download queued episodes</string>
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes</string>
     <string name="pref_automatic_download_on_battery_title">Download when not charging</string>
     <string name="pref_automatic_download_on_battery_sum">Allow automatic download when the battery is not charging</string>

--- a/ui/preferences/src/main/res/xml/preferences_autodownload.xml
+++ b/ui/preferences/src/main/res/xml/preferences_autodownload.xml
@@ -6,6 +6,11 @@
             android:key="prefEnableAutoDl"
             android:title="@string/pref_automatic_download_title"
             android:summary="@string/pref_automatic_download_global_description"/>
+    <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="prefEnableAutoDlQueue"
+            android:title="@string/pref_automatic_download_queue_title"
+            android:summary="@string/pref_automatic_download_queue_description"/>
     <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
             android:defaultValue="25"
             android:entries="@array/episode_cache_size_entries"


### PR DESCRIPTION
### Description

Add option to automatically download queue.
We already added the queue to the auto-download candidates. Now that auto-download was rewritten to not be a "master switch", the code is called even if auto-download is turned off for all subscriptions. This lead to queued episodes being downloaded for users who previously had auto-download disabled.

Convert the feature to an explicit setting to avoid behavior changes for users. Also, this implements a setting to auto-download the queue, which users have requested because they did not know that AntennaPod already does this. Finally, it should solve user confusion where they automatically add episodes to the queue but set the auto-download filter to ignore specific episodes.

Closes #5849
Closes #7619
Closes #7275
Closes #7172
Closes https://forum.antennapod.org/t/episodes-filter-works-in-about-90-of-cases/5662/5

> Still not sure if we really want that setting, but we cannot keep it as it is. The current code downloads queued episodes, which is a behavior change to earlier AntennaPod versions.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
