### PR TITLE
Fix flaky test sorting by release date

### DIFF
--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
@@ -153,6 +154,9 @@ public class DbReaderTest {
             Feed feed = saveFeedlist(numFeeds, numItems, false).get(0);
             List<FeedItem> items = feed.getItems();
             feed.setItems(null);
+            Collections.sort(items, (o1, o2) ->
+                    Long.compare(o2.getPubDate().getTime(), o1.getPubDate().getTime()));
+
             List<FeedItem> savedItems = DBReader.getFeedItemList(feed,
                     FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD, 0, Integer.MAX_VALUE);
             assertNotNull(savedItems);

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbTestUtils.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbTestUtils.java
@@ -43,9 +43,11 @@ abstract class DbTestUtils {
             Feed f = new Feed(0, null, "feed " + i, "link" + i, "descr", null, null,
                     null, null, "id" + i, null, null, "url" + i, System.currentTimeMillis());
             f.setItems(new ArrayList<>());
+            long itemDate = new Date().getTime();
             for (int j = 0; j < numItems; j++) {
-                FeedItem item = new FeedItem(0, "item " + j, "id" + j, "link" + j, new Date(),
+                FeedItem item = new FeedItem(0, "item " + j, "id" + j, "link" + j, new Date(itemDate),
                         FeedItem.PLAYED, f, withChapters);
+                itemDate += 24L * 60 * 60 * 1000;
                 if (withMedia) {
                     FeedMedia media = new FeedMedia(item, "url" + j, 1, "audio/mp3");
                     item.setMedia(media);


### PR DESCRIPTION
### Description

Fix flaky test sorting by release date

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
