### PR TITLE
Consistently do not allow to set sleep timer if no media is playing

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
@@ -20,6 +20,7 @@ import androidx.fragment.app.DialogFragment;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.playback.base.PlayerStatus;
 import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.playback.service.PlaybackService;
 import org.greenrobot.eventbus.EventBus;
@@ -145,7 +146,8 @@ public class SleepTimerDialog extends DialogFragment {
         });
         Button setButton = content.findViewById(R.id.setSleeptimerButton);
         setButton.setOnClickListener(v -> {
-            if (!PlaybackService.isRunning) {
+            if (!PlaybackService.isRunning
+                    || (controller != null && controller.getStatus() != PlayerStatus.PLAYING)) {
                 Snackbar.make(content, R.string.no_media_playing_label, Snackbar.LENGTH_LONG).show();
                 return;
             }


### PR DESCRIPTION
### Description
When you first try to set a sleep timer with no media playing you get an error saying that no media is playing.
But if you start playing and then stop playing and try to set a sleep timer you're allowed.
This fixes the inconsistency and doesn't care if it first playback or subsequent playbacks, it will behave the same way - it will not let you create a sleep timer unless something is playing.

Fixes #7246

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
