### PR TITLE
Fix sync queue state if a feed is both added and removed

### DIFF
--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
@@ -202,11 +202,8 @@ public class SyncService extends Worker {
                 synchronizationQueueStorage.clearFeedQueues();
                 newTimeStamp = uploadResponse.timestamp;
             } catch (SyncServiceException exception) {
-                // In some cases, syncing with gpodder will fail repeatedly because there is legacy data in the
-                // synchronization storage containing the same feed url as "added" and "removed".
-                // If synchronization fails, clean up any conflicts to make sure that when it fails
-                // for this reason the next sync can succeed.
                 synchronizationQueueStorage.removeLegacyConflictingFeedEntries(localSubscriptions);
+                throw exception;
             } finally {
                 LockingAsyncExecutor.unlock();
             }

--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SynchronizationQueueStorage.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SynchronizationQueueStorage.java
@@ -9,10 +9,7 @@ import org.json.JSONException;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
 
@@ -120,27 +117,10 @@ public class SynchronizationQueueStorage {
      * and `enqueueFeedAdded` already take care of removing conflicting entries.
      * */
     protected void removeLegacyConflictingFeedEntries(Collection<String> currentLocalSubscriptions) {
-
         List<String> removedQueue = this.getQueuedRemovedFeeds();
         List<String> addedQueue = this.getQueuedAddedFeeds();
-        Set<String> localSubscriptions = new HashSet<>(currentLocalSubscriptions);
-
-        Iterator<String> addedIterator = addedQueue.iterator();
-        while (addedIterator.hasNext()) {
-            if (!localSubscriptions.contains(addedIterator.next())) {
-                // Feed no longer in local subscriptions, so remove update from storage
-                addedIterator.remove();
-            }
-        }
-
-        Iterator<String> removedIterator = removedQueue.iterator();
-        while (removedIterator.hasNext()) {
-            if (localSubscriptions.contains(removedIterator.next())) {
-                // Feed has been added again, remove the removed entry from storage
-                removedIterator.remove();
-            }
-        }
-
+        removedQueue.removeAll(currentLocalSubscriptions);
+        addedQueue.removeAll(removedQueue);
         sharedPreferences.edit()
                 .putString(QUEUED_FEEDS_ADDED, addedQueue.toString())
                 .putString(QUEUED_FEEDS_REMOVED, removedQueue.toString())


### PR DESCRIPTION
### Description

When `queuedRemovedFeeds` and `queuedAddedFeeds` intersect when syncing subscriptins, remove the subscription from added or removed feeds to match the current local subscription status.


Closes #7570 

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
