### PR TITLE
Add an option to remember playback speed per-output

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="remember_playback_speed_per_output">Remember playback speed per-output</string>
+    <string name="remember_playback_speed_per_output_description">Remember different playback speed for every output
+        (such as for headphones, for phone speaker etc.)
+    </string>
+</resources>

--- a/ui/preferences/src/main/res/xml/preferences_playback.xml
+++ b/ui/preferences/src/main/res/xml/preferences_playback.xml
@@ -43,6 +43,12 @@
                 android:key="prefPlaybackSpeedLauncher"
                 android:summary="@string/pref_playback_speed_sum"
                 android:title="@string/playback_speed"/>
+
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:key="prefEnablePerOutputSpeed"
+                android:summary="@string/remember_playback_speed_per_output_description"
+                android:title="@string/remember_playback_speed_per_output" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/reassign_hardware_buttons">


### PR DESCRIPTION
### Description

PR adds an option to remember playback speed per-output instead of just being one global playback speed. This allows, for example, for a bluetooth headphones with a clearer sound to play on a higher speed, while worse quality phone speaker automatically plays on the lower speed, to be more legible. Per-feed speed is not affected and still overrides that speed.

It's still WIP for two reasons:

* Playback part works great, but saving does not. The reason for that is the temporary playback speed. Once user saves the speed, it will get saved to per-output setting, but will not take affect yet until user switches the track, as `PREF_CURRENTLY_PLAYING_TEMPORARY_PLAYBACK_SPEED` is still taking precedence. I would appreciate some pointers on how to best resolve this as I'm not that familiar with that system and why it needs to exist.
* PR uses MediaRouter2 directly, despite Google's recommendation, because the MediaRouter AndroidX library is outdated and does not get all the changes (https://issuetracker.google.com/issues/340805981). Consequently, this PR is not yet compatible with the SDK < 30. I'm thinking of also adding a MediaRouter AndroidX library and using it on the SDK < 30, while the newer SDKs get the MediaRouter2. Maybe I could write a class that wraps those two. What do you think?

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code
- [X] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://github.com/AntennaPod/AntennaPod/wiki/Code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
