### PR TITLE
Upgrade SearchPreference

### DIFF
--- a/ui/preferences/build.gradle
+++ b/ui/preferences/build.gradle
@@ -46,5 +46,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
     implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation 'com.github.ByteHamster:SearchPreference:2.7.1'
+    implementation 'com.github.ByteHamster:SearchPreference:2.7.2'
 }


### PR DESCRIPTION
### Description

I have no idea why but 2.7.1 disappeared from JitPack. The two versions are identical, 2.7.2 is just a new release with the same code. See https://github.com/ByteHamster/SearchPreference/issues/41

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
