### PR TITLE
Partially work around duplicated feeds when using sync

### DIFF
--- a/net/common/src/main/java/de/danoeh/antennapod/net/common/RedirectChecker.java
+++ b/net/common/src/main/java/de/danoeh/antennapod/net/common/RedirectChecker.java
@@ -1,0 +1,53 @@
+package de.danoeh.antennapod.net.common;
+
+import android.util.Log;
+import androidx.annotation.Nullable;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.http.StatusLine;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public abstract class RedirectChecker {
+    private static final String TAG = "RedirectChecker";
+
+    @Nullable
+    public static String getNewUrlIfPermanentRedirect(Response response) {
+        // detect 301 Moved permanently and 308 Permanent Redirect
+        ArrayList<Response> responses = new ArrayList<>();
+        while (response != null) {
+            responses.add(response);
+            response = response.priorResponse();
+        }
+        if (responses.size() < 2) {
+            return null;
+        }
+        Collections.reverse(responses);
+        int firstCode = responses.get(0).code();
+        String firstUrl = responses.get(0).request().url().toString();
+        String secondUrl = responses.get(1).request().url().toString();
+        if (firstCode == HttpURLConnection.HTTP_MOVED_PERM || firstCode == StatusLine.HTTP_PERM_REDIRECT) {
+            Log.d(TAG, "Detected permanent redirect from " + firstUrl + " to " + secondUrl);
+            return secondUrl;
+        } else if (secondUrl.equals(firstUrl.replace("http://", "https://"))) {
+            Log.d(TAG, "Treating http->https non-permanent redirect as permanent: " + firstUrl);
+            return secondUrl;
+        }
+        return null;
+    }
+
+    @Nullable
+    public static String getNewUrlIfPermanentRedirect(String downloadUrl) {
+        try {
+            Request httpReq = new Request.Builder().url(downloadUrl).head().build();
+            Response response = AntennapodHttpClient.getHttpClient().newCall(httpReq).execute();
+            return RedirectChecker.getNewUrlIfPermanentRedirect(response);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
@@ -24,6 +24,7 @@ import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.net.common.AntennapodHttpClient;
+import de.danoeh.antennapod.net.common.RedirectChecker;
 import de.danoeh.antennapod.net.common.UrlChecker;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.net.sync.gpoddernet.GpodnetService;
@@ -156,12 +157,20 @@ public class SyncService extends Worker {
             if (!downloadUrl.startsWith("http")) { // Also matches https
                 Log.d(TAG, "Skipping url: " + downloadUrl);
                 continue;
+            } else if (UrlChecker.containsUrl(localSubscriptions, downloadUrl)
+                    || queuedRemovedFeeds.contains(downloadUrl)) {
+                continue;
             }
-            if (!UrlChecker.containsUrl(localSubscriptions, downloadUrl) && !queuedRemovedFeeds.contains(downloadUrl)) {
-                Feed feed = new Feed(downloadUrl, null, "Unknown podcast");
-                feed.setItems(Collections.emptyList());
-                FeedDatabaseWriter.updateFeed(getApplicationContext(), feed, false);
+            String redirectedUrl = RedirectChecker.getNewUrlIfPermanentRedirect(downloadUrl);
+            if (redirectedUrl != null
+                    && (UrlChecker.containsUrl(localSubscriptions, redirectedUrl)
+                        || queuedRemovedFeeds.contains(redirectedUrl))) {
+                continue;
             }
+
+            Feed feed = new Feed(downloadUrl, null, "Unknown podcast");
+            feed.setItems(Collections.emptyList());
+            FeedDatabaseWriter.updateFeed(getApplicationContext(), feed, false);
         }
 
         // remove subscription if not just subscribed (again)


### PR DESCRIPTION
### Description

Connect to each newly added URL with a HEAD request. If there is a redirect to an existing URL, ignore the added feed.

This does not handle `itunes:new-feed-url` or other redirects. This will likely still cause problems with synchronization because the server still knows the old url. However, it makes the situation better than it was before by avoiding the duplicates. For a proper fix, we need a new protocol that can deal with redirects more elegantly (see #6506).

Closes #2214

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
