### PR TITLE
Fix: Prevent error icon from overlapping title text (#7571)

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
@@ -262,15 +262,7 @@ public class NavListAdapter extends RecyclerView.Adapter<NavListAdapter.Holder>
                     .dontAnimate())
                 .into(holder.image);
 
-        if (feed.hasLastUpdateFailed()) {
-            RelativeLayout.LayoutParams p = (RelativeLayout.LayoutParams) holder.title.getLayoutParams();
-            p.addRule(RelativeLayout.LEFT_OF, R.id.itxtvFailure);
-            holder.failure.setVisibility(View.VISIBLE);
-        } else {
-            RelativeLayout.LayoutParams p = (RelativeLayout.LayoutParams) holder.title.getLayoutParams();
-            p.addRule(RelativeLayout.LEFT_OF, R.id.txtvCount);
-            holder.failure.setVisibility(View.GONE);
-        }
+        holder.failure.setVisibility(feed.hasLastUpdateFailed() ? View.VISIBLE : View.GONE);
     }
 
     private void bindTagView(NavDrawerData.TagDrawerItem tag, FeedHolder holder) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavListAdapter.java
@@ -11,7 +11,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -8,6 +8,7 @@
     android:orientation="vertical"
     android:layout_marginHorizontal="8dp"
     android:background="@drawable/bg_drawer_item">
+
     <ImageView
         android:id="@+id/imgvCover"
         android:layout_width="@dimen/thumbnail_length_navlist"
@@ -24,6 +25,7 @@
         android:cropToPadding="true"
         android:scaleType="centerInside"
         tools:src="@drawable/ic_download_black" />
+
     <TextView
         android:id="@+id/txtvTitle"
         android:layout_width="wrap_content"
@@ -43,32 +45,36 @@
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="@dimen/text_size_navdrawer"
         tools:text="Navigation item title" />
+
     <LinearLayout
-            android:id="@+id/rightGroup"
+        android:id="@+id/rightGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/itxtvFailure"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            >
-        <ImageView
-                android:id="@+id/itxtvFailure"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:visibility="gone"
-                android:contentDescription="@string/refresh_failed_msg"
-                app:srcCompat="@drawable/ic_error"
-                tools:text="!" />
+            android:layout_marginEnd="8dp"
+            android:visibility="gone"
+            android:contentDescription="@string/refresh_failed_msg"
+            app:srcCompat="@drawable/ic_error"
+            tools:text="!" />
+
         <TextView
-                android:id="@+id/txtvCount"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:lines="1"
-                android:padding="8dp"
-                android:textColor="?android:attr/textColorTertiary"
-                android:textSize="14sp"
-                tools:text="23" />
+            android:id="@+id/txtvCount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:lines="1"
+            android:padding="8dp"
+            android:textColor="?android:attr/textColorTertiary"
+            android:textSize="14sp"
+            tools:text="23" />
+
     </LinearLayout>
+
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -8,7 +8,6 @@
     android:orientation="vertical"
     android:layout_marginHorizontal="8dp"
     android:background="@drawable/bg_drawer_item">
-
     <ImageView
         android:id="@+id/imgvCover"
         android:layout_width="@dimen/thumbnail_length_navlist"
@@ -25,7 +24,6 @@
         android:cropToPadding="true"
         android:scaleType="centerInside"
         tools:src="@drawable/ic_download_black" />
-
     <TextView
         android:id="@+id/txtvTitle"
         android:layout_width="wrap_content"
@@ -45,7 +43,6 @@
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="@dimen/text_size_navdrawer"
         tools:text="Navigation item title" />
-
     <LinearLayout
             android:id="@+id/rightGroup"
             android:layout_width="wrap_content"
@@ -55,7 +52,6 @@
             android:orientation="horizontal"
             android:gravity="center_vertical"
             >
-
         <ImageView
                 android:id="@+id/itxtvFailure"
                 android:layout_width="wrap_content"
@@ -65,7 +61,6 @@
                 android:contentDescription="@string/refresh_failed_msg"
                 app:srcCompat="@drawable/ic_error"
                 tools:text="!" />
-
         <TextView
                 android:id="@+id/txtvCount"
                 android:layout_width="wrap_content"
@@ -75,6 +70,5 @@
                 android:textColor="?android:attr/textColorTertiary"
                 android:textSize="14sp"
                 tools:text="23" />
-
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -33,8 +33,8 @@
         android:layout_centerVertical="true"
         android:layout_marginStart="@dimen/listitem_iconwithtext_textleftpadding"
         android:layout_marginLeft="@dimen/listitem_iconwithtext_textleftpadding"
-        android:layout_marginEnd="48dp"
-        android:layout_marginRight="48dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
         android:layout_toEndOf="@id/imgvCover"
         android:layout_toRightOf="@id/imgvCover"
         android:layout_toStartOf="@+id/rightGroup"
@@ -63,7 +63,8 @@
             android:visibility="gone"
             android:contentDescription="@string/refresh_failed_msg"
             app:srcCompat="@drawable/ic_error"
-            tools:text="!" />
+            tools:text="!"
+            tools:visibility="visible" />
 
         <TextView
             android:id="@+id/txtvCount"

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -37,6 +37,8 @@
         android:layout_marginRight="48dp"
         android:layout_toEndOf="@id/imgvCover"
         android:layout_toRightOf="@id/imgvCover"
+        android:layout_toStartOf="@+id/rightGroup"
+        android:layout_toLeftOf="@+id/rightGroup"
         android:ellipsize="end"
         android:lines="1"
         android:singleLine="true"
@@ -44,38 +46,40 @@
         android:textSize="@dimen/text_size_navdrawer"
         tools:text="Navigation item title" />
 
-    <ImageView
-        android:id="@+id/itxtvFailure"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignWithParentIfMissing="true"
-        android:layout_centerVertical="true"
-        android:layout_marginStart="@dimen/list_vertical_padding"
-        android:layout_marginLeft="@dimen/list_vertical_padding"
-        android:layout_marginEnd="@dimen/list_vertical_padding"
-        android:layout_marginRight="@dimen/list_vertical_padding"
-        android:layout_toStartOf="@id/txtvCount"
-        android:layout_toLeftOf="@id/txtvCount"
-        android:visibility="gone"
-        android:contentDescription="@string/refresh_failed_msg"
-        app:srcCompat="@drawable/ic_error"
-        tools:text="!" />
+    <LinearLayout
+            android:id="@+id/rightGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            >
 
-    <TextView
-        android:id="@+id/txtvCount"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_centerVertical="true"
-        android:layout_marginStart="4dp"
-        android:layout_marginLeft="4dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
-        android:lines="1"
-        android:padding="8dp"
-        android:textColor="?android:attr/textColorTertiary"
-        android:textSize="14sp"
-        tools:text="23" />
+        <ImageView
+                android:id="@+id/itxtvFailure"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:visibility="gone"
+                android:contentDescription="@string/refresh_failed_msg"
+                app:srcCompat="@drawable/ic_error"
+                tools:text="!" />
+
+        <TextView
+                android:id="@+id/txtvCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:lines="1"
+                android:padding="8dp"
+                android:textColor="?android:attr/textColorTertiary"
+                android:textSize="14sp"
+                tools:text="23" />
+
+    </LinearLayout>
+
+
+
+
 
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -77,9 +77,4 @@
                 tools:text="23" />
 
     </LinearLayout>
-
-
-
-
-
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -53,6 +53,8 @@
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:orientation="horizontal"
+        android:layout_marginRight="8dp"
+        android:layout_marginEnd="8dp"
         android:gravity="center_vertical">
 
         <ImageView


### PR DESCRIPTION
### Description
This PR fixes the UI issue where the title text and icons in the right group would overlap when both the error icon and inbox count were present. Previously, the layout did not properly space out these elements, leading to visual overlap.

In addition to fixing this, I’ve implemented a small UX improvement:
Rather than statically reserving space for the error icon (even when not shown), the layout now dynamically adjusts spacing. This avoids unnecessary truncation  of the title when there's no error icon, improving readability without affecting functionality.

Closes: #7571

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
