### PR TITLE
Add integration test for bottom navigation

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/BottomNavigationTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/BottomNavigationTest.java
@@ -1,0 +1,119 @@
+package de.test.antennapod.ui;
+
+import android.content.Intent;
+import android.os.Build;
+import androidx.annotation.StringRes;
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.screen.preferences.PreferenceActivity;
+import de.test.antennapod.EspressoTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static de.test.antennapod.EspressoTestUtils.waitForView;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * User interface tests for MainActivity bottom navigation.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BottomNavigationTest {
+
+    private UITestUtils uiTestUtils;
+
+    @Rule
+    public IntentsTestRule<MainActivity> activityRule = new IntentsTestRule<>(MainActivity.class, false, false);
+
+    @Before
+    public void setUp() throws IOException {
+        uiTestUtils = new UITestUtils(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        uiTestUtils.setup();
+
+        EspressoTestUtils.clearPreferences();
+        EspressoTestUtils.clearDatabase();
+        UserPreferences.setBottomNavigationEnabled(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        uiTestUtils.tearDown();
+    }
+
+    void clickBottomNavItem(@StringRes int text) {
+        onView(allOf(withText(text),
+                isDescendantOfA(withId(R.id.bottomNavigationView)), isDisplayed())).perform(click());
+    }
+
+    void clickBottomNavOverview(@StringRes int text) {
+        onView(allOf(withText(R.string.overflow_more),
+                isDescendantOfA(withId(R.id.bottomNavigationView)), isDisplayed())).perform(click());
+        onView(allOf(withText(text), isDisplayed())).perform(click());
+    }
+
+    @Test
+    public void testClickBottomNavigation() throws Exception {
+        uiTestUtils.addLocalFeedData(false);
+        UserPreferences.setDrawerItemOrder(Collections.emptyList(), Collections.emptyList());
+        activityRule.launchActivity(new Intent());
+
+        clickBottomNavItem(R.string.home_label_short);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.home_label)), 1000));
+
+        clickBottomNavItem(R.string.queue_label_short);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.queue_label)), 1000));
+
+        clickBottomNavItem(R.string.inbox_label_short);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.inbox_label)), 1000));
+
+        clickBottomNavItem(R.string.subscriptions_label_short);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.subscriptions_label)), 1000));
+
+        clickBottomNavOverview(R.string.episodes_label);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.episodes_label)), 1000));
+
+        clickBottomNavOverview(R.string.downloads_label);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.downloads_label)), 1000));
+
+        clickBottomNavOverview(R.string.playback_history_label);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.playback_history_label)), 1000));
+
+        clickBottomNavOverview(R.string.add_feed_label);
+        onView(isRoot()).perform(waitForView(allOf(isDescendantOfA(withId(R.id.toolbar)),
+                withText(R.string.add_feed_label)), 1000));
+    }
+
+    @Test
+    public void testGoToPreferences() {
+        assumeTrue(Build.VERSION.SDK_INT >= 30); // Unclear why this crashes on old Android versions
+        activityRule.launchActivity(new Intent());
+        clickBottomNavOverview(R.string.settings_label);
+        intended(hasComponent(PreferenceActivity.class.getName()));
+    }
+}


### PR DESCRIPTION
### Description

Add integration test for bottom navigation. We already have one for the navigation drawer but none for bottom navigation yet.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
