### PR TITLE
Remember last sleep timer value per type

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
@@ -145,6 +145,11 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
 
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                try {
+                    SleepTimerPreferences.setLastTimer(String.valueOf(getSelectedSleepTime()));
+                } catch (NumberFormatException ignore) {
+                    // Ignore silently and just not save it
+                }
                 final SleepTimerType sleepType = SleepTimerType.fromIndex(position);
                 SleepTimerPreferences.setSleepTimerType(sleepType);
                 // this callback is called even when the spinner is first initialized
@@ -154,12 +159,7 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
                     if (isSleepTimerConfiguredForMostOfTheDay()) {
                         viewBinding.autoEnableCheckbox.setChecked(false);
                     }
-                    // change suggested value back to default value for sleep type
-                    if (sleepType == SleepTimerType.EPISODES) {
-                        viewBinding.timeEditText.setText(SleepTimerPreferences.DEFAULT_SLEEP_TIMER_EPISODES);
-                    } else {
-                        viewBinding.timeEditText.setText(SleepTimerPreferences.DEFAULT_SLEEP_TIMER_MINUTES);
-                    }
+                    viewBinding.timeEditText.setText(SleepTimerPreferences.lastTimerValue());
                 }
                 sleepTimerTypeInitialized = true;
                 refreshUiState();

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/SleepTimerPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/SleepTimerPreferences.java
@@ -13,7 +13,8 @@ public class SleepTimerPreferences {
     private static final String TAG = "SleepTimerPreferences";
 
     public static final String PREF_NAME = "SleepTimerDialog";
-    private static final String PREF_VALUE = "LastValue";
+    private static final String PREF_VALUE_MINUTES = "LastValue";
+    private static final String PREF_VALUE_EPISODES = "LastValueEpisodes";
 
     private static final String PREF_TIMER_TYPE = "sleepTimerType";
     private static final String PREF_VIBRATE = "Vibrate";
@@ -22,8 +23,6 @@ public class SleepTimerPreferences {
     private static final String PREF_AUTO_ENABLE_FROM = "AutoEnableFrom";
     private static final String PREF_AUTO_ENABLE_TO = "AutoEnableTo";
 
-    public static final String DEFAULT_SLEEP_TIMER_MINUTES = "15";
-    public static final String DEFAULT_SLEEP_TIMER_EPISODES = "1";
     private static final int DEFAULT_TIMER_TYPE = 0;
     private static final int DEFAULT_AUTO_ENABLE_FROM = 22;
     private static final int DEFAULT_AUTO_ENABLE_TO = 6;
@@ -41,11 +40,16 @@ public class SleepTimerPreferences {
     }
 
     public static void setLastTimer(String value) {
-        prefs.edit().putString(PREF_VALUE, value).apply();
+        prefs.edit().putString(getSleepTimerType() == SleepTimerType.CLOCK
+                ? PREF_VALUE_MINUTES : PREF_VALUE_EPISODES, value).apply();
     }
 
     public static String lastTimerValue() {
-        return prefs.getString(PREF_VALUE, DEFAULT_SLEEP_TIMER_MINUTES);
+        if (getSleepTimerType() == SleepTimerType.CLOCK) {
+            return prefs.getString(PREF_VALUE_MINUTES, "15");
+        } else {
+            return prefs.getString(PREF_VALUE_EPISODES, "1");
+        }
     }
 
     public static long timerMillisOrEpisodes() {


### PR DESCRIPTION
### Description

Remember last sleep timer value per type
Closes #8173

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
