### PR TITLE
Fix bottom navigation box not ticked by default

### DIFF
--- a/ui/preferences/src/main/res/xml/preferences_user_interface.xml
+++ b/ui/preferences/src/main/res/xml/preferences_user_interface.xml
@@ -66,6 +66,7 @@
         <SwitchPreferenceCompat
                 android:title="@string/bottom_navigation"
                 android:summary="@string/bottom_navigation_summary"
+                android:defaultValue="true"
                 android:key="prefBottomNavigation" />
         <Preference
                 android:key="prefHiddenDrawerItems"


### PR DESCRIPTION
### Description

Fix bottom navigation box not ticked by default

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
