### PR TITLE
Enable 3-state auto-download setting in multi-select

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
@@ -63,14 +63,18 @@ public class FeedMultiSelectActionHandler {
     }
 
     private void autoDownloadPrefHandler() {
-        PreferenceSwitchDialog preferenceSwitchDialog = new PreferenceSwitchDialog(activity,
-                activity.getString(R.string.auto_download_settings_label),
+        PreferenceListDialog preferenceListDialog = new PreferenceListDialog(activity,
                 activity.getString(R.string.auto_download_label));
-        preferenceSwitchDialog.setOnPreferenceChangedListener(enabled ->
-                saveFeedPreferences(feedPreferences ->
-                        feedPreferences.setAutoDownload(FeedPreferences.AutoDownloadSetting.fromBoolean(enabled))
-                ));
-        preferenceSwitchDialog.openDialog();
+        String[] items = activity.getResources().getStringArray(R.array.spnEnableAutoDownloadItems);
+        preferenceListDialog.openDialog(items);
+        preferenceListDialog.setOnPreferenceChangedListener(which -> {
+            FeedPreferences.AutoDownloadSetting autoDownloadSetting = switch (which) {
+                case 1 -> FeedPreferences.AutoDownloadSetting.ENABLED;
+                case 2 -> FeedPreferences.AutoDownloadSetting.DISABLED;
+                default -> FeedPreferences.AutoDownloadSetting.GLOBAL;
+            };
+            saveFeedPreferences(feedPreferences -> feedPreferences.setAutoDownload(autoDownloadSetting));
+        });
     }
 
     private void playbackSpeedPrefHandler() {


### PR DESCRIPTION
### Description

Enable 3-state auto-download setting in multi-select
Closes #7655

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
