### PR TITLE
Weblate does not support cdata, cannot make text bold

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/RemoveFeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/RemoveFeedDialog.java
@@ -4,7 +4,6 @@ import android.animation.ValueAnimator;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
-import android.text.Html;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -75,8 +74,6 @@ public class RemoveFeedDialog extends BottomSheetDialogFragment {
             binding.archiveButton.setVisibility(View.GONE);
             binding.explanationArchiveText.setVisibility(View.GONE);
         }
-        binding.explanationArchiveText.setText(Html.fromHtml(getString(R.string.feed_delete_explanation_archive)));
-        binding.explanationDeleteText.setText(Html.fromHtml(getString(R.string.feed_delete_explanation_delete)));
         binding.cancelButton.setOnClickListener(v -> dismiss());
         binding.removeButton.setOnClickListener(v -> showRemoveConfirm());
         binding.removeConfirmButton.setOnClickListener(v -> onRemoveButtonPressed());

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -208,8 +208,8 @@
     <string name="remove_feed_label">Delete</string>
     <string name="share_label">Share</string>
     <string name="share_file_label">Share file</string>
-    <string name="feed_delete_explanation_delete"><![CDATA[<b>Deleting</b> will remove ALL its episodes including downloads, playback history, and statistics.]]></string>
-    <string name="feed_delete_explanation_archive"><![CDATA[<b>Archiving</b> will hide it from the subscription list and avoid it getting updates. Downloads, statistics and playback state are kept.]]></string>
+    <string name="feed_delete_explanation_delete">Deleting will remove ALL its episodes including downloads, playback history, and statistics.</string>
+    <string name="feed_delete_explanation_archive">Archiving will hide it from the subscription list and avoid it getting updates. Downloads, statistics and playback state are kept.</string>
     <string name="load_complete_feed">Refresh complete podcast</string>
     <string name="multi_select">Multi select</string>
     <string name="select_all_above">Select all above</string>


### PR DESCRIPTION
### Description

Weblate does not support cdata, cannot make text bold

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
