### PR TITLE
Add Predictive Back Gestures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:$viewPager2Version"
     implementation "androidx.work:work-runtime:$workManagerVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"
+    implementation "androidx.drawerlayout:drawerlayout:1.2.0"
 
     implementation "org.apache.commons:commons-lang3:$commonslangVersion"
     implementation "commons-io:commons-io:$commonsioVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
         android:logo="@mipmap/ic_launcher"
         android:resizeableActivity="true"
         android:allowAudioPlaybackCapture="true"
+        android:enableOnBackInvokedCallback="true"
         android:localeConfig="@xml/locale_config"
         android:networkSecurityConfig="@xml/network_security_config">
 
@@ -132,7 +133,6 @@
             android:name=".ui.screen.preferences.PreferenceActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="false"
-            android:enableOnBackInvokedCallback="true"
             android:label="@string/settings_label">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -166,7 +166,6 @@
         </activity>
         <activity
             android:name=".ui.screen.preferences.BugReportActivity"
-            android:enableOnBackInvokedCallback="true"
             android:label="@string/bug_report_title">
             <meta-data
                     android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.RelativeLayout;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -74,6 +75,7 @@ import de.danoeh.antennapod.ui.screen.preferences.PreferenceActivity;
 import de.danoeh.antennapod.ui.screen.queue.QueueFragment;
 import de.danoeh.antennapod.ui.screen.rating.RatingDialogManager;
 import de.danoeh.antennapod.ui.screen.subscriptions.SubscriptionFragment;
+import de.danoeh.antennapod.ui.view.BottomSheetBackPressedCallback;
 import de.danoeh.antennapod.ui.view.LockableBottomSheetBehavior;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
@@ -105,6 +107,8 @@ public class MainActivity extends CastEnabledActivity {
     private BottomNavigation bottomNavigation;
     private View navDrawer;
     private LockableBottomSheetBehavior sheetBehavior;
+    private BottomSheetBackPressedCallback bottomSheetBackPressedCallback;
+    private OnBackPressedCallback openDefaultPageBackPressedCallback;
     private RecyclerView.RecycledViewPool recycledViewPool = new RecyclerView.RecycledViewPool();
     private int lastTheme = 0;
     private Insets systemBarInsets = Insets.NONE;
@@ -156,6 +160,7 @@ public class MainActivity extends CastEnabledActivity {
             bottomNavigation = null;
             setNavDrawerSize();
         }
+        openDefaultPageBackPressedCallback = new OpenDefaultPageBackPressedCallback();
 
         // Consume navigation bar insets - we apply them in setPlayerVisible()
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main_view), (v, insets) -> {
@@ -198,6 +203,7 @@ public class MainActivity extends CastEnabledActivity {
         sheetBehavior = (LockableBottomSheetBehavior) BottomSheetBehavior.from(bottomSheet);
         sheetBehavior.setHideable(false);
         sheetBehavior.setBottomSheetCallback(bottomSheetCallback);
+        bottomSheetBackPressedCallback = new BottomSheetBackPressedCallback(false, sheetBehavior, bottomSheet);
 
         FeedUpdateManager.getInstance().restartUpdateAlarm(this, false);
         SynchronizationQueue.getInstance().syncIfNotSyncedRecently();
@@ -286,13 +292,16 @@ public class MainActivity extends CastEnabledActivity {
         public void onStateChanged(@NonNull View view, int state) {
             if (state == BottomSheetBehavior.STATE_COLLAPSED) {
                 onSlide(view, 0.0f);
+                bottomSheetBackPressedCallback.setEnabled(false);
             } else if (state == BottomSheetBehavior.STATE_EXPANDED) {
                 onSlide(view, 1.0f);
+                bottomSheetBackPressedCallback.setEnabled(true);
             } else if (state == BottomSheetBehavior.STATE_HIDDEN) {
                 IntentUtils.sendLocalBroadcast(MainActivity.this,
                         PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
                 PlaybackPreferences.writeNoMediaPlaying();
                 setPlayerVisible(false);
+                bottomSheetBackPressedCallback.setEnabled(false);
             }
         }
 
@@ -558,6 +567,8 @@ public class MainActivity extends CastEnabledActivity {
         if (bottomNavigation != null) {
             bottomNavigation.onStart();
         }
+        getOnBackPressedDispatcher().addCallback(this, openDefaultPageBackPressedCallback);
+        getOnBackPressedDispatcher().addCallback(this, bottomSheetBackPressedCallback);
     }
 
     @Override
@@ -617,25 +628,23 @@ public class MainActivity extends CastEnabledActivity {
         }
     }
 
-    @Override
-    public void onBackPressed() {
-        if (isDrawerOpen() && drawerLayout != null) {
-            drawerLayout.closeDrawer(navDrawer);
-        } else if (sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED) {
-            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
-        } else if (getSupportFragmentManager().getBackStackEntryCount() != 0) {
-            super.onBackPressed();
-        } else {
-            String toPage = UserPreferences.getDefaultPage();
-            if (NavDrawerFragment.getLastNavFragment(this).equals(toPage)
-                    || UserPreferences.DEFAULT_PAGE_REMEMBER.equals(toPage)) {
-                if (UserPreferences.backButtonOpensDrawer() && drawerLayout != null && bottomNavigation == null) {
-                    drawerLayout.openDrawer(navDrawer);
-                } else {
-                    super.onBackPressed();
-                }
+    class OpenDefaultPageBackPressedCallback extends OnBackPressedCallback {
+        OpenDefaultPageBackPressedCallback() {
+            super(true);
+        }
+
+        @Override
+        public void handleOnBackPressed() {
+            String defaultPage = UserPreferences.getDefaultPage();
+            if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+                getSupportFragmentManager().popBackStack();
+            } else if (!NavDrawerFragment.getLastNavFragment(MainActivity.this).equals(defaultPage)
+                    && !UserPreferences.DEFAULT_PAGE_REMEMBER.equals(defaultPage)) {
+                loadFragment(defaultPage, null);
+            } else if (UserPreferences.backButtonOpensDrawer() && drawerLayout != null && bottomNavigation == null) {
+                drawerLayout.openDrawer(navDrawer);
             } else {
-                loadFragment(toPage, null);
+                finish();
             }
         }
     }
@@ -669,11 +678,10 @@ public class MainActivity extends CastEnabledActivity {
             String tag = intent.getStringExtra(MainActivityStarter.EXTRA_FRAGMENT_TAG);
             Bundle args = intent.getBundleExtra(MainActivityStarter.EXTRA_FRAGMENT_ARGS);
             if (tag != null) {
-                Fragment fragment = createFragmentInstance(tag, args);
                 if (intent.getBooleanExtra(MainActivityStarter.EXTRA_ADD_TO_BACK_STACK, false)) {
-                    loadChildFragment(fragment);
+                    loadChildFragment(createFragmentInstance(tag, args));
                 } else {
-                    loadFragment(fragment);
+                    loadFragment(tag, null);
                 }
             }
             sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
@@ -96,7 +96,7 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
         FragmentContainerView containerView = new FragmentContainerView(getContext());
         containerView.setId(View.generateViewId());
         viewBinding.homeContainer.addView(containerView);
-        getChildFragmentManager().beginTransaction().add(containerView.getId(), section).commit();
+        getChildFragmentManager().beginTransaction().replace(containerView.getId(), section).commit();
     }
 
     private Fragment getSection(String tag) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/view/BottomSheetBackPressedCallback.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/BottomSheetBackPressedCallback.java
@@ -1,0 +1,49 @@
+package de.danoeh.antennapod.ui.view;
+
+import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.Transformation;
+import androidx.activity.BackEventCompat;
+import androidx.activity.OnBackPressedCallback;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import org.jetbrains.annotations.NotNull;
+
+public class BottomSheetBackPressedCallback extends OnBackPressedCallback {
+    private final BottomSheetBehavior<?> sheetBehavior;
+    private final View view;
+
+    public BottomSheetBackPressedCallback(boolean enabled, BottomSheetBehavior<?> sheetBehavior, View view) {
+        super(enabled);
+        this.sheetBehavior = sheetBehavior;
+        this.view = view;
+    }
+
+    @Override
+    public void handleOnBackProgressed(@NotNull BackEventCompat backEvent) {
+        float height = view.getHeight();
+        if (height <= 0f) {
+            return;
+        }
+        view.setTranslationY(height * 0.2f * backEvent.getProgress());
+    }
+
+    @Override
+    public void handleOnBackPressed() {
+        sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+        float from = view.getTranslationY();
+        Animation animation = new Animation() {
+            @Override
+            protected void applyTransformation(float interpolatedTime, Transformation t) {
+                super.applyTransformation(interpolatedTime, t);
+                view.setTranslationY((1.0f - interpolatedTime) * from);
+            }
+        };
+        animation.setDuration(100);
+        view.startAnimation(animation);
+    }
+
+    @Override
+    public void handleOnBackCancelled() {
+        view.setTranslationY(0);
+    }
+}


### PR DESCRIPTION
### Description

This does not add animations between fragments, but it adds animations to UI elements like bottom sheets.
Replaces #7257

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
