### PR TITLE
Run emulator tests on old API versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,13 +101,22 @@ jobs:
           path: app/build/outputs/apk/play/debug/app-play-debug.apk
 
   emulator-test:
-    name: "Emulator Test"
+    name: "Emulator Test API ${{ matrix.version.api-level }}"
     needs: static-analysis
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    env:
-      api-level: 30
+    strategy:
+      matrix:
+        version:
+          - api-level: 21
+            target: default
+          - api-level: 30
+            target: aosp_atd
+          - api-level: 34
+            target: aosp_atd
     steps:
+      - name: Remove unused packages to save space
+        run: sudo apt-get remove firefox google-chrome-stable microsoft-edge-stable snapd powershell azure-cli llvm-16 llvm-17 llvm-18 llvm-16-dev llvm-17-dev llvm-18-dev
       - uses: actions/checkout@v5
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -133,8 +142,9 @@ jobs:
       - name: Android Emulator test
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ env.api-level }}
-          target: aosp_atd
+          api-level: ${{ matrix.version.api-level }}
+          target: ${{ matrix.version.target }}
+          arch: x86_64
           channel: canary
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -145,3 +155,13 @@ jobs:
         with:
           name: test-report
           path: app/build/reports/androidTests/connected/flavors/PLAY/
+
+  ci-summary:
+    name: "CI Summary"
+    needs:
+      - wrapper-validation
+      - emulator-test
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All checks passed"

--- a/app/src/androidTest/java/de/test/antennapod/service/download/HttpDownloaderTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/download/HttpDownloaderTest.java
@@ -1,5 +1,6 @@
 package de.test.antennapod.service.download;
 
+import android.content.Context;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.filters.LargeTest;
 import android.util.Log;
@@ -51,7 +52,12 @@ public class HttpDownloaderTest {
     @Before
     public void setUp() throws Exception {
         UserPreferences.init(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        destDir = InstrumentationRegistry.getInstrumentation().getTargetContext().getExternalFilesDir(DOWNLOAD_DIR);
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        destDir = context.getExternalFilesDir(DOWNLOAD_DIR);
+        if (destDir == null) { // Emulator without SD card
+            destDir = new File(context.getFilesDir(), DOWNLOAD_DIR);
+            destDir.mkdirs();
+        }
         assertNotNull(destDir);
         assertTrue(destDir.exists());
         httpServer = new HTTPBin();

--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -2,6 +2,7 @@ package de.test.antennapod.service.playback;
 
 import android.content.Context;
 
+import android.os.Build;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.filters.MediumTest;
 
@@ -42,6 +43,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Test class for LocalPSMP
@@ -59,6 +61,9 @@ public class PlaybackServiceMediaPlayerTest {
     @After
     @UiThreadTest
     public void tearDown() throws Exception {
+        if (Build.VERSION.SDK_INT < 30) {
+            return; // Test ignored on old Android versions for now
+        }
         PodDBAdapter.deleteDatabase();
         httpServer.stop();
     }
@@ -66,6 +71,8 @@ public class PlaybackServiceMediaPlayerTest {
     @Before
     @UiThreadTest
     public void setUp() throws Exception {
+        assumeTrue(Build.VERSION.SDK_INT >= 30); // Ignored on old Android versions for now
+
         assertionError = null;
         EspressoTestUtils.clearPreferences();
         EspressoTestUtils.clearDatabase();

--- a/app/src/androidTest/java/de/test/antennapod/ui/NavigationDrawerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/NavigationDrawerTest.java
@@ -1,6 +1,7 @@
 package de.test.antennapod.ui;
 
 import android.content.Intent;
+import android.os.Build;
 import androidx.test.espresso.contrib.DrawerActions;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -33,6 +34,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static de.test.antennapod.EspressoTestUtils.onDrawerItem;
 import static de.test.antennapod.EspressoTestUtils.waitForView;
 import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * User interface tests for MainActivity drawer.
@@ -132,6 +134,7 @@ public class NavigationDrawerTest {
 
     @Test
     public void testGoToPreferences() {
+        assumeTrue(Build.VERSION.SDK_INT >= 30); // Unclear why this crashes on old Android versions
         activityRule.launchActivity(new Intent());
         openNavDrawer();
         onView(withText(R.string.settings_label)).perform(click());

--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 
+import android.os.Build;
 import androidx.annotation.StringRes;
 import androidx.preference.PreferenceManager;
 import androidx.test.filters.LargeTest;
@@ -41,6 +42,7 @@ import static de.test.antennapod.EspressoTestUtils.waitForView;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 @LargeTest
 public class PreferencesTest {
@@ -126,6 +128,7 @@ public class PreferencesTest {
 
     @Test
     public void testHeadPhonesReconnect() {
+        assumeTrue(Build.VERSION.SDK_INT < 31); // Setting hidden on Android 12+
         clickPreference(R.string.playback_pref);
         if (!UserPreferences.isPauseOnHeadsetDisconnect()) {
             onView(withText(R.string.pref_pauseOnHeadsetDisconnect_title)).perform(click());
@@ -143,6 +146,7 @@ public class PreferencesTest {
 
     @Test
     public void testBluetoothReconnect() {
+        assumeTrue(Build.VERSION.SDK_INT < 31); // Setting hidden on Android 12+
         clickPreference(R.string.playback_pref);
         if (!UserPreferences.isPauseOnHeadsetDisconnect()) {
             onView(withText(R.string.pref_pauseOnHeadsetDisconnect_title)).perform(click());


### PR DESCRIPTION
### Description

Run emulator tests on old API versions to catch "no such method error" earlier.

See #8096

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
