### PR TITLE
Hide middot separator when episode duration is unavailable

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -304,9 +304,14 @@ public class ItemFragment extends Fragment {
             actionButton1 = new MarkAsPlayedActionButton(item);
             actionButton2 = new VisitWebsiteActionButton(item);
             viewBinding.noMediaLabel.setVisibility(View.VISIBLE);
+            viewBinding.txtvDuration.setVisibility(View.GONE);
+            viewBinding.separatorIcons.setVisibility(View.GONE);
         } else {
             viewBinding.noMediaLabel.setVisibility(View.GONE);
-            if (media.getDuration() > 0) {
+            boolean hasDuration = media.getDuration() > 0;
+            viewBinding.txtvDuration.setVisibility(hasDuration ? View.VISIBLE : View.GONE);
+            viewBinding.separatorIcons.setVisibility(hasDuration ? View.VISIBLE : View.GONE);
+            if (hasDuration) {
                 viewBinding.txtvDuration.setText(Converter.getDurationStringLong(media.getDuration()));
                 viewBinding.txtvDuration.setContentDescription(
                         Converter.getDurationStringLocalized(getContext(), media.getDuration()));


### PR DESCRIPTION
### Description
When an episode has no duration available, the middot separator between duration and date was still displayed, resulting in an awkward display

This fix hides both the duration TextView and the separator when:
- Media is null (no media attached to episode)
- Media exists but duration is 0 or unavailable

Fixes #8131 
### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
