### PR TITLE
Run update worker hourly

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/PreferenceUpgrader.java
@@ -6,6 +6,7 @@ import android.view.KeyEvent;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.preference.PreferenceManager;
 
+import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.concurrent.TimeUnit;
@@ -175,6 +176,9 @@ public class PreferenceUpgrader {
         if (newVersion == 3070003) {
             // Enable bottom navigation for beta users, so only this exact app version
             UserPreferences.setBottomNavigationEnabled(true);
+        }
+        if (oldVersion < 3100000) {
+            FeedUpdateManager.getInstance().restartUpdateAlarm(context, true);
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
@@ -78,7 +78,7 @@ public class DownloadsPreferencesFragment extends AnimatedPreferenceFragment
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (UserPreferences.PREF_UPDATE_INTERVAL.equals(key)) {
+        if (UserPreferences.PREF_UPDATE_INTERVAL.equals(key) || UserPreferences.PREF_MOBILE_UPDATE.equals(key)) {
             FeedUpdateManager.getInstance().restartUpdateAlarm(getContext(), true);
         }
     }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
@@ -32,6 +32,7 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
     public static final String EXTRA_FEED_ID = "feed_id";
     public static final String EXTRA_NEXT_PAGE = "next_page";
     public static final String EXTRA_EVEN_ON_MOBILE = "even_on_mobile";
+    public static final String EXTRA_MANUAL = "manual";
     private static final String TAG = "AutoUpdateManager";
 
     /**
@@ -43,13 +44,14 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
             WorkManager.getInstance(context).cancelUniqueWork(WORK_ID_FEED_UPDATE);
         } else {
             PeriodicWorkRequest workRequest = new PeriodicWorkRequest.Builder(
-                    FeedUpdateWorker.class, UserPreferences.getUpdateInterval(), TimeUnit.HOURS)
+                    FeedUpdateWorker.class, 1, TimeUnit.HOURS)
                     .setConstraints(new Constraints.Builder()
                         .setRequiredNetworkType(UserPreferences.isAllowMobileFeedRefresh()
                             ? NetworkType.CONNECTED : NetworkType.UNMETERED).build())
                     .build();
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(WORK_ID_FEED_UPDATE,
-                    replace ? ExistingPeriodicWorkPolicy.REPLACE : ExistingPeriodicWorkPolicy.KEEP, workRequest);
+                    replace ? ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
+                            : ExistingPeriodicWorkPolicy.KEEP, workRequest);
         }
     }
 
@@ -72,6 +74,7 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
         }
         Data.Builder builder = new Data.Builder();
         builder.putBoolean(EXTRA_EVEN_ON_MOBILE, true);
+        builder.putBoolean(EXTRA_MANUAL, true);
         if (feed != null) {
             builder.putLong(EXTRA_FEED_ID, feed.getId());
             builder.putBoolean(EXTRA_NEXT_PAGE, nextPage);

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -37,6 +37,7 @@ import de.danoeh.antennapod.model.download.DownloadRequest;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadRequestBuilder;
 import de.danoeh.antennapod.parser.feed.FeedHandlerResult;
 import de.danoeh.antennapod.storage.database.NonSubscribedFeedsCleaner;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.notifications.NotificationUtils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -47,6 +48,7 @@ import java.util.concurrent.Executors;
 
 public class FeedUpdateWorker extends Worker {
     private static final String TAG = "FeedUpdateWorker";
+    private static final long JOB_SCHEDULE_TIME_VARIATION = TimeUnit.MINUTES.toMillis(15);
 
     private final NewEpisodesNotification newEpisodesNotification;
     private final NotificationManagerCompat notificationManager;
@@ -66,12 +68,21 @@ public class FeedUpdateWorker extends Worker {
         long feedId = getInputData().getLong(FeedUpdateManagerImpl.EXTRA_FEED_ID, -1);
         boolean allAreLocal = true;
         boolean force = false;
+        boolean isAutomaticRefresh = !getInputData().getBoolean(FeedUpdateManagerImpl.EXTRA_MANUAL, false);
+        boolean isAutomaticRefreshEnabled = !UserPreferences.isAutoUpdateDisabled();
         if (feedId == -1) { // Update all
             toUpdate = DBReader.getFeedList();
             Iterator<Feed> itr = toUpdate.iterator();
             while (itr.hasNext()) {
                 Feed feed = itr.next();
                 if (!feed.getPreferences().getKeepUpdated() || feed.getState() != Feed.STATE_SUBSCRIBED) {
+                    itr.remove();
+                    continue;
+                }
+                if (isAutomaticRefresh && isAutomaticRefreshEnabled
+                        && feed.getLastRefreshAttempt() > System.currentTimeMillis() - JOB_SCHEDULE_TIME_VARIATION
+                            - TimeUnit.HOURS.toMillis(UserPreferences.getUpdateInterval())) {
+                    // Recently updated, no need to automatically check again
                     itr.remove();
                     continue;
                 }

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -95,7 +95,7 @@ public abstract class UserPreferences {
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
     public static final String PREF_ENQUEUE_LOCATION = "prefEnqueueLocation";
     public static final String PREF_UPDATE_INTERVAL = "prefAutoUpdateIntervall";
-    private static final String PREF_MOBILE_UPDATE = "prefMobileUpdateTypes";
+    public static final String PREF_MOBILE_UPDATE = "prefMobileUpdateTypes";
     public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
     public static final String PREF_AUTODL_GLOBAL = "prefEnableAutoDl";


### PR DESCRIPTION
### Description

Only refresh the feeds that have not been refreshed since their last interval. This solves the problem where force-stopping the app during a long feed refresh would start the refresh all over instead of just taking the feeds that were not refreshed already.

Contributes to #7902
Fixes #7299

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
