### PR TITLE
Fix back stack being cleared after searching

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -97,7 +97,6 @@ public class MainActivity extends CastEnabledActivity {
 
     public static final String EXTRA_FEED_ID = "fragment_feed_id";
     public static final String EXTRA_REFRESH_ON_START = "refresh_on_start";
-    public static final String EXTRA_ADD_TO_BACK_STACK = "add_to_back_stack";
     public static final String KEY_GENERATED_VIEW_ID = "generated_view_id";
 
     private @Nullable DrawerLayout drawerLayout;
@@ -657,11 +656,10 @@ public class MainActivity extends CastEnabledActivity {
             long feedId = intent.getLongExtra(EXTRA_FEED_ID, 0);
             Bundle args = intent.getBundleExtra(MainActivityStarter.EXTRA_FRAGMENT_ARGS);
             if (feedId > 0) {
-                boolean addToBackStack = intent.getBooleanExtra(EXTRA_ADD_TO_BACK_STACK, false);
-                if (addToBackStack) {
-                    loadChildFragment(FeedItemlistFragment.newInstance(feedId));
-                } else {
+                if (intent.getBooleanExtra(MainActivityStarter.EXTRA_CLEAR_BACK_STACK, false)) {
                     loadFeedFragmentById(feedId, args);
+                } else {
+                    loadChildFragment(FeedItemlistFragment.newInstance(feedId));
                 }
             }
             sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
@@ -670,10 +668,10 @@ public class MainActivity extends CastEnabledActivity {
             Bundle args = intent.getBundleExtra(MainActivityStarter.EXTRA_FRAGMENT_ARGS);
             if (tag != null) {
                 Fragment fragment = createFragmentInstance(tag, args);
-                if (intent.getBooleanExtra(MainActivityStarter.EXTRA_ADD_TO_BACK_STACK, false)) {
-                    loadChildFragment(fragment);
-                } else {
+                if (intent.getBooleanExtra(MainActivityStarter.EXTRA_CLEAR_BACK_STACK, false)) {
                     loadFragment(fragment);
+                } else {
+                    loadChildFragment(fragment);
                 }
             }
             sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
@@ -385,6 +385,7 @@ public class NavDrawerFragment extends Fragment implements SharedPreferences.OnS
                     if (UserPreferences.getHiddenDrawerItems().contains(getLastNavFragment(getContext()))) {
                         new MainActivityStarter(getContext())
                                 .withFragmentLoaded(UserPreferences.getDefaultPage())
+                                .withClearBackStack()
                                 .withDrawerOpen()
                                 .start();
                     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -254,6 +254,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                 DBWriter.setFeedState(getContext(), feed, Feed.STATE_SUBSCRIBED);
                 MainActivityStarter mainActivityStarter = new MainActivityStarter(getContext());
                 mainActivityStarter.withOpenFeed(feed.getId());
+                mainActivityStarter.withClearBackStack();
                 getActivity().finish();
                 startActivity(mainActivityStarter.getIntent());
             });

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 
 import static de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter.ARG_FEEDURL;
-import static de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter.ARG_STARTED_FROM_SEARCH;
 import static de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter.ARG_WAS_MANUAL_URL;
 
 /**
@@ -358,9 +357,6 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
         // feed.getId() is always 0, we have to retrieve the id from the feed list from the database
         MainActivityStarter mainActivityStarter = new MainActivityStarter(this);
         mainActivityStarter.withOpenFeed(feedId);
-        if (getIntent().getBooleanExtra(ARG_STARTED_FROM_SEARCH, false)) {
-            mainActivityStarter.withAddToBackStack();
-        }
         finish();
         startActivity(mainActivityStarter.getIntent());
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -209,7 +209,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (showVideoPlayer) {
             return new VideoPlayerActivityStarter(context).getIntent();
         } else {
-            return new MainActivityStarter(context).withOpenPlayer().getIntent();
+            return new MainActivityStarter(context).withClearBackStack().withOpenPlayer().getIntent();
         }
     }
 
@@ -221,7 +221,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (media.getMediaType() == MediaType.VIDEO && !isCasting) {
             return new VideoPlayerActivityStarter(context).getIntent();
         } else {
-            return new MainActivityStarter(context).withOpenPlayer().getIntent();
+            return new MainActivityStarter(context).withClearBackStack().withOpenPlayer().getIntent();
         }
     }
 

--- a/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MainActivityStarter.java
+++ b/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MainActivityStarter.java
@@ -14,7 +14,7 @@ public class MainActivityStarter {
     public static final String INTENT = "de.danoeh.antennapod.intents.MAIN_ACTIVITY";
     public static final String EXTRA_OPEN_PLAYER = "open_player";
     public static final String EXTRA_FEED_ID = "fragment_feed_id";
-    public static final String EXTRA_ADD_TO_BACK_STACK = "add_to_back_stack";
+    public static final String EXTRA_CLEAR_BACK_STACK = "clear_back_stack";
     public static final String EXTRA_FRAGMENT_TAG = "fragment_tag";
     public static final String EXTRA_OPEN_DRAWER = "open_drawer";
     public static final String EXTRA_OPEN_DOWNLOAD_LOGS = "open_download_logs";
@@ -56,8 +56,8 @@ public class MainActivityStarter {
         return this;
     }
 
-    public MainActivityStarter withAddToBackStack() {
-        intent.putExtra(EXTRA_ADD_TO_BACK_STACK, true);
+    public MainActivityStarter withClearBackStack() {
+        intent.putExtra(EXTRA_CLEAR_BACK_STACK, true);
         return this;
     }
 

--- a/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/OnlineFeedviewActivityStarter.java
+++ b/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/OnlineFeedviewActivityStarter.java
@@ -7,18 +7,12 @@ public class OnlineFeedviewActivityStarter {
     public static final String INTENT = "de.danoeh.antennapod.intents.ONLINE_FEEDVIEW";
     public static final String ARG_FEEDURL = "arg.feedurl";
     public static final String ARG_WAS_MANUAL_URL = "manual_url";
-    public static final String ARG_STARTED_FROM_SEARCH = "started_from_search";
     private final Intent intent;
 
     public OnlineFeedviewActivityStarter(Context context, String feedUrl) {
         intent = new Intent(INTENT);
         intent.setPackage(context.getPackageName());
         intent.putExtra(ARG_FEEDURL, feedUrl);
-    }
-
-    public OnlineFeedviewActivityStarter withStartedFromSearch() {
-        intent.putExtra(ARG_STARTED_FROM_SEARCH, true);
-        return this;
     }
 
     public OnlineFeedviewActivityStarter withManualUrl() {

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/OnlineSearchFragment.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/OnlineSearchFragment.java
@@ -97,8 +97,7 @@ public class OnlineSearchFragment extends Fragment {
         //Show information about the podcast when the list item is clicked
         gridView.setOnItemClickListener((parent, view1, position, id) -> {
             PodcastSearchResult podcast = searchResults.get(position);
-            startActivity(new OnlineFeedviewActivityStarter(getContext(), podcast.feedUrl)
-                    .withStartedFromSearch().getIntent());
+            startActivity(new OnlineFeedviewActivityStarter(getContext(), podcast.feedUrl).getIntent());
         });
         progressBar = root.findViewById(R.id.progressBar);
         txtvError = root.findViewById(R.id.txtvError);

--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/QuickFeedDiscoveryFragment.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/QuickFeedDiscoveryFragment.java
@@ -47,7 +47,6 @@ public class QuickFeedDiscoveryFragment extends Fragment implements AdapterView.
         viewBinding = QuickFeedDiscoveryBinding.inflate(inflater);
         viewBinding.discoverMore.setOnClickListener(v -> startActivity(new MainActivityStarter(getContext())
                 .withFragmentLoaded(DiscoveryFragment.TAG)
-                .withAddToBackStack()
                 .getIntent()));
 
         adapter = new FeedDiscoverAdapter(getActivity());

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsDialogFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsDialogFragment.java
@@ -31,7 +31,7 @@ public class FeedStatisticsDialogFragment extends DialogFragment {
         dialog.setPositiveButton(android.R.string.ok, null);
         dialog.setNeutralButton(R.string.open_podcast, (dialogInterface, i) -> {
             long feedId = getArguments().getLong(EXTRA_FEED_ID);
-            new MainActivityStarter(getContext()).withOpenFeed(feedId).withAddToBackStack().start();
+            new MainActivityStarter(getContext()).withOpenFeed(feedId).start();
         });
         dialog.setTitle(getArguments().getString(EXTRA_FEED_TITLE));
         dialog.setView(R.layout.feed_statistics_dialog);

--- a/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
+++ b/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
@@ -69,7 +69,8 @@ public abstract class WidgetUpdater {
         if (widgetState.media != null && widgetState.media.getMediaType() == MediaType.VIDEO) {
             startMediaPlayer = new VideoPlayerActivityStarter(context).getPendingIntent();
         } else {
-            startMediaPlayer = new MainActivityStarter(context).withOpenPlayer().getPendingIntent();
+            startMediaPlayer = new MainActivityStarter(context)
+                    .withOpenPlayer().withClearBackStack().getPendingIntent();
         }
 
         PendingIntent startPlaybackSpeedDialog = new PlaybackSpeedActivityStarter(context).getPendingIntent();


### PR DESCRIPTION
### Description

Fix back stack being cleared after searching

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
