### PR TITLE
Fix app shortcuts not working on debug builds

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -6,9 +6,8 @@
         android:shortcutId="queue"
         android:shortcutShortLabel="@string/queue_label">
         <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="de.danoeh.antennapod">
+            android:action="de.danoeh.antennapod.intents.MAIN_ACTIVITY">
+            <category android:name="android.intent.category.DEFAULT"/>
             <extra
                 android:name="fragment_tag"
                 android:value="QueueFragment" />
@@ -21,9 +20,8 @@
         android:shortcutId="episodes"
         android:shortcutShortLabel="@string/episodes_label">
         <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="de.danoeh.antennapod">
+            android:action="de.danoeh.antennapod.intents.MAIN_ACTIVITY">
+            <category android:name="android.intent.category.DEFAULT"/>
             <extra
                 android:name="fragment_tag"
                 android:value="EpisodesFragment" />
@@ -36,9 +34,8 @@
         android:shortcutId="subscriptions"
         android:shortcutShortLabel="@string/subscriptions_label">
         <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="de.danoeh.antennapod">
+            android:action="de.danoeh.antennapod.intents.MAIN_ACTIVITY">
+            <category android:name="android.intent.category.DEFAULT"/>
             <extra
                 android:name="fragment_tag"
                 android:value="SubscriptionFragment" />
@@ -51,9 +48,8 @@
         android:shortcutId="refresh"
         android:shortcutShortLabel="@string/refresh_label">
         <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="de.danoeh.antennapod.activity.MainActivity"
-            android:targetPackage="de.danoeh.antennapod">
+            android:action="de.danoeh.antennapod.intents.MAIN_ACTIVITY">
+            <category android:name="android.intent.category.DEFAULT"/>
             <extra
                 android:name="refresh_on_start"
                 android:value="true" />


### PR DESCRIPTION
Close #7187
## Changes
Replace explicit activity targeting with custom intent action in shortcuts.xml to fix app shortcuts on debug builds.

Before | After
|---|---|
[Screen_recording_20251109_004618.webm](https://github.com/user-attachments/assets/e794b3b3-7895-4350-8975-6747f6adc300)|[Screen_recording_20251109_004753.webm](https://github.com/user-attachments/assets/5349a608-612c-4f3f-81a3-f1236c369e87)

## Testing
- Verified on debug build (package: de.danoeh.antennapod.debug)
- Tested all shortcuts:
  - Queue: Opens QueueFragment
  - Episodes: Opens EpisodesFragment
  - Subscriptions: Opens SubscriptionFragment
  - Refresh: Triggers refresh
No string resources were modified in this change.