### PR TITLE
Fix running integration tests in december

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EchoSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EchoSection.java
@@ -66,6 +66,8 @@ public class EchoSection extends Fragment {
     void hideThisYear() {
         getContext().getSharedPreferences(HomeFragment.PREF_NAME, Context.MODE_PRIVATE)
                 .edit().putInt(HomeFragment.PREF_HIDE_ECHO, EchoConfig.RELEASE_YEAR).apply();
-        ((MainActivity) getActivity()).loadFragment(HomeFragment.TAG, null);
+        if (isVisible()) {
+            ((MainActivity) getActivity()).loadFragment(HomeFragment.TAG, null);
+        }
     }
 }


### PR DESCRIPTION
### Description

Fix running integration tests in december. AntennaPod Echo should not restart the app and break all tests with it.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
