### PR TITLE
Fix crash in PlaybackService

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -64,6 +64,7 @@ import de.danoeh.antennapod.playback.service.internal.PlaybackVolumeUpdater;
 import de.danoeh.antennapod.playback.service.internal.WearMediaSession;
 import de.danoeh.antennapod.ui.notifications.NotificationUtils;
 import de.danoeh.antennapod.ui.widget.WidgetUpdater;
+import io.reactivex.disposables.CompositeDisposable;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -162,6 +163,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     private Disposable positionEventTimer;
     private PlaybackServiceNotificationBuilder notificationBuilder;
     private CastStateListener castStateListener;
+    private final CompositeDisposable singleShotDisposables = new CompositeDisposable();
 
     private String autoSkippedFeedMediaId = null;
     private String positionJustResetAfterPlayback = null;
@@ -313,6 +315,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 notificationManager.notify(R.id.notification_playing, notificationBuilder.build());
             }
         }
+        singleShotDisposables.clear();
         stateManager.stopForeground(!UserPreferences.isPersistNotify());
         isRunning = false;
         currentMediaType = MediaType.UNKNOWN;
@@ -349,7 +352,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     private void loadQueueForMediaSession() {
-        Single.<List<MediaSessionCompat.QueueItem>>create(emitter -> {
+        Disposable d = Single.<List<MediaSessionCompat.QueueItem>>create(emitter -> {
             List<MediaSessionCompat.QueueItem> queueItems = new ArrayList<>();
             for (FeedItem feedItem : DBReader.getQueue()) {
                 if (feedItem.getMedia() != null) {
@@ -362,6 +365,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(queueItems -> mediaSession.setQueue(queueItems), Throwable::printStackTrace);
+        singleShotDisposables.add(d);
     }
 
     private MediaBrowserCompat.MediaItem createBrowsableMediaItem(
@@ -405,7 +409,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         Log.d(TAG, "OnLoadChildren: parentMediaId=" + parentId);
         result.detach();
 
-        Completable.create(emitter -> {
+        Disposable d = Completable.create(emitter -> {
             result.sendResult(loadChildrenSynchronous(parentId));
             emitter.onComplete();
         })
@@ -417,6 +421,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                         e.printStackTrace();
                         result.sendResult(null);
                     });
+        singleShotDisposables.add(d);
     }
 
     private List<MediaBrowserCompat.MediaItem> loadChildrenSynchronous(@NonNull String parentId) {
@@ -536,7 +541,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             if (allowStreamAlways) {
                 UserPreferences.setAllowMobileStreaming(true);
             }
-            Observable.fromCallable(
+            Disposable d = Observable.fromCallable(
                     () -> {
                         if (playable instanceof FeedMedia) {
                             return DBReader.getFeedMedia(((FeedMedia) playable).getId());
@@ -553,6 +558,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                                 error.printStackTrace();
                                 stateManager.stopService();
                             });
+            singleShotDisposables.add(d);
         } else {
             mediaSession.getController().getTransportControls().sendCustomAction(customAction, null);
         }
@@ -741,7 +747,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     }
 
     private void startPlayingFromPreferences() {
-        Observable.fromCallable(() -> DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId()))
+        Disposable d = Observable.fromCallable(() -> DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
@@ -751,6 +757,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                             error.printStackTrace();
                             stateManager.stopService();
                         });
+        singleShotDisposables.add(d);
     }
 
     private void startPlaying(Playable playable, boolean allowStreamThisTime) {

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
@@ -133,7 +133,13 @@ public class ExoPlayerWrapper {
                         if (cause != null && "Source error".equals(cause.getMessage())) {
                             cause = cause.getCause();
                         }
-                        audioErrorListener.accept(cause != null ? cause.getMessage() : error.getMessage());
+                        if (cause != null && cause.getMessage() != null) {
+                            audioErrorListener.accept(cause.getMessage());
+                        } else if (error.getMessage() != null && cause != null) {
+                            audioErrorListener.accept(error.getMessage() + ": " + cause.getClass().getSimpleName());
+                        } else {
+                            audioErrorListener.accept(null);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description

Fix crash in PlaybackService. When service is quickly stopped again due to a playback error, background tasks might not have delivered their result yet. In this case, the service objects already get cleaned up. Now, if the result gets delivered, the service is in an invalid state.

This solves stack traces mentioned in #7135, #6549, #6772, #7182, #7664 and probably more. It probably does not fix these issues, but it at least solves the recorded crash. This is also one of the more common crashes reported through Google Play.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
