### PR TITLE
Fix layout of text above subscribe button

### DIFF
--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -120,6 +120,7 @@
             android:layout_toEndOf="@id/coverHolder"
             android:layout_above="@id/buttonContainer"
             android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
             android:orientation="vertical">
 
             <TextView


### PR DESCRIPTION
close #7920

### Description
Layout the text so it is above the subscribe button even when fonts are large

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ x] I have performed a self-review of my code
- [x ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] If it is a core feature, I have added automated tests

<img width="720" height="1560" alt="ap-screenshot" src="https://github.com/user-attachments/assets/2db2b6b2-87d5-4b79-ae25-f2eb37545748" />
