### PR TITLE
Clarify what deleting does

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -212,8 +212,8 @@
     <string name="remove_feed_label">Delete</string>
     <string name="share_label">Share</string>
     <string name="share_file_label">Share file</string>
-    <string name="feed_delete_explanation_delete">Deleting will remove ALL its episodes including downloads, playback history, and statistics.</string>
-    <string name="feed_delete_explanation_archive">Archiving will hide it from the subscription list and avoid it getting updates. Downloads, statistics and playback state are kept.</string>
+    <string name="feed_delete_explanation_delete">Deleting removes the subscription including all its episodes, downloads, playback history, and statistics.</string>
+    <string name="feed_delete_explanation_archive">Archiving hides the subscription from the list and stops looking for new episodes. Downloads, statistics and playback state are kept.</string>
     <string name="archiving_podcast_progress">Archiving podcast %1$d of %2$d…</string>
     <string name="deleting_podcast_progress">Deleting podcast %1$d of %2$d…</string>
     <string name="load_complete_feed">Refresh complete podcast</string>


### PR DESCRIPTION
### Description

We got reports from more than one person that they did not find how to remove a subscription: https://forum.antennapod.org/t/remove-podcast-not-showing-up-on-menu/7779
I think the problem here was that the explanation text does not mention the subscription itself. It only mentions that we remove all episodes.
Update the text to explicitly state that it removes the subscription including its episodes.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
