### PR TITLE
Feature multi select move

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -371,16 +371,30 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             return true;
         }
 
+        List<FeedItem> selectedItems;
+        FeedItem current;
         final int itemId = item.getItemId();
         if (itemId == R.id.move_to_top_item) {
-            queue.add(0, queue.remove(position));
-            recyclerAdapter.notifyItemMoved(position, 0);
-            DBWriter.moveQueueItemToTop(selectedItem.getId(), true);
+            selectedItems = recyclerAdapter.getSelectedItems();
+            for(int i = selectedItems.size() - 1; i >= 0; i--)
+            {
+                current = selectedItems.get(i);
+                position = FeedItemEvent.indexOfItemWithId(queue, current.getId());
+                queue.add(0, queue.remove(position));
+                recyclerAdapter.notifyItemMoved(position, 0);
+                DBWriter.moveQueueItemToTop(current.getId(), true);
+            }
             return true;
         } else if (itemId == R.id.move_to_bottom_item) {
-            queue.add(queue.size() - 1, queue.remove(position));
-            recyclerAdapter.notifyItemMoved(position, queue.size() - 1);
-            DBWriter.moveQueueItemToBottom(selectedItem.getId(), true);
+            selectedItems = recyclerAdapter.getSelectedItems();
+            for(int i = 0; i < selectedItems.size(); i++)
+            {
+                current = selectedItems.get(i);
+                position = FeedItemEvent.indexOfItemWithId(queue, current.getId());
+                queue.add(queue.size() - 1, queue.remove(position));
+                recyclerAdapter.notifyItemMoved(position, queue.size() - 1);
+                DBWriter.moveQueueItemToBottom(current.getId(), true);
+            }
             return true;
         }
         return FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), selectedItem);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -351,7 +351,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     }
 
     @Override
-    public boolean onContextItemSelected(MenuItem item) {
+    public boolean onContextItemSelected(@NonNull MenuItem item) {
         Log.d(TAG, "onContextItemSelected() called with: " + "item = [" + item + "]");
         if (!isVisible() || recyclerAdapter == null) {
             return false;
@@ -372,28 +372,28 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         }
 
         List<FeedItem> selectedItems;
-        FeedItem current;
+        FeedItem currentFeedItem;
         final int itemId = item.getItemId();
         if (itemId == R.id.move_to_top_item) {
             selectedItems = recyclerAdapter.getSelectedItems();
             for(int i = selectedItems.size() - 1; i >= 0; i--)
             {
-                current = selectedItems.get(i);
-                position = FeedItemEvent.indexOfItemWithId(queue, current.getId());
+                currentFeedItem = selectedItems.get(i);
+                position = FeedItemEvent.indexOfItemWithId(queue, currentFeedItem.getId());
                 queue.add(0, queue.remove(position));
                 recyclerAdapter.notifyItemMoved(position, 0);
-                DBWriter.moveQueueItemToTop(current.getId(), true);
+                DBWriter.moveQueueItemToTop(currentFeedItem.getId(), true);
             }
             return true;
         } else if (itemId == R.id.move_to_bottom_item) {
             selectedItems = recyclerAdapter.getSelectedItems();
             for(int i = 0; i < selectedItems.size(); i++)
             {
-                current = selectedItems.get(i);
-                position = FeedItemEvent.indexOfItemWithId(queue, current.getId());
+                currentFeedItem = selectedItems.get(i);
+                position = FeedItemEvent.indexOfItemWithId(queue, currentFeedItem.getId());
                 queue.add(queue.size() - 1, queue.remove(position));
                 recyclerAdapter.notifyItemMoved(position, queue.size() - 1);
-                DBWriter.moveQueueItemToBottom(current.getId(), true);
+                DBWriter.moveQueueItemToBottom(currentFeedItem.getId(), true);
             }
             return true;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -36,6 +36,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.Collections;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
@@ -372,10 +373,16 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         }
 
         List<FeedItem> selectedItems;
+        if(recyclerAdapter.inActionMode())
+        {
+            selectedItems = recyclerAdapter.getSelectedItems();
+        } else {
+            selectedItems = Collections.singletonList(selectedItem);
+        }
+
         FeedItem currentFeedItem;
         final int itemId = item.getItemId();
         if (itemId == R.id.move_to_top_item) {
-            selectedItems = recyclerAdapter.getSelectedItems();
             for(int i = selectedItems.size() - 1; i >= 0; i--)
             {
                 currentFeedItem = selectedItems.get(i);
@@ -386,7 +393,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             }
             return true;
         } else if (itemId == R.id.move_to_bottom_item) {
-            selectedItems = recyclerAdapter.getSelectedItems();
             for(int i = 0; i < selectedItems.size(); i++)
             {
                 currentFeedItem = selectedItems.get(i);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueRecyclerAdapter.java
@@ -79,18 +79,18 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
         inflater.inflate(R.menu.queue_context, menu);
         super.onCreateContextMenu(menu, v, menuInfo);
 
-        if (!inActionMode()) {
-            menu.findItem(R.id.multi_select).setVisible(true);
-            final boolean keepSorted = UserPreferences.isQueueKeepSorted();
-            if (getItem(0).getId() == getLongPressedItem().getId() || keepSorted) {
-                menu.findItem(R.id.move_to_top_item).setVisible(false);
-            }
-            if (getItem(getItemCount() - 1).getId() == getLongPressedItem().getId() || keepSorted) {
-                menu.findItem(R.id.move_to_bottom_item).setVisible(false);
-            }
-        } else {
             menu.findItem(R.id.move_to_top_item).setVisible(true);
             menu.findItem(R.id.move_to_bottom_item).setVisible(true);
+
+            if (!inActionMode()) {
+                menu.findItem(R.id.multi_select).setVisible(true);
+                final boolean keepSorted = UserPreferences.isQueueKeepSorted();
+                if (getItem(0).getId() == getLongPressedItem().getId() || keepSorted) {
+                    menu.findItem(R.id.move_to_top_item).setVisible(false);
+                }
+                if (getItem(getItemCount() - 1).getId() == getLongPressedItem().getId() || keepSorted) {
+                    menu.findItem(R.id.move_to_bottom_item).setVisible(false);
+            }
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueRecyclerAdapter.java
@@ -89,8 +89,8 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
                 menu.findItem(R.id.move_to_bottom_item).setVisible(false);
             }
         } else {
-            menu.findItem(R.id.move_to_top_item).setVisible(false);
-            menu.findItem(R.id.move_to_bottom_item).setVisible(false);
+            menu.findItem(R.id.move_to_top_item).setVisible(true);
+            menu.findItem(R.id.move_to_bottom_item).setVisible(true);
         }
     }
 }


### PR DESCRIPTION
### Description
Resolves #5784

This PR implements the "Move to top" and "Move to bottom" functions for multiple selected episodes in the queue, as per #5784

All selected episodes are moved to the top or bottom respectively, and maintain their internal order. 
Gaps between selected episodes are dropped.

<img src=https://github.com/user-attachments/assets/f6cfbe4e-30c4-4b73-ae4e-25bead0c278f width=50%></img>


As I'm not yet that familiar with the code base, I'm not sure if this PR is the right way to do it. Maybe the code that deals with removing and inserting into the queue should be its own function?

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
