### PR TITLE
Add button to inbox from queue

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -2,7 +2,6 @@ package de.danoeh.antennapod.ui.screen.queue;
 
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
@@ -29,7 +28,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
-import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.screen.InboxFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
@@ -454,21 +452,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         emptyView.attachToRecyclerView(recyclerView);
         emptyView.setIcon(R.drawable.ic_playlist_play);
         emptyView.setTitle(R.string.no_items_header_label);
-        boolean inboxHasEpisodes = DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)) > 0;
-        if (inboxHasEpisodes) {
-            emptyView.setMessage(R.string.no_queue_items_inbox_has_items_label);
-            emptyView.setButtonText(R.string.no_queue_items_inbox_has_items_button_label);
-            emptyView.setButtonVisibility(View.VISIBLE);
-            emptyView.setButtonOnClickListener(v -> {
-                Intent intent = new MainActivityStarter(getContext())
-                        .withFragmentLoaded(InboxFragment.TAG)
-                        .getIntent();
-                getActivity().finish();
-                startActivity(intent);
-            });
-        } else {
-            emptyView.setMessage(R.string.no_items_label);
-        }
+        emptyView.setMessage(R.string.no_items_label);
         emptyView.updateAdapter(recyclerAdapter);
 
         floatingSelectMenu = root.findViewById(R.id.floatingSelectMenu);
@@ -533,6 +517,14 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(items -> {
                     queue = items;
+                    if (queue.isEmpty() && DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)) > 0) {
+                        emptyView.setMessage(R.string.no_queue_items_inbox_has_items_label);
+                        emptyView.setButtonText(R.string.no_queue_items_inbox_has_items_button_label);
+                        emptyView.setButtonVisibility(View.VISIBLE);
+                        emptyView.setButtonOnClickListener(v -> {
+                            ((MainActivity) getActivity()).loadChildFragment(new InboxFragment());
+                        });
+                    }
                     progressBar.setVisibility(View.GONE);
                     recyclerAdapter.setDummyViews(0);
                     recyclerAdapter.updateItems(queue);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
@@ -86,7 +87,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     private MaterialToolbar toolbar;
     private SwipeRefreshLayout swipeRefreshLayout;
     private boolean displayUpArrow;
-    private boolean displayGoToInboxButton;
 
     private List<FeedItem> queue;
 
@@ -514,14 +514,14 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             emptyView.hide();
         }
         disposable = Observable.fromCallable(() -> {
-            displayGoToInboxButton = DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)) > 0;
-            return DBReader.getQueue();
+            boolean displayGoToInboxButton = DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)) > 0;
+            return new Pair<>(DBReader.getQueue(), displayGoToInboxButton);
         })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(items -> {
-                    queue = items;
-                    if (displayGoToInboxButton) {
+                .subscribe(itemsAndDisplayButton -> {
+                    queue = itemsAndDisplayButton.first;
+                    if (itemsAndDisplayButton.second) {
                         emptyView.setMessage(R.string.no_queue_items_inbox_has_items_label);
                         emptyView.setButtonText(R.string.no_queue_items_inbox_has_items_button_label);
                         emptyView.setButtonVisibility(View.VISIBLE);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.ui.screen.queue;
 
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
@@ -28,6 +29,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
+import de.danoeh.antennapod.ui.screen.InboxFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.ui.episodes.PlaybackSpeedUtils;
@@ -451,7 +454,21 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         emptyView.attachToRecyclerView(recyclerView);
         emptyView.setIcon(R.drawable.ic_playlist_play);
         emptyView.setTitle(R.string.no_items_header_label);
-        emptyView.setMessage(R.string.no_items_label);
+        boolean inboxHasEpisodes = DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)) > 0;
+        if (inboxHasEpisodes) {
+            emptyView.setMessage(R.string.no_queue_items_inbox_has_items_label);
+            emptyView.setButtonText(R.string.no_queue_items_inbox_has_items_button_label);
+            emptyView.setButtonVisibility(View.VISIBLE);
+            emptyView.setButtonOnClickListener(v -> {
+                Intent intent = new MainActivityStarter(getContext())
+                        .withFragmentLoaded(InboxFragment.TAG)
+                        .getIntent();
+                getActivity().finish();
+                startActivity(intent);
+            });
+        } else {
+            emptyView.setMessage(R.string.no_items_label);
+        }
         emptyView.updateAdapter(recyclerAdapter);
 
         floatingSelectMenu = root.findViewById(R.id.floatingSelectMenu);

--- a/app/src/main/java/de/danoeh/antennapod/ui/view/EmptyViewHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/EmptyViewHandler.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.DataSetObserver;
 import android.view.Gravity;
 import android.widget.AbsListView;
+import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ListAdapter;
 import androidx.annotation.DrawableRes;
@@ -27,12 +28,14 @@ public class EmptyViewHandler {
     private final TextView tvTitle;
     private final TextView tvMessage;
     private final ImageView ivIcon;
+    private final Button button;
 
     public EmptyViewHandler(Context context) {
         emptyView = View.inflate(context, R.layout.empty_view_layout, null);
         tvTitle = emptyView.findViewById(R.id.emptyViewTitle);
         tvMessage = emptyView.findViewById(R.id.emptyViewMessage);
         ivIcon = emptyView.findViewById(R.id.emptyViewIcon);
+        button = emptyView.findViewById(R.id.button);
     }
 
     public void setTitle(int title) {
@@ -49,6 +52,18 @@ public class EmptyViewHandler {
 
     public void setMessage(String message) {
         tvMessage.setText(message);
+    }
+
+    public void setButtonText(int message) {
+        button.setText(message);
+    }
+
+    public void setButtonVisibility(int visibility) {
+        button.setVisibility(visibility);
+    }
+
+    public void setButtonOnClickListener(View.OnClickListener onClickListener) {
+        button.setOnClickListener(onClickListener);
     }
 
     public void setIcon(@DrawableRes int icon) {

--- a/app/src/main/res/layout/empty_view_layout.xml
+++ b/app/src/main/res/layout/empty_view_layout.xml
@@ -35,4 +35,11 @@
         android:textAlignment="center"
         tools:text="Message" />
 
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        style="@style/Widget.Material3.Button.OutlinedButton" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/empty_view_layout.xml
+++ b/app/src/main/res/layout/empty_view_layout.xml
@@ -40,6 +40,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        style="@style/Widget.Material3.Button.OutlinedButton" />
+        android:layout_marginTop="16dp"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        tools:text="@string/no_queue_items_inbox_has_items_button_label"
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -383,6 +383,8 @@
     <!-- Empty list labels -->
     <string name="no_items_header_label">No queued episodes</string>
     <string name="no_items_label">Add an episode by downloading it, or long press an episode and select \"Add to queue\".</string>
+    <string name="no_queue_items_inbox_has_items_label">No episodes lined up, but there are new episodes that await you!</string>
+    <string name="no_queue_items_inbox_has_items_button_label">Go to inbox</string>
     <string name="no_shownotes_label">This episode has no shownotes.</string>
     <string name="no_comp_downloads_head_label">No downloaded episodes</string>
     <string name="no_comp_downloads_label">You can download episodes on the podcast details screen.</string>


### PR DESCRIPTION
### Description
If the queue is empty but there are new episodes in the inbox, a message informs the user of this and provides a button that redirects to the inbox. If the queue is either not empty or if the queue and inbox are both empty, then the messages are unchanged.

This commit changes the EmptyViewHandler to include a button field that is hidden by default. This is my first submission so please feel free to let me know if anything is askew.

<img width="189" alt="new-queue-feature" src="https://github.com/user-attachments/assets/f5066e6e-b3e5-4a6e-b246-6057dc4ff254" />

Closes: #7538 

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
