### PR TITLE
Fix multi-select staying enabled when leaving search

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -126,9 +126,6 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     @Override
     public void onStop() {
         super.onStop();
-        if (adapter != null && adapter.inActionMode()) {
-            adapter.endSelectMode();
-        }
         if (disposableFeeds != null) {
             disposableFeeds.dispose();
         }
@@ -180,6 +177,14 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
                                             ContextMenu.ContextMenuInfo contextMenuInfo) {
                 super.onCreateContextMenu(contextMenu, view, contextMenuInfo);
                 MenuItemUtils.setOnClickListeners(contextMenu, SearchFragment.this::onContextItemSelected);
+            }
+
+            @Override
+            protected void onClick(Feed feed) {
+                if (adapter != null && adapter.inActionMode()) {
+                    adapter.endSelectMode();
+                }
+                super.onClick(feed);
             }
         };
         recyclerViewFeeds.setAdapter(adapterFeeds);
@@ -421,6 +426,9 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     }
 
     private void searchOnline() {
+        if (adapter != null && adapter.inActionMode()) {
+            adapter.endSelectMode();
+        }
         searchView.clearFocus();
         InputMethodManager in = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         in.hideSoftInputFromWindow(searchView.getWindowToken(), 0);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -414,9 +414,6 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     }
 
     private void showInputMethod(View view) {
-        if (getActivity() == null) { //Fixes https://github.com/AntennaPod/AntennaPod/issues/7609
-            return;
-        }
         InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         if (imm != null) {
             imm.showSoftInput(view, 0);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -411,6 +411,9 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     }
 
     private void showInputMethod(View view) {
+        if (getActivity() == null) { //Fixes https://github.com/AntennaPod/AntennaPod/issues/7609
+            return;
+        }
         InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         if (imm != null) {
             imm.showSoftInput(view, 0);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -126,6 +126,9 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     @Override
     public void onStop() {
         super.onStop();
+        if (adapter != null && adapter.inActionMode()) {
+            adapter.endSelectMode();
+        }
         if (disposableFeeds != null) {
             disposableFeeds.dispose();
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/HorizontalFeedListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/HorizontalFeedListAdapter.java
@@ -74,8 +74,7 @@ public class HorizontalFeedListAdapter extends RecyclerView.Adapter<HorizontalFe
         holder.itemView.setAlpha(1.0f);
         final Feed podcast = data.get(position);
         holder.imageView.setContentDescription(podcast.getTitle());
-        holder.imageView.setOnClickListener(v ->
-                mainActivityRef.get().loadChildFragment(FeedItemlistFragment.newInstance(podcast.getId())));
+        holder.imageView.setOnClickListener(v -> onClick(podcast));
 
         holder.imageView.setOnCreateContextMenuListener(this);
         holder.imageView.setOnLongClickListener(v -> {
@@ -91,6 +90,10 @@ public class HorizontalFeedListAdapter extends RecyclerView.Adapter<HorizontalFe
                         .fitCenter()
                         .dontAnimate())
                 .into(holder.imageView);
+    }
+
+    protected void onClick(Feed feed) {
+        mainActivityRef.get().loadChildFragment(FeedItemlistFragment.newInstance(feed.getId()));
     }
 
     @Nullable


### PR DESCRIPTION
### Description

Fixes #7609

This is just a small hotfix that checks if the activity is null before the crash happens due to the activity being null. If the bug should be fixed in a different way, just tell me :)

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
