### PR TITLE
Feature subscription remember position (alternative approach)

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/ScrollPositionManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/ScrollPositionManager.java
@@ -1,0 +1,77 @@
+package de.danoeh.antennapod.ui;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View;
+
+import androidx.core.util.Pair;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScrollPositionManager {
+
+    private static final String PREF_PREFIX_SCROLL_POSITION = "scroll_position_";
+    private static final String PREF_PREFIX_SCROLL_OFFSET = "scroll_offset_";
+
+    private static final Map<String, Pair<Integer, Integer>> scrollPositions = new HashMap<>();
+
+    public static Pair<Integer, Integer> getCurrentScrollPosition(RecyclerView view) {
+        LinearLayoutManager layoutManager = (LinearLayoutManager) view.getLayoutManager();
+        int firstItem = layoutManager.findFirstVisibleItemPosition();
+        View firstItemView = layoutManager.findViewByPosition(firstItem);
+        int topOffset;
+        if (firstItemView == null) {
+            topOffset = 0;
+        } else {
+            topOffset = firstItemView.getTop();
+        }
+
+        return new Pair<>(firstItem, topOffset);
+    }
+
+    public static Pair<Integer, Integer> getStoredScrollPosition(String tag) {
+        return scrollPositions.get(tag);
+    }
+
+    public static void initializeScrollPositionToTop(String tag) {
+        storeScrollPosition(new Pair<>(0, 0), tag);
+    }
+
+    public static void storeScrollPosition(Pair<Integer, Integer> scrollPosition, String tag) {
+        scrollPositions.put(tag, scrollPosition);
+    }
+
+    public static void storeCurrentScrollPosition(RecyclerView view, String tag) {
+        Pair<Integer, Integer> scrollPosition = getCurrentScrollPosition(view);
+        scrollPositions.put(tag, scrollPosition);
+    }
+
+    public static void saveCurrentScrollPositionToPrefs(Context context, RecyclerView view, String prefName, String tag) {
+        Pair<Integer, Integer> scrollPosition = getCurrentScrollPosition(view);
+
+        context.getSharedPreferences(prefName, Context.MODE_PRIVATE).edit()
+                .putInt(PREF_PREFIX_SCROLL_POSITION + tag, scrollPosition.first)
+                .putInt(PREF_PREFIX_SCROLL_OFFSET + tag, scrollPosition.second)
+                .apply();
+    }
+
+    public static void restoreScrollPositionFromPrefs(Context context, RecyclerView view, String prefName, String tag) {
+        SharedPreferences prefs = context.getSharedPreferences(prefName, Context.MODE_PRIVATE);
+        int position = prefs.getInt(PREF_PREFIX_SCROLL_POSITION + tag, 0);
+        int offset = prefs.getInt(PREF_PREFIX_SCROLL_OFFSET + tag, 0);
+
+        LinearLayoutManager layoutManager = (LinearLayoutManager) view.getLayoutManager();
+        layoutManager.scrollToPositionWithOffset(position, offset);
+
+    }
+
+    public static void restoreStoredScrollPosition(RecyclerView view, String tag) {
+        LinearLayoutManager layoutManager = (LinearLayoutManager) view.getLayoutManager();
+        Pair<Integer, Integer> scrollPosition = getStoredScrollPosition(tag);
+        layoutManager.scrollToPositionWithOffset(scrollPosition.first, scrollPosition.second);
+    }
+
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/ScrollPositionManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/ScrollPositionManager.java
@@ -67,13 +67,16 @@ public class ScrollPositionManager {
 
         LinearLayoutManager layoutManager = (LinearLayoutManager) view.getLayoutManager();
         layoutManager.scrollToPositionWithOffset(position, offset);
-
     }
 
     public static void restoreStoredScrollPosition(RecyclerView view, String tag) {
         LinearLayoutManager layoutManager = (LinearLayoutManager) view.getLayoutManager();
-        Pair<Integer, Integer> scrollPosition = getStoredScrollPosition(tag);
-        layoutManager.scrollToPositionWithOffset(scrollPosition.first, scrollPosition.second);
+        if (scrollPositions.containsKey(tag)) {
+            Pair<Integer, Integer> scrollPosition = getStoredScrollPosition(tag);
+            layoutManager.scrollToPositionWithOffset(scrollPosition.first, scrollPosition.second);
+        } else {
+            initializeScrollPositionToTop(tag);
+        }
     }
 
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/ScrollPositionManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/ScrollPositionManager.java
@@ -49,7 +49,8 @@ public class ScrollPositionManager {
         scrollPositions.put(tag, scrollPosition);
     }
 
-    public static void saveCurrentScrollPositionToPrefs(Context context, RecyclerView view, String prefName, String tag) {
+    public static void saveCurrentScrollPositionToPrefs(Context context, RecyclerView view,
+                                                        String prefName, String tag) {
         Pair<Integer, Integer> scrollPosition = getCurrentScrollPosition(view);
 
         context.getSharedPreferences(prefName, Context.MODE_PRIVATE).edit()
@@ -58,7 +59,8 @@ public class ScrollPositionManager {
                 .apply();
     }
 
-    public static void restoreScrollPositionFromPrefs(Context context, RecyclerView view, String prefName, String tag) {
+    public static void restoreScrollPositionFromPrefs(Context context, RecyclerView view,
+                                                      String prefName, String tag) {
         SharedPreferences prefs = context.getSharedPreferences(prefName, Context.MODE_PRIVATE);
         int position = prefs.getInt(PREF_PREFIX_SCROLL_POSITION + tag, 0);
         int offset = prefs.getInt(PREF_PREFIX_SCROLL_OFFSET + tag, 0);

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
@@ -51,6 +51,7 @@ public class EpisodeItemListRecyclerView extends RecyclerView {
         setPadding(horizontalSpacing, getPaddingTop(), horizontalSpacing, getPaddingBottom());
     }
 
+
     public void saveScrollPosition(String tag) {
         int firstItem = layoutManager.findFirstVisibleItemPosition();
         View firstItemView = layoutManager.findViewByPosition(firstItem);
@@ -75,6 +76,7 @@ public class EpisodeItemListRecyclerView extends RecyclerView {
             layoutManager.scrollToPositionWithOffset(position, offset);
         }
     }
+
 
     public boolean isScrolledToBottom() {
         int visibleEpisodeCount = getChildCount();

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
@@ -51,33 +51,6 @@ public class EpisodeItemListRecyclerView extends RecyclerView {
         setPadding(horizontalSpacing, getPaddingTop(), horizontalSpacing, getPaddingBottom());
     }
 
-
-    public void saveScrollPosition(String tag) {
-        int firstItem = layoutManager.findFirstVisibleItemPosition();
-        View firstItemView = layoutManager.findViewByPosition(firstItem);
-        float topOffset;
-        if (firstItemView == null) {
-            topOffset = 0;
-        } else {
-            topOffset = firstItemView.getTop();
-        }
-
-        getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE).edit()
-                .putInt(PREF_PREFIX_SCROLL_POSITION + tag, firstItem)
-                .putInt(PREF_PREFIX_SCROLL_OFFSET + tag, (int) topOffset)
-                .apply();
-    }
-
-    public void restoreScrollPosition(String tag) {
-        SharedPreferences prefs = getContext().getSharedPreferences(TAG, Context.MODE_PRIVATE);
-        int position = prefs.getInt(PREF_PREFIX_SCROLL_POSITION + tag, 0);
-        int offset = prefs.getInt(PREF_PREFIX_SCROLL_OFFSET + tag, 0);
-        if (position > 0 || offset > 0) {
-            layoutManager.scrollToPositionWithOffset(position, offset);
-        }
-    }
-
-
     public boolean isScrolledToBottom() {
         int visibleEpisodeCount = getChildCount();
         int totalEpisodeCount = layoutManager.getItemCount();

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListRecyclerView.java
@@ -1,10 +1,8 @@
 package de.danoeh.antennapod.ui.episodeslist;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.util.AttributeSet;
-import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ContextThemeWrapper;
@@ -15,8 +13,6 @@ import de.danoeh.antennapod.R;
 
 public class EpisodeItemListRecyclerView extends RecyclerView {
     private static final String TAG = "EpisodeItemListRecyclerView";
-    private static final String PREF_PREFIX_SCROLL_POSITION = "scroll_position_";
-    private static final String PREF_PREFIX_SCROLL_OFFSET = "scroll_offset_";
 
     private LinearLayoutManager layoutManager;
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -23,6 +23,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 
 import de.danoeh.antennapod.event.MessageEvent;
+import de.danoeh.antennapod.ui.ScrollPositionManager;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.ui.view.FloatingSelectMenu;
@@ -85,8 +86,12 @@ public abstract class EpisodesListFragment extends Fragment
     @Override
     public void onStart() {
         super.onStart();
-        EventBus.getDefault().register(this);
+        if (isCalledFirstTime()) {
+            setCalledFirstTime(false);
+            ScrollPositionManager.initializeScrollPositionToTop(getFragmentTag());
+        }
         loadItems();
+        EventBus.getDefault().register(this);
     }
 
     @Override
@@ -98,7 +103,7 @@ public abstract class EpisodesListFragment extends Fragment
     @Override
     public void onPause() {
         super.onPause();
-        recyclerView.saveScrollPosition(getPrefName());
+        ScrollPositionManager.storeCurrentScrollPosition(recyclerView, getFragmentTag());
         unregisterForContextMenu(recyclerView);
     }
 
@@ -414,7 +419,7 @@ public abstract class EpisodesListFragment extends Fragment
                             listAdapter.updateItems(episodes);
                             listAdapter.setTotalNumberOfItems(data.second);
                             if (restoreScrollPosition) {
-                                recyclerView.restoreScrollPosition(getPrefName());
+                                ScrollPositionManager.restoreStoredScrollPosition(recyclerView, getFragmentTag());
                             }
                             updateToolbar();
                         }, error -> {
@@ -437,6 +442,10 @@ public abstract class EpisodesListFragment extends Fragment
     protected abstract String getFragmentTag();
 
     protected abstract String getPrefName();
+
+    protected abstract boolean isCalledFirstTime();
+
+    protected abstract void setCalledFirstTime(boolean value);
 
     protected void updateToolbar() {
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class AllEpisodesFragment extends EpisodesListFragment {
     public static final String TAG = "EpisodesFragment";
     public static final String PREF_NAME = "PrefAllEpisodesFragment";
+    private static boolean calledFirstTime = true;
 
     @NonNull
     @Override
@@ -87,6 +88,16 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     @Override
     protected String getPrefName() {
         return PREF_NAME;
+    }
+
+    @Override
+    protected boolean isCalledFirstTime() {
+        return calledFirstTime;
+    }
+
+    @Override
+    protected void setCalledFirstTime(boolean value) {
+        calledFirstTime = value;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
@@ -35,6 +35,7 @@ public class InboxFragment extends EpisodesListFragment {
     private static final String PREF_NAME = "PrefNewEpisodesFragment";
     private static final String PREF_DO_NOT_PROMPT_REMOVE_ALL_FROM_INBOX = "prefDoNotPromptRemovalAllFromInbox";
     private SharedPreferences prefs;
+    private static boolean calledFirstTime = true;
 
     @NonNull
     @Override
@@ -63,6 +64,16 @@ public class InboxFragment extends EpisodesListFragment {
     @Override
     protected String getPrefName() {
         return PREF_NAME;
+    }
+
+    @Override
+    protected boolean isCalledFirstTime() {
+        return calledFirstTime;
+    }
+
+    @Override
+    protected void setCalledFirstTime(boolean value) {
+        calledFirstTime = value;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
@@ -25,6 +25,7 @@ public class PlaybackHistoryFragment extends EpisodesListFragment {
     public static final String TAG = "PlaybackHistoryFragment";
     private static final FeedItemFilter FILTER_HISTORY = new FeedItemFilter(
             FeedItemFilter.IS_IN_HISTORY, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+    private static boolean calledFirstTime = true;
 
     @NonNull
     @Override
@@ -52,6 +53,16 @@ public class PlaybackHistoryFragment extends EpisodesListFragment {
     @Override
     protected String getPrefName() {
         return TAG;
+    }
+
+    @Override
+    protected boolean isCalledFirstTime() {
+        return calledFirstTime;
+    }
+
+    @Override
+    protected void setCalledFirstTime(boolean value) {
+        calledFirstTime = value;
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -113,7 +113,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     public void onStart() {
         super.onStart();
         if (queue != null) {
-            ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView, PREFS, TAG);
+            ScrollPositionManager.restoreScrollPositionFromPrefs(requireContext(), recyclerView, PREFS, TAG);
         }
         loadItems(true);
         EventBus.getDefault().register(this);
@@ -122,7 +122,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Override
     public void onPause() {
         super.onPause();
-        ScrollPositionManager.saveCurrentScrollPositionToPrefs(getContext(), recyclerView, PREFS, TAG);
+        ScrollPositionManager.saveCurrentScrollPositionToPrefs(requireContext(), recyclerView, PREFS, TAG);
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -30,6 +30,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.playback.SpeedChangedEvent;
+import de.danoeh.antennapod.ui.ScrollPositionManager;
 import de.danoeh.antennapod.ui.screen.InboxFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
@@ -112,7 +113,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     public void onStart() {
         super.onStart();
         if (queue != null) {
-            recyclerView.restoreScrollPosition(QueueFragment.TAG);
+            ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView, PREFS, TAG);
         }
         loadItems(true);
         EventBus.getDefault().register(this);
@@ -121,7 +122,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Override
     public void onPause() {
         super.onPause();
-        recyclerView.saveScrollPosition(QueueFragment.TAG);
+        ScrollPositionManager.saveCurrentScrollPositionToPrefs(getContext(), recyclerView, PREFS, TAG);
     }
 
     @Override
@@ -173,7 +174,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         }
         recyclerAdapter.updateDragDropEnabled();
         refreshToolbarState();
-        recyclerView.saveScrollPosition(QueueFragment.TAG);
+        ScrollPositionManager.saveCurrentScrollPositionToPrefs(getContext(), recyclerView, PREFS, TAG);
         refreshInfoBar();
     }
 
@@ -548,7 +549,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                     recyclerAdapter.setDummyViews(0);
                     recyclerAdapter.updateItems(queue);
                     if (restoreScrollPosition) {
-                        recyclerView.restoreScrollPosition(QueueFragment.TAG);
+                        ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView, PREFS, TAG);
                     }
                     refreshInfoBar();
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -81,6 +81,8 @@ import io.reactivex.schedulers.Schedulers;
 public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuItemClickListener,
         EpisodeItemListAdapter.OnSelectModeListener {
     public static final String TAG = "QueueFragment";
+    private static final String PREF_NAME = "PrefQueueFragment";
+    private static final String PREF_SHOW_LOCK_WARNING = "show_lock_warning";
     private static final String KEY_UP_ARROW = "up_arrow";
 
     private TextView infoBar;
@@ -93,9 +95,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
 
     private List<FeedItem> queue;
 
-    private static final String PREFS = "QueueFragment";
-    private static final String PREF_SHOW_LOCK_WARNING = "show_lock_warning";
-
     private Disposable disposable;
     private SwipeActions swipeActions;
     private SharedPreferences prefs;
@@ -106,14 +105,14 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        prefs = getActivity().getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        prefs = getActivity().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
     }
 
     @Override
     public void onStart() {
         super.onStart();
         if (queue != null) {
-            ScrollPositionManager.restoreScrollPositionFromPrefs(requireContext(), recyclerView, PREFS, TAG);
+            ScrollPositionManager.restoreScrollPositionFromPrefs(requireContext(), recyclerView, PREF_NAME, TAG);
         }
         loadItems(true);
         EventBus.getDefault().register(this);
@@ -122,7 +121,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Override
     public void onPause() {
         super.onPause();
-        ScrollPositionManager.saveCurrentScrollPositionToPrefs(requireContext(), recyclerView, PREFS, TAG);
+        ScrollPositionManager.saveCurrentScrollPositionToPrefs(requireContext(), recyclerView, PREF_NAME, TAG);
     }
 
     @Override
@@ -174,7 +173,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         }
         recyclerAdapter.updateDragDropEnabled();
         refreshToolbarState();
-        ScrollPositionManager.saveCurrentScrollPositionToPrefs(getContext(), recyclerView, PREFS, TAG);
+        ScrollPositionManager.saveCurrentScrollPositionToPrefs(getContext(), recyclerView, PREF_NAME, TAG);
         refreshInfoBar();
     }
 
@@ -549,7 +548,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                     recyclerAdapter.setDummyViews(0);
                     recyclerAdapter.updateItems(queue);
                     if (restoreScrollPosition) {
-                        ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView, PREFS, TAG);
+                        ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView, PREF_NAME, TAG);
                     }
                     refreshInfoBar();
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -548,7 +548,8 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                     recyclerAdapter.setDummyViews(0);
                     recyclerAdapter.updateItems(queue);
                     if (restoreScrollPosition) {
-                        ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView, PREF_NAME, TAG);
+                        ScrollPositionManager.restoreScrollPositionFromPrefs(getContext(), recyclerView,
+                                PREF_NAME, TAG);
                     }
                     refreshInfoBar();
                 }, error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -23,6 +23,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.storage.database.DBWriter;
+import de.danoeh.antennapod.ui.ScrollPositionManager;
 import de.danoeh.antennapod.ui.common.ConfirmationDialog;
 import de.danoeh.antennapod.ui.screen.AddFeedFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
@@ -84,6 +85,7 @@ public class SubscriptionFragment extends Fragment
     private ProgressBar progressBar;
     private String displayedFolder = null;
     private boolean displayUpArrow;
+    private static boolean calledFirstTime = true;
 
     private Disposable disposable;
     private SharedPreferences prefs;
@@ -278,8 +280,18 @@ public class SubscriptionFragment extends Fragment
     @Override
     public void onStart() {
         super.onStart();
-        EventBus.getDefault().register(this);
+        if (calledFirstTime) {
+            calledFirstTime = false;
+            ScrollPositionManager.initializeScrollPositionToTop(TAG);
+        }
         loadSubscriptions();
+        EventBus.getDefault().register(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        ScrollPositionManager.storeCurrentScrollPosition(subscriptionRecycler, TAG);
     }
 
     @Override
@@ -323,6 +335,7 @@ public class SubscriptionFragment extends Fragment
                         listItems = result;
                         progressBar.setVisibility(View.GONE);
                         subscriptionAdapter.setItems(result);
+                        ScrollPositionManager.restoreStoredScrollPosition(subscriptionRecycler, TAG);
                         emptyView.updateVisibility();
                     }, error -> {
                         Log.e(TAG, Log.getStackTraceString(error));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -63,7 +63,7 @@ public class SubscriptionFragment extends Fragment
         implements MaterialToolbar.OnMenuItemClickListener,
         SubscriptionsRecyclerAdapter.OnSelectModeListener {
     public static final String TAG = "SubscriptionFragment";
-    private static final String PREFS = "SubscriptionFragment";
+    private static final String PREF_NAME = "PrefSubscriptionFragment";
     private static final String PREF_NUM_COLUMNS = "columns";
     private static final String KEY_UP_ARROW = "up_arrow";
     private static final String ARGUMENT_FOLDER = "folder";
@@ -106,7 +106,7 @@ public class SubscriptionFragment extends Fragment
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        prefs = requireActivity().getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        prefs = requireActivity().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
     }
 
     @Override


### PR DESCRIPTION
### Description

Would supersede  #7766 and resolve #7697

This PR implements or changes saving, restoring and resetting the scroll position for the Subscriptions and Episodes screens, like in #7766.

This approach introduces a class `ScrollPositionManager`, that holds all scroll position-related logic. This avoids code duplication.

|Subscriptions|Episodes|
|---|---|
|<img src="https://github.com/user-attachments/assets/cfd0d63d-869a-467f-9441-64f62847aa86">|<img src="https://github.com/user-attachments/assets/71f1768c-f75d-443d-ba32-2543baaa0fb8">|

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
