### PR TITLE
Reset interrupted state on InterruptedException

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlaybackServiceNotificationBuilder.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlaybackServiceNotificationBuilder.java
@@ -88,11 +88,13 @@ public class PlaybackServiceNotificationBuilder {
                         .submit(iconSize, iconSize)
                         .get();
             } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
                 Log.e(TAG, "Media icon loader was interrupted");
             } catch (Throwable tr) {
                 Log.e(TAG, "Error loading the media icon for the notification", tr);
             }
         } catch (InterruptedException ignore) {
+            Thread.currentThread().interrupt();
             Log.e(TAG, "Media icon loader was interrupted");
         } catch (Throwable tr) {
             Log.e(TAG, "Error loading the media icon for the notification", tr);


### PR DESCRIPTION
### Description

This resets the interrupted state for the thread, because it is checked in the calling method.

If you catch a InterruptedException and do not call Thread.currentThread().interrupt(), the interrupt state of the thread is not set anymore and the calling method has no information about it. Without the correction the if (!Thread.currentThread().isInterrupted()) will always be true. Neither Thread.currentThread().interrupt() is called nor the exception is rethrown which can result in unexpected behavior.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
