### PR TITLE
Ignore new episodes action if autodownload is enabled

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -232,6 +232,7 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
                     FeedPreferences.AutoDownloadSetting.fromInteger(Integer.parseInt((String) newValue)));
             DBWriter.setFeedPreferences(feedPreferences);
             updateAutoDownloadEnabledSummary();
+            updateNewEpisodesActionSummary();
             return false;
         });
         findPreference(PREF_TAGS).setOnPreferenceClickListener(preference -> {
@@ -271,7 +272,17 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
     }
 
     private void updateNewEpisodesActionSummary() {
+        if (feed == null || feed.getPreferences() == null) {
+            return;
+        }
         ListPreference newEpisodesAction = findPreference(PREF_NEW_EPISODES_ACTION);
+        boolean isAutoDownload = feed.getPreferences().isAutoDownload(UserPreferences.isEnableAutodownloadGlobal());
+        if (isAutoDownload) {
+            newEpisodesAction.setEnabled(false);
+            newEpisodesAction.setSummary(R.string.feed_new_episodes_action_summary_autodownload);
+            return;
+        }
+        newEpisodesAction.setEnabled(true);
         newEpisodesAction.setValue("" + feedPreferences.getNewEpisodesAction().code);
         int globalStringResource = switch (UserPreferences.getNewEpisodesAction()) {
             case ADD_TO_INBOX -> R.string.feed_new_episodes_action_add_to_inbox;

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriter.java
@@ -191,6 +191,13 @@ public abstract class FeedDatabaseWriter {
                         if (action == FeedPreferences.NewEpisodesAction.GLOBAL) {
                             action = UserPreferences.getNewEpisodesAction();
                         }
+                        FeedPreferences.AutoDownloadSetting autoDownload = savedFeed.getPreferences().getAutoDownload();
+                        if (autoDownload == FeedPreferences.AutoDownloadSetting.ENABLED
+                                || (autoDownload == FeedPreferences.AutoDownloadSetting.GLOBAL
+                                        && UserPreferences.isEnableAutodownloadGlobal())) {
+                            // Auto download currently only considers episodes in the inbox
+                            action = FeedPreferences.NewEpisodesAction.ADD_TO_INBOX;
+                        }
                         switch (action) {
                             case ADD_TO_INBOX:
                                 item.setNew();

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -152,8 +152,9 @@
     <string name="feed_auto_download_always">Always</string>
     <string name="feed_auto_download_never">Never</string>
     <string name="feed_new_episodes_action_add_to_inbox">Add to inbox</string>
-    <string name="feed_new_episodes_action_add_to_queue">Add to queue, disable auto download</string>
-    <string name="feed_new_episodes_action_nothing">Nothing, disable auto download</string>
+    <string name="feed_new_episodes_action_add_to_queue">Add to queue</string>
+    <string name="feed_new_episodes_action_nothing">Nothing</string>
+    <string name="feed_new_episodes_action_summary_autodownload">Automatic download enabled. Episodes are added to the inbox and then moved to the queue once downloaded.</string>
     <string name="episode_cleanup_never">Never</string>
     <string name="episode_cleanup_except_favorite_removal">When not favorited</string>
     <string name="episode_cleanup_queue_removal">When not in queue</string>


### PR DESCRIPTION
### Description

The autodownload setting is a bit broken currently since the new episodes action was introduced. I tried making this more clear in the last update by adding a note to the new episodes action options. This apparently confuses users even more:

> Why the change? I updated the app last week and just noticed my regular podcasts weren't auto downloading to my queue. I looked at my new episode actions, and now the add to queue option disables auto download. Doesn't that.... Defeat the purpose of adding it to the queue? I do NOT want to have to open every single podcast I follow each week to refresh and download new episodes (which I am currently doing right now as I've missed several episodes already). What's the fix?

This PR changes the behavior to simply ignore the new episodes action if auto download is enabled.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
