### PR TITLE
Auto tag from category

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.model.feed;
 
+import android.text.TextUtils;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -62,6 +63,10 @@ public class Feed {
     private long lastRefreshAttempt;
 
     private ArrayList<FeedFunding> fundingList;
+    /**
+     * Feed categories from RSS/iTunes.
+     */
+    private List<String> categories = new ArrayList<>();
     /**
      * Feed type, for example RSS 2 or Atom.
      */
@@ -354,6 +359,16 @@ public class Feed {
 
     public ArrayList<FeedFunding> getPaymentLinks() {
         return fundingList;
+    }
+
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    public void addCategory(String category) {
+        if (!TextUtils.isEmpty(category) && !categories.contains(category)) {
+            categories.add(category.trim());
+        }
     }
 
     public String getLanguage() {

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
@@ -187,6 +187,10 @@ public class FeedPreferences implements Serializable {
             return;
         this.username = other.username;
         this.password = other.password;
+        // Preserve tags from the new feed (e.g., auto-tagged categories)
+        if (!other.tags.isEmpty()) {
+            this.tags.addAll(other.tags);
+        }
     }
 
     public long getFeedID() {

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Itunes.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Itunes.java
@@ -24,6 +24,7 @@ public class Itunes extends Namespace {
     private static final String SUBTITLE = "subtitle";
     private static final String SUMMARY = "summary";
     private static final String NEW_FEED_URL = "new-feed-url";
+    private static final String CATEGORY = "category";
 
     @Override
     public SyndElement handleElementStart(String localName, HandlerState state,
@@ -39,6 +40,11 @@ public class Itunes extends Namespace {
                 if (!TextUtils.isEmpty(url)) {
                     state.getFeed().setImageUrl(url);
                 }
+            }
+        } else if (CATEGORY.equals(localName) && state.getFeed() != null) {
+            String text = attributes.getValue("text");
+            if (!TextUtils.isEmpty(text)) {
+                state.getFeed().addCategory(text);
             }
         }
         return new SyndElement(localName, this);

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Rss20.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Rss20.java
@@ -34,6 +34,7 @@ public class Rss20 extends Namespace {
     private static final String IMAGE = "image";
     private static final String URL = "url";
     private static final String LANGUAGE = "language";
+    private static final String CATEGORY = "category";
 
     private static final String ENC_URL = "url";
     private static final String ENC_LEN = "length";
@@ -144,6 +145,8 @@ public class Rss20 extends Namespace {
                 }
             } else if (LANGUAGE.equals(localName) && state.getFeed() != null) {
                 state.getFeed().setLanguage(content.toLowerCase(Locale.US));
+            } else if (CATEGORY.equals(localName) && CHANNEL.equals(second) && state.getFeed() != null) {
+                state.getFeed().addCategory(content);
             }
         }
     }

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -62,6 +62,7 @@ public abstract class UserPreferences {
     public static final String PREF_SUBSCRIPTION_TITLE = "prefSubscriptionTitle";
     public static final String PREF_BACK_OPENS_DRAWER = "prefBackButtonOpensDrawer";
     public static final String PREF_BOTTOM_NAVIGATION = "prefBottomNavigation";
+    public static final String PREF_AUTO_TAG_CATEGORIES = "prefAutoTagCategories";
 
     public static final String PREF_QUEUE_KEEP_SORTED = "prefQueueKeepSorted";
     public static final String PREF_QUEUE_KEEP_SORTED_ORDER = "prefQueueKeepSortedOrder";
@@ -757,6 +758,10 @@ public abstract class UserPreferences {
 
     public static boolean isBottomNavigationEnabled() {
         return prefs.getBoolean(PREF_BOTTOM_NAVIGATION, false);
+    }
+
+    public static boolean isAutoTagCategoriesEnabled() {
+        return prefs.getBoolean(PREF_AUTO_TAG_CATEGORIES, true);
     }
 
     public static void setBottomNavigationEnabled(boolean enabled) {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -567,6 +567,8 @@
     <string name="remember_last_page">Remember last page</string>
     <string name="pref_delete_removes_from_queue_title">Delete removes from queue</string>
     <string name="pref_delete_removes_from_queue_sum">Automatically remove an episode from the queue when it is deleted</string>
+    <string name="pref_auto_tag_categories_title">Auto-tag from categories</string>
+    <string name="pref_auto_tag_categories_sum">Automatically add RSS/iTunes categories as tags when subscribing to feeds</string>
     <string name="pref_downloads_button_action_title">Play from downloads screen</string>
     <string name="pref_downloads_button_action_sum">Display play button instead of delete button on downloads screen</string>
     <string name="subscriptions_counter_greater_zero">Counter greater than zero</string>

--- a/ui/preferences/src/main/res/xml/preferences_downloads.xml
+++ b/ui/preferences/src/main/res/xml/preferences_downloads.xml
@@ -37,6 +37,12 @@
             android:key="prefDeleteRemovesFromQueue"
             android:summary="@string/pref_delete_removes_from_queue_sum"
             android:title="@string/pref_delete_removes_from_queue_title"/>
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:enabled="true"
+            android:key="prefAutoTagCategories"
+            android:summary="@string/pref_auto_tag_categories_sum"
+            android:title="@string/pref_auto_tag_categories_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/download_pref_details">


### PR DESCRIPTION
### Description
This PR is to make it easier to make a decision concerning Triage for #8105.
#### Summary
This PR implements automatic tagging of podcast feeds based on their RSS/iTunes categories when subscribing to new feeds.

#### Changes
• **New user preference**: Added "Auto-tag from categories" setting in Downloads preferences (enabled by default)
• **Feed parsing enhancement**: Automatically extracts categories from RSS and iTunes feed metadata and converts them to tags
• **Tag sanitization**: Implements proper sanitization of category names to ensure they work well as tags (removes special characters, limits length to 30 characters)
• **User control**: Users can disable this feature via preferences if they prefer manual tagging

Closes: #8105.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x ] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ x] I have performed a self-review of my code
- [ x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [ x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
