### PR TITLE
Fix no tag selected when tag no longer exists

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -367,11 +367,17 @@ public class SubscriptionFragment extends Fragment
                         if (FeedPreferences.TAG_ROOT.equals(tagAdapter.getSelectedTag())) {
                             openedFolderFeeds = result.first.feeds;
                         } else {
+                            boolean tagExists = false;
                             for (NavDrawerData.TagItem tag : result.first.tags) { // Filtered list
                                 if (tag.getTitle().equals(tagAdapter.getSelectedTag())) {
                                     openedFolderFeeds = tag.getFeeds();
+                                    tagExists = true;
                                     break;
                                 }
+                            }
+                            if (!tagExists) {
+                                tagAdapter.setSelectedTag(FeedPreferences.TAG_ROOT);
+                                openedFolderFeeds = result.first.feeds;
                             }
                         }
 


### PR DESCRIPTION
### Description

Fix no tag selected when tag no longer exists
closes #8040

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
