### PR TITLE
Increase touch target size of buttons

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/MainActivityTest.java
@@ -63,7 +63,7 @@ public class MainActivityTest {
         openNavDrawer();
         onView(withText(R.string.add_feed_label)).perform(click());
         onView(withId(R.id.addViaUrlButton)).perform(scrollTo(), click());
-        onView(withId(R.id.urlEditText)).perform(replaceText(feed.getDownloadUrl()));
+        onView(withId(R.id.textInput)).perform(replaceText(feed.getDownloadUrl()));
         onView(withText(R.string.confirm_label)).perform(scrollTo(), click());
 
         // subscribe podcast

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
@@ -132,19 +132,19 @@ public class AddFeedFragment extends Fragment {
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(getContext());
         builder.setTitle(R.string.add_podcast_by_url);
         final EditTextDialogBinding dialogBinding = EditTextDialogBinding.inflate(getLayoutInflater());
-        dialogBinding.urlEditText.setHint(R.string.add_podcast_by_url_hint);
+        dialogBinding.textInput.setHint(R.string.rss_address);
 
         ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
         final ClipData clipData = clipboard.getPrimaryClip();
         if (clipData != null && clipData.getItemCount() > 0 && clipData.getItemAt(0).getText() != null) {
             final String clipboardContent = clipData.getItemAt(0).getText().toString();
             if (clipboardContent.trim().startsWith("http")) {
-                dialogBinding.urlEditText.setText(clipboardContent.trim());
+                dialogBinding.textInput.setText(clipboardContent.trim());
             }
         }
         builder.setView(dialogBinding.getRoot());
         builder.setPositiveButton(R.string.confirm_label,
-                (dialog, which) -> addUrl(dialogBinding.urlEditText.getText().toString()));
+                (dialog, which) -> addUrl(dialogBinding.textInput.getText().toString()));
         builder.setNegativeButton(R.string.cancel_label, null);
         builder.show();
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/RenameFeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/RenameFeedDialog.java
@@ -41,12 +41,12 @@ public class RenameFeedDialog {
         final EditTextDialogBinding binding = EditTextDialogBinding.inflate(LayoutInflater.from(activity));
         String title = feed != null ? feed.getTitle() : drawerItem.getTitle();
 
-        binding.urlEditText.setText(title);
+        binding.textInput.setText(title);
         AlertDialog dialog = new MaterialAlertDialogBuilder(activity)
                 .setView(binding.getRoot())
                 .setTitle(feed != null ? R.string.rename_feed_label : R.string.rename_tag_label)
                 .setPositiveButton(android.R.string.ok, (d, input) -> {
-                    String newTitle = binding.urlEditText.getText().toString();
+                    String newTitle = binding.textInput.getText().toString();
                     if (feed != null) {
                         feed.setCustomTitle(newTitle);
                         DBWriter.setFeedCustomTitle(feed);
@@ -60,7 +60,7 @@ public class RenameFeedDialog {
 
         // To prevent cancelling the dialog on button click
         dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(
-                (view) -> binding.urlEditText.setText(title));
+                (view) -> binding.textInput.setText(title));
     }
 
     private void renameTag(String title) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/EditUrlSettingsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/EditUrlSettingsDialog.java
@@ -33,13 +33,13 @@ public abstract class EditUrlSettingsDialog {
 
         final EditTextDialogBinding binding = EditTextDialogBinding.inflate(LayoutInflater.from(activity));
 
-        binding.urlEditText.setText(feed.getDownloadUrl());
+        binding.textInput.setText(feed.getDownloadUrl());
 
         new MaterialAlertDialogBuilder(activity)
                 .setView(binding.getRoot())
                 .setTitle(R.string.edit_url_menu)
                 .setPositiveButton(android.R.string.ok, (d, input) ->
-                        showConfirmAlertDialog(String.valueOf(binding.urlEditText.getText())))
+                        showConfirmAlertDialog(String.valueOf(binding.textInput.getText())))
                 .setNegativeButton(R.string.cancel_label, null)
                 .show();
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -399,11 +399,12 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         builder.setTitle(R.string.edit_url_menu);
         final EditTextDialogBinding dialogBinding = EditTextDialogBinding.inflate(getLayoutInflater());
         if (downloader != null) {
-            dialogBinding.urlEditText.setText(downloader.getDownloadRequest().getSource());
+            dialogBinding.textInput.setText(downloader.getDownloadRequest().getSource());
+            dialogBinding.textInput.setHint(R.string.rss_address);
         }
         builder.setView(dialogBinding.getRoot());
         builder.setPositiveButton(R.string.confirm_label, (dialog, which) -> {
-            lookupUrlAndDownload(dialogBinding.urlEditText.getText().toString());
+            lookupUrlAndDownload(dialogBinding.textInput.getText().toString());
         });
         builder.setNegativeButton(R.string.cancel_label, (dialog1, which) -> dialog1.cancel());
         builder.setOnCancelListener(dialog1 -> {

--- a/app/src/main/res/layout/addfeed.xml
+++ b/app/src/main/res/layout/addfeed.xml
@@ -50,12 +50,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
+                    android:gravity="center_vertical"
                     android:background="?attr/colorSurfaceContainer">
 
                     <ImageView
                         android:id="@+id/searchButton"
-                        android:layout_width="40dp"
-                        android:layout_height="match_parent"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:padding="12dp"
                         android:layout_marginLeft="8dp"
                         android:layout_marginRight="8dp"
                         android:contentDescription="@string/search_podcast_hint"

--- a/app/src/main/res/layout/edit_text_dialog.xml
+++ b/app/src/main/res/layout/edit_text_dialog.xml
@@ -6,11 +6,18 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <EditText
-        android:id="@+id/urlEditText"
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:inputType="text"
-        android:ems="10" />
+        android:layout_marginBottom="8dp"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/textInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="1" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>

--- a/ui/discovery/src/main/res/layout/quick_feed_discovery.xml
+++ b/ui/discovery/src/main/res/layout/quick_feed_discovery.xml
@@ -71,7 +71,7 @@
             android:id="@+id/discover_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:minHeight="40dp"
+            android:minHeight="48dp"
             android:minWidth="0dp"
             android:text="@string/discover_more"
             style="@style/Widget.MaterialComponents.Button.TextButton" />

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -806,7 +806,7 @@
     <string name="search_podcastindex_label">Search Podcast Index</string>
     <string name="search_fyyd_label">Search fyyd</string>
     <string name="add_podcast_by_url">Add podcast by RSS address</string>
-    <string name="add_podcast_by_url_hint" translatable="false">www.example.com/feed</string>
+    <string name="rss_address">RSS address</string>
     <string name="discover">Discover</string>
     <string name="discover_hide">Hide</string>
     <string name="discover_is_hidden">You selected to hide suggestions.</string>

--- a/ui/preferences/build.gradle
+++ b/ui/preferences/build.gradle
@@ -46,5 +46,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
     implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation 'com.github.ByteHamster:SearchPreference:v2.5.0'
+    implementation 'com.github.ByteHamster:SearchPreference:v2.6.2'
 }


### PR DESCRIPTION
### Description

Increase touch target size of buttons. Google Play warns about these otherwise

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
