### PR TITLE
Remove separator lines in lists

### DIFF
--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -135,14 +135,14 @@
                     android:layout_marginEnd="4dp"
                     android:text="·"
                     android:importantForAccessibility="no"
-                    style="@style/AntennaPod.TextView.ListItemSecondaryTitle" />
+                    style="@style/AntennaPod.TextView.FeedListItemSecondaryTitle" />
 
                 <TextView
                     android:id="@+id/txtvPubDate"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="4dp"
-                    style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                    style="@style/AntennaPod.TextView.FeedListItemSecondaryTitle"
                     tools:text="@sample/episodes.json/data/published_at" />
 
                 <TextView
@@ -151,14 +151,14 @@
                     android:layout_marginEnd="4dp"
                     android:text="·"
                     android:importantForAccessibility="no"
-                    style="@style/AntennaPod.TextView.ListItemSecondaryTitle" />
+                    style="@style/AntennaPod.TextView.FeedListItemSecondaryTitle" />
 
                 <TextView
                     android:id="@+id/size"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="4dp"
-                    style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                    style="@style/AntennaPod.TextView.FeedListItemSecondaryTitle"
                     tools:text="10 MB" />
 
             </LinearLayout>
@@ -175,7 +175,7 @@
                 android:importantForAccessibility="no"
                 android:ellipsize="end"
                 android:textAlignment="viewStart"
-                style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
+                style="@style/AntennaPod.TextView.FeedListItemPrimaryTitle"
                 tools:text="@sample/episodes.json/data/title" />
 
             <LinearLayout
@@ -190,7 +190,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="0dp"
-                    style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                    style="@style/AntennaPod.TextView.FeedListItemSecondaryTitle"
                     tools:text="00:42:23" />
 
                 <com.google.android.material.progressindicator.LinearProgressIndicator
@@ -207,7 +207,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="0dp"
-                    style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
+                    style="@style/AntennaPod.TextView.FeedListItemSecondaryTitle"
                     tools:text="@sample/episodes.json/data/duration" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/horizontal_itemlist_item.xml
+++ b/app/src/main/res/layout/horizontal_itemlist_item.xml
@@ -64,7 +64,7 @@
                             android:layout_height="48dp"
                             android:layout_gravity="bottom|end"
                             android:layout_margin="4dp"
-                            app:foregroundColor="?attr/colorPrimary" />
+                            app:foregroundColor="?attr/colorOnPrimary" />
 
                         <ImageView
                             android:id="@+id/secondaryActionIcon"

--- a/app/src/main/res/layout/secondary_action.xml
+++ b/app/src/main/res/layout/secondary_action.xml
@@ -18,7 +18,6 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_gravity="center"
-        app:tint="?attr/colorAccent"
         tools:ignore="ContentDescription"
         tools:src="@sample/secondaryaction" />
 
@@ -27,6 +26,6 @@
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:layout_gravity="center"
-        app:foregroundColor="?attr/colorAccent" />
+        app:foregroundColor="?attr/action_icon_color" />
 
 </FrameLayout>

--- a/ui/common/src/main/java/de/danoeh/antennapod/ui/common/CircularProgressBar.java
+++ b/ui/common/src/main/java/de/danoeh/antennapod/ui/common/CircularProgressBar.java
@@ -75,8 +75,8 @@ public class CircularProgressBar extends View {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        float padding = getHeight() * 0.1f;
-        paintBackground.setStrokeWidth(getHeight() * 0.05f);
+        float padding = getHeight() * 0.08f;
+        paintBackground.setStrokeWidth(getHeight() * 0.03f);
         paintBackground.setPathEffect(isIndeterminate ? DASHED : null);
         paintProgress.setStrokeWidth(padding);
         bounds.set(padding, padding, getWidth() - padding, getHeight() - padding);

--- a/ui/common/src/main/res/values/dimens.xml
+++ b/ui/common/src/main/res/values/dimens.xml
@@ -13,7 +13,7 @@
 
     <dimen name="listitem_threeline_textleftpadding">16dp</dimen>
     <dimen name="listitem_threeline_textrightpadding">8dp</dimen>
-    <dimen name="listitem_threeline_verticalpadding">10dp</dimen>
+    <dimen name="listitem_threeline_verticalpadding">11dp</dimen>
 
     <dimen name="list_vertical_padding">8dp</dimen>
     <dimen name="listitem_icon_leftpadding">16dp</dimen>

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -276,13 +276,27 @@
     </style>
 
     <style name="AntennaPod.TextView.ListItemPrimaryTitle" parent="@style/TextAppearance.Material3.BodyLarge">
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:maxLines">2</item>
         <item name="android:ellipsize">end</item>
         <item name="lineHeight">20sp</item>
         <item name="android:lineHeight" tools:targetApi="p">20sp</item>
     </style>
 
-    <style name="AntennaPod.TextView.ListItemSecondaryTitle" parent="@style/TextAppearance.Material3.LabelSmall">
+    <style name="AntennaPod.TextView.FeedListItemPrimaryTitle" parent="@style/TextAppearance.Material3.BodyLarge">
+        <item name="android:maxLines">2</item>
+        <item name="android:ellipsize">end</item>
+        <item name="lineHeight">20sp</item>
+        <item name="android:lineHeight" tools:targetApi="p">20sp</item>
+    </style>
+
+    <style name="AntennaPod.TextView.ListItemSecondaryTitle" parent="@style/TextAppearance.Material3.BodyMedium">
+        <item name="android:textColor">?attr/colorOnSurfaceVariant</item>
+        <item name="android:lines">1</item>
+        <item name="android:ellipsize">end</item>
+    </style>
+
+    <style name="AntennaPod.TextView.FeedListItemSecondaryTitle" parent="@style/TextAppearance.Material3.LabelSmall">
         <item name="android:lines">1</item>
         <item name="android:ellipsize">end</item>
     </style>


### PR DESCRIPTION
### Description

Experiment with list item appearance. More modern and clean.

After (first commit) / Before / After (second commit):

<img width="200" alt="Screenshot_20251221-114220" src="https://github.com/user-attachments/assets/7acade6f-679e-465b-b4c3-232aba2e7cb2" /> <img width="200" alt="Screenshot_20251221-114241" src="https://github.com/user-attachments/assets/f51321d1-4abf-4a27-82dd-6cbac32f2ae8" /> <img width="200" alt="Screenshot_20260101-183831" src="https://github.com/user-attachments/assets/1131a77a-a813-43fc-91f8-3e27a5f2515e" />



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
