### PR TITLE
Show blue arc around whole circle when sleep timer set to “always”

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TimeRangeDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TimeRangeDialog.java
@@ -173,6 +173,7 @@ public class TimeRangeDialog extends MaterialAlertDialogBuilder {
             } else if (event.getAction() == MotionEvent.ACTION_MOVE) {
                 int newTime = (int) (24 * (angle / 360.0));
                 if (from == to && touching != 0) {
+                    // Switch which handle is focused such that selection is the longer arc
                     touching = (((newTime - to + 24) % 24) < 12) ? 1 : 2;
                 }
                 if (touching == 1) {


### PR DESCRIPTION
### Description
Show blue arc around whole circle when sleep timer set to “always” on time range dialog.
Fixes #8050 


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
