### PR TITLE
Hide subscription list setting when using buttom navigation

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/DrawerPreferencesDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/DrawerPreferencesDialog.java
@@ -34,6 +34,9 @@ public class DrawerPreferencesDialog extends ReorderDialog {
 
         final List<String> drawerItemOrder = UserPreferences.getVisibleDrawerItemOrder();
         for (String tag : drawerItemOrder) {
+            if (UserPreferences.isBottomNavigationEnabled() && tag.equals(NavListAdapter.SUBSCRIPTION_LIST_TAG)) {
+                continue;
+            }
             settingsDialogItems.add(new ReorderDialogItem(ReorderDialogItem.ViewType.Section,
                     tag, context.getString(NavigationNames.getLabel(tag))));
         }
@@ -43,6 +46,10 @@ public class DrawerPreferencesDialog extends ReorderDialog {
 
         final List<String> hiddenDrawerItems = UserPreferences.getHiddenDrawerItems();
         for (String sectionTag : hiddenDrawerItems) {
+            if (UserPreferences.isBottomNavigationEnabled()
+                    && sectionTag.equals(NavListAdapter.SUBSCRIPTION_LIST_TAG)) {
+                continue;
+            }
             settingsDialogItems.add(new ReorderDialogItem(ReorderDialogItem.ViewType.Section,
                     sectionTag, context.getString(NavigationNames.getLabel(sectionTag))));
         }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="downloads_log_label">Download log</string>
     <string name="subscriptions_label">Subscriptions</string>
     <string name="subscriptions_label_short">Subscriptions</string>
-    <string name="subscriptions_list_label">Subscriptions list (side menu only)</string>
+    <string name="subscriptions_list_label">Subscriptions list</string>
     <string name="cancel_download_label">Cancel download</string>
     <string name="playback_history_label">Playback history</string>
     <string name="playback_history_label_short">History</string>


### PR DESCRIPTION
### Description

Hide subscription list setting when using buttom navigation
See https://forum.antennapod.org/t/bottom-navigation-feedback/6277

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
