### PR TITLE
Work around VTT files using single-digit hours

### DIFF
--- a/parser/transcript/src/main/java/de/danoeh/antennapod/parser/transcript/VttTranscriptParser.java
+++ b/parser/transcript/src/main/java/de/danoeh/antennapod/parser/transcript/VttTranscriptParser.java
@@ -19,7 +19,7 @@ import de.danoeh.antennapod.model.feed.TranscriptSegment;
 
 public class VttTranscriptParser {
     private static final Pattern TIMESTAMP_PATTERN =
-            Pattern.compile("^(?:([0-9]{2}):)?([0-9]{2}):([0-9]{2})\\.([0-9]{3})$");
+            Pattern.compile("^(?:([0-9]{1,2}):)?([0-9]{2}):([0-9]{2})\\.([0-9]{3})$");
 
     private static final Pattern VOICE_SPAN =
             Pattern.compile("<v(?:\\.[^\\t\\n\\r &<>.]+)*[ \\t]([^\\n\\r&>]+)>");


### PR DESCRIPTION
### Description
I stumbled upon this podcast while testing transcript for another PR, called `Aaron Mahnke's Cabinet of Curiosities`.
You can add the podcast through [this url](https://omnycontent.com/d/playlist/e73c998e-6e60-432f-8610-ae210140c5b1/E062C374-9A39-42FA-888F-AE2C007B3C85/F0F95FE5-D5DE-4ABE-ADA4-AE2C007B3C8E/podcast.rss)
Transcript is supported, but it shows empty.

<details>
<summary>Screenshot</summary>
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/2214332e-ef61-4b42-81ab-c0971d988f58" />
</details>

The root cause of the issue ? The hours in the timestamp, being 1 digit long (0 instead of 00).
Here's a comparison between [a standard transcript file](https://podnews.net/audio/podnews250804.mp3.vtt), and [the transcript file of an episode](https://api.omny.fm/orgs/e73c998e-6e60-432f-8610-ae210140c5b1/clips/79c22e66-010a-44a1-a7a4-b2fe0135e81a/transcript?format=WebVTT&t=1750099859) from this podcast.

#### Standard Transcript File
```
WEBVTT - Episode Name

00:00:00.540 --> 00:00:03.980
 Text goes here...
```

#### This Podcast's Transcript File
```
WEBVTT - Citrus at Sea

0:00:04.080 --> 0:00:07.440
  Text goes here...
```
As you can compare timestamps, there is `00:00:00.540` (standard) vs `0:00:04.080` (this podcast)

That's why I changed the timestamp regex pattern from
```
^(?:([0-9]{2}):)?([0-9]{2}):([0-9]{2})\.([0-9]{3})$
```

To
```
^(?:([0-9]{1,2}):)?([0-9]{2}):([0-9]{2})\.([0-9]{3})$
```
To account for both cases, and as expected the issue is fixed

<details>
<summary>Screenshot</summary>

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/a4864e84-a67e-4e79-9541-7d96beca9c2d" />

</details>

### Suggestion of Further Improvement

Should I also change the pattern to account for a variable number of digits in minutes, seconds and milliseconds too ? (cases like `00:0:04.080`, `00:00:04.0`, and so on) ?

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
