### PR TITLE
Add 10 minute option to "smart mark as played"

### DIFF
--- a/ui/preferences/src/main/res/values/arrays.xml
+++ b/ui/preferences/src/main/res/values/arrays.xml
@@ -101,6 +101,7 @@
         <item>60</item>
         <item>120</item>
         <item>300</item>
+        <item>600</item>
     </string-array>
 
 


### PR DESCRIPTION
### Description
Some of my podcasts list every single Patreon subscriber at a certain level in the outro (exhausting, I know). This can take up to 10 minutes, and when I skip to the next episode, I want this episode to be marked as "played". This is not possible currently as the maximum "smart mark as played" setting is 5 minutes. This PR adds a 10 minute option

Motivating example: 
<img height="400" alt="image" src="https://github.com/user-attachments/assets/86985752-c5ef-466a-af71-1d0fa3a547cf" />

Screenshot: 
<img height="400" alt="Screenshot_20250822_172315" src="https://github.com/user-attachments/assets/31b489f9-a0dd-4f66-9b76-992f9645422b" />


### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [~] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`

Tests failed: https://pastebin.com/aNiiwn4t

- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
