### PR TITLE
Migrate update interval from hours to minutes

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/EspressoTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/EspressoTestUtils.java
@@ -180,7 +180,7 @@ public class EspressoTestUtils {
 
         PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getInstrumentation().getTargetContext())
                 .edit()
-                .putString(UserPreferences.PREF_UPDATE_INTERVAL, "0")
+                .putString(UserPreferences.PREF_UPDATE_INTERVAL_MINUTES, "0")
                 .commit();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/PreferenceUpgrader.java
+++ b/app/src/main/java/de/danoeh/antennapod/PreferenceUpgrader.java
@@ -144,8 +144,9 @@ public class PreferenceUpgrader {
                         .apply();
             }
             UserPreferences.setAllowMobileSync(true);
-            if (prefs.getString(UserPreferences.PREF_UPDATE_INTERVAL, ":").contains(":")) { // Unset or "time of day"
-                prefs.edit().putString(UserPreferences.PREF_UPDATE_INTERVAL, "12").apply();
+            if (prefs.getString(UserPreferences.PREF_UPDATE_INTERVAL_MINUTES, ":").contains(":")) {
+                // Unset or "time of day"
+                prefs.edit().putString(UserPreferences.PREF_UPDATE_INTERVAL_MINUTES, "12").apply();
             }
         }
         if (oldVersion < 3020000) {
@@ -178,6 +179,8 @@ public class PreferenceUpgrader {
             UserPreferences.setBottomNavigationEnabled(true);
         }
         if (oldVersion < 3100000) {
+            // Migrate refresh interval from hours to minutes
+            UserPreferences.setUpdateInterval(60L * UserPreferences.getUpdateInterval());
             FeedUpdateManager.getInstance().restartUpdateAlarm(context, true);
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/DownloadsPreferencesFragment.java
@@ -78,7 +78,8 @@ public class DownloadsPreferencesFragment extends AnimatedPreferenceFragment
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (UserPreferences.PREF_UPDATE_INTERVAL.equals(key) || UserPreferences.PREF_MOBILE_UPDATE.equals(key)) {
+        if (UserPreferences.PREF_UPDATE_INTERVAL_MINUTES.equals(key)
+                || UserPreferences.PREF_MOBILE_UPDATE.equals(key)) {
             FeedUpdateManager.getInstance().restartUpdateAlarm(getContext(), true);
         }
     }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -81,7 +81,7 @@ public class FeedUpdateWorker extends Worker {
                 }
                 if (isAutomaticRefresh && isAutomaticRefreshEnabled
                         && feed.getLastRefreshAttempt() > System.currentTimeMillis() - JOB_SCHEDULE_TIME_VARIATION
-                            - TimeUnit.HOURS.toMillis(UserPreferences.getUpdateInterval())) {
+                            - TimeUnit.MINUTES.toMillis(UserPreferences.getUpdateInterval())) {
                     // Recently updated, no need to automatically check again
                     itr.remove();
                     continue;

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -94,7 +94,7 @@ public abstract class UserPreferences {
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
     public static final String PREF_ENQUEUE_LOCATION = "prefEnqueueLocation";
-    public static final String PREF_UPDATE_INTERVAL = "prefAutoUpdateIntervall";
+    public static final String PREF_UPDATE_INTERVAL_MINUTES = "prefAutoUpdateIntervall";
     public static final String PREF_MOBILE_UPDATE = "prefMobileUpdateTypes";
     public static final String PREF_EPISODE_CLEANUP = "prefEpisodeCleanup";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
@@ -456,7 +456,11 @@ public abstract class UserPreferences {
     }
 
     public static long getUpdateInterval() {
-        return Integer.parseInt(prefs.getString(PREF_UPDATE_INTERVAL, "12"));
+        return Integer.parseInt(prefs.getString(PREF_UPDATE_INTERVAL_MINUTES, "720"));
+    }
+
+    public static void setUpdateInterval(long interval) {
+        prefs.edit().putString(PREF_UPDATE_INTERVAL_MINUTES, String.valueOf(interval)).apply();
     }
 
     public static boolean isAutoUpdateDisabled() {

--- a/ui/preferences/src/main/res/values/arrays.xml
+++ b/ui/preferences/src/main/res/values/arrays.xml
@@ -59,13 +59,13 @@
 
     <string-array name="feed_refresh_interval_values">
         <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>4</item>
-        <item>8</item>
-        <item>12</item>
-        <item>24</item>
-        <item>72</item>
+        <item>60</item>
+        <item>120</item>
+        <item>240</item>
+        <item>480</item>
+        <item>720</item>
+        <item>1440</item>
+        <item>4320</item>
     </string-array>
 
     <string-array name="globalNewEpisodesActionItems">

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -14,7 +14,7 @@
             android:key="prefAutoUpdateIntervall"
             android:title="@string/feed_refresh_title"
             android:summary="@string/feed_refresh_sum"
-            android:defaultValue="12"/>
+            android:defaultValue="720"/>
         <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
             android:entryValues="@array/globalNewEpisodesActionValues"
             android:entries="@array/globalNewEpisodesActionItems"


### PR DESCRIPTION
### Description

Migrate update interval from hours to minutes.
This is a bit of a hack so that we have "1" available for "global" (instead of 1 hour) because we cannot change sql default values.

This is a step towards #7902

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
