### PR TITLE
Check that PR titles do not reference issue

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -1,0 +1,19 @@
+name: PR Conventions
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited, labeled, unlabeled ]
+
+jobs:
+  pr-title:
+    name: "Title"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prevent issue reference in title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueRegex = /#\d+/i;
+            if (issueRegex.test(context.payload.pull_request.title)) {
+              core.setFailed("Please mention the issue number in the PR description, not in the title. Make sure to write 'closes: #<number>'.");
+            }


### PR DESCRIPTION
### Description

Check that PR titles do not reference issue. Issue numbers should be referenced in the PR description, not just in the title.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
