### PR TITLE
Crash debug version when doing I/O on main thread

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
+++ b/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
@@ -21,12 +21,14 @@ public class PodcastApp extends Application {
 
         if (BuildConfig.DEBUG) {
             StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder()
-                    .detectLeakedSqlLiteObjects()
+                    .penaltyDeath()
                     .penaltyLog()
-                    .penaltyDropBox()
+                    .detectLeakedSqlLiteObjects()
                     .detectActivityLeaks()
-                    .detectLeakedClosableObjects()
                     .detectLeakedRegistrationObjects();
+            if (android.os.Build.VERSION.SDK_INT >= 26) {
+                builder.detectContentUriWithoutPermission();
+            }
             StrictMode.setVmPolicy(builder.build());
         }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -10,6 +10,8 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.os.Build;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -387,7 +389,24 @@ public class PodDBAdapter {
         return newDb;
     }
 
+    private boolean isTest() {
+        if ("robolectric".equals(Build.FINGERPRINT)) {
+            return true;
+        }
+        try {
+            Class.forName("org.junit.Test");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
     public synchronized PodDBAdapter open() {
+        if (BuildConfig.DEBUG) {
+            if (Looper.myLooper() == Looper.getMainLooper() && !isTest()) {
+                throw new RuntimeException("I/O on main thread");
+            }
+        }
         // do nothing
         return this;
     }


### PR DESCRIPTION
### Description

Crash debug version when doing I/O on main thread. Should avoid problems like #8062 in the future.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
