### PR TITLE
Expand Searchview

### DIFF
--- a/app/src/main/java/de/danoeh/antennae/views/CollapsibleSearchView.java
+++ b/app/src/main/java/de/danoeh/antennae/views/CollapsibleSearchView.java
@@ -1,0 +1,37 @@
+package de.danoeh.antennae.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.CollapsibleActionView;
+import android.view.ViewGroup;
+
+import androidx.appcompat.widget.SearchView;
+
+/**
+ * A SearchView implementation that can be used as an expanded action view.
+ * It overrides the default behavior to take the full width of the screen.
+ */
+public class CollapsibleSearchView extends SearchView implements CollapsibleActionView {
+    public CollapsibleSearchView(Context context) {
+        super(context);
+    }
+
+    public CollapsibleSearchView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CollapsibleSearchView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void onActionViewExpanded() {
+        super.onActionViewExpanded();
+        ViewGroup.LayoutParams params = getLayoutParams();
+        if (params != null) {
+            params.width = ViewGroup.LayoutParams.MATCH_PARENT;
+            setLayoutParams(params);
+        }
+        setIconifiedByDefault(false);
+    }
+}

--- a/app/src/main/res/menu/search.xml
+++ b/app/src/main/res/menu/search.xml
@@ -6,6 +6,6 @@
             android:id="@+id/action_search"
             android:icon="@drawable/ic_search"
             app:showAsAction="collapseActionView|always"
-            app:actionViewClass="androidx.appcompat.widget.SearchView"
+            app:actionViewClass="de.danoeh.antennae.views.CollapsibleSearchView"
             android:title="@string/search_label"/>
 </menu>


### PR DESCRIPTION
### Description

Make the searchbar use the full available width

Before:

<img width="1080" height="1920" alt="Screenshot_20250824_180553" src="https://github.com/user-attachments/assets/b003212c-af39-4340-ba7e-b37a1294f20a" />

After:

<img width="1080" height="1920" alt="Screenshot_20250824_180443" src="https://github.com/user-attachments/assets/11cc846b-64ac-4dd9-a003-522e79583bd7" />



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style

