### PR TITLE
Work around crashing WebView on GrapheneOS

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/view/ShownotesWebView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/ShownotesWebView.java
@@ -10,13 +10,17 @@ import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.ContextMenu;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import android.widget.TextView;
 import androidx.core.content.ContextCompat;
 import androidx.core.util.Consumer;
 
@@ -86,6 +90,26 @@ public class ShownotesWebView extends WebView implements View.OnLongClickListene
                 if (pageFinishedListener != null) {
                     pageFinishedListener.run();
                 }
+            }
+
+            @Override
+            public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+                ViewGroup parent = (ViewGroup) view.getParent();
+                if (parent == null) {
+                    return true;
+                }
+                ViewGroup.LayoutParams params = parent.getLayoutParams();
+                TextView errorText = new TextView(getContext());
+                int position = parent.indexOfChild(view);
+                parent.removeView(view);
+                parent.addView(errorText, position, params);
+                int padding = (int) (40 * getContext().getResources().getDisplayMetrics().density);
+                errorText.setPadding(padding, padding, padding, padding);
+                errorText.setGravity(Gravity.CENTER);
+                errorText.setTextAlignment(TextView.TEXT_ALIGNMENT_CENTER);
+                errorText.setText("Your Android System WebView crashed. Try restarting the phone. If this happens "
+                        + "repeatedly, contact the phone manufacturer or the creator of your custom ROM.");
+                return true;
             }
         });
     }


### PR DESCRIPTION
### Description

Work around crashing WebView. I have only seen repeated WebView crashes on GrapheneOS, but maybe this also helps other systems.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
