### PR TITLE
Fix device surface colors leaking into default blue theme

### DIFF
--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -100,6 +100,7 @@
                     android:layout_width="14sp"
                     android:layout_height="14sp"
                     android:contentDescription="@string/is_inbox_label"
+                    app:tint="?attr/colorOnSurfaceVariant"
                     app:srcCompat="@drawable/ic_inbox" />
 
                 <ImageView
@@ -107,6 +108,7 @@
                     android:layout_width="14sp"
                     android:layout_height="14sp"
                     android:contentDescription="@string/media_type_video_label"
+                    app:tint="?attr/colorOnSurfaceVariant"
                     app:srcCompat="@drawable/ic_videocam" />
 
                 <ImageView
@@ -114,6 +116,7 @@
                     android:layout_width="14sp"
                     android:layout_height="14sp"
                     android:contentDescription="@string/is_favorite_label"
+                    app:tint="?attr/colorOnSurfaceVariant"
                     app:srcCompat="@drawable/ic_star" />
 
                 <ImageView
@@ -121,6 +124,7 @@
                     android:layout_width="14sp"
                     android:layout_height="14sp"
                     android:contentDescription="@string/in_queue_label"
+                    app:tint="?attr/colorOnSurfaceVariant"
                     app:srcCompat="@drawable/ic_playlist_play" />
 
                 <TextView

--- a/ui/common/src/main/res/values/colors.xml
+++ b/ui/common/src/main/res/values/colors.xml
@@ -18,10 +18,16 @@
     <color name="non_square_icon_background">#22777777</color>
     <color name="seek_background_light">#90000000</color>
     <color name="seek_background_dark">#905B5B5B</color>
+    <color name="text_color_secondary_light">#444444</color>
+    <color name="text_color_secondary_dark">#cccccc</color>
+    <color name="color_surface_variant_light">#D3DCE0</color>
+    <color name="color_surface_variant_dark">#2F3B4F</color>
+    <color name="color_secondary_container_light">#A5B8C0</color>
+    <color name="color_secondary_container_dark">#4D5F80</color>
 
     <color name="accent_light">#0078C2</color>
     <color name="accent_dark">#3D8BFF</color>
-    
+
     <color name="gradient_000">#364ff3</color>
     <color name="gradient_025">#2E6FF6</color>
     <color name="gradient_075">#1EB0FC</color>

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -43,9 +43,22 @@
         <item name="colorOnPrimaryContainer">@color/black</item>
         <item name="android:colorBackground">@color/background_light</item>
         <item name="colorSurface">@color/background_light</item>
-        <item name="colorSurfaceVariant">#D3DCE0</item>
+        <item name="colorOnSurface">@color/black</item>
+        <item name="colorOnContainer">@color/black</item>
+        <item name="colorSurfaceVariant">@color/color_surface_variant_light</item>
+        <item name="colorOnSurfaceVariant">@color/text_color_secondary_light</item>
         <item name="colorSurfaceContainer">#EBEEF3</item>
-        <item name="colorSecondaryContainer">#D3DCE0</item>
+        <item name="colorSecondaryContainer">@color/color_secondary_container_light</item>
+        <item name="colorOnSecondaryContainer">@color/black</item>
+        <item name="android:textColorPrimary">@color/black</item>
+        <item name="android:textColorSecondary">@color/text_color_secondary_light</item>
+        <item name="android:textColorTertiary">@color/text_color_secondary_light</item>
+        <item name="colorOutline">@color/text_color_secondary_light</item>
+        <item name="colorOutlineVariant">@color/text_color_secondary_light</item>
+        <item name="colorSurfaceContainerHigh">@color/color_surface_variant_light</item>
+        <item name="colorSurfaceContainerHighest">@color/color_surface_variant_light</item>
+        <item name="colorSurfaceContainerLow">@color/color_surface_variant_light</item>
+        <item name="colorSurfaceContainerLowest">@color/color_surface_variant_light</item>
     </style>
 
     <style name="Theme.AntennaPod.Dynamic.Dark" parent="Theme.Base.AntennaPod.Dynamic.Dark">
@@ -88,9 +101,22 @@
         <item name="colorOnPrimaryContainer">@color/white</item>
         <item name="android:colorBackground">@color/background_darktheme</item>
         <item name="colorSurface">@color/background_darktheme</item>
-        <item name="colorSurfaceVariant">#2F3B4F</item>
+        <item name="colorOnSurface">@color/white</item>
+        <item name="colorOnContainer">@color/white</item>
+        <item name="colorSurfaceVariant">@color/color_surface_variant_dark</item>
+        <item name="colorOnSurfaceVariant">@color/text_color_secondary_dark</item>
         <item name="colorSurfaceContainer">#1C2024</item>
-        <item name="colorSecondaryContainer">#2F3B4F</item>
+        <item name="colorSecondaryContainer">@color/color_secondary_container_dark</item>
+        <item name="colorOnSecondaryContainer">@color/white</item>
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:textColorSecondary">@color/text_color_secondary_dark</item>
+        <item name="android:textColorTertiary">@color/text_color_secondary_dark</item>
+        <item name="colorOutline">@color/text_color_secondary_dark</item>
+        <item name="colorOutlineVariant">@color/text_color_secondary_dark</item>
+        <item name="colorSurfaceContainerHigh">@color/color_surface_variant_dark</item>
+        <item name="colorSurfaceContainerHighest">@color/color_surface_variant_dark</item>
+        <item name="colorSurfaceContainerLow">@color/color_surface_variant_dark</item>
+        <item name="colorSurfaceContainerLowest">@color/color_surface_variant_dark</item>
     </style>
 
     <style name="Theme.AntennaPod.Dynamic.TrueBlack" parent="Theme.AntennaPod.Dynamic.Dark">


### PR DESCRIPTION
### Description

Fix device surface colors leaking into default blue theme. Selecting a non-blue system wide accent color made the AntennaPod default colors all mixed up. In the future, we should probably give up trying to do our own colors and just always rely on the system default colors.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
