### PR TITLE
Enforce 'closes' syntax for referencing issues in PR descriptions

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -6,14 +6,20 @@ on:
 
 jobs:
   pr-title:
-    name: "Title"
+    name: "Check"
     runs-on: ubuntu-latest
     steps:
-      - name: Prevent issue reference in title
+      - name: Check PR Conventions
         uses: actions/github-script@v7
         with:
           script: |
             const issueRegex = /#\d+/i;
             if (issueRegex.test(context.payload.pull_request.title)) {
-              core.setFailed("Please mention the issue number in the PR description, not in the title. Make sure to write 'closes: #<number>'.");
+              core.setFailed("Please mention the issue number in the PR description, not in the title. Make sure to write 'closes #<number>'.");
+            }
+
+            const closingRegex = /\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+#\d+/i;
+            if (issueRegex.test(context.payload.pull_request.body) && !closingRegex.test(context.payload.pull_request.body)) {
+              core.setFailed("The PR description must contain 'closes #<number>' to link to the issue that it closes.");
+              return;
             }


### PR DESCRIPTION
### Description

Enforce 'closes' syntax for referencing issues in PR descriptions.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
