### PR TITLE
Ascending order for date-based sorting in queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -567,9 +567,15 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
 
         @Override
         protected void onAddItem(int title, SortOrder ascending, SortOrder descending, boolean ascendingIsDefault) {
-            if (ascending != SortOrder.EPISODE_FILENAME_A_Z && ascending != SortOrder.SIZE_SMALL_LARGE) {
-                super.onAddItem(title, ascending, descending, ascendingIsDefault);
+            if (ascending == SortOrder.EPISODE_FILENAME_A_Z || ascending == SortOrder.SIZE_SMALL_LARGE) {
+                return;
             }
+
+            boolean defaultOrder = (ascending == SortOrder.DATE_OLD_NEW || ascending == SortOrder.SMART_SHUFFLE_OLD_NEW)
+                    ? !ascendingIsDefault
+                    : ascendingIsDefault;
+
+            super.onAddItem(title, ascending, descending, defaultOrder);
         }
 
         @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -570,12 +570,10 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             if (ascending == SortOrder.EPISODE_FILENAME_A_Z || ascending == SortOrder.SIZE_SMALL_LARGE) {
                 return;
             }
-
-            boolean defaultOrder = (ascending == SortOrder.DATE_OLD_NEW || ascending == SortOrder.SMART_SHUFFLE_OLD_NEW)
-                    ? !ascendingIsDefault
-                    : ascendingIsDefault;
-
-            super.onAddItem(title, ascending, descending, defaultOrder);
+            if (ascending == SortOrder.DATE_OLD_NEW || ascending == SortOrder.SMART_SHUFFLE_OLD_NEW) {
+                ascendingIsDefault = true;
+            }
+            super.onAddItem(title, ascending, descending, ascendingIsDefault);
         }
 
         @Override


### PR DESCRIPTION
### Description

Fixes: #7519

Hi,

This pull request changes the "date" and "smart shuffle" queue sorting criteria, both of which are sorted as descending by default at the moment, to ascending. This makes all queue sorting criteria now sort as ascending by default, which improves consistency.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x ] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x ] I have performed a self-review of my code
- [x ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x ] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
