### PR TITLE
Android Auto: Grid view for subscriptions

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -445,14 +445,14 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED)), false));
             mediaItems.add(createBrowsableMediaItem(R.string.downloads_label, R.drawable.ic_download_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.DOWNLOADED)), false));
+            mediaItems.add(createBrowsableMediaItem(R.string.episodes_label, R.drawable.ic_feed_black,
+                    DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.UNPLAYED)), false));
             mediaItems.add(createBrowsableMediaItem(R.string.subscriptions_label, R.drawable.ic_subscriptions_black,
                     DBReader.getFeedList().size(), true));
             return mediaItems;
         }
 
         if (parentId.equals(getResources().getString(R.string.subscriptions_label))) {
-            mediaItems.add(createBrowsableMediaItem(R.string.episodes_label, R.drawable.ic_feed_black,
-                    DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.UNPLAYED)), false));
             List<Feed> feeds = DBReader.getFeedList();
             for (Feed feed : feeds) {
                 if (feed.getState() == Feed.STATE_SUBSCRIBED) {

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -434,6 +434,12 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.QUEUED))));
             mediaItems.add(createBrowsableMediaItem(R.string.downloads_label, R.drawable.ic_download_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.DOWNLOADED))));
+            mediaItems.add(createBrowsableMediaItem(R.string.subscriptions_label, R.drawable.ic_subscriptions_black,
+                    DBReader.getFeedList().size()));
+            return mediaItems;
+        }
+
+        if (parentId.equals(getResources().getString(R.string.subscriptions_label))) {
             mediaItems.add(createBrowsableMediaItem(R.string.episodes_label, R.drawable.ic_feed_black,
                     DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.UNPLAYED))));
             List<Feed> feeds = DBReader.getFeedList();


### PR DESCRIPTION
### Description

This reorganises the media tree for Android Auto so that subscriptions are in a dedicated section which is hinted to display as a grid layout ([originally suggested on the forum](https://forum.antennapod.org/t/android-auto-assorted-quirks/6846#p-19744-grid-view-for-subscriptions-2) -- seeing as I had the change prepared already, hopefully you won't mind me coming straight in with the PR; obviously happy to discuss alternatives).  Original context:

I’d find it a lot easier to scroll through the subscription list by thumbnail than by name. By making subscriptions a dedicated tab (instead of AA constructing the _More_ menu), its layout can be set to a grid, similar to the main Android app:

![Grid view for subscriptions](https://forum.antennapod.org/uploads/default/original/2X/d/d755483356a3554e83800e056d752a83b98a4dea.jpeg)

Note that the _A-Z_ button produces a list view after you pick a letter, so it’s technically possible to still get a list if you want it.

The _Episodes_ menu is here rather than beside _Subscriptions_ so that we don't overflow the top level capacity of 4 when _Current_ is present.  As it will always display the large icon without a palette flip when outside of the top menu, I suspect it will need swapping out for a white icon rather than black.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
  - Ditto last time -- lint passes, checkstyle and spotbugs seem to fail to run locally
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
