### PR TITLE
Organize FeedItem(s) action section of strings.xml

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/MarkAsPlayedActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/MarkAsPlayedActionButton.java
@@ -18,7 +18,7 @@ public class MarkAsPlayedActionButton extends ItemActionButton {
     @Override
     @StringRes
     public int getLabel() {
-        return (item.hasMedia() ? R.string.mark_read_label : R.string.mark_read_no_media_label);
+        return (item.hasMedia() ? R.string.mark_as_played_label : R.string.mark_read_no_media_label);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -61,13 +61,13 @@ public class EpisodeMultiSelectActionHandler {
             }
         }
         DBWriter.addQueueItem(activity, toQueue.toArray(new FeedItem[0]));
-        showMessage(R.plurals.added_to_queue_batch_label, toQueue.size());
+        showMessage(R.plurals.added_to_queue_message, toQueue.size());
     }
 
     private void removeFromQueueChecked(List<FeedItem> items) {
         long[] checkedIds = getSelectedIds(items);
         DBWriter.removeQueueItem(activity, true, checkedIds);
-        showMessage(R.plurals.removed_from_queue_batch_label, checkedIds.length);
+        showMessage(R.plurals.removed_from_queue_message, checkedIds.length);
     }
 
     private void removeFromInboxChecked(List<FeedItem> items) {
@@ -84,13 +84,13 @@ public class EpisodeMultiSelectActionHandler {
     private void markedCheckedPlayed(List<FeedItem> items) {
         long[] checkedIds = getSelectedIds(items);
         DBWriter.markItemPlayed(FeedItem.PLAYED, checkedIds);
-        showMessage(R.plurals.marked_read_batch_label, checkedIds.length);
+        showMessage(R.plurals.marked_as_played_message, checkedIds.length);
     }
 
     private void markedCheckedUnplayed(List<FeedItem> items) {
         long[] checkedIds = getSelectedIds(items);
         DBWriter.markItemPlayed(FeedItem.UNPLAYED, checkedIds);
-        showMessage(R.plurals.marked_unread_batch_label, checkedIds.length);
+        showMessage(R.plurals.marked_as_unplayed_message, checkedIds.length);
     }
 
     private void downloadChecked(List<FeedItem> items) {
@@ -102,7 +102,7 @@ public class EpisodeMultiSelectActionHandler {
                 downloaded++;
             }
         }
-        showMessage(R.plurals.downloading_batch_label, downloaded);
+        showMessage(R.plurals.downloading_episodes_message, downloaded);
     }
 
     private void deleteChecked(List<FeedItem> items) {
@@ -114,7 +114,7 @@ public class EpisodeMultiSelectActionHandler {
                 DBWriter.deleteFeedMediaOfItem(activity, feedItem.getMedia());
             }
         }
-        showMessage(R.plurals.deleted_multi_episode_batch_label, countHasMedia);
+        showMessage(R.plurals.deleted_episode_message, countHasMedia);
     }
 
     private void moveToTopChecked(List<FeedItem> items) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -211,7 +211,7 @@ public abstract class EpisodesListFragment extends Fragment
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (listAdapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected,
+                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
                         Snackbar.LENGTH_SHORT);
                 return false;
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -116,8 +116,8 @@ public class FeedItemMenuHandler {
             setItemTitle(menu, R.id.mark_read_item, R.string.mark_read_no_media_label);
             setItemTitle(menu, R.id.mark_unread_item, R.string.mark_unread_label_no_media);
         } else {
-            setItemTitle(menu, R.id.mark_read_item, R.string.mark_read_label);
-            setItemTitle(menu, R.id.mark_unread_item, R.string.mark_unread_label);
+            setItemTitle(menu, R.id.mark_read_item, R.string.mark_as_played_label);
+            setItemTitle(menu, R.id.mark_unread_item, R.string.mark_as_unplayed_label);
         }
 
         setItemVisibility(menu, R.id.add_to_favorites_item, canAddFavorite);
@@ -232,8 +232,8 @@ public class FeedItemMenuHandler {
             IntentUtils.openInBrowser(context, selectedItem.getLinkWithFallback());
         } else if (menuItemId == R.id.open_social_interact_url) {
             new MaterialAlertDialogBuilder(context)
-                    .setTitle(R.string.visit_social_interact_query_title)
-                    .setMessage(context.getString(R.string.visit_social_interact_query_message,
+                    .setTitle(R.string.visit_social_interact_confirm_dialog_title)
+                    .setMessage(context.getString(R.string.visit_social_interact_confirm_dialog_message,
                             selectedItem.getSocialInteractUrl()))
                     .setPositiveButton(R.string.confirm_label, (dialog, which) ->
                             IntentUtils.openInBrowser(context, selectedItem.getSocialInteractUrl()))
@@ -290,14 +290,14 @@ public class FeedItemMenuHandler {
             case FeedItem.UNPLAYED:
                 if (item.getPlayState() == FeedItem.NEW) {
                     //was new
-                    playStateStringRes = R.string.removed_inbox_label;
+                    playStateStringRes = R.string.removed_from_inbox_message;
                 } else {
                     //was played
-                    playStateStringRes = R.string.marked_as_unplayed_label;
+                    playStateStringRes = R.string.marked_as_unplayed_message;
                 }
                 break;
             case FeedItem.PLAYED:
-                playStateStringRes = R.string.marked_as_played_label;
+                playStateStringRes = R.string.marked_as_played_message;
                 break;
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -225,7 +225,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (adapter.getSelectedCount() == 0) {
                 ((MainActivity) getActivity())
-                        .showSnackbarAbovePlayer(R.string.no_items_selected, Snackbar.LENGTH_SHORT);
+                        .showSnackbarAbovePlayer(R.string.no_items_selected_message, Snackbar.LENGTH_SHORT);
                 return false;
             }
             new EpisodeMultiSelectActionHandler((MainActivity) getActivity(), menuItem.getItemId())

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -121,7 +121,7 @@ public class CompletedDownloadsFragment extends Fragment
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (adapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected,
+                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
                         Snackbar.LENGTH_SHORT);
                 return false;
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -151,7 +151,7 @@ public class ItemFragment extends Fragment {
                     && Objects.equals(item.getMedia().getIdentifier(), controller.getMedia().getIdentifier())) {
                 controller.seekTo(time);
             } else {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.play_this_to_seek_position,
+                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.play_this_to_seek_position_message,
                         Snackbar.LENGTH_LONG);
             }
         });

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -198,7 +198,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         viewBinding.floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         viewBinding.floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (adapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected,
+                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
                         Snackbar.LENGTH_SHORT);
                 return false;
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -477,7 +477,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (recyclerAdapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected,
+                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
                         Snackbar.LENGTH_SHORT);
                 return false;
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromQueueSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromQueueSwipeAction.java
@@ -43,7 +43,7 @@ public class RemoveFromQueueSwipeAction implements SwipeAction {
 
         if (willRemove(filter, item)) {
             ((MainActivity) fragment.requireActivity()).showSnackbarAbovePlayer(
-                    fragment.getResources().getQuantityString(R.plurals.removed_from_queue_batch_label, 1, 1),
+                    fragment.getResources().getQuantityString(R.plurals.removed_from_queue_message, 1, 1),
                     Snackbar.LENGTH_LONG)
                     .setAction(fragment.getString(R.string.undo), v ->
                             DBWriter.addQueueItemAt(fragment.requireActivity(), item.getId(), position));

--- a/app/src/main/java/de/danoeh/antennapod/ui/view/LocalDeleteModal.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/LocalDeleteModal.java
@@ -24,7 +24,7 @@ public class LocalDeleteModal {
 
         new MaterialAlertDialogBuilder(context)
                 .setTitle(R.string.delete_label)
-                .setMessage(R.string.delete_local_feed_warning_body)
+                .setMessage(R.string.delete_local_feed_confirmation_dialog_message)
                 .setPositiveButton(R.string.delete_label, (dialog, which) -> deleteCommand.run())
                 .setNegativeButton(R.string.cancel_label, null)
                 .show();

--- a/app/src/main/res/layout/transcript_dialog.xml
+++ b/app/src/main/res/layout/transcript_dialog.xml
@@ -30,6 +30,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
-        android:text="@string/transcript_follow" />
+        android:text="@string/transcript_follow_audio_label" />
 
 </LinearLayout>

--- a/app/src/main/res/menu/episodes_apply_action_speeddial.xml
+++ b/app/src/main/res/menu/episodes_apply_action_speeddial.xml
@@ -20,12 +20,12 @@
     <item
         android:id="@+id/mark_unread_item"
         android:icon="@drawable/ic_mark_unplayed"
-        android:title="@string/mark_unread_label" />
+        android:title="@string/mark_as_unplayed_label" />
 
     <item
         android:id="@+id/mark_read_item"
         android:icon="@drawable/ic_mark_played"
-        android:title="@string/mark_read_label" />
+        android:title="@string/mark_as_played_label" />
 
     <item
         android:id="@+id/remove_from_queue_item"

--- a/app/src/main/res/menu/feeditem_options.xml
+++ b/app/src/main/res/menu/feeditem_options.xml
@@ -16,12 +16,12 @@
     <item
         android:id="@+id/mark_read_item"
         custom:showAsAction="collapseActionView"
-        android:title="@string/mark_read_label">
+        android:title="@string/mark_as_played_label">
     </item>
     <item
         android:id="@+id/mark_unread_item"
         custom:showAsAction="collapseActionView"
-        android:title="@string/mark_unread_label">
+        android:title="@string/mark_as_unplayed_label">
     </item>
 
     <item
@@ -48,7 +48,7 @@
     <item
         android:id="@+id/reset_position"
         custom:showAsAction="collapseActionView"
-        android:title="@string/reset_position">
+        android:title="@string/reset_playback_position_label">
     </item>
     <item
         android:id="@+id/visit_website_item"

--- a/app/src/main/res/menu/feeditemlist_context.xml
+++ b/app/src/main/res/menu/feeditemlist_context.xml
@@ -13,12 +13,12 @@
     <item
         android:id="@+id/mark_read_item"
         android:menuCategory="container"
-        android:title="@string/mark_read_label" />
+        android:title="@string/mark_as_played_label" />
 
     <item
         android:id="@+id/mark_unread_item"
         android:menuCategory="container"
-        android:title="@string/mark_unread_label" />
+        android:title="@string/mark_as_unplayed_label" />
 
     <item
         android:id="@+id/add_to_queue_item"
@@ -48,7 +48,7 @@
     <item
         android:id="@+id/reset_position"
         android:menuCategory="container"
-        android:title="@string/reset_position" />
+        android:title="@string/reset_playback_position_label" />
 
     <item
         android:id="@+id/share_item"

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -230,7 +230,7 @@
 
     <!-- actions on feeditems -->
     <string name="download_label">Download</string>
-    <plurals name="downloading_batch_label">
+    <plurals name="downloading_episodes_message">
         <item quantity="one">Downloading %d episode.</item>
         <item quantity="other">Downloading %d episodes.</item>
     </plurals>
@@ -238,35 +238,35 @@
     <string name="pause_label">Pause</string>
     <string name="stream_label">Stream</string>
     <string name="delete_label">Delete</string>
-    <plurals name="deleted_multi_episode_batch_label">
+    <plurals name="deleted_episode_message">
         <item quantity="one">%d downloaded episode deleted.</item>
         <item quantity="other">%d downloaded episodes deleted.</item>
     </plurals>
     <string name="remove_inbox_label">Remove from inbox</string>
-    <string name="removed_inbox_label">Removed from inbox</string>
-    <string name="mark_read_label">Mark as played</string>
+    <string name="removed_from_inbox_message">Removed from inbox</string>
+    <string name="mark_as_played_label">Mark as played</string>
     <string name="toggle_played_label">Toggle played state</string>
-    <string name="marked_as_played_label">Marked as played</string>
-    <string name="marked_as_unplayed_label">Marked as unplayed</string>
+    <string name="marked_as_played_message">Marked as played</string>
+    <string name="marked_as_unplayed_message">Marked as unplayed</string>
     <string name="mark_read_no_media_label">Mark as read</string>
-    <string name="play_this_to_seek_position">To jump to positions, you need to play the episode</string>
-    <plurals name="marked_read_batch_label">
+    <string name="play_this_to_seek_position_message">To jump to positions, you need to play the episode</string>
+    <plurals name="marked_as_played_message">
         <item quantity="one">%d episode marked as played.</item>
         <item quantity="other">%d episodes marked as played.</item>
     </plurals>
-    <string name="mark_unread_label">Mark as unplayed</string>
+    <string name="mark_as_unplayed_label">Mark as unplayed</string>
     <string name="mark_unread_label_no_media">Mark as unread</string>
-    <plurals name="marked_unread_batch_label">
+    <plurals name="marked_as_unplayed_message">
         <item quantity="one">%d episode marked as unplayed.</item>
         <item quantity="other">%d episodes marked as unplayed.</item>
     </plurals>
     <string name="add_to_queue_label">Add to queue</string>
-    <plurals name="added_to_queue_batch_label">
+    <plurals name="added_to_queue_message">
         <item quantity="one">%d episode added to queue.</item>
         <item quantity="other">%d episodes added to queue.</item>
     </plurals>
     <string name="remove_from_queue_label">Remove from queue</string>
-    <plurals name="removed_from_queue_batch_label">
+    <plurals name="removed_from_queue_message">
         <item quantity="one">%d episode removed from queue.</item>
         <item quantity="other">%d episodes removed from queue.</item>
     </plurals>
@@ -277,17 +277,17 @@
     <string name="add_to_favorite_label">Add to favorites</string>
     <string name="show_transcript">Show transcript</string>
     <string name="transcript">Transcript</string>
-    <string name="transcript_follow">Follow audio</string>
+    <string name="transcript_follow_audio_label">Follow audio</string>
     <string name="no_transcript_label">No transcript</string>
     <string name="remove_from_favorite_label">Remove from favorites</string>
     <string name="visit_website_label">Visit website</string>
     <string name="visit_social_interact_label">Show comments</string>
-    <string name="visit_social_interact_query_title">You are leaving AntennaPod</string>
-    <string name="visit_social_interact_query_message">Please make sure that you trust the website \"%1$s\".</string>
+    <string name="visit_social_interact_confirm_dialog_title">You are leaving AntennaPod</string>
+    <string name="visit_social_interact_confirm_dialog_message">Please make sure that you trust the website \"%1$s\".</string>
     <string name="skip_episode_label">Skip episode</string>
-    <string name="reset_position">Reset playback position</string>
-    <string name="no_items_selected">No items selected</string>
-    <string name="delete_local_feed_warning_body">Deleting removes the episode from AntennaPod and deletes the media file from your device storage. It cannot be downloaded again through AntennaPod.</string>
+    <string name="reset_playback_position_label">Reset playback position</string>
+    <string name="no_items_selected_message">No items selected</string>
+    <string name="delete_local_feed_confirmation_dialog_message">Deleting removes the episode from AntennaPod and deletes the media file from your device storage. It cannot be downloaded again through AntennaPod.</string>
 
     <!-- Download messages and labels -->
     <string name="download_successful">successful</string>


### PR DESCRIPTION
### Description

As discussed in https://github.com/AntennaPod/AntennaPod/pull/7696#discussion_r2019828358

The naming of strings is quite unorganized and inconsistent. This PR organizes the FeedItem Action section of strings.xml (as it was relevant to https://github.com/AntennaPod/AntennaPod/pull/7696) by renaming some items for consistency and grouping related items together.

This is the first part of an ongoing effort to improve strings.xml.



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
