### PR TITLE
Tweak padding of floating select menu

### DIFF
--- a/app/src/main/res/layout/floating_select_menu.xml
+++ b/app/src/main/res/layout/floating_select_menu.xml
@@ -16,7 +16,9 @@
         <HorizontalScrollView
             android:id="@+id/scrollView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:paddingHorizontal="8dp"
+            android:clipToPadding="false">
 
             <LinearLayout
                 android:id="@+id/selectContainer"

--- a/app/src/main/res/layout/floating_select_menu_item.xml
+++ b/app/src/main/res/layout/floating_select_menu_item.xml
@@ -3,8 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:paddingHorizontal="2dp"
-    android:paddingVertical="8dp"
+    android:paddingHorizontal="4dp"
+    android:paddingBottom="8dp"
+    android:paddingTop="12dp"
     android:background="?attr/selectableItemBackgroundBorderless"
     android:orientation="vertical">
 
@@ -17,13 +18,16 @@
 
     <TextView
         android:id="@id/titleLabel"
-        android:layout_width="96dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:maxWidth="96dp"
+        android:minWidth="72dp"
         android:layout_marginTop="8dp"
         android:textColor="?android:attr/textColorPrimary"
         android:maxLines="2"
         android:textAlignment="center"
         android:ellipsize="end"
+        android:hyphenationFrequency="full"
         style="@style/TextAppearance.Material3.BodySmall" />
 
 </LinearLayout>


### PR DESCRIPTION
### Description

Tweak padding of floating select menu
Fixes partially #7462

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
