### PR TITLE
Fix: Display of single item message in multi select mode

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -114,9 +114,6 @@ public class EpisodeMultiSelectActionHandler {
     }
 
     private void showMessage(@PluralsRes int msgId, int numItems) {
-        if (numItems == 1) {
-            return;
-        }
         totalNumItems += numItems;
         activity.runOnUiThread(() -> {
             String text = activity.getResources().getQuantityString(msgId, totalNumItems, totalNumItems);


### PR DESCRIPTION
### Description

In multi-select mode, it's still possible to select a single item to perform an action (e.g., mark it as played).

Previously, the popup message that appears after the action had been completed was only shown when an action was performed on multiple items.
This PR changes that behavior so that the popup is also displayed when an action is performed on a single item.

|Before|After|
|---|---|
|<img src="https://github.com/user-attachments/assets/970c5310-9b54-4e66-b2ec-d88b0f80ff53" width="300">|<img src="https://github.com/user-attachments/assets/3455362b-cb14-46a1-8c59-6e2bdc249753" width="300">|

### Reason

When using multi-select mode with multiple items (as is typically the case), users become familiar with a post-action popup that summarizes what was done to the selected items.
However, when performing a multi-select action on a single item, no such popup appears. This could lead users to believe that the action didn't work—despite other visual cues like greyed-out items or updated icons indicating otherwise.

### Questions

This PR introduces an inconsistency with the single-item actions accessible via the long-press menu, which currently do **not** trigger a confirmation popup.
We could address this inconsistency in one of two ways:

- Show the same confirmation messages after actions initiated via the long-press menu.

- Restrict multi-select actions to cases where more than one item is selected (though enforcing this might be tricky).

If we had to choose between the two, **Option 1** definitely feels like the more straightforward and consistent solution.

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
