### PR TITLE
Feature subscription remember position

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
@@ -8,6 +8,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.util.Pair;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -51,20 +52,29 @@ public class EpisodeItemListRecyclerView extends RecyclerView {
         setPadding(horizontalSpacing, getPaddingTop(), horizontalSpacing, getPaddingBottom());
     }
 
-    public void saveScrollPosition(String tag) {
+    public Pair<Integer, Integer> getScrollPosition() {
         int firstItem = layoutManager.findFirstVisibleItemPosition();
         View firstItemView = layoutManager.findViewByPosition(firstItem);
-        float topOffset;
+        int topOffset;
         if (firstItemView == null) {
             topOffset = 0;
         } else {
             topOffset = firstItemView.getTop();
         }
+        return new Pair<>(firstItem, topOffset);
+    }
+
+    public void saveScrollPosition(String tag) {
+        Pair<Integer, Integer> scrollPosition = getScrollPosition();
 
         getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE).edit()
-                .putInt(PREF_PREFIX_SCROLL_POSITION + tag, firstItem)
-                .putInt(PREF_PREFIX_SCROLL_OFFSET + tag, (int) topOffset)
+                .putInt(PREF_PREFIX_SCROLL_POSITION + tag, scrollPosition.first)
+                .putInt(PREF_PREFIX_SCROLL_OFFSET + tag, scrollPosition.second)
                 .apply();
+    }
+
+    public void restoreScrollPosition(Pair<Integer, Integer> scrollPosition) {
+        layoutManager.scrollToPositionWithOffset(scrollPosition.first, scrollPosition.second);
     }
 
     public void restoreScrollPosition(String tag) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -85,8 +85,11 @@ public abstract class EpisodesListFragment extends Fragment
     @Override
     public void onStart() {
         super.onStart();
-        EventBus.getDefault().register(this);
+        if (isResetScrollPositionToTop()) {
+            setResetScrollPositionToTop(false);
+        }
         loadItems();
+        EventBus.getDefault().register(this);
     }
 
     @Override
@@ -98,7 +101,7 @@ public abstract class EpisodesListFragment extends Fragment
     @Override
     public void onPause() {
         super.onPause();
-        recyclerView.saveScrollPosition(getPrefName());
+        setScrollPosition(recyclerView.getScrollPosition());
         unregisterForContextMenu(recyclerView);
     }
 
@@ -416,7 +419,7 @@ public abstract class EpisodesListFragment extends Fragment
                             listAdapter.updateItems(episodes);
                             listAdapter.setTotalNumberOfItems(data.second);
                             if (restoreScrollPosition) {
-                                recyclerView.restoreScrollPosition(getPrefName());
+                                recyclerView.restoreScrollPosition(getScrollPosition());
                             }
                             updateToolbar();
                         }, error -> {
@@ -438,7 +441,14 @@ public abstract class EpisodesListFragment extends Fragment
 
     protected abstract String getFragmentTag();
 
-    protected abstract String getPrefName();
+    protected abstract boolean isResetScrollPositionToTop();
+
+    protected abstract void setResetScrollPositionToTop(boolean reset);
+
+    protected abstract Pair<Integer, Integer> getScrollPosition();
+
+    protected abstract void setScrollPosition(Pair<Integer, Integer> scrollPosition);
+
 
     protected void updateToolbar() {
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
@@ -7,6 +7,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.ui.AllEpisodesFilterDialog;
@@ -31,6 +33,9 @@ import java.util.List;
 public class AllEpisodesFragment extends EpisodesListFragment {
     public static final String TAG = "EpisodesFragment";
     public static final String PREF_NAME = "PrefAllEpisodesFragment";
+    private static boolean resetScrollPositionToTop = true;
+    private static Pair<Integer, Integer> scrollPosition = new Pair<>(0, 0);
+
 
     @NonNull
     @Override
@@ -85,8 +90,23 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     }
 
     @Override
-    protected String getPrefName() {
-        return PREF_NAME;
+    protected boolean isResetScrollPositionToTop() {
+        return resetScrollPositionToTop;
+    }
+
+    @Override
+    protected void setResetScrollPositionToTop(boolean reset) {
+        resetScrollPositionToTop = reset;
+    }
+
+    @Override
+    protected Pair<Integer, Integer> getScrollPosition() {
+        return scrollPosition;
+    }
+
+    @Override
+    protected void setScrollPosition(Pair<Integer, Integer> pos) {
+        scrollPosition = pos;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
@@ -11,6 +11,8 @@ import android.widget.CheckBox;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
@@ -36,6 +38,8 @@ public class InboxFragment extends EpisodesListFragment {
     private static final String PREF_NAME = "PrefNewEpisodesFragment";
     private static final String PREF_DO_NOT_PROMPT_REMOVE_ALL_FROM_INBOX = "prefDoNotPromptRemovalAllFromInbox";
     private SharedPreferences prefs;
+    private static boolean resetScrollPositionToTop = true;
+    private static Pair<Integer, Integer> scrollPosition = new Pair<>(0, 0);
 
     @NonNull
     @Override
@@ -61,9 +65,22 @@ public class InboxFragment extends EpisodesListFragment {
         return TAG;
     }
 
+    protected boolean isResetScrollPositionToTop() {
+        return resetScrollPositionToTop;
+    }
+
+    protected void setResetScrollPositionToTop(boolean reset) {
+        resetScrollPositionToTop = reset;
+    }
+
     @Override
-    protected String getPrefName() {
-        return PREF_NAME;
+    protected Pair<Integer, Integer> getScrollPosition() {
+        return scrollPosition;
+    }
+
+    @Override
+    protected void setScrollPosition(Pair<Integer, Integer> pos) {
+        scrollPosition = pos;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
@@ -7,6 +7,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
+
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.ui.common.ConfirmationDialog;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -25,6 +27,8 @@ public class PlaybackHistoryFragment extends EpisodesListFragment {
     public static final String TAG = "PlaybackHistoryFragment";
     private static final FeedItemFilter FILTER_HISTORY = new FeedItemFilter(
             FeedItemFilter.IS_IN_HISTORY, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+    private static boolean resetScrollPositionToTop = true;
+    private static Pair<Integer, Integer> scrollPosition = new Pair<>(0, 0);
 
     @NonNull
     @Override
@@ -49,9 +53,22 @@ public class PlaybackHistoryFragment extends EpisodesListFragment {
         return TAG;
     }
 
+    protected boolean isResetScrollPositionToTop() {
+        return resetScrollPositionToTop;
+    }
+
+    protected void setResetScrollPositionToTop(boolean reset) {
+        resetScrollPositionToTop = reset;
+    }
+
     @Override
-    protected String getPrefName() {
-        return TAG;
+    protected Pair<Integer, Integer> getScrollPosition() {
+        return scrollPosition;
+    }
+
+    @Override
+    protected void setScrollPosition(Pair<Integer, Integer> pos) {
+        scrollPosition = pos;
     }
 
     @Override


### PR DESCRIPTION
### Description
Resolves #7697 

This PR implements or changes saving, restoring and resetting the scroll position for the Subscriptions and Episodes screens, as discussed here:

> Hi @SevenFactors 
> Thanks for chipping in with this suggestion. We discussed this in the [Needs: Decision meeting](https://antennapod.org/events/needs-decision), and:
> * Agree that the scroll position should be remembered
> * Think that it should not be remembered forever but until the app is closed (this can be done by using static variable)
> * Think that the Episodes screen should be aligned with this (it currently remembers the position forever, but when new episodes arrive to the top of the list, this effectively shifts the position to some seemingly random place)
> * Don't want to have the double-tap in the app, because it adds code complexity while it's not discoverable 

 _Originally posted by @keunes in [#7697](https://github.com/AntennaPod/AntennaPod/issues/7697#issuecomment-2755884766)_

|Subscriptions|Episodes|
|---|---|
|<img src="https://github.com/user-attachments/assets/cfd0d63d-869a-467f-9441-64f62847aa86">|<img src="https://github.com/user-attachments/assets/71f1768c-f75d-443d-ba32-2543baaa0fb8">|


### Follow up questions
Currently the Inbox screen also remembers the scroll position forever. Maybe also change this, so the scroll position resets after the app closes and restarts?

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
