### PR TITLE
Tweak error messages when interacting with text only episode

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/StartDownloadSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/StartDownloadSwipeAction.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import androidx.fragment.app.Fragment;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.actionbutton.DownloadActionButton;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import org.greenrobot.eventbus.EventBus;
 
 public class StartDownloadSwipeAction implements SwipeAction {
 
@@ -31,9 +33,12 @@ public class StartDownloadSwipeAction implements SwipeAction {
 
     @Override
     public void performAction(FeedItem item, Fragment fragment, FeedItemFilter filter) {
-        if (!item.isDownloaded() && !item.getFeed().isLocalFeed()) {
-            new DownloadActionButton(item)
-                    .onClick(fragment.requireContext());
+        if (item.getMedia() == null) {
+            EventBus.getDefault().post(new MessageEvent(fragment.getString(R.string.no_media_label)));
+        } else if (item.getFeed().isLocalFeed() || item.isDownloaded()) {
+            EventBus.getDefault().post(new MessageEvent(fragment.getString(R.string.already_downloaded)));
+        } else {
+            new DownloadActionButton(item).onClick(fragment.requireContext());
         }
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -345,6 +345,7 @@
     <string name="confirm_mobile_streaming_notification_message">Streaming over mobile data connection is disabled in the settings. Tap to stream anyway.</string>
     <string name="confirm_mobile_streaming_button_always">Always</string>
     <string name="confirm_mobile_streaming_button_once">Once</string>
+    <string name="already_downloaded">Episode is already downloaded</string>
 
     <!-- Mediaplayer messages -->
     <string name="playback_error_generic">The media file could not be played.\n\n- Try deleting and re-downloading the episode.\n- Check your network connection, and make sure no VPN or login page is blocking access.\n- Try long-pressing and sharing the \"Media address\" to your web browser to see if it can be played there. If not, contact the podcast creators.</string>


### PR DESCRIPTION
### Description

Tweak error messages when interacting with text only episode
Closes #7978

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
