### PR TITLE
Added a small vibration when the phone is shaken to reset the sleep timer

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ShakeListener.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ShakeListener.java
@@ -5,6 +5,10 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.os.Build;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.os.VibratorManager;
 import android.util.Log;
 
 public class ShakeListener implements SensorEventListener {
@@ -42,6 +46,25 @@ public class ShakeListener implements SensorEventListener {
         }
     }
 
+    protected void vibrate() {
+        final Vibrator vibrator;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            VibratorManager vibratorManager = (VibratorManager) mContext.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            vibrator = vibratorManager.getDefaultVibrator();
+        } else {
+            vibrator = (Vibrator) mContext.getSystemService(Context.VIBRATOR_SERVICE);
+        }
+
+        final int duration = 100;
+        if (vibrator != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator.vibrate(VibrationEffect.createOneShot(duration, 120));
+            } else {
+                vibrator.vibrate(duration);
+            }
+        }
+    }
+
     @Override
     public void onSensorChanged(SensorEvent event) {
         float gX = event.values[0] / SensorManager.GRAVITY_EARTH;
@@ -52,6 +75,7 @@ public class ShakeListener implements SensorEventListener {
         if (gForce > 2.25) {
             Log.d(TAG, "Detected shake " + gForce);
             mSleepTimer.restart();
+            vibrate();
         }
     }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ShakeListener.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ShakeListener.java
@@ -49,7 +49,8 @@ public class ShakeListener implements SensorEventListener {
     protected void vibrate() {
         final Vibrator vibrator;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            VibratorManager vibratorManager = (VibratorManager) mContext.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            VibratorManager vibratorManager = (VibratorManager)
+                    mContext.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
             vibrator = vibratorManager.getDefaultVibrator();
         } else {
             vibrator = (Vibrator) mContext.getSystemService(Context.VIBRATOR_SERVICE);
@@ -71,7 +72,7 @@ public class ShakeListener implements SensorEventListener {
         float gY = event.values[1] / SensorManager.GRAVITY_EARTH;
         float gZ = event.values[2] / SensorManager.GRAVITY_EARTH;
 
-        double gForce = Math.sqrt(gX*gX + gY*gY + gZ*gZ);
+        double gForce = Math.sqrt(gX * gX + gY * gY + gZ * gZ);
         if (gForce > 2.25) {
             Log.d(TAG, "Detected shake " + gForce);
             mSleepTimer.restart();


### PR DESCRIPTION
### Description
Added a small vibration when the phone is shaken to reset the sleep timer so the user has feedback that the reset was applied.
Right now the user has no idea if the reset was applied or not, it's hard to tell when shake to reset is applied, a small vibration will give the user feedback.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
