### PR TITLE
Don't cast class to MainActivity to show message

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/FeedSettingsTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/FeedSettingsTest.java
@@ -7,6 +7,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.test.antennapod.EspressoTestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -44,7 +45,7 @@ public class FeedSettingsTest {
         uiTestUtils.addLocalFeedData(false);
         feed = uiTestUtils.hostedFeeds.get(0);
         Intent intent = new Intent(InstrumentationRegistry.getInstrumentation().getTargetContext(), MainActivity.class);
-        intent.putExtra(MainActivity.EXTRA_FEED_ID, feed.getId());
+        intent.putExtra(MainActivityStarter.EXTRA_FEED_ID, feed.getId());
         activityRule.launchActivity(intent);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.activity;
 
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -97,7 +96,6 @@ public class MainActivity extends CastEnabledActivity {
     public static final String PREF_NAME = "MainActivityPrefs";
     public static final String PREF_IS_FIRST_LAUNCH = "prefMainActivityIsFirstLaunch";
 
-    public static final String EXTRA_FEED_ID = "fragment_feed_id";
     public static final String EXTRA_REFRESH_ON_START = "refresh_on_start";
     public static final String KEY_GENERATED_VIEW_ID = "generated_view_id";
 
@@ -111,14 +109,6 @@ public class MainActivity extends CastEnabledActivity {
     private RecyclerView.RecycledViewPool recycledViewPool = new RecyclerView.RecycledViewPool();
     private int lastTheme = 0;
     private Insets systemBarInsets = Insets.NONE;
-
-    @NonNull
-    public static Intent getIntentToOpenFeed(@NonNull Context context, long feedId) {
-        Intent intent = new Intent(context.getApplicationContext(), MainActivity.class);
-        intent.putExtra(MainActivity.EXTRA_FEED_ID, feedId);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        return intent;
-    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -670,8 +660,8 @@ public class MainActivity extends CastEnabledActivity {
     private void handleNavIntent() {
         Log.d(TAG, "handleNavIntent()");
         Intent intent = getIntent();
-        if (intent.hasExtra(EXTRA_FEED_ID)) {
-            long feedId = intent.getLongExtra(EXTRA_FEED_ID, 0);
+        if (intent.hasExtra(MainActivityStarter.EXTRA_FEED_ID)) {
+            long feedId = intent.getLongExtra(MainActivityStarter.EXTRA_FEED_ID, 0);
             Bundle args = intent.getBundleExtra(MainActivityStarter.EXTRA_FRAGMENT_ARGS);
             if (feedId > 0) {
                 if (intent.getBooleanExtra(MainActivityStarter.EXTRA_CLEAR_BACK_STACK, false)) {

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -651,8 +651,17 @@ public class MainActivity extends CastEnabledActivity {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(MessageEvent event) {
         Log.d(TAG, "onEvent(" + event + ")");
+        Snackbar snackbar;
+        if (getBottomSheet().getState() == BottomSheetBehavior.STATE_COLLAPSED) {
+            snackbar = Snackbar.make(findViewById(R.id.main_content_view), event.message, Snackbar.LENGTH_LONG);
+            if (findViewById(R.id.audioplayerFragment).getVisibility() == View.VISIBLE) {
+                snackbar.setAnchorView(findViewById(R.id.audioplayerFragment));
+            }
+        } else {
+            snackbar = Snackbar.make(findViewById(android.R.id.content), event.message, Snackbar.LENGTH_LONG);
+        }
+        snackbar.show();
 
-        Snackbar snackbar = showSnackbarAbovePlayer(event.message, Snackbar.LENGTH_LONG);
         if (event.action != null) {
             snackbar.setAction(event.actionText, v -> event.action.accept(this));
         }
@@ -710,24 +719,6 @@ public class MainActivity extends CastEnabledActivity {
         handleNavIntent();
     }
 
-    public Snackbar showSnackbarAbovePlayer(CharSequence text, int duration) {
-        Snackbar s;
-        if (getBottomSheet().getState() == BottomSheetBehavior.STATE_COLLAPSED) {
-            s = Snackbar.make(findViewById(R.id.main_content_view), text, duration);
-            if (findViewById(R.id.audioplayerFragment).getVisibility() == View.VISIBLE) {
-                s.setAnchorView(findViewById(R.id.audioplayerFragment));
-            }
-        } else {
-            s = Snackbar.make(findViewById(android.R.id.content), text, duration);
-        }
-        s.show();
-        return s;
-    }
-
-    public Snackbar showSnackbarAbovePlayer(int text, int duration) {
-        return showSnackbarAbovePlayer(getResources().getText(text), duration);
-    }
-
     /**
      * Handles the deep link incoming via App Actions.
      * Performs an in-app search or opens the relevant feature of the app
@@ -771,8 +762,7 @@ public class MainActivity extends CastEnabledActivity {
                         loadFragment(SubscriptionFragment.TAG, null);
                         break;
                     default:
-                        showSnackbarAbovePlayer(getString(R.string.app_action_not_found, feature),
-                                Snackbar.LENGTH_LONG);
+                        EventBus.getDefault().post(new MessageEvent(getString(R.string.app_action_not_found, feature)));
                         return;
                 }
                 break;

--- a/app/src/main/java/de/danoeh/antennapod/activity/SelectSubscriptionActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/SelectSubscriptionActivity.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.activity;
 
-import static de.danoeh.antennapod.activity.MainActivity.EXTRA_FEED_ID;
-
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
@@ -26,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.common.ThemeSwitcher;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.NavDrawerData;
@@ -93,7 +92,7 @@ public class SelectSubscriptionActivity extends AppCompatActivity {
         Intent intent = new Intent(this, MainActivity.class);
         intent.setAction(Intent.ACTION_MAIN);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        intent.putExtra(EXTRA_FEED_ID, feed.getId());
+        intent.putExtra(MainActivityStarter.EXTRA_FEED_ID, feed.getId());
         String id = "subscription-" + feed.getId();
         IconCompat icon;
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -21,8 +21,8 @@ import androidx.recyclerview.widget.SimpleItemAnimator;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.google.android.material.appbar.MaterialToolbar;
-import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.ui.view.FloatingSelectMenu;
@@ -211,8 +211,7 @@ public abstract class EpisodesListFragment extends Fragment
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (listAdapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
-                        Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_items_selected_message)));
                 return false;
             }
             int confirmationString = 0;
@@ -241,8 +240,7 @@ public abstract class EpisodesListFragment extends Fragment
     }
 
     private void performMultiSelectAction(int actionItemId) {
-        EpisodeMultiSelectActionHandler handler =
-                new EpisodeMultiSelectActionHandler(((MainActivity) getActivity()), actionItemId);
+        EpisodeMultiSelectActionHandler handler = new EpisodeMultiSelectActionHandler(getActivity(), actionItemId);
         Completable.fromAction(
                 () -> {
                     handler.handleAction(listAdapter.getSelectedItems());

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -11,13 +11,12 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.snackbar.Snackbar;
 
 import java.util.Arrays;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
@@ -34,6 +33,7 @@ import de.danoeh.antennapod.net.sync.serviceinterface.EpisodeAction;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
 import de.danoeh.antennapod.ui.view.LocalDeleteModal;
+import org.greenrobot.eventbus.EventBus;
 
 /**
  * Handles interactions with the FeedItemMenu.
@@ -301,19 +301,15 @@ public class FeedItemMenuHandler {
                 break;
         }
 
-        int duration = Snackbar.LENGTH_LONG;
-
         if (showSnackbar) {
-            ((MainActivity) fragment.getActivity()).showSnackbarAbovePlayer(
-                    playStateStringRes, duration)
-                    .setAction(fragment.getString(R.string.undo), v -> {
+            EventBus.getDefault().post(new MessageEvent(fragment.getString(playStateStringRes),
+                    context -> {
                         DBWriter.markItemPlayed(item.getPlayState(), item.getId());
                         // don't forget to cancel the thing that's going to remove the media
                         h.removeCallbacks(r);
-                    });
+                    }, fragment.getString(R.string.undo)));
         }
-
-        h.postDelayed(r, (int) Math.ceil(duration * 1.05f));
+        h.postDelayed(r, 2000);
     }
 
     public static void removeNewFlagWithUndo(@NonNull Fragment fragment, FeedItem item) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/HorizontalItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/HorizontalItemViewHolder.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.ui.episodeslist;
 
+import android.app.Activity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,7 +10,6 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.ui.CoverLoader;
 import de.danoeh.antennapod.actionbutton.ItemActionButton;
 import de.danoeh.antennapod.ui.common.DateFormatter;
@@ -33,10 +33,10 @@ public class HorizontalItemViewHolder extends RecyclerView.ViewHolder {
     private final CircularProgressBar circularProgressBar;
     private final View progressBarReplacementSpacer;
 
-    private final MainActivity activity;
+    private final Activity activity;
     private FeedItem item;
 
-    public HorizontalItemViewHolder(MainActivity activity, ViewGroup parent) {
+    public HorizontalItemViewHolder(Activity activity, ViewGroup parent) {
         super(LayoutInflater.from(activity).inflate(R.layout.horizontal_itemlist_item, parent, false));
         this.activity = activity;
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
@@ -23,11 +23,11 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.widget.NestedScrollView;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.Fragment;
-import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.activity.OpmlImportActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
@@ -45,6 +45,7 @@ import de.danoeh.antennapod.ui.view.LiftOnScrollListener;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
+import org.greenrobot.eventbus.EventBus;
 
 import java.util.Collections;
 
@@ -103,8 +104,7 @@ public class AddFeedFragment extends Fragment {
                 chooseOpmlImportPathLauncher.launch("*/*");
             } catch (ActivityNotFoundException e) {
                 e.printStackTrace();
-                ((MainActivity) getActivity())
-                        .showSnackbarAbovePlayer(R.string.unable_to_start_system_file_manager, Snackbar.LENGTH_LONG);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.unable_to_start_system_file_manager)));
             }
         });
 
@@ -113,8 +113,7 @@ public class AddFeedFragment extends Fragment {
                 addLocalFolderLauncher.launch(null);
             } catch (ActivityNotFoundException e) {
                 e.printStackTrace();
-                ((MainActivity) getActivity())
-                        .showSnackbarAbovePlayer(R.string.unable_to_start_system_file_manager, Snackbar.LENGTH_LONG);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.unable_to_start_system_file_manager)));
             }
         });
         viewBinding.searchButton.setOnClickListener(view -> performSearch());
@@ -188,8 +187,7 @@ public class AddFeedFragment extends Fragment {
                             ((MainActivity) getActivity()).loadChildFragment(fragment);
                         }, error -> {
                             Log.e(TAG, Log.getStackTraceString(error));
-                            ((MainActivity) getActivity())
-                                    .showSnackbarAbovePlayer(error.getLocalizedMessage(), Snackbar.LENGTH_LONG);
+                            EventBus.getDefault().post(new MessageEvent(error.getLocalizedMessage()));
                         });
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
@@ -8,12 +8,11 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
-import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.ui.screen.feed.ItemSortDialog;
@@ -106,7 +105,7 @@ public class InboxFragment extends EpisodesListFragment {
 
     private void removeAllFromInbox() {
         DBWriter.removeAllNewFlags();
-        ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.removed_all_inbox_msg, Toast.LENGTH_SHORT);
+        EventBus.getDefault().post(new MessageEvent(getString(R.string.removed_all_inbox_msg)));
     }
 
     private void showRemoveAllDialog() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -22,10 +22,10 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.chip.Chip;
-import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemListAdapter;
 import de.danoeh.antennapod.ui.screen.subscriptions.HorizontalFeedListAdapter;
 import de.danoeh.antennapod.ui.MenuItemUtils;
@@ -224,11 +224,10 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (adapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity())
-                        .showSnackbarAbovePlayer(R.string.no_items_selected_message, Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_items_selected_message)));
                 return false;
             }
-            new EpisodeMultiSelectActionHandler((MainActivity) getActivity(), menuItem.getItemId())
+            new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId())
                     .handleAction(adapter.getSelectedItems());
             adapter.endSelectMode();
             return true;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -12,6 +12,7 @@ import android.widget.ProgressBar;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.google.android.material.appbar.MaterialToolbar;
@@ -107,7 +108,7 @@ public class CompletedDownloadsFragment extends Fragment
 
         recyclerView = root.findViewById(R.id.recyclerView);
         recyclerView.setRecycledViewPool(((MainActivity) getActivity()).getRecycledViewPool());
-        adapter = new CompletedDownloadsListAdapter((MainActivity) getActivity());
+        adapter = new CompletedDownloadsListAdapter(getActivity());
         adapter.setOnSelectModeListener(this);
         recyclerView.setAdapter(adapter);
         recyclerView.addOnScrollListener(new LiftOnScrollListener(root.findViewById(R.id.appbar)));
@@ -362,7 +363,7 @@ public class CompletedDownloadsFragment extends Fragment
 
     private class CompletedDownloadsListAdapter extends EpisodeItemListAdapter {
 
-        public CompletedDownloadsListAdapter(MainActivity mainActivity) {
+        public CompletedDownloadsListAdapter(FragmentActivity mainActivity) {
             super(mainActivity);
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -15,10 +15,10 @@ import androidx.fragment.app.Fragment;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.google.android.material.appbar.MaterialToolbar;
-import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.ui.common.ConfirmationDialog;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemListAdapter;
 import de.danoeh.antennapod.actionbutton.DeleteActionButton;
@@ -121,8 +121,7 @@ public class CompletedDownloadsFragment extends Fragment
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (adapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
-                        Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_items_selected_message)));
                 return false;
             }
             new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId())

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogAdapter.java
@@ -6,16 +6,16 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
-import android.widget.Toast;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.actionbutton.DownloadActionButton;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.model.download.DownloadError;
 import de.danoeh.antennapod.model.download.DownloadResult;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedMedia;
+import org.greenrobot.eventbus.EventBus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -114,8 +114,8 @@ public class DownloadLogAdapter extends BaseAdapter {
                             return;
                         }
                         new DownloadActionButton(media.getItem()).onClick(context);
-                        ((MainActivity) context).showSnackbarAbovePlayer(
-                                R.string.status_downloading_label, Toast.LENGTH_SHORT);
+                        EventBus.getDefault().post(new MessageEvent(
+                                context.getResources().getString(R.string.status_downloading_label)));
                     });
                 }
             }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -20,7 +20,6 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
-import com.google.android.material.snackbar.Snackbar;
 import com.skydoves.balloon.ArrowOrientation;
 import com.skydoves.balloon.ArrowOrientationRules;
 import com.skydoves.balloon.Balloon;
@@ -38,6 +37,7 @@ import de.danoeh.antennapod.actionbutton.PlayLocalActionButton;
 import de.danoeh.antennapod.actionbutton.StreamActionButton;
 import de.danoeh.antennapod.actionbutton.VisitWebsiteActionButton;
 import de.danoeh.antennapod.event.EpisodeDownloadEvent;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.playback.service.PlaybackStatus;
 import de.danoeh.antennapod.event.FeedItemEvent;
@@ -151,8 +151,7 @@ public class ItemFragment extends Fragment {
                     && Objects.equals(item.getMedia().getIdentifier(), controller.getMedia().getIdentifier())) {
                 controller.seekTo(time);
             } else {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.play_this_to_seek_position_message,
-                        Snackbar.LENGTH_LONG);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.play_this_to_seek_position_message)));
             }
         });
         registerForContextMenu(webvDescription);
@@ -218,8 +217,7 @@ public class ItemFragment extends Fragment {
             UserPreferences.setStreamOverDownload(offerStreaming);
             // Update all visible lists to reflect new streaming action button
             EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-            ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                    R.string.on_demand_config_setting_changed, Snackbar.LENGTH_SHORT);
+            EventBus.getDefault().post(new MessageEvent(getString(R.string.on_demand_config_setting_changed)));
             balloon.dismiss();
         });
         negativeButton.setOnClickListener(v1 -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemPagerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemPagerFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.ui.screen.episode;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -16,13 +15,13 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -183,8 +182,7 @@ public class ItemPagerFragment extends Fragment implements MaterialToolbar.OnMen
             return;
         }
         if (item.getFeed().getState() == Feed.STATE_SUBSCRIBED) {
-            Intent intent = MainActivity.getIntentToOpenFeed(getContext(), item.getFeedId());
-            startActivity(intent);
+            new MainActivityStarter(getContext()).withOpenFeed(item.getFeedId()).withClearTop().start();
         } else {
             startActivity(new OnlineFeedviewActivityStarter(getContext(), item.getFeed().getDownloadUrl()).getIntent());
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -15,7 +15,6 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -26,10 +25,10 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.databinding.FeedinfoBinding;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -52,6 +51,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import org.apache.commons.lang3.StringUtils;
+import org.greenrobot.eventbus.EventBus;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -87,11 +87,8 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                 android.content.ClipboardManager cm = (android.content.ClipboardManager) getContext()
                         .getSystemService(Context.CLIPBOARD_SERVICE);
                 cm.setPrimaryClip(clipData);
-                if (Build.VERSION.SDK_INT <= 32 && getActivity() instanceof MainActivity) {
-                    ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.copied_to_clipboard,
-                            Snackbar.LENGTH_SHORT);
-                } else if (Build.VERSION.SDK_INT <= 32) {
-                    Snackbar.make(getView(), R.string.copied_to_clipboard, Snackbar.LENGTH_SHORT).show();
+                if (Build.VERSION.SDK_INT <= 32) {
+                    EventBus.getDefault().post(new MessageEvent(getString(R.string.copied_to_clipboard)));
                 }
             }
         }
@@ -285,8 +282,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         if (feed == null) {
-            ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                    R.string.please_wait_for_data, Toast.LENGTH_LONG);
+            EventBus.getDefault().post(new MessageEvent(getString(R.string.please_wait_for_data)));
             return false;
         }
         if (item.getItemId() == R.id.visit_website_item) {
@@ -346,10 +342,8 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        () -> ((MainActivity) getActivity())
-                                .showSnackbarAbovePlayer(android.R.string.ok, Snackbar.LENGTH_SHORT),
-                        error -> ((MainActivity) getActivity())
-                                .showSnackbarAbovePlayer(error.getLocalizedMessage(), Snackbar.LENGTH_LONG));
+                        () -> EventBus.getDefault().post(new MessageEvent(getString(android.R.string.ok))),
+                        error -> EventBus.getDefault().post(new MessageEvent(error.getLocalizedMessage())));
     }
 
     private static class AddLocalFolder extends ActivityResultContracts.OpenDocumentTree {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -11,7 +11,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
-import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
@@ -21,7 +20,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.appbar.MaterialToolbar;
-import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.databinding.FeedItemListFragmentBinding;
@@ -31,6 +29,7 @@ import de.danoeh.antennapod.event.FeedEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.event.QueueEvent;
 import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
@@ -198,8 +197,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         viewBinding.floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         viewBinding.floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (adapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
-                        Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_items_selected_message)));
                 return false;
             }
             EpisodeMultiSelectActionHandler handler
@@ -333,8 +331,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             return true;
         }
 
-        Runnable showRemovedAllSnackbar = () -> ((MainActivity) getActivity())
-                .showSnackbarAbovePlayer(R.string.removed_all_inbox_msg, Toast.LENGTH_SHORT);
+        Runnable showRemovedAllSnackbar = () -> EventBus.getDefault().post(
+                new MessageEvent(getString(R.string.removed_all_inbox_msg)));
         return FeedMenuHandler.onMenuItemClicked(this, item.getItemId(), feed, showRemovedAllSnackbar);
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -516,7 +516,6 @@ public class AudioPlayerFragment extends Fragment implements
         }
         if (feed.getState() == Feed.STATE_SUBSCRIBED) {
             new MainActivityStarter(getContext()).withOpenFeed(feed.getId()).withClearTop().start();
-            startActivity(intent);
         } else {
             startActivity(new OnlineFeedviewActivityStarter(getContext(), feed.getDownloadUrl()).getIntent());
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.ui.screen.playback.audio;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -26,6 +25,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.playback.service.PlaybackController;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
 import de.danoeh.antennapod.ui.chapters.ChapterUtils;
@@ -515,7 +515,7 @@ public class AudioPlayerFragment extends Fragment implements
             return;
         }
         if (feed.getState() == Feed.STATE_SUBSCRIBED) {
-            Intent intent = MainActivity.getIntentToOpenFeed(getContext(), feed.getId());
+            new MainActivityStarter(getContext()).withOpenFeed(feed.getId()).withClearTop().start();
             startActivity(intent);
         } else {
             startActivity(new OnlineFeedviewActivityStarter(getContext(), feed.getDownloadUrl()).getIntent());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
@@ -29,9 +29,9 @@ import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
-import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
 import de.danoeh.antennapod.ui.chapters.ChapterUtils;
@@ -349,8 +349,7 @@ public class CoverFragment extends Fragment {
             clipboardManager.setPrimaryClip(ClipData.newPlainText("AntennaPod", text));
         }
         if (Build.VERSION.SDK_INT <= 32) {
-            ((MainActivity) requireActivity()).showSnackbarAbovePlayer(
-                    getResources().getString(R.string.copied_to_clipboard), Snackbar.LENGTH_SHORT);
+            EventBus.getDefault().post(new MessageEvent(getString(R.string.copied_to_clipboard)));
         }
         return true;
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
@@ -6,7 +6,6 @@ import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.ClipData;
 import android.content.ClipboardManager;
-import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.ColorFilter;
 import android.graphics.drawable.Drawable;
@@ -30,9 +29,9 @@ import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
 import de.danoeh.antennapod.ui.chapters.ChapterUtils;
 import de.danoeh.antennapod.ui.screen.chapter.ChaptersFragment;
@@ -169,8 +168,7 @@ public class CoverFragment extends Fragment {
             return;
         }
         if (feed.getState() == Feed.STATE_SUBSCRIBED) {
-            Intent intent = MainActivity.getIntentToOpenFeed(getContext(), feed.getId());
-            startActivity(intent);
+            new MainActivityStarter(getContext()).withOpenFeed(feed.getId()).withClearTop().start();
         } else {
             startActivity(new OnlineFeedviewActivityStarter(getContext(), feed.getDownloadUrl()).getIntent());
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/VideoplayerActivity.java
@@ -634,8 +634,7 @@ public class VideoplayerActivity extends CastEnabledActivity implements SeekBar.
             PlaybackControlsDialog dialog = PlaybackControlsDialog.newInstance();
             dialog.show(getSupportFragmentManager(), "playback_controls");
         } else if (item.getItemId() == R.id.open_feed_item && feedItem != null) {
-            Intent intent = MainActivity.getIntentToOpenFeed(this, feedItem.getFeedId());
-            startActivity(intent);
+            new MainActivityStarter(this).withOpenFeed(feedItem.getFeedId()).withClearTop().start();
         } else if (item.getItemId() == R.id.visit_website_item) {
             IntentUtils.openInBrowser(VideoplayerActivity.this, getWebsiteLinkWithFallback(media));
         } else if (item.getItemId() == R.id.share_item && feedItem != null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -27,8 +27,8 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
 import de.danoeh.antennapod.ui.screen.InboxFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
@@ -351,11 +351,11 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         if (recyclerAdapter != null) {
             recyclerAdapter.updateDragDropEnabled();
         }
-        if (queue.size() == 0) {
+        if (queue.isEmpty()) {
             if (locked) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.queue_locked, Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.queue_locked)));
             } else {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.queue_unlocked, Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.queue_unlocked)));
             }
         }
     }
@@ -477,8 +477,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         floatingSelectMenu.inflate(R.menu.episodes_apply_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
             if (recyclerAdapter.getSelectedCount() == 0) {
-                ((MainActivity) getActivity()).showSnackbarAbovePlayer(R.string.no_items_selected_message,
-                        Snackbar.LENGTH_SHORT);
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_items_selected_message)));
                 return false;
             }
             new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId())

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueRecyclerAdapter.java
@@ -7,8 +7,8 @@ import android.view.MenuInflater;
 import android.view.MotionEvent;
 import android.view.View;
 
+import androidx.fragment.app.FragmentActivity;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeItemListAdapter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.swipeactions.SwipeActions;
@@ -24,7 +24,7 @@ public class QueueRecyclerAdapter extends EpisodeItemListAdapter {
     private boolean dragDropEnabled;
 
 
-    public QueueRecyclerAdapter(MainActivity mainActivity, SwipeActions swipeActions) {
+    public QueueRecyclerAdapter(FragmentActivity mainActivity, SwipeActions swipeActions) {
         super(mainActivity);
         this.swipeActions = swipeActions;
         dragDropEnabled = ! (UserPreferences.isQueueKeepSorted() || UserPreferences.isQueueLocked());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
@@ -6,14 +6,13 @@ import androidx.annotation.PluralsRes;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.util.Consumer;
 
-import com.google.android.material.snackbar.Snackbar;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.databinding.PlaybackSpeedFeedSettingDialogBinding;
 import de.danoeh.antennapod.ui.screen.feed.RemoveFeedDialog;
@@ -22,6 +21,7 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.ui.screen.preferences.PreferenceListDialog;
 import de.danoeh.antennapod.ui.screen.preferences.PreferenceSwitchDialog;
+import org.greenrobot.eventbus.EventBus;
 
 public class FeedMultiSelectActionHandler {
     private static final String TAG = "FeedSelectHandler";
@@ -121,8 +121,8 @@ public class FeedMultiSelectActionHandler {
     }
 
     private void showMessage(@PluralsRes int msgId, int numItems) {
-        activity.showSnackbarAbovePlayer(activity.getResources()
-                .getQuantityString(msgId, numItems, numItems), Snackbar.LENGTH_LONG);
+        EventBus.getDefault().post(new MessageEvent(activity.getResources()
+                .getQuantityString(msgId, numItems, numItems)));
     }
 
     private void saveFeedPreferences(Consumer<FeedPreferences> preferencesConsumer) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMultiSelectActionHandler.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.ui.screen.subscriptions;
 import android.util.Log;
 
 import androidx.annotation.PluralsRes;
+import androidx.fragment.app.FragmentActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.util.Consumer;
 
@@ -11,7 +12,6 @@ import java.util.List;
 import java.util.Locale;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.databinding.PlaybackSpeedFeedSettingDialogBinding;
@@ -25,10 +25,10 @@ import org.greenrobot.eventbus.EventBus;
 
 public class FeedMultiSelectActionHandler {
     private static final String TAG = "FeedSelectHandler";
-    private final MainActivity activity;
+    private final FragmentActivity activity;
     private final List<Feed> selectedItems;
 
-    public FeedMultiSelectActionHandler(MainActivity activity, List<Feed> selectedItems) {
+    public FeedMultiSelectActionHandler(FragmentActivity activity, List<Feed> selectedItems) {
         this.activity = activity;
         this.selectedItems = selectedItems;
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -178,7 +178,7 @@ public class SubscriptionFragment extends Fragment
         floatingSelectMenu = root.findViewById(R.id.floatingSelectMenu);
         floatingSelectMenu.inflate(R.menu.nav_feed_action_speeddial);
         floatingSelectMenu.setOnMenuItemClickListener(menuItem -> {
-            new FeedMultiSelectActionHandler((MainActivity) getActivity(), subscriptionAdapter.getSelectedItems())
+            new FeedMultiSelectActionHandler(getActivity(), subscriptionAdapter.getSelectedItems())
                     .handleAction(menuItem.getItemId());
             return true;
         });

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionViewHolder.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.ui.screen.subscriptions;
 
+import android.app.Activity;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.CheckBox;
@@ -11,7 +12,6 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.storage.database.NavDrawerData;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
@@ -30,9 +30,9 @@ public class SubscriptionViewHolder extends RecyclerView.ViewHolder {
     public final CheckBox selectCheckbox;
     public final CardView card;
     public final View errorIcon;
-    public final WeakReference<MainActivity> mainActivityRef;
+    public final WeakReference<Activity> mainActivityRef;
 
-    public SubscriptionViewHolder(@NonNull View itemView, MainActivity mainActivity) {
+    public SubscriptionViewHolder(@NonNull View itemView, Activity mainActivity) {
         super(itemView);
         title = itemView.findViewById(R.id.titleLabel);
         coverImage = itemView.findViewById(R.id.coverImage);

--- a/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromHistorySwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromHistorySwipeAction.java
@@ -3,16 +3,14 @@ package de.danoeh.antennapod.ui.swipeactions;
 import android.content.Context;
 
 import androidx.fragment.app.Fragment;
-
-import com.google.android.material.snackbar.Snackbar;
-
 import java.util.Date;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import org.greenrobot.eventbus.EventBus;
 
 public class RemoveFromHistorySwipeAction implements SwipeAction {
 
@@ -40,15 +38,11 @@ public class RemoveFromHistorySwipeAction implements SwipeAction {
 
     @Override
     public void performAction(FeedItem item, Fragment fragment, FeedItemFilter filter) {
-
         Date playbackCompletionDate = item.getMedia().getPlaybackCompletionDate();
-
         DBWriter.deleteFromPlaybackHistory(item);
-
-        ((MainActivity) fragment.requireActivity())
-                .showSnackbarAbovePlayer(R.string.removed_history_label, Snackbar.LENGTH_LONG)
-                .setAction(fragment.getString(R.string.undo),
-                        v -> DBWriter.addItemToPlaybackHistory(item.getMedia(), playbackCompletionDate));
+        EventBus.getDefault().post(new MessageEvent(fragment.getString(R.string.removed_history_label),
+                context -> DBWriter.addItemToPlaybackHistory(item.getMedia(), playbackCompletionDate),
+                fragment.getString(R.string.undo)));
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromQueueSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromQueueSwipeAction.java
@@ -1,17 +1,14 @@
 package de.danoeh.antennapod.ui.swipeactions;
 
 import android.content.Context;
-
 import androidx.fragment.app.Fragment;
-
-import com.google.android.material.snackbar.Snackbar;
-
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import org.greenrobot.eventbus.EventBus;
 
 public class RemoveFromQueueSwipeAction implements SwipeAction {
 
@@ -38,15 +35,12 @@ public class RemoveFromQueueSwipeAction implements SwipeAction {
     @Override
     public void performAction(FeedItem item, Fragment fragment, FeedItemFilter filter) {
         int position = DBReader.getQueueIDList().indexOf(item.getId());
-
         DBWriter.removeQueueItem(fragment.requireActivity(), true, item);
-
         if (willRemove(filter, item)) {
-            ((MainActivity) fragment.requireActivity()).showSnackbarAbovePlayer(
+            EventBus.getDefault().post(new MessageEvent(
                     fragment.getResources().getQuantityString(R.plurals.removed_from_queue_message, 1, 1),
-                    Snackbar.LENGTH_LONG)
-                    .setAction(fragment.getString(R.string.undo), v ->
-                            DBWriter.addQueueItemAt(fragment.requireActivity(), item.getId(), position));
+                    context -> DBWriter.addQueueItemAt(fragment.requireActivity(), item.getId(), position),
+                    fragment.getString(R.string.undo)));
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/view/ShownotesWebView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/ShownotesWebView.java
@@ -23,13 +23,14 @@ import androidx.core.util.Consumer;
 import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.ui.MenuItemUtils;
 import de.danoeh.antennapod.ui.common.Converter;
 import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.ui.share.ShareUtils;
 import de.danoeh.antennapod.ui.cleaner.ShownotesCleaner;
+import org.greenrobot.eventbus.EventBus;
 
 public class ShownotesWebView extends WebView implements View.OnLongClickListener {
     private static final String TAG = "ShownotesWebView";
@@ -104,10 +105,9 @@ public class ShownotesWebView extends WebView implements View.OnLongClickListene
             if (clipboardManager != null) {
                 clipboardManager.setPrimaryClip(ClipData.newPlainText("AntennaPod", r.getExtra()));
             }
-            if (Build.VERSION.SDK_INT <= 32 && this.getContext() instanceof MainActivity) {
-                ((MainActivity) this.getContext()).showSnackbarAbovePlayer(
-                        getResources().getString(R.string.copied_to_clipboard),
-                        Snackbar.LENGTH_SHORT);
+            if (Build.VERSION.SDK_INT <= 32) {
+                EventBus.getDefault().post(new MessageEvent(
+                        getContext().getResources().getString(R.string.copied_to_clipboard)));
             }
             return true;
         }

--- a/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MainActivityStarter.java
+++ b/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MainActivityStarter.java
@@ -76,6 +76,11 @@ public class MainActivityStarter {
         return this;
     }
 
+    public MainActivityStarter withClearTop() {
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        return this;
+    }
+
     public MainActivityStarter withFragmentArgs(String name, boolean value) {
         if (fragmentArgs == null) {
             fragmentArgs = new Bundle();


### PR DESCRIPTION
### Description

We can do that using an event.
This commit fixes one of the most prominent crashes on Google Play where we cast the OnlineFeedViewActivity to MainActivity.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
