### PR TITLE
Add screen to view episodes filtered by feed tag

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/NavigationDrawerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/NavigationDrawerTest.java
@@ -123,8 +123,8 @@ public class NavigationDrawerTest {
         onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
                 withText(R.string.add_feed_label), isDisplayed()), 1000));
 
-        // podcasts (all except the first, since it is not displayed at root level in the drawer)
-        for (int i = 1; i < uiTestUtils.hostedFeeds.size(); i++) {
+        // podcasts (all except the last, since it is not displayed at root level in the drawer)
+        for (int i = 0; i < uiTestUtils.hostedFeeds.size() - 1; i++) {
             Feed f = uiTestUtils.hostedFeeds.get(i);
             openNavDrawer();
             onDrawerItem(withText(f.getTitle())).perform(click());
@@ -143,9 +143,10 @@ public class NavigationDrawerTest {
         }
 
         // opening a tag folder
-        Feed f = uiTestUtils.hostedFeeds.get(0);
         openNavDrawer();
         onView(allOf(withId(R.id.imgvCover), hasSibling(withText("tag 0")))).perform(click());
+        onView(withId(R.id.drawer_layout)).perform(swipeUp());
+        Feed f = uiTestUtils.hostedFeeds.get(uiTestUtils.hostedFeeds.size() - 1);
         onDrawerItem(withText(f.getTitle())).check(isCompletelyBelow(withText("tag 0")));
         onDrawerItem(withText(f.getTitle())).perform(click());
         onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.appBar)),

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -10,6 +10,8 @@ import de.danoeh.antennapod.event.QueueEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
+import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
 import de.danoeh.antennapod.storage.database.PodDBAdapter;
 import de.test.antennapod.util.service.download.HTTPBin;
 import de.test.antennapod.util.syndication.feedgenerator.Rss2Generator;
@@ -141,6 +143,22 @@ public class UITestUtils {
             feed.setItems(items);
             feed.setDownloadUrl(hostFeed(feed));
             hostedFeeds.add(feed);
+        }
+
+        // add tags to the feeds
+        for (int i = 0; i < NUM_FEEDS; i++) {
+            Feed f = hostedFeeds.get(i);
+            FeedPreferences prefs = new FeedPreferences(f.getId(), FeedPreferences.AutoDownloadSetting.GLOBAL,
+                    FeedPreferences.AutoDeleteAction.GLOBAL, VolumeAdaptionSetting.OFF,
+                    FeedPreferences.NewEpisodesAction.GLOBAL, null, null);
+            f.setPreferences(prefs);
+            if (i > 0) {
+                // ensure that the feed at index 0 will not be displayed in the drawer until the tag folder is opened
+                prefs.getTags().add(FeedPreferences.TAG_ROOT);
+            }
+            for (int j = i; j < NUM_FEEDS; j++) {
+                prefs.getTags().add("tag " + j);
+            }
         }
         feedDataHosted = true;
     }

--- a/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/UITestUtils.java
@@ -152,11 +152,11 @@ public class UITestUtils {
                     FeedPreferences.AutoDeleteAction.GLOBAL, VolumeAdaptionSetting.OFF,
                     FeedPreferences.NewEpisodesAction.GLOBAL, null, null);
             f.setPreferences(prefs);
-            if (i > 0) {
-                // ensure that the feed at index 0 will not be displayed in the drawer until the tag folder is opened
+            if (i < NUM_FEEDS - 1) {
+                // ensure that the last feed will not be displayed in the drawer until the tag folder is opened
                 prefs.getTags().add(FeedPreferences.TAG_ROOT);
             }
-            for (int j = i; j < NUM_FEEDS; j++) {
+            for (int j = 0; j < NUM_FEEDS; j++) {
                 prefs.getTags().add("tag " + j);
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -69,6 +69,7 @@ import de.danoeh.antennapod.ui.common.ThemeUtils;
 import de.danoeh.antennapod.ui.discovery.DiscoveryFragment;
 import de.danoeh.antennapod.ui.screen.AddFeedFragment;
 import de.danoeh.antennapod.ui.screen.AllEpisodesFragment;
+import de.danoeh.antennapod.ui.screen.EpisodesByFeedTagFragment;
 import de.danoeh.antennapod.ui.screen.InboxFragment;
 import de.danoeh.antennapod.ui.screen.PlaybackHistoryFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
@@ -472,6 +473,15 @@ public class MainActivity extends CastEnabledActivity {
             fragment.setArguments(args);
         }
         NavDrawerFragment.saveLastNavFragment(this, String.valueOf(feedId));
+        loadFragment(fragment);
+    }
+
+    public void loadEpisodesByFeedTagFragment(String feedTag, Bundle args) {
+        Fragment fragment = EpisodesByFeedTagFragment.newInstance(feedTag);
+        if (args != null) {
+            fragment.setArguments(args);
+        }
+        NavDrawerFragment.saveLastNavFragment(this, feedTag);
         loadFragment(fragment);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/EpisodesByFeedTagFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/EpisodesByFeedTagFragment.java
@@ -1,0 +1,63 @@
+package de.danoeh.antennapod.ui.screen;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import org.apache.commons.lang3.Validate;
+
+import java.util.List;
+
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.storage.database.DBReader;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+
+/**
+ * Shows all episodes from feeds that have a certain tag (possibly filtered by user).
+ */
+public class EpisodesByFeedTagFragment extends AllEpisodesFragment {
+    public static final String TAG = "EpisodesByFeedTagFragment";
+    private static final String ARGUMENT_FEED_TAG = "argument.de.danoeh.antennapod.feed_tag";
+    private String feedTag;
+
+    public static EpisodesByFeedTagFragment newInstance(String feedTag) {
+        EpisodesByFeedTagFragment i = new EpisodesByFeedTagFragment();
+        Bundle b = new Bundle();
+        b.putString(ARGUMENT_FEED_TAG, feedTag);
+        i.setArguments(b);
+        return i;
+    }
+
+    @NonNull
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View root = super.onCreateView(inflater, container, savedInstanceState);
+        Bundle args = getArguments();
+        Validate.notNull(args);
+        feedTag = args.getString(ARGUMENT_FEED_TAG);
+        toolbar.setTitle(getContext().getString(R.string.episodes_by_tag_label, feedTag));
+        return root;
+    }
+
+    @NonNull
+    @Override
+    protected List<FeedItem> loadData() {
+        return DBReader.getEpisodes(0, page * EPISODES_PER_PAGE, getFilter(),
+                UserPreferences.getAllEpisodesSortOrder(), feedTag);
+    }
+
+    @NonNull
+    @Override
+    protected List<FeedItem> loadMoreData(int page) {
+        return DBReader.getEpisodes((page - 1) * EPISODES_PER_PAGE, EPISODES_PER_PAGE, getFilter(),
+                UserPreferences.getAllEpisodesSortOrder(), feedTag);
+    }
+
+    @Override
+    protected int loadTotalItemCount() {
+        return DBReader.getEpisodesByFeedTagCount(feedTag, getFilter());
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
@@ -160,7 +160,7 @@ public class NavListAdapter extends RecyclerView.Adapter<NavListAdapter.Holder>
             if (item.type == NavDrawerData.DrawerItem.Type.FEED) {
                 bindFeedView((NavDrawerData.FeedDrawerItem) item, (FeedHolder) holder);
             } else {
-                bindTagView((NavDrawerData.TagDrawerItem) item, (FeedHolder) holder);
+                bindTagView((NavDrawerData.TagDrawerItem) item, (FeedHolder) holder, position);
             }
             holder.itemView.setOnCreateContextMenuListener(itemAccess);
         }
@@ -273,16 +273,19 @@ public class NavListAdapter extends RecyclerView.Adapter<NavListAdapter.Holder>
         }
     }
 
-    private void bindTagView(NavDrawerData.TagDrawerItem tag, FeedHolder holder) {
+    private void bindTagView(NavDrawerData.TagDrawerItem tag, FeedHolder holder, int position) {
         Activity context = activity.get();
         if (context == null) {
             return;
         }
         if (tag.isOpen()) {
             holder.count.setVisibility(View.GONE);
+            holder.image.setImageResource(R.drawable.ic_arrow_down);
+        } else {
+            holder.image.setImageResource(R.drawable.ic_arrow_right);
         }
         Glide.with(context).clear(holder.image);
-        holder.image.setImageResource(R.drawable.ic_tag);
+        holder.image.setOnClickListener(v -> itemAccess.onFolderIconClick(position));
         holder.failure.setVisibility(View.GONE);
     }
 
@@ -349,6 +352,8 @@ public class NavListAdapter extends RecyclerView.Adapter<NavListAdapter.Holder>
         void onItemClick(int position);
 
         boolean onItemLongClick(int position);
+
+        void onFolderIconClick(int position);
 
         @Override
         void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo);

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbTestUtils.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbTestUtils.java
@@ -8,6 +8,8 @@ import de.danoeh.antennapod.model.feed.Chapter;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
+import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
 import de.danoeh.antennapod.storage.database.PodDBAdapter;
 
 import static org.junit.Assert.assertTrue;
@@ -72,5 +74,22 @@ abstract class DbTestUtils {
         adapter.close();
 
         return feeds;
+    }
+
+    public static void addTagsToFeed(List<String> tags, Feed f) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+
+        FeedPreferences prefs = new FeedPreferences(f.getId(), FeedPreferences.AutoDownloadSetting.GLOBAL,
+                FeedPreferences.AutoDeleteAction.GLOBAL, VolumeAdaptionSetting.OFF,
+                FeedPreferences.NewEpisodesAction.GLOBAL, null, null);
+
+        prefs.getTags().add(FeedPreferences.TAG_ROOT);
+        for (String tag : tags) {
+            prefs.getTags().add(tag);
+        }
+
+        f.setPreferences(prefs);
+        adapter.setFeedPreferences(prefs);
     }
 }

--- a/ui/common/src/main/res/drawable/ic_arrow_right.xml
+++ b/ui/common/src/main/res/drawable/ic_arrow_right.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path android:fillColor="?attr/action_icon_color" android:pathData="M8.59,16.59L13.17,12 8.59,7.41 10,6l6,6 -6,6 -1.41,-1.41z"/>
+</vector>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="years_statistics_label">Years</string>
     <string name="notification_pref_fragment">Notifications</string>
     <string name="current_playing_episode">Current</string>
+    <string name="episodes_by_tag_label">Tag: %1$s</string>
 
     <!-- Google Assistant -->
     <string name="app_action_not_found">\"%1$s\" not found</string>


### PR DESCRIPTION
### Description

With this PR, when clicking nav drawer items that represent tags, a new screen will open, that lists all episodes from feeds which have the selected tag.

> In the current version of AntennaPod, clicking the item would fold/unfold the list of feeds that have been assigned this tag.

The folding/unfolding action for tag items in the drawer now happens, when the icon to the left of the tag name is clicked. Additionally, this icon changes upon clicks to give a visual clue about the folding state.

If you have any suggestions for improvement, I would be happy to incorporate them, especially since this is my first time contributing code to an app.

Closes: #5222

|New screen: episodes by feed tag|Drawer folder open|Drawer folder closed|
|---|---|---|
|![Screenshot_20250326_191939](https://github.com/user-attachments/assets/597995cd-fab6-428e-a837-781b3837e564)|![Screenshot_20250326_191920](https://github.com/user-attachments/assets/6cf2f862-0340-45e2-abfd-91ad3b13d3f0)|![Screenshot_20250326_191931](https://github.com/user-attachments/assets/c6090157-e728-4d3c-85c1-e7fd4ac27aaf)

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
