### PR TITLE
Enable copying podcast title and host #7809

### DIFF
--- a/app/src/main/res/layout/feeditem_fragment.xml
+++ b/app/src/main/res/layout/feeditem_fragment.xml
@@ -55,6 +55,7 @@
                     android:textColor="?android:attr/textColorPrimary"
                     android:ellipsize="end"
                     android:maxLines="5"
+                    android:textIsSelectable="true"
                     tools:text="@sample/episodes.json/data/title" />
 
                 <LinearLayout

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -131,6 +131,7 @@
                 android:shadowRadius="2"
                 android:textColor="@color/white"
                 style="@style/AntennaPod.TextView.Heading"
+                android:textIsSelectable="true"
                 tools:text="Podcast title" />
 
             <TextView
@@ -143,6 +144,7 @@
                 android:shadowRadius="2"
                 android:textColor="@color/white"
                 android:textSize="@dimen/text_size_small"
+                android:textIsSelectable="true"
                 tools:text="Podcast author" />
 
         </LinearLayout>


### PR DESCRIPTION
Closes #7809

### Description

Added **android:textIsSelectable** in 
`<TextView
                    android:id="@+id/txtvTitle"
                    android:textIsSelectable="true" 
... />`

located at _feeditem_fragment.xml_. This makes episode's title selectable inside **ItemFragment**.

Also added **android:textIsSelectable** in 
`<TextView
                android:id="@+id/txtvTitle"
                android:textIsSelectable="true"
                ... />`

and 

`<TextView
                android:id="@+id/txtvAuthor"
                android:textIsSelectable="true"
                ... />`

located at _feeditemlist_header.xml_. This makes podcasts title and author selectable inside **FeedInfoFragment**.
 
### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
