### PR TITLE
Fix stale issue action

### DIFF
--- a/.github/workflows/close-if-no-reply.yml
+++ b/.github/workflows/close-if-no-reply.yml
@@ -20,7 +20,7 @@ jobs:
           stale-pr-label: 'Needs: Reply still'
           stale-issue-message: "This issue will be closed when we don't get a reply within 7 days."
           stale-pr-message: "This PR will be closed when we don't get a reply within 7 days."
-          labels-to-remove-when-stale: 'Needs: Reply'
+          labels-to-remove-when-unstale: 'Needs: Reply,Needs: Reply still'
           close-issue-label: "Close reason: No reply"
           close-pr-label: "Close reason: No reply"
           close-issue-message: "This issue was closed because we didn't get a reply for 14 days."


### PR DESCRIPTION
### Description

Partially reverts 5e1ec5fc2e823102b5be7181d4fb9293551f9de4. This prevented closing issues/PRs by removing the stale label again.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
