### PR TITLE
Fix transcripts jumping when close to bottom

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TranscriptDialogFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TranscriptDialogFragment.java
@@ -213,6 +213,10 @@ public class TranscriptDialogFragment extends DialogFragment
         doInitialScroll = false;
 
         boolean quickScroll = Math.abs(layoutManager.findFirstVisibleItemPosition() - pos) > 5;
+        if (layoutManager.findFirstVisibleItemPosition() < pos - 1
+                && !viewBinding.transcriptList.canScrollVertically(1)) {
+            return;
+        }
         if (quickScroll) {
             viewBinding.transcriptList.scrollToPosition(pos - 1);
             // Additionally, smooth scroll, so that currently active segment is on top of screen


### PR DESCRIPTION
### Description

Fix transcripts jumping when close to bottom
Closes #7930

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
