### PR TITLE
If one PSMP test fails, don't fail all the others

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/PlaybackServiceMediaPlayerTest.java
@@ -1,6 +1,7 @@
 package de.test.antennapod.service.playback;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.filters.MediumTest;
@@ -48,12 +49,14 @@ import static org.junit.Assert.fail;
  */
 @MediumTest
 public class PlaybackServiceMediaPlayerTest {
+    private static final String TAG = "PsmpTest";
     private static final String PLAYABLE_DEST_URL = "psmptestfile.mp3";
     private String PLAYABLE_LOCAL_URL = null;
     private static final int LATCH_TIMEOUT_SECONDS = 3;
 
     private HTTPBin httpServer;
     private String playableFileUrl;
+    private PlaybackServiceMediaPlayer psmp = null;
     private volatile AssertionFailedError assertionError;
 
     @After
@@ -61,12 +64,17 @@ public class PlaybackServiceMediaPlayerTest {
     public void tearDown() throws Exception {
         PodDBAdapter.deleteDatabase();
         httpServer.stop();
+        if (psmp != null) {
+            psmp.shutdown();
+            psmp = null;
+        }
     }
 
     @Before
     @UiThreadTest
     public void setUp() throws Exception {
         assertionError = null;
+        psmp = null;
         EspressoTestUtils.clearPreferences();
         EspressoTestUtils.clearDatabase();
 
@@ -125,8 +133,7 @@ public class PlaybackServiceMediaPlayerTest {
     @UiThreadTest
     public void testInit() {
         final Context c = getInstrumentation().getTargetContext();
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, new DefaultPSMPCallback());
-        psmp.shutdown();
+        psmp = new LocalPSMP(c, new DefaultPSMPCallback());
     }
 
     private Playable writeTestPlayable(String downloadUrl, String fileUrl) {
@@ -177,7 +184,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, null);
         psmp.playMediaObject(p, true, false, false);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -188,7 +195,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertSame(PlayerStatus.INITIALIZED, psmp.getPSMPInfo().getPlayerStatus());
         assertFalse(psmp.isStartWhenPrepared());
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -219,7 +225,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, null);
         psmp.playMediaObject(p, true, true, false);
 
@@ -231,7 +237,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertSame(PlayerStatus.INITIALIZED, psmp.getPSMPInfo().getPlayerStatus());
         assertTrue(psmp.isStartWhenPrepared());
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -265,7 +270,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, null);
         psmp.playMediaObject(p, true, false, true);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -274,8 +279,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertTrue(res);
         assertSame(PlayerStatus.PREPARED, psmp.getPSMPInfo().getPlayerStatus());
         callback.cancel();
-
-        psmp.shutdown();
     }
 
     @Test
@@ -311,7 +314,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, null);
         psmp.playMediaObject(p, true, true, true);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -320,7 +323,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertTrue(res);
         assertSame(PlayerStatus.PLAYING, psmp.getPSMPInfo().getPlayerStatus());
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -351,7 +353,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         psmp.playMediaObject(p, false, false, false);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -361,7 +363,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertSame(PlayerStatus.INITIALIZED, psmp.getPSMPInfo().getPlayerStatus());
         assertFalse(psmp.isStartWhenPrepared());
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -392,7 +393,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         psmp.playMediaObject(p, false, true, false);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -402,7 +403,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertSame(PlayerStatus.INITIALIZED, psmp.getPSMPInfo().getPlayerStatus());
         assertTrue(psmp.isStartWhenPrepared());
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -436,7 +436,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         psmp.playMediaObject(p, false, false, true);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -445,7 +445,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertTrue(res);
         assertSame(PlayerStatus.PREPARED, psmp.getPSMPInfo().getPlayerStatus());
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -483,7 +482,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         psmp.playMediaObject(p, false, true, true);
         boolean res = countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -492,7 +491,6 @@ public class PlaybackServiceMediaPlayerTest {
         assertTrue(res);
         assertSame(PlayerStatus.PLAYING, psmp.getPSMPInfo().getPlayerStatus());
         callback.cancel();
-        psmp.shutdown();
     }
 
     private void pauseTestSkeleton(final PlayerStatus initialState, final boolean stream, final boolean abandonAudioFocus, final boolean reinit, long timeoutSeconds) throws InterruptedException {
@@ -503,6 +501,7 @@ public class PlaybackServiceMediaPlayerTest {
         CancelablePSMPCallback callback = new CancelablePSMPCallback(new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
+                Log.d(TAG, "pauseTestSkeleton: statusChanged: " + newInfo.getPlayerStatus());
                 checkPSMPInfo(newInfo);
                 if (newInfo.getPlayerStatus() == PlayerStatus.ERROR) {
                     if (assertionError == null) {
@@ -544,7 +543,7 @@ public class PlaybackServiceMediaPlayerTest {
                     assertionError = new AssertionFailedError("Unexpected call to shouldStop");
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         if (initialState == PlayerStatus.PLAYING) {
             psmp.playMediaObject(p, stream, true, true);
@@ -555,7 +554,6 @@ public class PlaybackServiceMediaPlayerTest {
             throw assertionError;
         assertTrue(res || initialState != PlayerStatus.PLAYING);
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -621,6 +619,7 @@ public class PlaybackServiceMediaPlayerTest {
         CancelablePSMPCallback callback = new CancelablePSMPCallback(new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
+                Log.d(TAG, "resumeTestSkeleton: statusChanged: " + newInfo.getPlayerStatus());
                 checkPSMPInfo(newInfo);
                 if (newInfo.getPlayerStatus() == PlayerStatus.ERROR) {
                     if (assertionError == null) {
@@ -638,7 +637,7 @@ public class PlaybackServiceMediaPlayerTest {
 
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         if (initialState == PlayerStatus.PREPARED || initialState == PlayerStatus.PLAYING || initialState == PlayerStatus.PAUSED) {
             boolean startWhenPrepared = (initialState != PlayerStatus.PREPARED);
             psmp.playMediaObject(writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL), false, startWhenPrepared, true);
@@ -652,7 +651,6 @@ public class PlaybackServiceMediaPlayerTest {
             throw assertionError;
         assertTrue(res || (initialState != PlayerStatus.PAUSED && initialState != PlayerStatus.PREPARED));
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -680,6 +678,7 @@ public class PlaybackServiceMediaPlayerTest {
         CancelablePSMPCallback callback = new CancelablePSMPCallback(new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
+                Log.d(TAG, "prepareTestSkeleton: statusChanged: " + newInfo.getPlayerStatus());
                 checkPSMPInfo(newInfo);
                 if (newInfo.getPlayerStatus() == PlayerStatus.ERROR) {
                     if (assertionError == null) {
@@ -695,7 +694,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         if (initialState == PlayerStatus.INITIALIZED
                 || initialState == PlayerStatus.PLAYING
@@ -719,7 +718,6 @@ public class PlaybackServiceMediaPlayerTest {
             throw assertionError;
         assertTrue(res);
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test
@@ -753,6 +751,7 @@ public class PlaybackServiceMediaPlayerTest {
         CancelablePSMPCallback callback = new CancelablePSMPCallback(new DefaultPSMPCallback() {
             @Override
             public void statusChanged(LocalPSMP.PSMPInfo newInfo) {
+                Log.d(TAG, "reinitTestSkeleton: statusChanged: " + newInfo.getPlayerStatus());
                 checkPSMPInfo(newInfo);
                 if (newInfo.getPlayerStatus() == PlayerStatus.ERROR) {
                     if (assertionError == null) {
@@ -768,7 +767,7 @@ public class PlaybackServiceMediaPlayerTest {
                 }
             }
         });
-        PlaybackServiceMediaPlayer psmp = new LocalPSMP(c, callback);
+        psmp = new LocalPSMP(c, callback);
         Playable p = writeTestPlayable(playableFileUrl, PLAYABLE_LOCAL_URL);
         boolean prepareImmediately = initialState != PlayerStatus.INITIALIZED;
         boolean startImmediately = initialState != PlayerStatus.PREPARED;
@@ -782,7 +781,6 @@ public class PlaybackServiceMediaPlayerTest {
             throw assertionError;
         assertTrue(res);
         callback.cancel();
-        psmp.shutdown();
     }
 
     @Test


### PR DESCRIPTION
### Description

If one PSMP test fails, don't fail all the others

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
