### PR TITLE
Add ability to mark podcasts as a priority

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -60,6 +60,7 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
     private static final String PREF_AUTO_SKIP = "feedAutoSkip";
     private static final String PREF_NOTIFICATION = "episodeNotification";
     private static final String PREF_TAGS = "tags";
+    private static final String PREF_PRIORITY = "feedPriority";
 
     private Feed feed;
     private Disposable disposable;
@@ -216,6 +217,15 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
             feedPreferences.setNewEpisodesAction(FeedPreferences.NewEpisodesAction.fromCode(code));
             DBWriter.setFeedPreferences(feedPreferences);
             updateNewEpisodesActionSummary();
+            return false;
+        });
+        SwitchPreferenceCompat priorityPreference = findPreference(PREF_PRIORITY);
+        priorityPreference.setChecked(feedPreferences.getPriority());
+        priorityPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            boolean checked = Boolean.TRUE.equals(newValue);
+            feedPreferences.setPriority(checked);
+            DBWriter.setFeedPreferences(feedPreferences);
+            priorityPreference.setChecked(checked);
             return false;
         });
         SwitchPreferenceCompat keepUpdated = findPreference("keepUpdated");

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -65,6 +65,12 @@
         android:summary="@string/global_default"
         android:title="@string/pref_new_episodes_action_title" />
 
+    <SwitchPreferenceCompat
+        android:icon="@drawable/ic_star"
+        android:key="feedPriority"
+        android:summary="@string/feed_priority_summary"
+        android:title="@string/feed_priority_label" />
+
     <PreferenceCategory
         android:key="autoDownloadCategory"
         android:title="@string/auto_download_inbox_category">

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
@@ -122,6 +122,7 @@ public class FeedPreferences implements Serializable {
     private int feedSkipEnding;
     private SkipSilence feedSkipSilence;
     private boolean showEpisodeNotification;
+    private boolean priority;
     private final Set<String> tags = new HashSet<>();
 
     public FeedPreferences(long feedID, AutoDownloadSetting autoDownload, AutoDeleteAction autoDeleteAction,
@@ -129,14 +130,14 @@ public class FeedPreferences implements Serializable {
                            String username, String password) {
         this(feedID, autoDownload, true, autoDeleteAction, volumeAdaptionSetting, username, password,
                 new FeedFilter(), SPEED_USE_GLOBAL, 0, 0, SkipSilence.GLOBAL,
-                false, newEpisodesAction, new HashSet<>());
+                false, newEpisodesAction, false, new HashSet<>());
     }
 
     public FeedPreferences(long feedID, AutoDownloadSetting autoDownload, boolean keepUpdated,
                             AutoDeleteAction autoDeleteAction, VolumeAdaptionSetting volumeAdaptionSetting,
                             String username, String password, @NonNull FeedFilter filter,
                             float feedPlaybackSpeed, int feedSkipIntro, int feedSkipEnding, SkipSilence feedSkipSilence,
-                            boolean showEpisodeNotification, NewEpisodesAction newEpisodesAction,
+                            boolean showEpisodeNotification, NewEpisodesAction newEpisodesAction, boolean priority,
                             Set<String> tags) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
@@ -152,6 +153,7 @@ public class FeedPreferences implements Serializable {
         this.feedSkipSilence = feedSkipSilence;
         this.showEpisodeNotification = showEpisodeNotification;
         this.newEpisodesAction = newEpisodesAction;
+        this.priority = priority;
         this.tags.addAll(tags);
     }
 
@@ -320,5 +322,13 @@ public class FeedPreferences implements Serializable {
 
     public void setShowEpisodeNotification(boolean showEpisodeNotification) {
         this.showEpisodeNotification = showEpisodeNotification;
+    }
+
+    public boolean getPriority() {
+        return priority;
+    }
+
+    public void setPriority(boolean priority) {
+        this.priority = priority;
     }
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -355,6 +355,10 @@ class DBUpgrader {
             db.execSQL("DELETE FROM " + PodDBAdapter.TABLE_NAME_FAVORITES + " WHERE " + PodDBAdapter.KEY_FEEDITEM
                     + " NOT IN (SELECT " + PodDBAdapter.KEY_ID + " FROM " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + ")");
         }
+        if (oldVersion < 3120000) {
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_FEED_PRIORITY + " INTEGER DEFAULT 0");
+        }
     }
 
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -393,13 +393,13 @@ public class DBWriter {
             ItemEnqueuePositionCalculator positionCalculator =
                     new ItemEnqueuePositionCalculator(UserPreferences.getEnqueueLocation());
             Playable currentlyPlaying = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
-            int insertPosition = positionCalculator.calcPosition(queue, currentlyPlaying);
             for (FeedItem item : items) {
                 if (itemListContains(queue, item.getId())) {
                     continue;
                 } else if (!item.hasMedia()) {
                     continue;
                 }
+                int insertPosition = positionCalculator.calcPosition(queue, currentlyPlaying, item);
                 queue.add(insertPosition, item);
                 events.add(QueueEvent.added(item, insertPosition));
 
@@ -408,7 +408,6 @@ public class DBWriter {
                 if (item.isNew()) {
                     markAsUnplayedIds.add(item.getId());
                 }
-                insertPosition++;
             }
             if (!updatedItems.isEmpty()) {
                 applySortOrder(queue, events);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/ItemEnqueuePositionCalculator.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/ItemEnqueuePositionCalculator.java
@@ -29,6 +29,36 @@ public class ItemEnqueuePositionCalculator {
      *
      * @param curQueue           the queue to which the item is to be inserted
      * @param currentPlaying     the currently playing media
+     * @param item               the item to be inserted
+     */
+    public int calcPosition(@NonNull List<FeedItem> curQueue,
+                            @Nullable Playable currentPlaying, @NonNull FeedItem item) {
+        if (item.getFeed() != null && item.getFeed().getPreferences() != null
+                && item.getFeed().getPreferences().getPriority()) {
+            return getPositionForPriorityItem(curQueue);
+        }
+        return calcPosition(curQueue, currentPlaying);
+    }
+
+    private int getPositionForPriorityItem(List<FeedItem> curQueue) {
+        int position = 0;
+        for (FeedItem queueItem : curQueue) {
+            if (queueItem.getFeed() != null
+                    && queueItem.getFeed().getPreferences() != null
+                    && queueItem.getFeed().getPreferences().getPriority()) {
+                position++;
+            } else {
+                break;
+            }
+        }
+        return getPositionOfFirstNonDownloadingItem(position, curQueue);
+    }
+
+    /**
+     * Determine the position (0-based) that the item(s) should be inserted to the named queue.
+     *
+     * @param curQueue           the queue to which the item is to be inserted
+     * @param currentPlaying     the currently playing media
      */
     public int calcPosition(@NonNull List<FeedItem> curQueue, @Nullable Playable currentPlaying) {
         switch (enqueueLocation) {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -54,7 +54,7 @@ public class PodDBAdapter {
 
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
-    public static final int VERSION = 3110000;
+    public static final int VERSION = 3120000;
 
     /**
      * Maximum number of arguments for IN-operator.
@@ -122,6 +122,7 @@ public class PodDBAdapter {
     public static final String KEY_FEED_TAGS = "tags";
     public static final String KEY_EPISODE_NOTIFICATION = "episode_notification";
     public static final String KEY_NEW_EPISODES_ACTION = "new_episodes_action";
+    public static final String KEY_FEED_PRIORITY = "priority";
     public static final String KEY_PODCASTINDEX_CHAPTER_URL = "podcastindex_chapter_url";
     public static final String KEY_SOCIAL_INTERACT_URL = "social_interact_url";
     public static final String KEY_STATE = "state";
@@ -178,7 +179,8 @@ public class PodDBAdapter {
             + KEY_FEED_SKIP_ENDING + " INTEGER DEFAULT 0,"
             + KEY_EPISODE_NOTIFICATION + " INTEGER DEFAULT 0,"
             + KEY_STATE + " INTEGER DEFAULT " + Feed.STATE_SUBSCRIBED + ","
-            + KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0)";
+            + KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0,"
+            + KEY_FEED_PRIORITY + " INTEGER DEFAULT 0)";
 
     private static final String CREATE_TABLE_FEED_ITEMS = "CREATE TABLE "
             + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY
@@ -337,7 +339,8 @@ public class PodDBAdapter {
             + TABLE_NAME_FEEDS + "." + KEY_FEED_SKIP_ENDING + ", "
             + TABLE_NAME_FEEDS + "." + KEY_EPISODE_NOTIFICATION + ", "
             + TABLE_NAME_FEEDS + "." + KEY_STATE + ", "
-            + TABLE_NAME_FEEDS + "." + KEY_NEW_EPISODES_ACTION;
+            + TABLE_NAME_FEEDS + "." + KEY_NEW_EPISODES_ACTION + ", "
+            + TABLE_NAME_FEEDS + "." + KEY_FEED_PRIORITY;
 
     private static final String JOIN_FEED_ITEM_AND_MEDIA = " LEFT JOIN " + TABLE_NAME_FEED_MEDIA
             + " ON " + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + "=" + TABLE_NAME_FEED_MEDIA + "." + KEY_FEEDITEM + " ";
@@ -509,6 +512,7 @@ public class PodDBAdapter {
         values.put(KEY_FEED_SKIP_ENDING, prefs.getFeedSkipEnding());
         values.put(KEY_EPISODE_NOTIFICATION, prefs.getShowEpisodeNotification());
         values.put(KEY_NEW_EPISODES_ACTION, prefs.getNewEpisodesAction().code);
+        values.put(KEY_FEED_PRIORITY, prefs.getPriority());
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(prefs.getFeedID())});
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedPreferencesCursor.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedPreferencesCursor.java
@@ -32,6 +32,7 @@ public class FeedPreferencesCursor extends CursorWrapper {
     private final int indexAutoSkipEnding;
     private final int indexEpisodeNotification;
     private final int indexNewEpisodesAction;
+    private final int indexPriority;
     private final int indexTags;
 
     public FeedPreferencesCursor(Cursor cursor) {
@@ -52,6 +53,7 @@ public class FeedPreferencesCursor extends CursorWrapper {
         indexAutoSkipEnding = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FEED_SKIP_ENDING);
         indexEpisodeNotification = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_EPISODE_NOTIFICATION);
         indexNewEpisodesAction = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_NEW_EPISODES_ACTION);
+        indexPriority = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FEED_PRIORITY);
         indexTags = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FEED_TAGS);
     }
 
@@ -80,6 +82,7 @@ public class FeedPreferencesCursor extends CursorWrapper {
                 FeedPreferences.SkipSilence.fromCode(getInt(indexFeedSkipSilence)),
                 getInt(indexEpisodeNotification) > 0,
                 FeedPreferences.NewEpisodesAction.fromCode(getInt(indexNewEpisodesAction)),
+                getInt(indexPriority) > 0,
                 new HashSet<>(Arrays.asList(tagsString.split(FeedPreferences.TAG_SEPARATOR))));
     }
 }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -1009,4 +1009,6 @@
 
     <string name="echo_share_heading">My favorite podcasts</string>
     <string name="echo_share">My year %d in podcasts. #AntennaPodEcho</string>
+    <string name="feed_priority_label">Priority podcast</string>
+    <string name="feed_priority_summary">Episodes are added to the top of the queue</string>
 </resources>


### PR DESCRIPTION
Addresses #2437
Priority podcasts get added to the top of the queue.

### Description

This is a proof of concept for the idea of podcast priority. It specifically implement my simplified idea in https://github.com/AntennaPod/AntennaPod/issues/2437#issuecomment-3683849103 In the setting for a podcast the user has the option to mark it as a priority. When a priority podcast is downloaded, and the user has configured AntennaPod to automatically add new downloads to the queue, then it will be added to the very top. If the top podcast or podcasts are also priority podcast, then the download will be pushed down the stack until the stack find a non-priority podcast for it to be above.

To be completely transparent about this implementation, it was 100% coded by Gemini-cli. I have only confirmed that the solution works at solving the problem, not that it is actually a good solution. My intention is for it to serve as a proof-of-concept of the idea that can be easily compiled and tried out. If the maintainers of this project like the idea, then I am willing to do the real work of coding this properly.

I'd like to hear what ya'll think of the idea. I know personally this would be very useful.

<img width="363" height="616" alt="image" src="https://github.com/user-attachments/assets/f99e5206-3c0f-4016-8b0f-8e4cc0945f93" />

In the following queue, The Daily is marked as priority, and The Rest Is History is not. In this screenshot the episodes were downloaded like this:

1. The Rest Is History - Jack The Ripper Part 5
2. The Rest Is History - Jack The Ripper Part 4
3. The Daily - The Messy Reality
4. The Rest Is History - Jack The Ripper Part 3
5. The Daily - Trump Says the Economy Is Good

<img width="372" height="475" alt="image" src="https://github.com/user-attachments/assets/06d34d3b-18dd-41f4-8a49-d5eee51b5baf" />

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ ] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ ] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
