### PR TITLE
Added event when playback ends for the current episode.

### DIFF
--- a/event/src/main/java/de/danoeh/antennapod/event/playback/PlaybackEndedEvent.java
+++ b/event/src/main/java/de/danoeh/antennapod/event/playback/PlaybackEndedEvent.java
@@ -1,0 +1,23 @@
+package de.danoeh.antennapod.event.playback;
+
+public class PlaybackEndedEvent {
+    public final boolean hasEnded;
+    public final boolean wasSkipped;
+    public final boolean shouldContinue;
+    public final boolean toStoppedState;
+
+    private PlaybackEndedEvent(boolean hasEnded, boolean wasSkipped, boolean shouldContinue, boolean toStoppedState) {
+        this.hasEnded = hasEnded;
+        this.wasSkipped = wasSkipped;
+        this.shouldContinue = shouldContinue;
+        this.toStoppedState = toStoppedState;
+    }
+
+    public static PlaybackEndedEvent ended(
+            boolean hasEnded,
+            boolean wasSkipped,
+            boolean shouldContinue,
+            boolean toStoppedState) {
+        return new PlaybackEndedEvent(hasEnded, wasSkipped, shouldContinue, toStoppedState);
+    }
+}

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/LocalPSMP.java
@@ -16,6 +16,7 @@ import androidx.media.AudioFocusRequestCompat;
 import androidx.media.AudioManagerCompat;
 import de.danoeh.antennapod.event.PlayerErrorEvent;
 import de.danoeh.antennapod.event.playback.BufferUpdateEvent;
+import de.danoeh.antennapod.event.playback.PlaybackEndedEvent;
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
@@ -680,6 +681,8 @@ public class LocalPSMP extends PlaybackServiceMediaPlayer {
     protected void endPlayback(final boolean hasEnded, final boolean wasSkipped,
                                     final boolean shouldContinue, final boolean toStoppedState) {
         releaseWifiLockIfNecessary();
+
+        EventBus.getDefault().post(PlaybackEndedEvent.ended(hasEnded, wasSkipped, shouldContinue, toStoppedState));
 
         boolean isPlaying = playerStatus == PlayerStatus.PLAYING;
 


### PR DESCRIPTION
### Description
Added event when playback ends for the current episode.

Useful when you want to count how many episodes have played, say for a sleep timer based on episodes.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
