### PR TITLE
Fix I/O on main thread in ItemDescriptionFragment

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ItemDescriptionFragment.java
@@ -15,6 +15,7 @@ import androidx.fragment.app.Fragment;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.storage.database.DBReader;
+import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.ui.cleaner.ShownotesCleaner;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.playback.Playable;
@@ -127,11 +128,10 @@ public class ItemDescriptionFragment extends Fragment {
         Log.d(TAG, "Saving preferences");
         SharedPreferences prefs = getActivity().getSharedPreferences(PREF, Activity.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
-        if (controller != null && controller.getMedia() != null && webvDescription != null) {
+        if (controller != null && webvDescription != null) {
             Log.d(TAG, "Saving scroll position: " + webvDescription.getScrollY());
             editor.putInt(PREF_SCROLL_Y, webvDescription.getScrollY());
-            editor.putString(PREF_PLAYABLE_ID, controller.getMedia().getIdentifier()
-                    .toString());
+            editor.putString(PREF_PLAYABLE_ID, "" + PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
         } else {
             Log.d(TAG, "savePreferences was called while media or webview was null");
             editor.putInt(PREF_SCROLL_Y, -1);
@@ -140,22 +140,20 @@ public class ItemDescriptionFragment extends Fragment {
         editor.apply();
     }
 
-    private boolean restoreFromPreference() {
+    private void restoreFromPreference() {
         Log.d(TAG, "Restoring from preferences");
         Activity activity = getActivity();
         if (activity != null) {
             SharedPreferences prefs = activity.getSharedPreferences(PREF, Activity.MODE_PRIVATE);
             String id = prefs.getString(PREF_PLAYABLE_ID, "");
             int scrollY = prefs.getInt(PREF_SCROLL_Y, -1);
-            if (controller != null && scrollY != -1 && controller.getMedia() != null
-                    && id.equals(controller.getMedia().getIdentifier().toString())
+            if (controller != null && scrollY != -1
+                    && id.equals("" + PlaybackPreferences.getCurrentlyPlayingFeedMediaId())
                     && webvDescription != null) {
                 Log.d(TAG, "Restored scroll Position: " + scrollY);
                 webvDescription.scrollTo(webvDescription.getScrollX(), scrollY);
-                return true;
             }
         }
-        return false;
     }
 
     public void scrollToTop() {


### PR DESCRIPTION
### Description

Fix I/O on main thread in ItemDescriptionFragment. That's currently the top crash in Google Play Console.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
