### PR TITLE
Check description position in PR check

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -16,10 +16,21 @@ jobs:
             const issueRegex = /#\d+/i;
             if (issueRegex.test(context.payload.pull_request.title)) {
               core.setFailed("Please mention the issue number in the PR description, not in the title. Make sure to write 'closes #<number>'.");
+              return;
             }
 
-            const closingRegex = /\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+#\d+/i;
+            const closingRegex = /\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|contributes to):?\s+#\d+/i;
             if (issueRegex.test(context.payload.pull_request.body) && !closingRegex.test(context.payload.pull_request.body)) {
               core.setFailed("The PR description must contain 'closes #<number>' to link to the issue that it closes.");
+              return;
+            }
+
+            const bodyLines = (context.payload.pull_request.body || "").split(/\r?\n/);
+            const checklistIndex = bodyLines.map(l => l.includes("https://antennapod.org")).lastIndexOf(true);
+            if (checklistIndex === -1) {
+              core.setFailed("It looks like you did not follow the PR template. The checklist from the template is missing or incomplete.");
+              return;
+            } else if (bodyLines.length - checklistIndex - 1 > 5) {
+              core.setFailed("It looks like you did not follow the PR template. Please add your description above the checklist, not below.");
               return;
             }


### PR DESCRIPTION
### Description

Recently, contributors have started putting the description in random places of the PR template instead of in the "description" section. This adds a check to remind them to follow the template.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests