### PR TITLE
Update actions and address a deprecation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: actions/checkout@v5
+      - uses: gradle/actions/wrapper-validation@v3
 
   static-analysis:
     name: "Static Code Analysis"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -72,12 +72,12 @@ jobs:
             execute-tests: false
             upload-artifact: false
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -108,12 +108,12 @@ jobs:
     env:
       api-level: 30
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v3
+      - uses: gradle/actions/wrapper-validation@v4
 
   static-analysis:
     name: "Static Code Analysis"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
 
   static-analysis:
     name: "Static Code Analysis"

--- a/.github/workflows/close-if-no-reply.yml
+++ b/.github/workflows/close-if-no-reply.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-stale: 7
           days-before-close: 7

--- a/.github/workflows/remove-labels-when-issue-gets-closed.yml
+++ b/.github/workflows/remove-labels-when-issue-gets-closed.yml
@@ -10,7 +10,7 @@ jobs:
     
     steps:
       - name: Remove labels from closed issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const labelsToRemove = ['Needs: Triage', 'Needs: Decision', 'Needs: Reply still'];


### PR DESCRIPTION
### Description
As [recommended](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/#what-you-need-to-do) by GitHub, this PR ensures our workflows use the latest versions of actions (including using the [latest available Java version](https://github.com/actions/setup-java?tab=readme-ov-file#eclipse-temurin) for `setup-java`), preparing us for upcoming deprecations.

It also addresses the deprecation of [gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action).



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
