### PR TITLE
Communicate to user if db backup files could not be deleted

### DIFF
--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/AutomaticDatabaseExportWorker.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/AutomaticDatabaseExportWorker.java
@@ -98,7 +98,7 @@ public class AutomaticDatabaseExportWorker extends Worker {
             }
         }
         if (hasDeletionFailed) {
-            throw new IOException("Unable to delete some db backup files");
+            throw new IOException("Unable to delete some database backup files");
         }
     }
 

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/AutomaticDatabaseExportWorker.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/AutomaticDatabaseExportWorker.java
@@ -90,8 +90,15 @@ public class AutomaticDatabaseExportWorker extends Worker {
             }
         }
         Collections.sort(files, (o1, o2) -> Long.compare(o2.lastModified(), o1.lastModified()));
+        boolean hasDeletionFailed = false;
         for (int i = 5; i < files.size(); i++) {
-            files.get(i).delete();
+            boolean isDeleted = files.get(i).delete();
+            if (!hasDeletionFailed && !isDeleted) {
+                hasDeletionFailed = true;
+            }
+        }
+        if (hasDeletionFailed) {
+            throw new IOException("Unable to delete some db backup files");
         }
     }
 


### PR DESCRIPTION
### Description

One user reports that, when enabling automatic database export, files get created but not deleted. This is somewhat  hard to debug without direct access to that users phone.
Also, there is currently no code to check if deletion was actually successfull. Instead it is assumed that it always succeeds when a directory can be written to, which might be wrong for some devices.

This PR adds code to check if backup files could be deleted and show an error message to the user if not. This could be used as a starting point for further investigation.

Supports #7869

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code
- [X] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] If it is a core feature, I have added automated tests
