### PR TITLE
Android Auto: Current tab icon and visibility fixes

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -428,7 +428,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (parentId.equals(getResources().getString(R.string.app_name))) {
             FeedMedia playable = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
             if (playable != null) {
-                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode, R.drawable.ic_play_48dp, 1));
+                mediaItems.add(createBrowsableMediaItem(R.string.current_playing_episode, R.drawable.ic_play_48dp_black, 1));
             }
             mediaItems.add(createBrowsableMediaItem(R.string.queue_label, R.drawable.ic_playlist_play_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));

--- a/ui/common/src/main/res/drawable/ic_play_48dp_black.xml
+++ b/ui/common/src/main/res/drawable/ic_play_48dp_black.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path android:fillColor="#000000" android:pathData="M8,5v14l11,-7z"/>
+</vector>


### PR DESCRIPTION
### Description

This fixes two minor bugs with the _Current_ tab in Android Auto ([originally noted on the forum](https://forum.antennapod.org/t/android-auto-assorted-quirks/6846#p-19744-additional-small-quirks-1)):

* The _Current_ tab’s icon (▶) doesn’t display because its colour is based on a theme variable which presumably isn’t available in AA’s style. This should just be a plain black icon for tabs, which is then inverted in AA.

* I keep seeing an empty _Current_ tab – there are two different detections for whether to show the tab vs. which feed item to display, and the latter lookup is probably more suitable to also use when deciding whether to show the tab or not.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
  - Ditto last time -- lint passes, checkstyle and spotbugs seem to fail to run locally
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
