### PR TITLE
Fix feed statistics dialog: align totals with their corresponding values

### DIFF
--- a/ui/statistics/src/main/res/layout/feed_statistics.xml
+++ b/ui/statistics/src/main/res/layout/feed_statistics.xml
@@ -34,11 +34,11 @@
         tools:visibility="visible">
 
         <include
-            android:id="@+id/episodesTotal"
+            android:id="@+id/durationTotal"
             layout="@layout/feed_statistics_card" />
 
         <include
-            android:id="@+id/durationTotal"
+            android:id="@+id/episodesTotal"
             layout="@layout/feed_statistics_card" />
 
         <include


### PR DESCRIPTION
### Description
Fixes alignment in feed statistics dialog by swapping the order of total duration and total episodes in the second row, so totals now appear directly under their corresponding "played" values instead of in opposite columns.
Fixes #8065

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
