### PR TITLE
Count running downloads towards number of downloaded episodes

### DIFF
--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
@@ -15,7 +15,7 @@ public abstract class DownloadServiceInterface {
     public static final String WORK_DATA_MEDIA_ID = "media_id";
     public static final String WORK_DATA_WAS_QUEUED = "was_queued";
     private static DownloadServiceInterface impl;
-    protected Map<String, DownloadStatus> currentDownloads = new HashMap<>();
+    private Map<String, DownloadStatus> currentDownloads = new HashMap<>();
 
     public static DownloadServiceInterface get() {
         return impl;

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
@@ -15,7 +15,7 @@ public abstract class DownloadServiceInterface {
     public static final String WORK_DATA_MEDIA_ID = "media_id";
     public static final String WORK_DATA_WAS_QUEUED = "was_queued";
     private static DownloadServiceInterface impl;
-    private Map<String, DownloadStatus> currentDownloads = new HashMap<>();
+    protected Map<String, DownloadStatus> currentDownloads = new HashMap<>();
 
     public static DownloadServiceInterface get() {
         return impl;
@@ -56,4 +56,6 @@ public abstract class DownloadServiceInterface {
     public int getProgress(String url) {
         return isDownloadingEpisode(url) ? currentDownloads.get(url).getProgress() : -1;
     }
+
+    public abstract int getNumberOfActiveDownloads(Context context);
 }

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterfaceStub.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterfaceStub.java
@@ -21,4 +21,9 @@ public class DownloadServiceInterfaceStub extends DownloadServiceInterface {
     @Override
     public void cancelAll(Context context) {
     }
+
+    @Override
+    public int getNumberOfActiveDownloads(Context context) {
+        return 0;
+    }
 }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
@@ -85,6 +85,7 @@ public class AutomaticDownloadAlgorithm {
 
                 int autoDownloadableEpisodes = candidates.size();
                 int downloadedEpisodes = DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.DOWNLOADED));
+                downloadedEpisodes += DownloadServiceInterface.get().getNumberOfActiveDownloads(context);
                 int deletedEpisodes = EpisodeCleanupAlgorithmFactory.build()
                         .makeRoomForEpisodes(context, autoDownloadableEpisodes);
                 boolean cacheIsUnlimited =
@@ -99,7 +100,7 @@ public class AutomaticDownloadAlgorithm {
                 }
 
                 List<FeedItem> itemsToDownload = candidates.subList(0, episodeSpaceLeft);
-                if (itemsToDownload.size() > 0) {
+                if (!itemsToDownload.isEmpty()) {
                     Log.d(TAG, "Enqueueing " + itemsToDownload.size() + " items for download");
 
                     for (FeedItem episode : itemsToDownload) {

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
@@ -9,7 +9,6 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.OutOfQuotaPolicy;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
-import de.danoeh.antennapod.model.download.DownloadStatus;
 import de.danoeh.antennapod.net.download.service.episode.EpisodeDownloadWorker;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.model.feed.FeedItem;
@@ -102,17 +101,6 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
 
     @Override
     public int getNumberOfActiveDownloads(Context context) {
-        if (!currentDownloads.isEmpty()) {
-            // App is running, we have up-to-date items
-            int count = 0;
-            for (DownloadStatus status : currentDownloads.values()) {
-                if (status.getState() == DownloadStatus.STATE_RUNNING
-                        || status.getState() == DownloadStatus.STATE_QUEUED) {
-                    count++;
-                }
-            }
-            return count;
-        }
         try {
             List<WorkInfo> workInfos = WorkManager.getInstance(context)
                     .getWorkInfosByTag(DownloadServiceInterface.WORK_TAG).get();

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
@@ -126,7 +126,7 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
             }
             return count;
         } catch (ExecutionException | InterruptedException e) {
-            return 999;
+            return 0;
         }
     }
 }


### PR DESCRIPTION
### Description

This prevents auto-download ending up downloading more episodes than intended.

Closes #7707

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
