### PR TITLE
Fix 'reconnect folder' clearing item's state

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -340,7 +340,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                 throw new IllegalArgumentException("Unable to retrieve document tree");
             }
             feed.setDownloadUrl(Feed.PREFIX_LOCAL_FOLDER + uri.toString());
-            FeedDatabaseWriter.updateFeed(getContext(), feed, true);
+            FeedDatabaseWriter.updateFeed(getContext(), feed, false);
         })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
### Description

Fix 'reconnect folder' clearing item's state.

See #7680
CC @Mrnofish

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
