### PR TITLE
Ignore 'show in main list' for subscriptions screen

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -21,6 +21,7 @@ import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.feed.FeedOrder;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.model.feed.SubscriptionsFilter;
 import de.danoeh.antennapod.model.download.DownloadResult;
@@ -760,6 +761,9 @@ public final class DBReader {
         List<Feed> feeds = getFeedList();
         for (Feed feed : feeds) {
             for (String tag : feed.getPreferences().getTags()) {
+                if (FeedPreferences.TAG_ROOT.equals(tag)) {
+                    continue;
+                }
                 if (!tags.containsKey(tag)) {
                     tags.put(tag, new NavDrawerData.TagItem(tag));
                 }
@@ -768,6 +772,12 @@ public final class DBReader {
         }
         List<NavDrawerData.TagItem> tagsSorted = new ArrayList<>(tags.values());
         Collections.sort(tagsSorted, (o1, o2) -> o1.getTitle().compareToIgnoreCase(o2.getTitle()));
+        // Root tag here means "all feeds", this is different from the nav drawer.
+        NavDrawerData.TagItem rootTag = new NavDrawerData.TagItem(FeedPreferences.TAG_ROOT);
+        for (Feed feed : feeds) {
+            rootTag.addFeed(feed, 0);
+        }
+        tagsSorted.add(0, rootTag);
         return tagsSorted;
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -755,7 +755,7 @@
     <string name="authentication_descr">Change your username and password for this podcast and its episodes</string>
     <string name="feed_tags_label">Tags</string>
     <string name="feed_tags_summary">Change the tags of this podcast to help organize your subscriptions</string>
-    <string name="feed_folders_include_root">Show this podcast in \"all\" tag</string>
+    <string name="feed_folders_include_root">Show above tags (side navigation only)</string>
     <string name="tag_all">All</string>
     <string name="multi_feed_common_tags_info">Only common tags from all selected subscriptions are shown. Other tags stay unaffected.</string>
     <string name="auto_download_inbox_category">Automatically download episodes from the inbox</string>


### PR DESCRIPTION
### Description

Ignore 'show in main list' for subscriptions screen.
This no longer makes sense with tags always at the top, users can always create their own main list.
After we remove the side navigation, we can remove the tag setting.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
