### PR TITLE
Fix scroll position in episode list of podcast preview

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -104,6 +104,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     private Feed feed;
     private Disposable disposable;
     private FeedItemListFragmentBinding viewBinding;
+    private Pair<Integer, Integer> scrollPosition = null;
 
     /**
      * Creates new ItemlistFragment which shows the Feeditems of a specific
@@ -246,6 +247,12 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         }
         viewBinding.recyclerView.setPadding(viewBinding.recyclerView.getPaddingLeft(), 0,
                 viewBinding.recyclerView.getPaddingRight(), paddingBottom);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        scrollPosition = getScrollPosition();
     }
 
     @Override
@@ -654,6 +661,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                         adapter.updateItems(feed.getItems());
                         adapter.setTotalNumberOfItems(result.second);
                         updateToolbar();
+                        restoreScrollPosition(scrollPosition);
                     }, error -> {
                         feed = null;
                         refreshHeaderView();
@@ -711,6 +719,14 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             default:
                 break;
         }
+    }
+
+    private Pair<Integer, Integer> getScrollPosition() {
+        return viewBinding.recyclerView.getScrollPosition();
+    }
+
+    private void restoreScrollPosition(Pair<Integer, Integer> scrollPosition) {
+        viewBinding.recyclerView.restoreScrollPosition(scrollPosition);
     }
 
     private class FeedItemListAdapter extends EpisodeItemListAdapter {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -662,6 +662,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                         adapter.setTotalNumberOfItems(result.second);
                         updateToolbar();
                         viewBinding.recyclerView.restoreScrollPosition(scrollPosition);
+                        scrollPosition = null;
                     }, error -> {
                         feed = null;
                         refreshHeaderView();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -661,7 +661,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                         adapter.updateItems(feed.getItems());
                         adapter.setTotalNumberOfItems(result.second);
                         updateToolbar();
-                        restoreScrollPosition(scrollPosition);
+                        viewBinding.recyclerView.restoreScrollPosition(scrollPosition);
                     }, error -> {
                         feed = null;
                         refreshHeaderView();
@@ -719,10 +719,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             default:
                 break;
         }
-    }
-
-    private void restoreScrollPosition(Pair<Integer, Integer> scrollPosition) {
-        viewBinding.recyclerView.restoreScrollPosition(scrollPosition);
     }
 
     private class FeedItemListAdapter extends EpisodeItemListAdapter {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -267,11 +267,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-    }
-
-    @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
         super.onSaveInstanceState(outState);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -252,7 +252,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     @Override
     public void onPause() {
         super.onPause();
-        scrollPosition = getScrollPosition();
+        scrollPosition = viewBinding.recyclerView.getScrollPosition();
     }
 
     @Override
@@ -264,6 +264,11 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             disposable.dispose();
         }
         adapter.endSelectMode();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
     }
 
     @Override
@@ -719,10 +724,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             default:
                 break;
         }
-    }
-
-    private Pair<Integer, Integer> getScrollPosition() {
-        return viewBinding.recyclerView.getScrollPosition();
     }
 
     private void restoreScrollPosition(Pair<Integer, Integer> scrollPosition) {

--- a/app/src/main/res/layout/feed_item_list_fragment.xml
+++ b/app/src/main/res/layout/feed_item_list_fragment.xml
@@ -2,6 +2,7 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinatorLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">


### PR DESCRIPTION
### Description
When viewing episodes in what I think is the podcast preview screen / BottomSheet, the scroll position is now being remembered when viewing details of an episode and going back.

Closes #7767

| <img src="https://github.com/user-attachments/assets/8a78af44-8689-406d-aff7-16cbd22dbfc0" width="200"/> | <img src="https://github.com/user-attachments/assets/9d2e9938-a766-4d55-bc3f-65c54dc64e82" width="200"/> | <img src="https://github.com/user-attachments/assets/9b0dfada-27e9-4666-bbcc-bb992dc70580" width="200"/> |
|---|---|---|



### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] If it is a core feature, I have added automated tests
