### PR TITLE
Remove cloud icon on cloud screen, no other subscreen has icons

### DIFF
--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
@@ -124,7 +124,7 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
         } else {
             preferenceHeader.setTitle(R.string.synchronization_choose_title);
             preferenceHeader.setSummary(R.string.synchronization_summary_unchoosen);
-            preferenceHeader.setIcon(R.drawable.ic_cloud);
+            preferenceHeader.setIcon(null);
             preferenceHeader.setOnPreferenceClickListener((preference) -> {
                 chooseProviderAndLogin();
                 return true;

--- a/ui/preferences/src/main/res/xml/preferences_synchronization.xml
+++ b/ui/preferences/src/main/res/xml/preferences_synchronization.xml
@@ -5,7 +5,6 @@
 
     <Preference
         android:key="preference_synchronization_description"
-        android:icon="@drawable/ic_notification_sync"
         android:summary="@string/synchronization_summary_unchoosen"/>
 
     <Preference


### PR DESCRIPTION
### Description

Remove cloud icon on cloud screen, no other subscreen has icons

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
