### PR TITLE
Hide pull to refresh on cancel

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
@@ -111,6 +111,9 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
                     UserPreferences.setAllowMobileFeedRefresh(true);
                     runOnce(context, feed);
                 })
+                .setOnCancelListener((d) -> {
+                    EventBus.getDefault().postSticky(new FeedUpdateRunningEvent(false));
+                })
                 .setNegativeButton(R.string.no, (dialog, which) -> {
                     EventBus.getDefault().postSticky(new FeedUpdateRunningEvent(false));
                 });


### PR DESCRIPTION
### Description

Fixes #7945 

Make clicking somewhere else than the refresh dialog behave like the No-Button

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
