### PR TITLE
Tweak error messages related to feed types again

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
@@ -79,7 +79,8 @@ public class DownloadActionButton extends ItemActionButton {
                             })
                     .setNegativeButton(R.string.cancel_label, null);
             if (NetworkUtils.isNetworkRestricted() && NetworkUtils.isVpnOverWifi()) {
-                builder.setMessage(R.string.confirm_mobile_download_dialog_message_vpn);
+                builder.setMessage(context.getString(R.string.confirm_mobile_download_dialog_message)
+                        + "\n\n" + context.getString(R.string.confirm_mobile_download_dialog_message_vpn));
             } else {
                 builder.setMessage(R.string.confirm_mobile_download_dialog_message);
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/StreamingConfirmationDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/StreamingConfirmationDialog.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.ui;
 import android.content.Context;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.playback.service.PlaybackServiceStarter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.model.playback.Playable;
@@ -17,16 +18,21 @@ public class StreamingConfirmationDialog {
     }
 
     public void show() {
-        new MaterialAlertDialogBuilder(context)
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context)
                 .setTitle(R.string.stream_label)
-                .setMessage(R.string.confirm_mobile_streaming_notification_message)
                 .setPositiveButton(R.string.confirm_mobile_streaming_button_once, (dialog, which) -> stream())
                 .setNegativeButton(R.string.confirm_mobile_streaming_button_always, (dialog, which) -> {
                     UserPreferences.setAllowMobileStreaming(true);
                     stream();
                 })
-                .setNeutralButton(R.string.cancel_label, null)
-                .show();
+                .setNeutralButton(R.string.cancel_label, null);
+        if (NetworkUtils.isNetworkRestricted() && NetworkUtils.isVpnOverWifi()) {
+            builder.setMessage(context.getString(R.string.confirm_mobile_streaming_notification_message)
+                    + "\n\n" + context.getString(R.string.confirm_mobile_download_dialog_message_vpn));
+        } else {
+            builder.setMessage(R.string.confirm_mobile_streaming_notification_message);
+        }
+        builder.show();
     }
 
     private void stream() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -295,6 +295,16 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(this::showFeedFragment, error -> {
             error.printStackTrace();
+            if (error instanceof UnsupportedFeedtypeException
+                    && "html".equalsIgnoreCase(((UnsupportedFeedtypeException) error).getRootElement())) {
+                if (getIntent().getBooleanExtra(ARG_WAS_MANUAL_URL, false)) {
+                    showErrorDialog(getString(R.string.download_error_unsupported_type_html_manual),
+                            error.getMessage());
+                } else {
+                    showErrorDialog(getString(R.string.download_error_unsupported_type_html), error.getMessage());
+                }
+                return;
+            }
             showErrorDialog(getString(R.string.download_error_parser_exception), error.getMessage());
         });
     }
@@ -319,9 +329,6 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
                 boolean dialogShown = showFeedDiscoveryDialog(destinationFile, selectedDownloadUrl);
                 if (dialogShown) {
                     return null; // We handled the problem
-                } else {
-                    throw new UnsupportedFeedtypeException(
-                            getString(R.string.download_error_unsupported_type_html) + "\n" + e.getMessage());
                 }
             }
             throw e;

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -301,6 +301,7 @@
     <string name="download_error_parser_exception">The podcast host\'s server sent a broken podcast feed. We recommend checking with a podcast validator such as castfeedvalidator.com and contacting the podcast creator to let them know.</string>
     <string name="download_error_unsupported_type">Unsupported feed type</string>
     <string name="download_error_unsupported_type_html">The podcast host\'s server sent a website, not a podcast.</string>
+    <string name="download_error_unsupported_type_html_manual">The address you entered is a website address, not a podcast RSS address.</string>
     <string name="download_error_not_found">The podcast host\'s server does not know where to find the file. It may have been deleted.</string>
     <string name="download_error_connection_error">Connection error</string>
     <string name="download_error_no_connection">No network connection</string>
@@ -330,7 +331,7 @@
     <string name="authentication_notification_title">Authentication required</string>
     <string name="confirm_mobile_download_dialog_title">Confirm mobile download</string>
     <string name="confirm_mobile_download_dialog_message">Downloading over mobile data connection is disabled in the settings. AntennaPod can download the episode later automatically when Wi-Fi is available.</string>
-    <string name="confirm_mobile_download_dialog_message_vpn">Your VPN app pretends to be a mobile network (metered connection). Downloading over mobile data connection is disabled in the settings. If you want this problem to be fixed, contact the creators of your VPN app.</string>
+    <string name="confirm_mobile_download_dialog_message_vpn">- Using a VPN? Your VPN app pretends to be a mobile network (metered connection). If you want this problem fixed, contact the creators of your VPN app.\n- Not using a VPN? Open the Android Wi-Fi settings and change the type of your Wi-Fi to not be metered.</string>
     <string name="confirm_mobile_download_dialog_download_later">Download later</string>
     <string name="confirm_mobile_download_dialog_allow_this_time">Download anyway</string>
     <plurals name="mobile_download_notice">


### PR DESCRIPTION
### Description

Tweak error messages related to feed types again, addition to #7629. If a user entered a url manually, show a different error message: "You entered a website address" instead of "Server returned a website". When showing the error message about trying to download on metered networks, also say something about non-VPN users (even though VPN users are the vast majority or users having this problem).

Closes #7632

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
