### PR TITLE
Replace usage of StringUtils.equals with non-deprecated method.

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -12,7 +12,7 @@ import de.danoeh.antennapod.model.MediaMetadataRetrieverCompat;
 import de.danoeh.antennapod.model.playback.MediaType;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.model.playback.RemoteMedia;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.io.File;
 import java.util.Date;
@@ -152,7 +152,7 @@ public class FeedMedia implements Playable {
      * @return true if attribute values are different, false otherwise
      */
     public boolean compareWithOther(FeedMedia other) {
-        if (!StringUtils.equals(downloadUrl, other.downloadUrl)) {
+        if (!Strings.CS.equals(downloadUrl, other.downloadUrl)) {
             return true;
         }
         if (other.mimeType != null) {

--- a/model/src/main/java/de/danoeh/antennapod/model/playback/RemoteMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/playback/RemoteMedia.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
@@ -280,21 +281,21 @@ public class RemoteMedia implements Playable {
     public boolean equals(Object other) {
         if (other instanceof RemoteMedia) {
             RemoteMedia rm = (RemoteMedia) other;
-            return StringUtils.equals(downloadUrl, rm.downloadUrl)
-                    && StringUtils.equals(feedUrl, rm.feedUrl)
-                    && StringUtils.equals(itemIdentifier, rm.itemIdentifier);
+            return Strings.CS.equals(downloadUrl, rm.downloadUrl)
+                    && Strings.CS.equals(feedUrl, rm.feedUrl)
+                    && Strings.CS.equals(itemIdentifier, rm.itemIdentifier);
         }
         if (other instanceof FeedMedia) {
             FeedMedia fm = (FeedMedia) other;
-            if (!StringUtils.equals(downloadUrl, fm.getStreamUrl())) {
+            if (!Strings.CS.equals(downloadUrl, fm.getStreamUrl())) {
                 return false;
             }
             FeedItem fi = fm.getItem();
-            if (fi == null || !StringUtils.equals(itemIdentifier, fi.getItemIdentifier())) {
+            if (fi == null || !Strings.CS.equals(itemIdentifier, fi.getItemIdentifier())) {
                 return false;
             }
             Feed feed = fi.getFeed();
-            return feed != null && StringUtils.equals(feedUrl, feed.getDownloadUrl());
+            return feed != null && Strings.CS.equals(feedUrl, feed.getDownloadUrl());
         }
         return false;
     }

--- a/parser/transcript/src/main/java/de/danoeh/antennapod/parser/transcript/SrtTranscriptParser.java
+++ b/parser/transcript/src/main/java/de/danoeh/antennapod/parser/transcript/SrtTranscriptParser.java
@@ -1,6 +1,7 @@
 package de.danoeh.antennapod.parser.transcript;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.jsoup.internal.StringUtil;
 
 import java.util.Arrays;
@@ -81,7 +82,7 @@ public class SrtTranscriptParser {
                 speaker = parts[0];
                 speakers.add(speaker);
                 body = new StringBuilder(parts[1].strip());
-                if (StringUtils.isNotEmpty(prevSpeaker) && !StringUtils.equals(speaker, prevSpeaker)) {
+                if (StringUtils.isNotEmpty(prevSpeaker) && !Strings.CS.equals(speaker, prevSpeaker)) {
                     if (StringUtils.isNotEmpty(segmentBody)) {
                         transcript.addSegment(new TranscriptSegment(spanStartTimecode,
                                 spanEndTimecode, segmentBody, prevSpeaker));

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesser.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedItemDuplicateGuesser.java
@@ -6,6 +6,7 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 import java.text.DateFormat;
 import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 /**
  * Publishers sometimes mess up their feed by adding episodes twice or by changing the ID of existing episodes.
@@ -45,7 +46,7 @@ public class FeedItemDuplicateGuesser {
         DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.SHORT, Locale.US); // MM/DD/YY
         String dateOriginal = dateFormat.format(item2.getPubDate());
         String dateNew = dateFormat.format(item1.getPubDate());
-        return StringUtils.equals(dateOriginal, dateNew); // Same date; time is ignored.
+        return Strings.CS.equals(dateOriginal, dateNew); // Same date; time is ignored.
     }
 
     private static boolean durationsLookSimilar(FeedMedia media1, FeedMedia media2) {
@@ -62,7 +63,7 @@ public class FeedItemDuplicateGuesser {
             mimeType1 = mimeType1.substring(0, mimeType1.indexOf("/"));
             mimeType2 = mimeType2.substring(0, mimeType2.indexOf("/"));
         }
-        return StringUtils.equals(mimeType1, mimeType2);
+        return Strings.CS.equals(mimeType1, mimeType2);
     }
 
     private static boolean titlesLookSimilar(FeedItem item1, FeedItem item2) {


### PR DESCRIPTION
Replace usage of org.apache.commons.lang3.StringUtils.equals with the replacement org.apache.commons.lang3.String.cS.equals

### Description
Replace usage of StringUtils.equals with non-deprecated method.
Closes https://github.com/AntennaPod/AntennaPod/issues/8054

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: ~~https://github.com/AntennaPod/AntennaPod/wiki/Code-style~~ https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
