### PR TITLE
Implement fading effect in multi-select bottom menu

### DIFF
--- a/app/src/main/res/layout/floating_select_menu.xml
+++ b/app/src/main/res/layout/floating_select_menu.xml
@@ -18,13 +18,16 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingHorizontal="8dp"
-            android:clipToPadding="false">
+            android:clipToPadding="true"
+            android:requiresFadingEdge="horizontal"
+            android:fadingEdgeLength="48dp">
 
             <LinearLayout
                 android:id="@+id/selectContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:orientation="horizontal" />
+                android:orientation="horizontal"
+                />
 
         </HorizontalScrollView>
 

--- a/app/src/main/res/layout/floating_select_menu.xml
+++ b/app/src/main/res/layout/floating_select_menu.xml
@@ -26,8 +26,7 @@
                 android:id="@+id/selectContainer"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
-                />
+                android:orientation="horizontal" />
 
         </HorizontalScrollView>
 


### PR DESCRIPTION
### Description

Closes https://github.com/AntennaPod/AntennaPod/issues/7462

Tried to implement the fade out effect in the bottom multi-select menu, as discussed here.

> We discussed at the Needs decision meeting:
> We experimented a bit and added spacing on top, and made elements a bit narrower where possible (more word breaks, decrease size if there's short words) while increasing the padding both on top and between items.
> 
> The only thing that's left: fading - which we agree but needs to be implemented still. 

 _Originally posted by @keunes in [#7462](https://github.com/AntennaPod/AntennaPod/issues/7462#issuecomment-2738121465)_

|Before|After|
|---|---|
<img src="https://github.com/user-attachments/assets/0247dadb-1459-427f-99a9-18b0e1067ac7"></img>|<img src="https://github.com/user-attachments/assets/7dc5ddb6-d4c1-46b2-bc2c-44ea71f44711"></img>

I changed the clipping of the HorizontalScrollView in thie PR to `true`, I personally thought it looked better. But UI stuff is always highly subjective.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
