### PR TITLE
Restructure feed settings

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -284,7 +284,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         if (feed.getState() == Feed.STATE_NOT_SUBSCRIBED) {
             viewBinding.toolbar.getMenu().findItem(R.id.sort_items).setVisible(false);
             viewBinding.toolbar.getMenu().findItem(R.id.refresh_item).setVisible(false);
-            viewBinding.toolbar.getMenu().findItem(R.id.rename_item).setVisible(false);
             viewBinding.toolbar.getMenu().findItem(R.id.action_search).setVisible(false);
         } else if (feed.getState() == Feed.STATE_ARCHIVED) {
             viewBinding.toolbar.getMenu().findItem(R.id.sort_items).setVisible(false);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -34,6 +34,7 @@ import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.screen.synchronization.AuthenticationDialog;
+import de.danoeh.antennapod.ui.screen.feed.RenameFeedDialog;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeOnSubscribe;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -54,11 +55,11 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
     private static final String PREF_SCREEN = "feedSettingsScreen";
     private static final String PREF_AUTHENTICATION = "authentication";
     private static final String PREF_AUTO_DELETE = "autoDelete";
-    private static final String PREF_CATEGORY_AUTO_DOWNLOAD = "autoDownloadCategory";
     private static final String PREF_NEW_EPISODES_ACTION = "feedNewEpisodesAction";
     private static final String PREF_FEED_PLAYBACK_SPEED = "feedPlaybackSpeed";
     private static final String PREF_AUTO_SKIP = "feedAutoSkip";
     private static final String PREF_NOTIFICATION = "episodeNotification";
+    private static final String PREF_RENAME = "rename";
     private static final String PREF_TAGS = "tags";
 
     private Feed feed;
@@ -130,7 +131,8 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
 
                     if (feed.isLocalFeed()) {
                         findPreference(PREF_AUTHENTICATION).setVisible(false);
-                        findPreference(PREF_CATEGORY_AUTO_DOWNLOAD).setVisible(false);
+                        findPreference(PREF_AUTODOWNLOAD).setVisible(false);
+                        findPreference(PREF_EPISODE_FILTER).setVisible(false);
                     }
 
                     findPreference(PREF_SCREEN).setVisible(true);
@@ -254,6 +256,10 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
             notificationPreference.setChecked(checked);
             return false;
         });
+        findPreference(PREF_RENAME).setOnPreferenceClickListener(preference -> {
+            new RenameFeedDialog(getActivity(), feed).show();
+            return true;
+        });
     }
 
     private void updateAutoDeleteSummary() {
@@ -303,7 +309,7 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
             return;
         }
         boolean enabled = feed.getPreferences().isAutoDownload(UserPreferences.isEnableAutodownloadGlobal());
-        findPreference(PREF_EPISODE_FILTER).setEnabled(enabled);
+        findPreference(PREF_EPISODE_FILTER).setVisible(enabled);
         ListPreference autoDownloadPreference = findPreference(PREF_AUTODOWNLOAD);
         String summary = switch (feedPreferences.getAutoDownload()) {
             case GLOBAL -> getString(R.string.global_default_with_value,

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMenuHandler.java
@@ -88,8 +88,6 @@ public abstract class FeedMenuHandler {
         } else if (menuItemId == R.id.edit_tags) {
             TagSettingsDialog.newInstance(Collections.singletonList(selectedFeed.getPreferences()))
                     .show(fragment.getChildFragmentManager(), TagSettingsDialog.TAG);
-        } else if (menuItemId == R.id.rename_item) {
-            new RenameFeedDialog(fragment.getActivity(), selectedFeed).show();
         } else if (menuItemId == R.id.remove_archive_feed || menuItemId == R.id.remove_restore_feed) {
             new RemoveFeedDialog(Collections.singletonList(selectedFeed))
                     .show(fragment.getChildFragmentManager(), null);

--- a/app/src/main/res/menu/feedlist.xml
+++ b/app/src/main/res/menu/feedlist.xml
@@ -50,12 +50,6 @@
         android:icon="@drawable/ic_check"/>
 
     <item
-        android:id="@+id/rename_item"
-        android:menuCategory="container"
-        android:title="@string/rename_feed_label"
-        custom:showAsAction="never" />
-
-    <item
         android:id="@+id/remove_archive_feed"
         android:icon="@drawable/ic_delete"
         android:menuCategory="container"

--- a/app/src/main/res/menu/nav_feed_context.xml
+++ b/app/src/main/res/menu/nav_feed_context.xml
@@ -12,11 +12,6 @@
         android:title="@string/edit_tags" />
 
     <item
-        android:id="@+id/rename_item"
-        android:menuCategory="container"
-        android:title="@string/rename_feed_label" />
-
-    <item
         android:id="@+id/remove_archive_feed"
         android:menuCategory="container"
         android:title="@string/remove_archive_feed_label" />

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -1,73 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:key="feedSettingsScreen">
 
-    <SwitchPreferenceCompat
-        android:icon="@drawable/ic_refresh"
-        android:key="keepUpdated"
-        android:summary="@string/keep_updated_summary"
-        android:title="@string/keep_updated" />
+    <PreferenceCategory
+        android:title="@string/pref_display">
 
-    <SwitchPreferenceCompat
-        android:defaultValue="false"
-        android:dependency="keepUpdated"
-        android:icon="@drawable/ic_notifications"
-        android:key="episodeNotification"
-        android:summary="@string/episode_notification_summary"
-        android:title="@string/episode_notification" />
+        <Preference
+            android:icon="@drawable/ic_rename"
+            android:key="rename"
+            android:title="@string/rename_feed_label" />
 
-    <Preference
-        android:icon="@drawable/ic_key"
-        android:key="authentication"
-        android:summary="@string/authentication_descr"
-        android:title="@string/authentication_label" />
+        <Preference
+            android:icon="@drawable/ic_tag"
+            android:key="tags"
+            android:summary="@string/feed_tags_summary"
+            android:title="@string/feed_tags_label" />
 
-    <Preference
-        android:icon="@drawable/ic_tag"
-        android:key="tags"
-        android:summary="@string/feed_tags_summary"
-        android:title="@string/feed_tags_label" />
-
-    <Preference
-        android:icon="@drawable/ic_playback_speed"
-        android:key="feedPlaybackSpeed"
-        android:summary="@string/pref_feed_playback_speed_sum"
-        android:title="@string/playback_speed" />
-
-    <Preference
-        android:icon="@drawable/ic_skip_24dp"
-        android:key="feedAutoSkip"
-        android:summary="@string/pref_feed_skip_sum"
-        android:title="@string/pref_feed_skip" />
-
-    <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
-        android:entries="@array/spnAutoDeleteItems"
-        android:entryValues="@array/spnAutoDeleteValues"
-        android:icon="@drawable/ic_delete"
-        android:key="autoDelete"
-        android:summary="@string/global_default"
-        android:title="@string/pref_auto_delete_playback_title" />
-
-    <de.danoeh.antennapod.ui.screen.feed.preferences.VolumeAdaptationPreference
-        android:defaultValue="off"
-        android:entries="@array/spnVolumeAdaptationItems"
-        android:entryValues="@array/spnVolumeAdaptationValues"
-        android:icon="@drawable/ic_volume_adaption"
-        android:key="volumeReduction"
-        android:summary="@string/feed_volume_adaptation_summary"
-        android:title="@string/feed_volume_adapdation" />
-
-    <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
-        android:entries="@array/feedNewEpisodesActionItems"
-        android:entryValues="@array/feedNewEpisodesActionValues"
-        android:icon="@drawable/ic_feed"
-        android:key="feedNewEpisodesAction"
-        android:summary="@string/global_default"
-        android:title="@string/pref_new_episodes_action_title" />
+    </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="autoDownloadCategory"
-        android:title="@string/auto_download_inbox_category">
+        android:title="@string/playback_pref">
+
+        <Preference
+            android:icon="@drawable/ic_playback_speed"
+            android:key="feedPlaybackSpeed"
+            android:summary="@string/pref_feed_playback_speed_sum"
+            android:title="@string/playback_speed" />
+
+        <Preference
+            android:icon="@drawable/ic_skip_24dp"
+            android:key="feedAutoSkip"
+            android:summary="@string/pref_feed_skip_sum"
+            android:title="@string/pref_feed_skip" />
+
+        <de.danoeh.antennapod.ui.screen.feed.preferences.VolumeAdaptationPreference
+            android:defaultValue="off"
+            android:entries="@array/spnVolumeAdaptationItems"
+            android:entryValues="@array/spnVolumeAdaptationValues"
+            android:icon="@drawable/ic_volume_adaption"
+            android:key="volumeReduction"
+            android:summary="@string/feed_volume_adaptation_summary"
+            android:title="@string/feed_volume_adapdation" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/automation">
+
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_refresh"
+            android:key="keepUpdated"
+            android:summary="@string/keep_updated_summary"
+            android:title="@string/keep_updated" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:dependency="keepUpdated"
+            android:icon="@drawable/ic_notifications"
+            android:key="episodeNotification"
+            android:summary="@string/episode_notification_summary"
+            android:title="@string/episode_notification" />
+
+        <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
+            android:entries="@array/spnAutoDeleteItems"
+            android:entryValues="@array/spnAutoDeleteValues"
+            android:icon="@drawable/ic_delete"
+            android:key="autoDelete"
+            android:summary="@string/global_default"
+            android:title="@string/pref_auto_delete_playback_title" />
+
+        <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
+            android:entries="@array/feedNewEpisodesActionItems"
+            android:entryValues="@array/feedNewEpisodesActionValues"
+            android:icon="@drawable/ic_feed"
+            android:key="feedNewEpisodesAction"
+            android:summary="@string/global_default"
+            android:title="@string/pref_new_episodes_action_title" />
 
         <de.danoeh.antennapod.ui.preferences.preference.MaterialListPreference
             android:entries="@array/spnEnableAutoDownloadItems"
@@ -80,5 +89,18 @@
             android:key="episodeFilter"
             android:summary="@string/episode_filters_description"
             android:title="@string/episode_filters_label" />
+
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/pref_advanced">
+
+        <Preference
+            android:key="authentication"
+            android:icon="@drawable/ic_key"
+            android:summary="@string/authentication_descr"
+            android:title="@string/authentication_label" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/ui/common/src/main/res/drawable/ic_rename.xml
+++ b/ui/common/src/main/res/drawable/ic_rename.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M15 16L11 20H21V16H15M12.06 7.19L3 16.25V20H6.75L15.81 10.94L12.06 7.19M18.71 8.04C19.1 7.65 19.1 7 18.71 6.63L16.37 4.29C16.17 4.09 15.92 4 15.66 4C15.41 4 15.15 4.1 14.96 4.29L13.13 6.12L16.88 9.87L18.71 8.04Z" />
+
+</vector>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -607,6 +607,8 @@
     <string name="report_bug_crash_log_message">Created: %1$s.</string>
     <string name="report_bug_forum_title">Forum</string>
     <string name="report_bug_github_title">GitHub</string>
+    <string name="pref_advanced">Advanced</string>
+    <string name="pref_display">Display</string>
 
     <!-- About screen -->
     <string name="about_pref">About</string>
@@ -808,7 +810,6 @@
     <string name="tag_all">All</string>
     <string name="tag_untagged">Untagged</string>
     <string name="multi_feed_common_tags_info">Only common tags from all selected subscriptions are shown. Other tags stay unaffected.</string>
-    <string name="auto_download_inbox_category">Automatically download episodes from the inbox</string>
     <string name="episode_filters_label">Episode filter</string>
     <string name="episode_filters_description">List of terms used to decide if an episode should be included or excluded when auto downloading</string>
     <string name="add_term">Add term</string>


### PR DESCRIPTION
### Description

Restructure feed settings. In my user test I had the following feedback:
- They were confused that some settings are on the feed settings screen and some are in the overflow menu. It was not clear which one to look at when wanting to change a setting. I think we should consistently move all settings to the settings screen.
- Confusion about authentication settings: They asked if they need to create an AntennaPod account now (even though there is no such thing as an AntennaPod account)

Actions taken:
- Moved the authentication settings item to the very bottom
- Grouped settings by category
- Moved rename function from overflow menu to settings screen. It is likely not so frequently used: once you set it up once, you never need to change it again. So you don't need to see it every day

<img width="250" alt="Screenshot_20251224-094553" src="https://github.com/user-attachments/assets/a5b4a289-9a62-412e-97d0-f444825e4cd4" />


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
