### PR TITLE
Let proguard keep needed RxJava and fyydlin files for Fyyd search 

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -31,7 +31,11 @@
 # android-iconify
 -keep class com.joanzapata.** { *; }
 
+# RxJava
+-keep,allowobfuscation,allowshrinking class io.reactivex.Single
+
 #### Proguard rules for fyyd client
+-keep class de.mfietz.fyydlin.** { *; }
 # Retrofit 2.0
 -dontwarn retrofit2.**
 -keep class retrofit2.** { *; }

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -32,7 +32,7 @@
 -keep class com.joanzapata.** { *; }
 
 # RxJava
--keep,allowobfuscation,allowshrinking class io.reactivex.Single
+-keep class io.reactivex.Single
 
 #### Proguard rules for fyyd client
 -keep class de.mfietz.fyydlin.** { *; }


### PR DESCRIPTION
### Description

Proguard removed some classes the app needed for the Fyyd search.

Closes #7866

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code
- [X] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] If it is a core feature, I have added automated tests
