### PR TITLE
Share link normally

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/share/ShareUtils.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/share/ShareUtils.java
@@ -11,7 +11,6 @@ import androidx.core.content.FileProvider;
 
 import de.danoeh.antennapod.ui.common.Converter;
 import java.io.File;
-import java.net.URLEncoder;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -36,12 +35,7 @@ public class ShareUtils {
     }
 
     public static void shareFeedLink(Context context, Feed feed) {
-        String feedurl = URLEncoder.encode(feed.getDownloadUrl());
-        feedurl = feedurl.replace("htt", "%68%74%74"); // To not confuse users by having a url inside a url
-        String text = feed.getTitle() + "\n\n"
-                + "https://antennapod.org/deeplink/subscribe/?url=" + feedurl
-                + "&title=" + URLEncoder.encode(feed.getTitle());
-        shareLink(context, text);
+        shareLink(context, feed.getDownloadUrl());
     }
 
     public static boolean hasLinkToShare(FeedItem item) {


### PR DESCRIPTION
Without sending users to a privacy-leaking upsell / ad site. Or a
separate title line which confuses browsers.
