### PR TITLE
Show website title in 'server sent a website' error

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -318,13 +318,13 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             if ("html".equalsIgnoreCase(e.getRootElement())) {
                 boolean dialogShown = showFeedDiscoveryDialog(destinationFile, selectedDownloadUrl);
                 if (dialogShown) {
-                    return null; // Should not display an error message
+                    return null; // We handled the problem
                 } else {
-                    throw new UnsupportedFeedtypeException(getString(R.string.download_error_unsupported_type_html));
+                    throw new UnsupportedFeedtypeException(
+                            getString(R.string.download_error_unsupported_type_html) + "\n" + e.getMessage());
                 }
-            } else {
-                throw e;
             }
+            throw e;
         } catch (Exception e) {
             Log.e(TAG, Log.getStackTraceString(e));
             throw e;

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/UnsupportedFeedtypeException.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/UnsupportedFeedtypeException.java
@@ -1,31 +1,17 @@
 package de.danoeh.antennapod.parser.feed;
 
-import de.danoeh.antennapod.parser.feed.util.TypeGetter;
-import de.danoeh.antennapod.parser.feed.util.TypeGetter.Type;
-
 public class UnsupportedFeedtypeException extends Exception {
     private static final long serialVersionUID = 9105878964928170669L;
-    private final TypeGetter.Type type;
     private String rootElement;
-    private String message = null;
+    private String message;
 
-    public UnsupportedFeedtypeException(Type type) {
-        super();
-        this.type = type;
-    }
-
-    public UnsupportedFeedtypeException(Type type, String rootElement) {
-        this.type = type;
+    public UnsupportedFeedtypeException(String rootElement, String message) {
         this.rootElement = rootElement;
+        this.message = message;
     }
 
     public UnsupportedFeedtypeException(String message) {
         this.message = message;
-        type = Type.INVALID;
-    }
-
-    public TypeGetter.Type getType() {
-        return type;
     }
 
     public String getRootElement() {
@@ -36,10 +22,10 @@ public class UnsupportedFeedtypeException extends Exception {
     public String getMessage() {
         if (message != null) {
             return message;
-        } else if (type == TypeGetter.Type.INVALID) {
-            return "Invalid type";
+        } else if (rootElement != null) {
+            return "Server returned " + rootElement;
         } else {
-            return "Type " + type + " not supported";
+            return "Unknown type";
         }
     }
 }


### PR DESCRIPTION
### Description

Show website title in 'server sent a website' error. Titles like "Log into this free WiFi", "Confirm that you are human", and similar should make it easier to see why the server returned a website.
See https://forum.antennapod.org/t/unsupported-feed-type-still-getting-new-episodes/6073

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
