### PR TITLE
Switch dependency version on JitPack

### DIFF
--- a/net/discovery/build.gradle
+++ b/net/discovery/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
 
-    implementation 'com.github.mfietz:fyydlin:v0.5.0'
+    implementation 'com.github.mfietz:fyydlin:0.5.0'
 
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"


### PR DESCRIPTION
### Description

Switch dependency version on JitPack. Who knows what happened exactly, but JitPack changed something to the way they deliver dependencies. The version with the v prefix got rebuilt (files inside jar have a new time stamp, jar has a new hash, but contents are the same). Now it no longer has any dependencies attached to it. Switching to the version without v, which still works.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
