### PR TITLE
Fix local feed delete stops working after some time

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
@@ -220,8 +220,7 @@ public class AddFeedFragment extends Fragment {
             return super.createIntent(context, input)
                     .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
                             | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                    );
+                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
@@ -218,7 +218,10 @@ public class AddFeedFragment extends Fragment {
         @Override
         public Intent createIntent(@NonNull final Context context, @Nullable final Uri input) {
             return super.createIntent(context, input)
-                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                    );
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -367,8 +367,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
             return super.createIntent(context, input)
                     .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
                             | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                    );
+                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -344,7 +344,8 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
 
         Completable.fromAction(() -> {
             getActivity().getContentResolver()
-                    .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             DocumentFile documentFile = DocumentFile.fromTreeUri(getContext(), uri);
             if (documentFile == null) {
                 throw new IllegalArgumentException("Unable to retrieve document tree");
@@ -364,7 +365,10 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
         @Override
         public Intent createIntent(@NonNull final Context context, @Nullable final Uri input) {
             return super.createIntent(context, input)
-                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                    );
         }
     }
 }


### PR DESCRIPTION
### Description

This is a follow up to the #6400. It appears deletion works after (re)connecting a folder, but then it stops working after a while. It appears the issue is the permissions - we did not specify the proper flags when requesting access, so Android revoked the access after a while.

From my testing, adding these extra flags seems to fix the issue.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code
- [X] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
