### PR TITLE
Refresh bottom nav counter even if app is not open

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -145,6 +145,7 @@ public class MainActivity extends CastEnabledActivity {
                 drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
             }
             drawerLayout = null;
+            bottomNavigation.onCreateView();
         } else {
             bottomNavigation.hide();
             bottomNavigation = null;
@@ -337,7 +338,7 @@ public class MainActivity extends CastEnabledActivity {
             drawerLayout.removeDrawerListener(drawerToggle);
         }
         if (bottomNavigation != null) {
-            bottomNavigation.onDestroy();
+            bottomNavigation.onDestroyView();
         }
     }
 
@@ -571,9 +572,6 @@ public class MainActivity extends CastEnabledActivity {
         super.onStart();
         EventBus.getDefault().register(this);
         new RatingDialogManager(this).showIfNeeded();
-        if (bottomNavigation != null) {
-            bottomNavigation.onStart();
-        }
         getOnBackPressedDispatcher().addCallback(this, openDefaultPageBackPressedCallback);
         getOnBackPressedDispatcher().addCallback(this, bottomSheetBackPressedCallback);
     }
@@ -603,9 +601,6 @@ public class MainActivity extends CastEnabledActivity {
     protected void onStop() {
         super.onStop();
         EventBus.getDefault().unregister(this);
-        if (bottomNavigation != null) {
-            bottomNavigation.onStop();
-        }
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/BottomNavigation.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/BottomNavigation.java
@@ -148,15 +148,12 @@ public class BottomNavigation {
         bottomNavigationView.setVisibility(View.GONE);
     }
 
-    public void onStart() {
+    public void onCreateView() {
         EventBus.getDefault().register(this);
     }
 
-    public void onStop() {
+    public void onDestroyView() {
         EventBus.getDefault().unregister(this);
-    }
-
-    public void onDestroy() {
         if (bottomNavigationBadgeLoader != null) {
             bottomNavigationBadgeLoader.dispose();
             bottomNavigationBadgeLoader = null;


### PR DESCRIPTION
### Description

Refresh bottom nav counter even if app is not open
Closes #7677

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
