### PR TITLE
Fix crash when clicking buttons when feed is not loaded yet

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -55,7 +55,7 @@ public class FeedItemMenuHandler {
      * @return Returns true if selectedItem is not null.
      */
     public static boolean onPrepareMenu(Menu menu, List<FeedItem> selectedItems, int... excludeIds) {
-        if (menu == null || selectedItems == null) {
+        if (menu == null || selectedItems == null || selectedItems.isEmpty() || selectedItems.get(0) == null) {
             return false;
         }
         boolean canSkip = false;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -533,6 +533,9 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         viewBinding.header.imgvCover.setOnClickListener(v -> showFeedInfo());
         viewBinding.header.headerDescriptionLabel.setOnClickListener(v -> showFeedInfo());
         viewBinding.header.butSubscribe.setOnClickListener(view -> {
+            if (feed == null) {
+                return;
+            }
             DBWriter.setFeedState(getContext(), feed, Feed.STATE_SUBSCRIBED);
             MainActivityStarter mainActivityStarter = new MainActivityStarter(getContext());
             mainActivityStarter.withOpenFeed(feed.getId());
@@ -540,13 +543,18 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             startActivity(mainActivityStarter.getIntent());
         });
         viewBinding.header.butShowSettings.setOnClickListener(v -> {
-            if (feed != null) {
-                FeedSettingsFragment fragment = FeedSettingsFragment.newInstance(feed);
-                ((MainActivity) getActivity()).loadChildFragment(fragment, TransitionEffect.SLIDE);
+            if (feed == null) {
+                return;
             }
+            FeedSettingsFragment fragment = FeedSettingsFragment.newInstance(feed);
+            ((MainActivity) getActivity()).loadChildFragment(fragment, TransitionEffect.SLIDE);
         });
-        viewBinding.header.butFilter.setOnClickListener(v ->
-                FeedItemFilterDialog.newInstance(feed).show(getChildFragmentManager(), null));
+        viewBinding.header.butFilter.setOnClickListener(v -> {
+            if (feed == null) {
+                return;
+            }
+            FeedItemFilterDialog.newInstance(feed).show(getChildFragmentManager(), null);
+        });
         viewBinding.header.txtvFailure.setOnClickListener(v -> showErrorDetails());
     }
 


### PR DESCRIPTION
### Description

Fix crash when clicking buttons when feed is not loaded yet
Closes #7787
Closes #7786

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
