### PR TITLE
Fix Echo "check out again" recommendation logic

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -622,7 +622,7 @@ public final class DBReader {
             int indexPlayedTime = cursor.getColumnIndexOrThrow("played_time");
             int indexNumDownloaded = cursor.getColumnIndexOrThrow("num_downloaded");
             int indexDownloadSize = cursor.getColumnIndexOrThrow("download_size");
-            int indexHasRecentUnplayed = cursor.getColumnIndexOrThrow("has_recent_unplayed");
+            int indexNumRecentUnplayed = cursor.getColumnIndexOrThrow("num_recent_unplayed");
 
             while (cursor.moveToNext()) {
                 Feed feed = cursor.getFeed();
@@ -634,7 +634,7 @@ public final class DBReader {
                 long totalDownloadSize = cursor.getLong(indexDownloadSize);
                 long episodesDownloadCount = cursor.getLong(indexNumDownloaded);
                 long oldestDate = cursor.getLong(indexOldestDate);
-                boolean hasRecentUnplayed = cursor.getInt(indexHasRecentUnplayed) == 1;
+                boolean hasRecentUnplayed = cursor.getLong(indexNumRecentUnplayed) > 0;
 
                 if (episodes > 0 && oldestDate < Long.MAX_VALUE) {
                     result.oldestDate = Math.min(result.oldestDate, oldestDate);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -612,8 +612,9 @@ public final class DBReader {
         adapter.open();
 
         StatisticsResult result = new StatisticsResult();
+        long sixMonthsAgo = System.currentTimeMillis() - (long) (1000L * 3600 * 24 * 30.44 * 6);
         try (FeedCursor cursor = new FeedCursor(adapter.getFeedStatisticsCursor(
-                includeMarkedAsPlayed, timeFilterFrom, timeFilterTo))) {
+                includeMarkedAsPlayed, timeFilterFrom, timeFilterTo, sixMonthsAgo))) {
             int indexOldestDate = cursor.getColumnIndexOrThrow("oldest_date");
             int indexNumEpisodes = cursor.getColumnIndexOrThrow("num_episodes");
             int indexEpisodesStarted = cursor.getColumnIndexOrThrow("episodes_started");
@@ -621,6 +622,7 @@ public final class DBReader {
             int indexPlayedTime = cursor.getColumnIndexOrThrow("played_time");
             int indexNumDownloaded = cursor.getColumnIndexOrThrow("num_downloaded");
             int indexDownloadSize = cursor.getColumnIndexOrThrow("download_size");
+            int indexHasRecentUnplayed = cursor.getColumnIndexOrThrow("has_recent_unplayed");
 
             while (cursor.moveToNext()) {
                 Feed feed = cursor.getFeed();
@@ -632,13 +634,14 @@ public final class DBReader {
                 long totalDownloadSize = cursor.getLong(indexDownloadSize);
                 long episodesDownloadCount = cursor.getLong(indexNumDownloaded);
                 long oldestDate = cursor.getLong(indexOldestDate);
+                boolean hasRecentUnplayed = cursor.getInt(indexHasRecentUnplayed) == 1;
 
                 if (episodes > 0 && oldestDate < Long.MAX_VALUE) {
                     result.oldestDate = Math.min(result.oldestDate, oldestDate);
                 }
 
                 result.feedTime.add(new StatisticsItem(feed, feedTotalTime, feedPlayedTime, episodes,
-                        episodesStarted, totalDownloadSize, episodesDownloadCount));
+                        episodesStarted, totalDownloadSize, episodesDownloadCount, hasRecentUnplayed));
             }
         }
         adapter.close();

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1215,7 +1215,8 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getFeedStatisticsCursor(boolean includeMarkedAsPlayed, long timeFilterFrom, long timeFilterTo, long sixMonthsAgo) {
+    public final Cursor getFeedStatisticsCursor(
+            boolean includeMarkedAsPlayed, long timeFilterFrom, long timeFilterTo, long sixMonthsAgo) {
         final String lastPlayedTime = TABLE_NAME_FEED_MEDIA + "." + KEY_LAST_PLAYED_TIME;
         String wasStarted = TABLE_NAME_FEED_MEDIA + "." + KEY_PLAYBACK_COMPLETION_DATE + " > 0"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_PLAYED_DURATION + " > 0";
@@ -1251,7 +1252,8 @@ public class PodDBAdapter {
                         + "  SELECT 1 FROM " + TABLE_NAME_FEED_ITEMS + " fi"
                         + "  WHERE fi." + KEY_FEED + " = " + TABLE_NAME_FEEDS + "." + KEY_ID
                         + "    AND fi." + KEY_READ + " != " + FeedItem.PLAYED
-                        + "    AND fi." + KEY_PUBDATE + " >= " + sixMonthsAgo + " ) THEN 1 ELSE 0 END AS has_recent_unplayed "
+                        + "    AND fi." + KEY_PUBDATE + " >= " + sixMonthsAgo
+                + " ) THEN 1 ELSE 0 END AS has_recent_unplayed "
                 + " FROM " + TABLE_NAME_FEED_ITEMS
                 + JOIN_FEED_ITEM_AND_MEDIA
                 + " INNER JOIN " + TABLE_NAME_FEEDS

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1215,7 +1215,7 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getFeedStatisticsCursor(boolean includeMarkedAsPlayed, long timeFilterFrom, long timeFilterTo) {
+    public final Cursor getFeedStatisticsCursor(boolean includeMarkedAsPlayed, long timeFilterFrom, long timeFilterTo, long sixMonthsAgo) {
         final String lastPlayedTime = TABLE_NAME_FEED_MEDIA + "." + KEY_LAST_PLAYED_TIME;
         String wasStarted = TABLE_NAME_FEED_MEDIA + "." + KEY_PLAYBACK_COMPLETION_DATE + " > 0"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_PLAYED_DURATION + " > 0";
@@ -1246,7 +1246,12 @@ public class PodDBAdapter {
                         + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + " > 0"
                                 + " THEN 1 ELSE 0 END) AS num_downloaded, "
                         + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + " > 0"
-                                + " THEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_SIZE + " ELSE 0 END) AS download_size"
+                                + " THEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_SIZE + " ELSE 0 END) AS download_size, "
+                        + "CASE WHEN EXISTS ("
+                        + "  SELECT 1 FROM " + TABLE_NAME_FEED_ITEMS + " fi"
+                        + "  WHERE fi." + KEY_FEED + " = " + TABLE_NAME_FEEDS + "." + KEY_ID
+                        + "    AND fi." + KEY_READ + " != " + FeedItem.PLAYED
+                        + "    AND fi." + KEY_PUBDATE + " >= " + sixMonthsAgo + " ) THEN 1 ELSE 0 END AS has_recent_unplayed "
                 + " FROM " + TABLE_NAME_FEED_ITEMS
                 + JOIN_FEED_ITEM_AND_MEDIA
                 + " INNER JOIN " + TABLE_NAME_FEEDS

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1215,8 +1215,8 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getFeedStatisticsCursor(
-            boolean includeMarkedAsPlayed, long timeFilterFrom, long timeFilterTo, long sixMonthsAgo) {
+    public final Cursor getFeedStatisticsCursor(boolean includeMarkedAsPlayed, long timeFilterFrom,
+                                                long timeFilterTo, long sixMonthsAgo) {
         final String lastPlayedTime = TABLE_NAME_FEED_MEDIA + "." + KEY_LAST_PLAYED_TIME;
         String wasStarted = TABLE_NAME_FEED_MEDIA + "." + KEY_PLAYBACK_COMPLETION_DATE + " > 0"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_PLAYED_DURATION + " > 0";
@@ -1248,10 +1248,9 @@ public class PodDBAdapter {
                                 + " THEN 1 ELSE 0 END) AS num_downloaded, "
                         + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + " > 0"
                                 + " THEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_SIZE + " ELSE 0 END) AS download_size, "
-                        + "SUM(CASE WHEN "
-                        + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + " != " + FeedItem.PLAYED
-                        + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " >= " + sixMonthsAgo
-                        + " THEN 1 ELSE 0 END) AS num_recent_unplayed "
+                        + "SUM(CASE WHEN " + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + " != " + FeedItem.PLAYED
+                                + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " >= " + sixMonthsAgo
+                                + " THEN 1 ELSE 0 END) AS num_recent_unplayed "
                 + " FROM " + TABLE_NAME_FEED_ITEMS
                 + JOIN_FEED_ITEM_AND_MEDIA
                 + " INNER JOIN " + TABLE_NAME_FEEDS

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1248,12 +1248,10 @@ public class PodDBAdapter {
                                 + " THEN 1 ELSE 0 END) AS num_downloaded, "
                         + "SUM(CASE WHEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + " > 0"
                                 + " THEN " + TABLE_NAME_FEED_MEDIA + "." + KEY_SIZE + " ELSE 0 END) AS download_size, "
-                        + "CASE WHEN EXISTS ("
-                        + "  SELECT 1 FROM " + TABLE_NAME_FEED_ITEMS + " fi"
-                        + "  WHERE fi." + KEY_FEED + " = " + TABLE_NAME_FEEDS + "." + KEY_ID
-                        + "    AND fi." + KEY_READ + " != " + FeedItem.PLAYED
-                        + "    AND fi." + KEY_PUBDATE + " >= " + sixMonthsAgo
-                + " ) THEN 1 ELSE 0 END AS has_recent_unplayed "
+                        + "SUM(CASE WHEN "
+                        + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + " != " + FeedItem.PLAYED
+                        + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " >= " + sixMonthsAgo
+                        + " THEN 1 ELSE 0 END) AS num_recent_unplayed "
                 + " FROM " + TABLE_NAME_FEED_ITEMS
                 + JOIN_FEED_ITEM_AND_MEDIA
                 + " INNER JOIN " + TABLE_NAME_FEEDS

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/StatisticsItem.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/StatisticsItem.java
@@ -45,10 +45,4 @@ public class StatisticsItem {
         this.episodesDownloadCount = episodesDownloadCount;
         this.hasRecentUnplayed = hasRecentUnplayed;
     }
-
-    public StatisticsItem(Feed feed, long time, long timePlayed,
-                          long episodes, long episodesStarted,
-                          long totalDownloadSize, long episodesDownloadCount) {
-        this(feed, time, timePlayed, episodes, episodesStarted, totalDownloadSize, episodesDownloadCount, false);
-    }
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/StatisticsItem.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/StatisticsItem.java
@@ -31,9 +31,11 @@ public class StatisticsItem {
      */
     public final long episodesDownloadCount;
 
+    public final boolean hasRecentUnplayed;
+
     public StatisticsItem(Feed feed, long time, long timePlayed,
                           long episodes, long episodesStarted,
-                          long totalDownloadSize, long episodesDownloadCount) {
+                          long totalDownloadSize, long episodesDownloadCount, boolean hasRecentUnplayed) {
         this.feed = feed;
         this.time = time;
         this.timePlayed = timePlayed;
@@ -41,5 +43,12 @@ public class StatisticsItem {
         this.episodesStarted = episodesStarted;
         this.totalDownloadSize = totalDownloadSize;
         this.episodesDownloadCount = episodesDownloadCount;
+        this.hasRecentUnplayed = hasRecentUnplayed;
+    }
+
+    public StatisticsItem(Feed feed, long time, long timePlayed,
+                          long episodes, long episodesStarted,
+                          long totalDownloadSize, long episodesDownloadCount) {
+        this(feed, time, timePlayed, episodes, episodesStarted, totalDownloadSize, episodesDownloadCount, false);
     }
 }

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
@@ -8,11 +8,8 @@ import de.danoeh.antennapod.storage.database.StatisticsItem;
 import de.danoeh.antennapod.ui.echo.R;
 import de.danoeh.antennapod.ui.echo.background.WavesBackground;
 import de.danoeh.antennapod.ui.echo.databinding.SimpleEchoScreenBinding;
-import de.danoeh.antennapod.model.feed.FeedItem;
-import de.danoeh.antennapod.model.feed.FeedItemFilter;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class HoarderScreen extends EchoScreen {
     private final SimpleEchoScreenBinding viewBinding;

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
@@ -66,19 +66,6 @@ public class HoarderScreen extends EchoScreen {
             // Therefore, we need to explicitly load the episode list from the DB and set it to the Feed here.
             List<FeedItem> episodes = de.danoeh.antennapod.storage.database.DBReader.getFeedItemList(item.feed, new FeedItemFilter(), null, 0, Integer.MAX_VALUE);
             item.feed.setItems(episodes);
-            if (item.feed.getItems() != null) {
-                for (FeedItem episode : item.feed.getItems()) {
-                    if (episode.getPubDate() != null &&
-                        episode.getPubDate().getTime() >= sixMonthsAgo &&
-                        !episode.isPlayed()) {
-                        String title = item.feed.getTitle();
-                        if (title == null || title.isEmpty()) {
-                            title = item.feed.getFeedIdentifier();
-                        }
-                        unplayedActive.add(title);
-                    }
-                }
-            }
             if (item.feed.getPreferences().getKeepUpdated()) {
                 totalActivePodcasts++;
                 if (item.timePlayed > 0) {

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.ui.echo.screen;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -64,7 +65,7 @@ public class HoarderScreen extends EchoScreen {
                     playedActivePodcasts++;
                 } else if (item.hasRecentUnplayed) {
                     String title = item.feed.getTitle();
-                    if (title == null || title.isEmpty()) {
+                    if (TextUtils.isEmpty(title)) {
                         title = item.feed.getFeedIdentifier();
                     }
                     unplayedActive.add(title);

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
@@ -60,42 +60,22 @@ public class HoarderScreen extends EchoScreen {
         int playedActivePodcasts = 0;
         String randomUnplayedActivePodcast = "";
         ArrayList<String> unplayedActive = new ArrayList<>();
-        long sixMonthsAgo = System.currentTimeMillis() - (long) (1000L * 3600 * 24 * 30.44 * 6);
         for (StatisticsItem item : statisticsResult.feedTime) {
-            // The Feed objects returned by DBReader.getStatistics() do not contain episode lists (items).
-            // Therefore, we need to explicitly load the episode list from the DB and set it to the Feed here.
-            List<FeedItem> episodes = de.danoeh.antennapod.storage.database.DBReader.getFeedItemList(
-                    item.feed, new FeedItemFilter(), null, 0, Integer.MAX_VALUE);
-            item.feed.setItems(episodes);
             if (item.feed.getPreferences().getKeepUpdated()) {
                 totalActivePodcasts++;
                 if (item.timePlayed > 0) {
                     playedActivePodcasts++;
-                } else {
-                    boolean hasRecentUnplayedEpisode = false;
-                    if (item.feed.getItems() != null) {
-                        for (FeedItem episode : item.feed.getItems()) {
-                            if (episode.getPubDate() != null
-                                    && episode.getPubDate().getTime() >= sixMonthsAgo
-                                    && !episode.isPlayed()) {
-                                hasRecentUnplayedEpisode = true;
-                                break;
-                            }
-                        }
+                } else if (item.hasRecentUnplayed) {
+                    String title = item.feed.getTitle();
+                    if (title == null || title.isEmpty()) {
+                        title = item.feed.getFeedIdentifier();
                     }
-                    if (hasRecentUnplayedEpisode) {
-                        String title = item.feed.getTitle();
-                        if (title == null || title.isEmpty()) {
-                            title = item.feed.getFeedIdentifier();
-                        }
-                        unplayedActive.add(title);
-                    }
+                    unplayedActive.add(title);
                 }
             }
         }
         if (!unplayedActive.isEmpty()) {
-            randomUnplayedActivePodcast = unplayedActive.get(
-                    (int) (Math.random() * unplayedActive.size()));
+            randomUnplayedActivePodcast = unplayedActive.get((int) (Math.random() * unplayedActive.size()));
         }
         display(playedActivePodcasts, totalActivePodcasts, randomUnplayedActivePodcast);
     }

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/HoarderScreen.java
@@ -60,11 +60,12 @@ public class HoarderScreen extends EchoScreen {
         int playedActivePodcasts = 0;
         String randomUnplayedActivePodcast = "";
         ArrayList<String> unplayedActive = new ArrayList<>();
-        long sixMonthsAgo = System.currentTimeMillis() - (long)(1000L * 3600 * 24 * 30.44 * 6);
+        long sixMonthsAgo = System.currentTimeMillis() - (long) (1000L * 3600 * 24 * 30.44 * 6);
         for (StatisticsItem item : statisticsResult.feedTime) {
             // The Feed objects returned by DBReader.getStatistics() do not contain episode lists (items).
             // Therefore, we need to explicitly load the episode list from the DB and set it to the Feed here.
-            List<FeedItem> episodes = de.danoeh.antennapod.storage.database.DBReader.getFeedItemList(item.feed, new FeedItemFilter(), null, 0, Integer.MAX_VALUE);
+            List<FeedItem> episodes = de.danoeh.antennapod.storage.database.DBReader.getFeedItemList(
+                    item.feed, new FeedItemFilter(), null, 0, Integer.MAX_VALUE);
             item.feed.setItems(episodes);
             if (item.feed.getPreferences().getKeepUpdated()) {
                 totalActivePodcasts++;
@@ -74,9 +75,9 @@ public class HoarderScreen extends EchoScreen {
                     boolean hasRecentUnplayedEpisode = false;
                     if (item.feed.getItems() != null) {
                         for (FeedItem episode : item.feed.getItems()) {
-                            if (episode.getPubDate() != null &&
-                                episode.getPubDate().getTime() >= sixMonthsAgo &&
-                                !episode.isPlayed()) {
+                            if (episode.getPubDate() != null
+                                    && episode.getPubDate().getTime() >= sixMonthsAgo
+                                    && !episode.isPlayed()) {
                                 hasRecentUnplayedEpisode = true;
                                 break;
                             }
@@ -93,7 +94,8 @@ public class HoarderScreen extends EchoScreen {
             }
         }
         if (!unplayedActive.isEmpty()) {
-            randomUnplayedActivePodcast = unplayedActive.get((int) (Math.random() * unplayedActive.size()));
+            randomUnplayedActivePodcast = unplayedActive.get(
+                    (int) (Math.random() * unplayedActive.size()));
         }
         display(playedActivePodcasts, totalActivePodcasts, randomUnplayedActivePodcast);
     }


### PR DESCRIPTION
### Description
Fixes #7547

This PR updates the Echo "check out again" recommendation logic.  
Now, only podcasts that have released at least one episode in the past 6 months and still have unplayed episodes are suggested.  
If a podcast title is empty, the feed identifier is used as a fallback.

Manually tested: The Echo screen now only suggests appropriate podcasts, and titles are displayed correctly.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
