### PR TITLE
Handle release stats for multi-per-day podcasts

### DIFF
--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/ReleaseScheduleGuesserTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/ReleaseScheduleGuesserTest.java
@@ -41,6 +41,52 @@ public class ReleaseScheduleGuesserTest {
     }
 
     @Test
+    public void testIntradailyEveryDay() {
+        ArrayList<Date> releaseDates = new ArrayList<>();
+        releaseDates.add(makeDate("2024-01-01 12:00"));
+        releaseDates.add(makeDate("2024-01-01 16:00"));
+        releaseDates.add(makeDate("2024-01-02 12:00"));
+        releaseDates.add(makeDate("2024-01-02 16:00"));
+        releaseDates.add(makeDate("2024-01-03 12:00"));
+        releaseDates.add(makeDate("2024-01-03 16:00"));
+        releaseDates.add(makeDate("2024-01-04 12:00"));
+        releaseDates.add(makeDate("2024-01-04 16:00"));
+        releaseDates.add(makeDate("2024-01-06 12:00"));
+        releaseDates.add(makeDate("2024-01-06 16:00"));
+        releaseDates.add(makeDate("2024-01-07 12:00"));
+        releaseDates.add(makeDate("2024-01-07 16:00"));
+        ReleaseScheduleGuesser.Guess guess = performGuess(releaseDates);
+        assertEquals(ReleaseScheduleGuesser.Schedule.INTRADAILY, guess.schedule);
+        ArrayList<Integer> expectedDays = new ArrayList<>();
+        expectedDays.add(1);
+        expectedDays.add(2);
+        expectedDays.add(3);
+        expectedDays.add(4);
+        expectedDays.add(5);
+        expectedDays.add(7);
+        assertEquals(expectedDays, guess.days);
+        assertClose(makeDate("2024-01-08 12:00"), guess.nextExpectedDate, ONE_DAY);
+    }
+
+    @Test
+    public void testIntradailyWeekdays() {
+        ArrayList<Date> releaseDates = new ArrayList<>();
+        releaseDates.add(makeDate("2024-01-01 00:00"));
+        releaseDates.add(makeDate("2024-01-01 12:00"));
+        releaseDates.add(makeDate("2024-01-02 00:00"));
+        releaseDates.add(makeDate("2024-01-02 12:00"));
+        releaseDates.add(makeDate("2024-01-03 00:00"));
+        releaseDates.add(makeDate("2024-01-03 12:00"));
+        releaseDates.add(makeDate("2024-01-04 00:00"));
+        releaseDates.add(makeDate("2024-01-04 12:00"));
+        releaseDates.add(makeDate("2024-01-05 00:00"));
+        releaseDates.add(makeDate("2024-01-05 12:00"));
+        ReleaseScheduleGuesser.Guess guess = performGuess(releaseDates);
+        assertEquals(ReleaseScheduleGuesser.Schedule.INTRADAILY, guess.schedule);
+        assertClose(makeDate("2024-01-08 12:00"), guess.nextExpectedDate, ONE_DAY);
+    }
+
+    @Test
     public void testDaily() {
         ArrayList<Date> releaseDates = new ArrayList<>();
         releaseDates.add(makeDate("2024-01-01 16:30")); // Monday
@@ -158,15 +204,15 @@ public class ReleaseScheduleGuesserTest {
     public void testUnknown() {
         ArrayList<Date> releaseDates = new ArrayList<>();
         releaseDates.add(makeDate("2024-01-01 16:30"));
-        releaseDates.add(makeDate("2024-01-03 16:30"));
-        releaseDates.add(makeDate("2024-01-03 16:31"));
         releaseDates.add(makeDate("2024-01-04 16:30"));
-        releaseDates.add(makeDate("2024-01-04 16:31"));
-        releaseDates.add(makeDate("2024-01-07 16:30"));
-        releaseDates.add(makeDate("2024-01-07 16:31"));
-        releaseDates.add(makeDate("2024-01-10 16:30"));
+        releaseDates.add(makeDate("2024-01-10 16:31"));
+        releaseDates.add(makeDate("2024-01-11 16:30"));
+        releaseDates.add(makeDate("2024-01-20 16:31"));
+        releaseDates.add(makeDate("2024-01-22 16:30"));
+        releaseDates.add(makeDate("2024-01-25 16:31"));
+        releaseDates.add(makeDate("2024-01-25 16:30"));
         ReleaseScheduleGuesser.Guess guess = performGuess(releaseDates);
         assertEquals(ReleaseScheduleGuesser.Schedule.UNKNOWN, guess.schedule);
-        assertClose(makeDate("2024-01-12 16:30"), guess.nextExpectedDate, 2 * ONE_DAY);
+        assertClose(makeDate("2024-01-27 16:30"), guess.nextExpectedDate, 2 * ONE_DAY);
     }
 }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -789,6 +789,7 @@
     <string name="statistics_release_schedule">release schedule</string>
     <string name="statistics_release_next">next episode (estimate)</string>
     <string name="statistics_expected_next_episode_any_day">Any day now</string>
+    <string name="statistics_expected_next_episode_any_time">Any time now</string>
     <string name="statistics_expected_next_episode_unknown">Unknown</string>
     <string name="statistics_view_all">All podcasts »</string>
     <string name="statistics_years_barchart_description">Time played per month</string>
@@ -797,6 +798,7 @@
     <string name="edit_url_confirmation_msg">Changing the RSS address can easily break the playback state and episode listings of the podcast. We do NOT recommend changing it and will NOT provide support if anything goes wrong. This cannot be undone. The broken subscription CANNOT be repaired by simply changing the address back. We recommend creating a backup before continuing.</string>
 
     <!-- Podcast release schedules -->
+    <string name="release_schedule_intradaily">multiple times per day</string>
     <string name="release_schedule_daily">daily</string>
     <string name="release_schedule_weekdays">on weekdays</string>
     <string name="release_schedule_weekly">weekly</string>

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
@@ -121,8 +121,21 @@ public class FeedStatisticsFragment extends Fragment {
         }
     }
 
+    private String getSpecificDaysString(ReleaseScheduleGuesser.Guess guess) {
+        StringBuilder days = new StringBuilder();
+        for (int i = 0; i < guess.days.size(); i++) {
+            if (i != 0) {
+                days.append(", ");
+            }
+            days.append(getReadableDay(guess.days.get(i)));
+        }
+        return days.toString();
+    }
+
     private String getReadableSchedule(ReleaseScheduleGuesser.Guess guess) {
         switch (guess.schedule) {
+            case INTRADAILY:
+                return getString(R.string.release_schedule_intradaily) + ", " + getSpecificDaysString(guess);
             case DAILY:
                 return getString(R.string.release_schedule_daily);
             case WEEKDAYS:
@@ -136,14 +149,7 @@ public class FeedStatisticsFragment extends Fragment {
             case FOURWEEKLY:
                 return getString(R.string.release_schedule_monthly) + ", " + getReadableDay(guess.days.get(0));
             case SPECIFIC_DAYS:
-                StringBuilder days = new StringBuilder();
-                for (int i = 0; i < guess.days.size(); i++) {
-                    if (i != 0) {
-                        days.append(", ");
-                    }
-                    days.append(getReadableDay(guess.days.get(i)));
-                }
-                return days.toString();
+                return getSpecificDaysString(guess);
             default:
                 return getString(R.string.statistics_expected_next_episode_unknown);
         }
@@ -190,7 +196,10 @@ public class FeedStatisticsFragment extends Fragment {
             viewBinding.episodeSchedule.mainLabel.setText(R.string.statistics_expected_next_episode_unknown);
         } else {
             if (guess.nextExpectedDate.getTime() <= new Date().getTime()) {
-                viewBinding.expectedNextEpisode.mainLabel.setText(R.string.statistics_expected_next_episode_any_day);
+                viewBinding.expectedNextEpisode.mainLabel.setText(
+                        guess.schedule.equals(ReleaseScheduleGuesser.Schedule.INTRADAILY)
+                                ? R.string.statistics_expected_next_episode_any_time
+                                : R.string.statistics_expected_next_episode_any_day);
             } else {
                 viewBinding.expectedNextEpisode.mainLabel.setText(
                         DateFormatter.formatAbbrev(getContext(), guess.nextExpectedDate));


### PR DESCRIPTION
### Description
Fixes a bug where stats were rendering incorrectly for podcasts with multiple-per-day releases. The prediction code is already pretty good for podcasts released daily or less frequently so I prioritized leaving that alone as much as possible. With multiple for day, the next release will very commonly be "any time now" since we before this we standardized on a granularity of days. Any predictions for when inside the day podcasts will release may require some rethinking. This should correctly handle cases where a podcast releases multiple episodes some days and none other days (a test case was added for this)

Prior to this, running the real world data test `testRealWorld()` gave the following results:

```
Podcasts tested: 482
Found schedule: 80.70539419087137
Off by less than 3 hours: 55.3941908713693
Correct day when schedule found: 71.72236503856041
Correct day: 59.75103734439834
Off by less than 2 days: 72.19917012448133
```

After the changes, the results are:

```
Podcasts tested: 482
Found schedule: 82.57261410788382
Off by less than 3 hours: 58.09128630705394
Correct day when schedule found: 74.37185929648241
Correct day: 62.448132780082986
Off by less than 2 days: 73.02904564315352
```

<img width="188" alt="image" src="https://github.com/user-attachments/assets/3df5a7c1-4274-45d4-9e34-7a7a47a6dade" />

Closes: #7679 

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
