### PR TITLE
Only load the download log entries we actually need

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -589,8 +589,8 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     private void showErrorDetails() {
         Maybe.fromCallable(
                 () -> {
-                    List<DownloadResult> feedDownloadLog = DBReader.getFeedDownloadLog(feedID);
-                    if (feedDownloadLog.size() == 0 || feedDownloadLog.get(0).isSuccessful()) {
+                    List<DownloadResult> feedDownloadLog = DBReader.getFeedDownloadLog(feedID, 1);
+                    if (feedDownloadLog.isEmpty() || feedDownloadLog.get(0).isSuccessful()) {
                         return null;
                     }
                     return feedDownloadLog.get(0);

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -244,7 +244,7 @@ public class FeedUpdateWorker extends Worker {
             return savedFeed; // No download logs for new subscriptions
         }
         // we create a 'successful' download log if the feed's last refresh failed
-        List<DownloadResult> log = DBReader.getFeedDownloadLog(request.getFeedfileId());
+        List<DownloadResult> log = DBReader.getFeedDownloadLog(request.getFeedfileId(), 1);
         if (!log.isEmpty() && !log.get(0).isSuccessful()) {
             DBWriter.addDownloadStatus(parserTask.getDownloadStatus());
         }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -321,13 +321,13 @@ public final class DBReader {
      * @return A list with DownloadStatus objects that represent the feed's download log,
      * newest events first.
      */
-    public static List<DownloadResult> getFeedDownloadLog(long feedId) {
+    public static List<DownloadResult> getFeedDownloadLog(long feedId, long limit) {
         Log.d(TAG, "getFeedDownloadLog() called with: " + "feed = [" + feedId + "]");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (DownloadResultCursor cursor = new DownloadResultCursor(
-                adapter.getDownloadLog(Feed.FEEDFILETYPE_FEED, feedId))) {
+                adapter.getDownloadLog(Feed.FEEDFILETYPE_FEED, feedId, limit))) {
             List<DownloadResult> downloadLog = new ArrayList<>(cursor.getCount());
             while (cursor.moveToNext()) {
                 downloadLog.add(cursor.getDownloadResult());

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1015,10 +1015,10 @@ public class PodDBAdapter {
         );
     }
 
-    public final Cursor getDownloadLog(final int feedFileType, final long feedFileId) {
+    public final Cursor getDownloadLog(final int feedFileType, final long feedFileId, final long limit) {
         final String query = "SELECT * FROM " + TABLE_NAME_DOWNLOAD_LOG +
                 " WHERE " + KEY_FEEDFILE + "=" + feedFileId + " AND " + KEY_FEEDFILETYPE + "=" + feedFileType
-                + " ORDER BY " + KEY_COMPLETION_DATE + " DESC";
+                + " ORDER BY " + KEY_COMPLETION_DATE + " DESC LIMIT " + limit;
         return db.rawQuery(query, null);
     }
 


### PR DESCRIPTION
### Description

Only load the download log entries we actually need
See #7664

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
