### PR TITLE
When shaking to reset a sleep timer about to expire also reset volume back to full

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1216,7 +1216,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         if (sleepTimerActive()) {
             sleepTimer.updateRemainingTime(waitingTime);
         } else {
-            sleepTimer = new ClockSleepTimer(getApplicationContext(), mediaPlayer);
+            sleepTimer = new ClockSleepTimer(getApplicationContext());
             sleepTimer.start(waitingTime);
         }
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ClockSleepTimer.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ClockSleepTimer.java
@@ -13,7 +13,6 @@ import org.greenrobot.eventbus.ThreadMode;
 
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.event.playback.SleepTimerUpdatedEvent;
-import de.danoeh.antennapod.playback.base.PlaybackServiceMediaPlayer;
 import de.danoeh.antennapod.storage.preferences.SleepTimerPreferences;
 
 public class ClockSleepTimer implements SleepTimer {
@@ -26,11 +25,9 @@ public class ClockSleepTimer implements SleepTimer {
     private long lastTick = 0;
     private boolean hasVibrated = false;
     private ShakeListener shakeListener;
-    private final PlaybackServiceMediaPlayer mediaPlayer;
 
-    public ClockSleepTimer(final Context context, PlaybackServiceMediaPlayer mediaPlayer) {
+    public ClockSleepTimer(final Context context) {
         this.context = context;
-        this.mediaPlayer = mediaPlayer;
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -83,7 +80,7 @@ public class ClockSleepTimer implements SleepTimer {
         }
         // start listening for shakes if shake to reset is enabled
         if (shakeListener == null && SleepTimerPreferences.shakeToReset()) {
-            shakeListener = new ShakeListener(getContext(), this, mediaPlayer);
+            shakeListener = new ShakeListener(getContext(), this);
         }
     }
 
@@ -135,6 +132,8 @@ public class ClockSleepTimer implements SleepTimer {
 
     @Override
     public void reset() {
+        EventBus.getDefault().post(SleepTimerUpdatedEvent.cancelled());
         updateRemainingTime(initialWaitingTime);
+        EventBus.getDefault().post(SleepTimerUpdatedEvent.justEnabled(getTimeLeft()));
     }
 }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ShakeListener.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ShakeListener.java
@@ -11,8 +11,6 @@ import android.os.Vibrator;
 import android.os.VibratorManager;
 import android.util.Log;
 
-import de.danoeh.antennapod.playback.base.PlaybackServiceMediaPlayer;
-
 public class ShakeListener implements SensorEventListener {
     private static final String TAG = ShakeListener.class.getSimpleName();
 
@@ -20,12 +18,10 @@ public class ShakeListener implements SensorEventListener {
     private SensorManager mSensorMgr;
     private final SleepTimer mSleepTimer;
     private final Context mContext;
-    private final PlaybackServiceMediaPlayer mediaPlayer;
 
-    public ShakeListener(Context context, SleepTimer sleepTimer, PlaybackServiceMediaPlayer mediaPlayer) {
+    public ShakeListener(Context context, SleepTimer sleepTimer) {
         mContext = context;
         mSleepTimer = sleepTimer;
-        this.mediaPlayer = mediaPlayer;
         resume();
     }
 
@@ -79,7 +75,6 @@ public class ShakeListener implements SensorEventListener {
         double gForce = Math.sqrt(gX * gX + gY * gY + gZ * gZ);
         if (gForce > 2.25) {
             Log.d(TAG, "Detected shake " + gForce);
-            mediaPlayer.setVolume(1.0f, 1.0f); //set the volume back to full when resetting
             mSleepTimer.reset();
             vibrate();
         }


### PR DESCRIPTION
### Description
When shaking to reset a sleep timer about to expire also reset volume back to full.

Closes #8052

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
