### PR TITLE
Don't crash when using invalid characters in host name

### DIFF
--- a/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/HostnameParser.java
+++ b/net/sync/gpoddernet/src/main/java/de/danoeh/antennapod/net/sync/HostnameParser.java
@@ -19,7 +19,11 @@ public class HostnameParser {
         Matcher m = URLSPLIT_REGEX.matcher(hosturl);
         if (m.matches()) {
             scheme = m.group(1);
-            host = IDN.toASCII(m.group(2));
+            try {
+                host = IDN.toASCII(m.group(2));
+            } catch (IllegalArgumentException e) {
+                host = "invalid-hostname";
+            }
             if (m.group(3) == null) {
                 port = -1;
             } else {
@@ -33,7 +37,11 @@ public class HostnameParser {
         } else {
             // URL does not match regex: use it anyway -> this will cause an exception on connect
             scheme = "https";
-            host = IDN.toASCII(hosturl);
+            try {
+                host = IDN.toASCII(hosturl);
+            } catch (IllegalArgumentException e) {
+                host = "invalid-hostname";
+            }
             port = 443;
         }
 


### PR DESCRIPTION
### Description

Don't crash when using invalid characters in host name
Closes #7783

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
