### PR TITLE
Add default sort for episode list #6969

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/ItemSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/ItemSortDialog.java
@@ -20,6 +20,7 @@ import de.danoeh.antennapod.model.feed.SortOrder;
 public class ItemSortDialog extends BottomSheetDialogFragment {
     protected SortOrder sortOrder;
     protected SortDialogBinding viewBinding;
+    protected boolean showDefault;
 
     @Nullable
     @Override
@@ -32,8 +33,15 @@ public class ItemSortDialog extends BottomSheetDialogFragment {
         return viewBinding.getRoot();
     }
 
+    public void setShowDefaultSortButton(boolean showDefault) {
+        this.showDefault = showDefault;
+    }
+
     private void populateList() {
         viewBinding.gridLayout.removeAllViews();
+        if (showDefault) {
+            onAddDefaultItem(R.string.user_default);
+        }
         onAddItem(R.string.episode_title, SortOrder.EPISODE_TITLE_A_Z, SortOrder.EPISODE_TITLE_Z_A, true);
         onAddItem(R.string.feed_title, SortOrder.FEED_TITLE_A_Z, SortOrder.FEED_TITLE_Z_A, true);
         onAddItem(R.string.duration, SortOrder.DURATION_SHORT_LONG, SortOrder.DURATION_LONG_SHORT, true);
@@ -42,6 +50,27 @@ public class ItemSortDialog extends BottomSheetDialogFragment {
         onAddItem(R.string.filename, SortOrder.EPISODE_FILENAME_A_Z, SortOrder.EPISODE_FILENAME_Z_A, true);
         onAddItem(R.string.random, SortOrder.RANDOM, SortOrder.RANDOM, true);
         onAddItem(R.string.smart_shuffle, SortOrder.SMART_SHUFFLE_OLD_NEW, SortOrder.SMART_SHUFFLE_NEW_OLD, false);
+    }
+
+
+    protected void onAddDefaultItem(int title) {
+        if (sortOrder == null) {
+            SortDialogItemActiveBinding item = SortDialogItemActiveBinding.inflate(
+                    getLayoutInflater(), viewBinding.gridLayout, false);
+            item.button.setText(title);
+            viewBinding.gridLayout.addView(item.getRoot());
+        } else {
+            viewBinding.gridLayout.removeAllViews();
+            SortDialogItemBinding item = SortDialogItemBinding.inflate(
+                    getLayoutInflater(), viewBinding.gridLayout, false);
+            item.button.setText(title);
+            item.button.setOnClickListener(v -> {
+                sortOrder = null;
+                populateList();
+                onSelectionChanged();
+            });
+            viewBinding.gridLayout.addView(item.getRoot());
+        }
     }
 
     protected void onAddItem(int title, SortOrder ascending, SortOrder descending, boolean ascendingIsDefault) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/SingleFeedSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/SingleFeedSortDialog.java
@@ -16,11 +16,12 @@ public class SingleFeedSortDialog extends ItemSortDialog {
         bundle.putLong(ARG_FEED_ID, feed.getId());
         bundle.putBoolean(ARG_FEED_IS_LOCAL, feed.isLocalFeed());
         if (feed.getSortOrder() == null) {
-            bundle.putString(ARG_SORT_ORDER, String.valueOf(SortOrder.DATE_NEW_OLD.code));
+            bundle.putString(ARG_SORT_ORDER, null);
         } else {
             bundle.putString(ARG_SORT_ORDER, String.valueOf(feed.getSortOrder().code));
         }
         SingleFeedSortDialog dialog = new SingleFeedSortDialog();
+        dialog.setShowDefaultSortButton(true);
         dialog.setArguments(bundle);
         return dialog;
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
@@ -16,6 +16,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.storage.preferences.UsageStatistics;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
+import de.danoeh.antennapod.ui.screen.subscriptions.EpisodeListDefaultSortDialog;
 import de.danoeh.antennapod.ui.screen.subscriptions.FeedSortDialog;
 import org.greenrobot.eventbus.EventBus;
 
@@ -87,6 +88,14 @@ public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment
                     FeedSortDialog.showDialog(requireContext());
                     return true;
                 }));
+
+        findPreference(UserPreferences.PREF_DEFAULT_SORTED_ORDER)
+                .setOnPreferenceClickListener((preference -> {
+                    EpisodeListDefaultSortDialog dialog = EpisodeListDefaultSortDialog.newInstance();
+                    dialog.show(getChildFragmentManager(), "SortDialog");
+                    return true;
+                }));
+
         findPreference(PREF_SWIPE)
                 .setOnPreferenceClickListener(preference -> {
                     ((PreferenceActivity) getActivity()).openScreen(R.xml.preferences_swipe);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/EpisodeListDefaultSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/EpisodeListDefaultSortDialog.java
@@ -1,0 +1,44 @@
+package de.danoeh.antennapod.ui.screen.subscriptions;
+import android.os.Bundle;
+import androidx.annotation.Nullable;
+
+import de.danoeh.antennapod.model.feed.SortOrder;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.screen.feed.ItemSortDialog;
+
+public class EpisodeListDefaultSortDialog extends ItemSortDialog {
+    private static final String ARG_SORT_ORDER = "sortOrder";
+
+    public static EpisodeListDefaultSortDialog newInstance() {
+        Bundle bundle = new Bundle();
+        SortOrder currentSortOrder = UserPreferences.getPrefDefaultSortedOrder();
+        if (currentSortOrder == null) {
+            bundle.putString(ARG_SORT_ORDER, String.valueOf(SortOrder.DATE_NEW_OLD.code));
+        } else {
+            bundle.putString(ARG_SORT_ORDER, String.valueOf(currentSortOrder.code));
+        }
+        EpisodeListDefaultSortDialog dialog = new EpisodeListDefaultSortDialog();
+        dialog.setArguments(bundle);
+        return dialog;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        sortOrder = SortOrder.fromCodeString(getArguments().getString(ARG_SORT_ORDER));
+    }
+
+    @Override
+    protected void onAddItem(int title, SortOrder ascending, SortOrder descending, boolean ascendingIsDefault) {
+        if (ascending == SortOrder.DATE_OLD_NEW || ascending == SortOrder.DURATION_SHORT_LONG
+                || ascending == SortOrder.EPISODE_TITLE_A_Z) {
+            super.onAddItem(title, ascending, descending, ascendingIsDefault);
+        }
+    }
+
+    @Override
+    protected void onSelectionChanged() {
+        super.onSelectionChanged();
+        UserPreferences.setPrefDefaultSortedOrder(sortOrder);
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/EpisodeListDefaultSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/EpisodeListDefaultSortDialog.java
@@ -1,4 +1,5 @@
 package de.danoeh.antennapod.ui.screen.subscriptions;
+
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemSortQuery.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemSortQuery.java
@@ -2,11 +2,12 @@ package de.danoeh.antennapod.storage.database.mapper;
 
 import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.storage.database.PodDBAdapter;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
 
 public class FeedItemSortQuery {
     public static String generateFrom(SortOrder sortOrder) {
         if (sortOrder == null) {
-            sortOrder = SortOrder.DATE_NEW_OLD;
+            sortOrder = UserPreferences.getPrefDefaultSortedOrder();
         }
         switch (sortOrder) {
             case EPISODE_TITLE_A_Z:

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -64,6 +64,7 @@ public abstract class UserPreferences {
     public static final String PREF_BACK_OPENS_DRAWER = "prefBackButtonOpensDrawer";
     public static final String PREF_BOTTOM_NAVIGATION = "prefBottomNavigation";
 
+    public static final String PREF_DEFAULT_SORTED_ORDER = "prefDefaultSortedOrder";
     public static final String PREF_QUEUE_KEEP_SORTED = "prefQueueKeepSorted";
     public static final String PREF_QUEUE_KEEP_SORTED_ORDER = "prefQueueKeepSortedOrder";
     public static final String PREF_NEW_EPISODES_ACTION = "prefNewEpisodesAction";
@@ -855,6 +856,14 @@ public abstract class UserPreferences {
 
     public static void setShouldShowSubscriptionTitle(boolean show) {
         prefs.edit().putBoolean(PREF_SUBSCRIPTION_TITLE, show).apply();
+    }
+
+    public static void setPrefDefaultSortedOrder(SortOrder sortOrder) {
+        prefs.edit().putString(PREF_DEFAULT_SORTED_ORDER, "" + sortOrder.code).apply();
+    }
+
+    public static SortOrder getPrefDefaultSortedOrder() {
+        return SortOrder.fromCodeString(prefs.getString(PREF_DEFAULT_SORTED_ORDER, "" + SortOrder.DATE_NEW_OLD.code));
     }
 
     public static void setAllEpisodesSortOrder(SortOrder s) {

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -225,8 +225,7 @@ public abstract class UserPreferences {
     }
 
     public static List<Integer> getFullNotificationButtons() {
-        String[] buttons = TextUtils.split(
-            prefs.getString(PREF_FULL_NOTIFICATION_BUTTONS,
+        String[] buttons = TextUtils.split(prefs.getString(PREF_FULL_NOTIFICATION_BUTTONS,
                 NOTIFICATION_BUTTON_SKIP + "," + NOTIFICATION_BUTTON_PLAYBACK_SPEED), ",");
 
         List<Integer> notificationButtons = new ArrayList<>();

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -377,6 +377,7 @@
     <string name="date">Date</string>
     <string name="duration">Duration</string>
     <string name="episode_title">Episode title</string>
+    <string name="user_default">User Default</string>
     <string name="feed_title">Podcast title</string>
     <string name="random">Random</string>
     <string name="smart_shuffle">Smart shuffle</string>
@@ -576,6 +577,8 @@
     <string name="pref_new_episodes_action_title">New episodes action</string>
     <string name="pref_new_episodes_action_sum">Action to take for new episodes</string>
     <string name="episode_information">Episode information</string>
+    <string name="pref_default_episode_list_sort_order_title">Default Episode Order</string>
+    <string name="pref_default_episode_list_sort_order_sum">Set default episode list sort order when no podcast-specific option is set</string>
 
     <!-- About screen -->
     <string name="about_pref">About</string>

--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -96,6 +96,10 @@
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/episode_lists">
         <Preference
+                android:key="prefDefaultSortedOrder"
+                android:title="@string/pref_default_episode_list_sort_order_title"
+                android:summary="@string/pref_default_episode_list_sort_order_sum" />
+        <Preference
                 android:key="prefSwipe"
                 android:summary="@string/swipeactions_summary"
                 android:title="@string/swipeactions_label"/>


### PR DESCRIPTION
### Description
Closes: #6969 

Added an option to set the default sort for single feed podcast episode lists. Some notes:

1. I added a "User Default" button so users can reset their individual podcast feed sort selection back to default. Without this, you would never be able to go back to default sort if you ever select an different sort method for a podcast. I have this as the first button in the list but let me know if the end of the list makes more sense
2. I added the "showDefault" field to the ItemSortDialog class so the default button from above basically needs to be opted into for showing on the different dialogs that inherit this. It'll be easy to add this to other lists if we want (All Episodes list, Inbox, etc.) but by default for the scope of this task they don't have that. Only the subscribed and unsubscribed podcast episode lists will sort initially by default selection. The other option was adding the default button creation method as an overridable method but this would involve every other dialog having to override this method to opt-out which seemed like the worse option
3. I didn't add the on suggestion from the request for adding the current sort method to the preference menu item description. I excluded this for consistency because no other option does this in the User Interface menu. I figure if we do want to add this, we can open a separate request to do it for everything
4. I also didn't move the "show episode image" to the "Episode lists" category because that category was created after this request was created and it wasn't moved then. However, if need be I can move this over as well as part of this request

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code
- [X] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] If it is a core feature, I have added automated tests
