### PR TITLE
Make emulator tests more stable

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -154,7 +154,7 @@ jobs:
         if: failure()
         with:
           name: test-report
-          path: app/build/reports/androidTests/connected/flavors/PLAY/
+          path: app/build/reports/androidTests/
 
   ci-summary:
     name: "CI Summary"

--- a/.github/workflows/runEmulatorTests.sh
+++ b/.github/workflows/runEmulatorTests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -o pipefail
+adb logcat -c
 
 runTests() {
     ./gradlew connectedPlayDebugAndroidTest connectedDebugAndroidTest \
@@ -8,4 +9,11 @@ runTests() {
 }
 
 # Retry tests to make them less flaky
-runTests || runTests || runTests
+if runTests || runTests || runTests; then
+    echo "Tests succeeded"
+else
+    echo "Tests FAILED. Dumping logcat:"
+    adb logcat -d > app/build/reports/androidTests/logcat.txt
+    exit 1
+fi
+

--- a/app/src/androidTest/java/de/test/antennapod/EspressoTestUtils.java
+++ b/app/src/androidTest/java/de/test/antennapod/EspressoTestUtils.java
@@ -99,9 +99,8 @@ public class EspressoTestUtils {
      *
      * @param viewMatcher The view to wait for.
      * @param timeoutMillis Maximum waiting period in milliseconds.
-     * @throws Exception Throws an Exception in case of a timeout.
      */
-    public static void waitForViewGlobally(@NonNull Matcher<View> viewMatcher, long timeoutMillis) throws Exception {
+    public static void waitForViewGlobally(@NonNull Matcher<View> viewMatcher, long timeoutMillis) {
         long startTime = System.currentTimeMillis();
         long endTime = startTime + timeoutMillis;
 
@@ -110,14 +109,21 @@ public class EspressoTestUtils {
                 onView(viewMatcher).check(matches(isDisplayed()));
                 // no Exception thrown -> check successful
                 return;
-            } catch (NoMatchingViewException | AssertionFailedError ignore) {
+            } catch (NoMatchingViewException | AssertionFailedError exception) {
                 // check was not successful "not found" -> continue waiting
+                if (System.currentTimeMillis() >= endTime) {
+                    throw exception;
+                }
             }
-            //noinspection BusyWait
-            Thread.sleep(50);
-        } while (System.currentTimeMillis() < endTime);
+            try {
+                //noinspection BusyWait
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                break;
+            }
+        } while (true);
 
-        throw new Exception("Timeout after " + timeoutMillis + " ms");
+        throw new RuntimeException("Timeout after " + timeoutMillis + " ms");
     }
 
     /**

--- a/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
+++ b/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
@@ -1,7 +1,6 @@
 package de.danoeh.antennapod;
 
 import android.app.Application;
-import android.os.StrictMode;
 import android.util.Log;
 
 import com.google.android.material.color.DynamicColors;
@@ -18,19 +17,6 @@ public class PodcastApp extends Application {
         super.onCreate();
         Thread.setDefaultUncaughtExceptionHandler(new CrashReportExceptionHandler());
         RxJavaErrorHandlerSetup.setupRxJavaErrorHandler();
-
-        if (BuildConfig.DEBUG) {
-            StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder()
-                    .penaltyDeath()
-                    .penaltyLog()
-                    .detectLeakedSqlLiteObjects()
-                    .detectActivityLeaks()
-                    .detectLeakedRegistrationObjects();
-            if (android.os.Build.VERSION.SDK_INT >= 26) {
-                builder.detectContentUriWithoutPermission();
-            }
-            StrictMode.setVmPolicy(builder.build());
-        }
 
         try {
             // Robolectric calls onCreate for every test, which causes problems with static members


### PR DESCRIPTION
### Description

Make emulator tests more stable. Also add logs to artifacts to simplify debugging

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
