### PR TITLE
Make scroll bar easier to grab

### DIFF
--- a/ui/common/src/main/res/drawable/scrollbar_thumb_default.xml
+++ b/ui/common/src/main/res/drawable/scrollbar_thumb_default.xml
@@ -5,10 +5,11 @@
             <size android:height="24dp" android:width="24dp"/>
         </shape>
     </item>
-    <item android:gravity="end">
+    <item android:gravity="end" android:right="4dp">
         <shape android:shape="rectangle">
             <solid android:color="#99666666"/>
-            <size android:height="4dp" android:width="4dp"/>
+            <corners android:radius="4dp"/>
+            <size android:height="4dp" android:width="8dp"/>
         </shape>
     </item>
 </layer-list>

--- a/ui/common/src/main/res/drawable/scrollbar_thumb_pressed_dark.xml
+++ b/ui/common/src/main/res/drawable/scrollbar_thumb_pressed_dark.xml
@@ -5,10 +5,11 @@
             <size android:height="24dp" android:width="24dp"/>
         </shape>
     </item>
-    <item android:gravity="end">
+    <item android:gravity="end" android:right="4dp">
         <shape android:shape="rectangle">
             <solid android:color="@color/accent_dark"/>
-            <size android:height="4dp" android:width="4dp"/>
+            <corners android:radius="4dp"/>
+            <size android:height="4dp" android:width="8dp"/>
         </shape>
     </item>
 </layer-list>

--- a/ui/common/src/main/res/drawable/scrollbar_thumb_pressed_light.xml
+++ b/ui/common/src/main/res/drawable/scrollbar_thumb_pressed_light.xml
@@ -5,10 +5,11 @@
             <size android:height="24dp" android:width="24dp"/>
         </shape>
     </item>
-    <item android:gravity="end">
+    <item android:gravity="end" android:right="4dp">
         <shape android:shape="rectangle">
             <solid android:color="@color/accent_light"/>
-            <size android:height="4dp" android:width="4dp"/>
+            <corners android:radius="4dp"/>
+            <size android:height="4dp" android:width="8dp"/>
         </shape>
     </item>
 </layer-list>

--- a/ui/common/src/main/res/drawable/scrollbar_track.xml
+++ b/ui/common/src/main/res/drawable/scrollbar_track.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/transparent"/>
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size android:height="24dp" android:width="24dp"/>
+        </shape>
+    </item>
+    <item android:gravity="end" android:right="4dp" android:top="4dp" android:bottom="4dp">
+        <shape android:shape="rectangle">
+            <solid android:color="#22666666"/>
+            <corners android:radius="4dp"/>
+            <size android:height="4dp" android:width="8dp"/>
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
### Description

Before / After:

<img width="250" src="https://github.com/user-attachments/assets/95e2e760-17b4-4b28-992f-db12f81a193b" /> <img width="250" src="https://github.com/user-attachments/assets/3e5068f1-c60a-4b0a-83b7-5f7a07383572" />

Actually, the touchable area has the exact same size as before. Still, it feels easier to grab because it looks larger. It's just a psychological change but it does help a lot. We can't really make it larger because it would otherwise interfere with the buttons (we had that before, see #3400).

Closes #6864

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
