### PR TITLE
fix bottomNavigation not updating when app is launched through shortcut

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -481,8 +481,11 @@ public class MainActivity extends CastEnabledActivity {
         }
     }
 
-    public void loadChildFragment(Fragment fragment, TransitionEffect transition) {
+    public void loadChildFragment(Fragment fragment, TransitionEffect transition, String navigationTag) {
         Validate.notNull(fragment);
+        if (navigationTag != null && bottomNavigation != null) {
+            bottomNavigation.updateSelectedItem(navigationTag);
+        }
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
         if (transition == TransitionEffect.FADE) {
@@ -500,6 +503,10 @@ public class MainActivity extends CastEnabledActivity {
                 .add(R.id.main_content_view, fragment, MAIN_FRAGMENT_TAG)
                 .addToBackStack(null)
                 .commit();
+    }
+
+    public void loadChildFragment(Fragment fragment, TransitionEffect transition) {
+        loadChildFragment(fragment, transition, null);
     }
 
     public void loadChildFragment(Fragment fragment) {
@@ -688,7 +695,7 @@ public class MainActivity extends CastEnabledActivity {
                 if (intent.getBooleanExtra(MainActivityStarter.EXTRA_CLEAR_BACK_STACK, false)) {
                     loadFragment(tag, null);
                 } else {
-                    loadChildFragment(createFragmentInstance(tag, args));
+                    loadChildFragment(createFragmentInstance(tag, args), TransitionEffect.NONE, tag);
                 }
             }
             sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);


### PR DESCRIPTION
### Description
This PR directly addresses #7898

When MainActivity is launched through shortcuts, this code gets executed

https://github.com/AntennaPod/AntennaPod/blob/cfd9e1f8862cd2175fc0a2a184196582664691ae/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java#L684-L693

The problem is in the line `loadChildFragment(createFragmentInstance(tag, args));`, which does not update bottom navigation upon call.

To fix it, I added a third optional argument to `MainActivity.loadChildFragment`, called `navigationTag`, which refreshes bottomNavigation if the argument is not `null`. Tested and working

fixes #7898

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
