### PR TITLE
Fix and tune feed item duplicate guesser

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesser.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesser.java
@@ -69,7 +69,7 @@ public class FeedItemDuplicateGuesser {
         return sameAndNotEmpty(canonicalizeTitle(item1.getTitle()), canonicalizeTitle(item2.getTitle()));
     }
 
-    private static String canonicalizeTitle(String title) {
+    public static String canonicalizeTitle(String title) {
         if (title == null) {
             return "";
         }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesserPool.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesserPool.java
@@ -1,0 +1,60 @@
+package de.danoeh.antennapod.storage.database;
+
+import de.danoeh.antennapod.model.feed.FeedItem;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FeedItemDuplicateGuesserPool {
+    private final Map<String, List<FeedItem>> normalizedTitles = new HashMap<>();
+    private final Map<String, FeedItem> downloadUrls = new HashMap<>();
+    private final Map<String, FeedItem> identifiers = new HashMap<>();
+
+    public FeedItemDuplicateGuesserPool(List<FeedItem> itemsList) {
+        for (FeedItem item : itemsList) {
+            add(item);
+        }
+    }
+
+    public void add(FeedItem item) {
+        String normalizedTitle = FeedItemDuplicateGuesser.canonicalizeTitle(item.getTitle());
+        if (!normalizedTitles.containsKey(normalizedTitle)) {
+            normalizedTitles.put(normalizedTitle, new java.util.ArrayList<>());
+        }
+        normalizedTitles.get(normalizedTitle).add(item);
+        if (item.getMedia() != null && !StringUtils.isEmpty(item.getMedia().getStreamUrl())
+                && !downloadUrls.containsKey(item.getMedia().getStreamUrl())) {
+            downloadUrls.put(item.getMedia().getStreamUrl(), item);
+        }
+        if (item.getIdentifyingValue() != null && !identifiers.containsKey(item.getIdentifyingValue())) {
+            identifiers.put(item.getIdentifyingValue(), item);
+        }
+    }
+
+    public FeedItem guessDuplicate(FeedItem searchItem) {
+        if (searchItem.getMedia() != null && !StringUtils.isEmpty(searchItem.getMedia().getStreamUrl())
+                && downloadUrls.containsKey(searchItem.getMedia().getStreamUrl())) {
+            return downloadUrls.get(searchItem.getMedia().getStreamUrl());
+        }
+        String normalizedTitle = FeedItemDuplicateGuesser.canonicalizeTitle(searchItem.getTitle());
+        List<FeedItem> candidates = normalizedTitles.get(normalizedTitle);
+        if (candidates == null) {
+            return null;
+        }
+        for (FeedItem item : candidates) {
+            if (FeedItemDuplicateGuesser.seemDuplicates(item, searchItem)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    public FeedItem findById(FeedItem item) {
+        if (identifiers.containsKey(item.getIdentifyingValue())) {
+            return identifiers.get(item.getIdentifyingValue());
+        }
+        return null;
+    }
+}

--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesserPoolTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesserPoolTest.java
@@ -1,0 +1,40 @@
+package de.danoeh.antennapod.storage.database;
+
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertSame;
+
+@RunWith(JUnit4.class)
+public class FeedItemDuplicateGuesserPoolTest {
+
+    @Test
+    public void testDuplicateIsConsistent() {
+        Feed feed = new Feed("url", null, null);
+        FeedItem item1 = createItem("id1", "Title", feed);
+        FeedItem item2 = createItem("id2", "Title", feed);
+
+        FeedItemDuplicateGuesserPool pool = new FeedItemDuplicateGuesserPool(new ArrayList<>());
+        pool.add(item1);
+        assertSame(item1, pool.guessDuplicate(item1));
+        assertSame(item1, pool.guessDuplicate(item2));
+        pool.add(item2);
+        assertSame(item1, pool.guessDuplicate(item1));
+        assertSame(item1, pool.guessDuplicate(item2));
+    }
+
+    private FeedItem createItem(String identifier, String title, Feed feed) {
+        FeedItem item = new FeedItem();
+        item.setItemIdentifier(identifier);
+        item.setTitle(title);
+        item.setMedia(new FeedMedia(item, "url-" + title, 2, "mime"));
+        item.setFeed(feed);
+        return item;
+    }
+}


### PR DESCRIPTION
### Description

Fix and tune feed item duplicate guesser
See #7664

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
