### PR TITLE
Reduce font size of bottom navigation

### DIFF
--- a/app/src/main/res/layout-sw720dp/main.xml
+++ b/app/src/main/res/layout-sw720dp/main.xml
@@ -56,7 +56,11 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigationView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="64dp"
+        app:itemTextAppearanceInactive="@style/TextBottomNav"
+        app:itemTextAppearanceActive="@style/TextBottomNav"
+        app:itemPaddingTop="6dp"
+        app:itemPaddingBottom="12dp"
         app:labelVisibilityMode="labeled" />
 
     <View

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -56,7 +56,11 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigationView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="64dp"
+        app:itemTextAppearanceInactive="@style/TextBottomNav"
+        app:itemTextAppearanceActive="@style/TextBottomNav"
+        app:itemPaddingTop="6dp"
+        app:itemPaddingBottom="12dp"
         app:labelVisibilityMode="labeled" />
 
     <View

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -309,6 +309,10 @@
         <item name="android:paddingEnd">8dp</item>
     </style>
 
+    <style name="TextBottomNav" parent="TextAppearance.Material3.TitleSmall">
+       <item name="android:textSize">11sp</item>
+    </style>
+
     <style name="AppPreferenceThemeOverlay" parent="@style/PreferenceThemeOverlay">
         <item name="switchPreferenceCompatStyle">@style/AppSwitchPreference</item>
     </style>


### PR DESCRIPTION
### Description

Reduce font size of bottom navigation.
See https://forum.antennapod.org/t/bottom-navigation-enhancements-improvements/5720/8

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
