### PR TITLE
Fix crash on feed settings page

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
@@ -108,7 +108,7 @@ public class FeedSettingsFragment extends Fragment {
 
     public static class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
         private static final String PREF_EPISODE_FILTER = "episodeFilter";
-        private static final String PREF_AUTODOWNLOAD = "autoDownload";
+        private static final String PREF_AUTODOWNLOAD = "includeAutoDownload";
         private static final String PREF_SCREEN = "feedSettingsScreen";
         private static final String PREF_AUTHENTICATION = "authentication";
         private static final String PREF_AUTO_DELETE = "autoDelete";

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -73,7 +73,7 @@
             android:entries="@array/spnEnableAutoDownloadItems"
             android:entryValues="@array/spnEnableAutoDownloadValues"
             android:icon="@drawable/ic_download"
-            android:key="autoDownload"
+            android:key="includeAutoDownload"
             android:title="@string/auto_download_label" />
 
         <Preference


### PR DESCRIPTION
### Description

We migrated from a checkbox to a list preference.
The (unused) stored value causes a ClassCastException

Closes #7649

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
