### PR TITLE
Fix subs jumping when entering multi-select while there are no tags

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -85,6 +85,7 @@ public class SubscriptionFragment extends Fragment
     private ProgressBar progressBar;
     private CollapsingToolbarLayout collapsingContainer;
     private boolean displayUpArrow;
+    private boolean shouldShowTags = false;
 
     private Disposable disposable;
     private SharedPreferences prefs;
@@ -405,9 +406,9 @@ public class SubscriptionFragment extends Fragment
                             restoreScrollPosition(scrollPosition);
                         }
                         emptyView.updateVisibility();
+                        shouldShowTags = false;
                         if (tagAdapter != null) {
                             tagAdapter.setTags(result.second);
-                            boolean shouldShowTags = false;
                             for (NavDrawerData.TagItem tag : result.second) {
                                 if (!FeedPreferences.TAG_ROOT.equals(tag.getTitle())
                                         && !FeedPreferences.TAG_UNTAGGED.equals(tag.getTitle())) {
@@ -477,7 +478,7 @@ public class SubscriptionFragment extends Fragment
     public void onEndSelectMode() {
         floatingSelectMenu.setVisibility(View.GONE);
         subscriptionAddButton.setVisibility(View.VISIBLE);
-        tagsRecycler.setVisibility(tagAdapter.getItemCount() > 1 ? View.VISIBLE : View.GONE);
+        tagsRecycler.setVisibility(shouldShowTags ? View.VISIBLE : View.GONE);
         updateFilterVisibility();
         setCollapsingToolbarFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                 | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
@@ -488,7 +489,7 @@ public class SubscriptionFragment extends Fragment
     public void onStartSelectMode() {
         floatingSelectMenu.setVisibility(View.VISIBLE);
         subscriptionAddButton.setVisibility(View.GONE);
-        tagsRecycler.setVisibility(tagAdapter.getItemCount() > 1 ? View.INVISIBLE : View.GONE);
+        tagsRecycler.setVisibility(shouldShowTags ? View.INVISIBLE : View.GONE);
         updateFilterVisibility();
         setCollapsingToolbarFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                 | AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED);


### PR DESCRIPTION
### Description

Fix subs jumping when entering multi-select while there are no tags

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
