### PR TITLE
Fix layout issues when exporting HTML

### DIFF
--- a/storage/importexport/src/main/assets/html-export-template.html
+++ b/storage/importexport/src/main/assets/html-export-template.html
@@ -83,7 +83,7 @@
                 box-shadow: none;
                 text-align: left;
             }
-            .cropped-img {
+            .remove-white-space {
                 width: 70px;
                 height: 100px;
                 object-fit: cover;
@@ -95,7 +95,7 @@
         </style>
     </head>
     <body>
-        <img src="https://antennapod.org/assets/img/antennapod-logo.png" class="cropped-img"/><span class="wrapped-white-space"> </span>
+        <img src="https://antennapod.org/assets/img/antennapod-logo.png" class="remove-white-space"/><span class="wrapped-white-space"> </span>
         <h1>AntennaPod {TITLE}</h1>
         <ul>
             {FEEDS}


### PR DESCRIPTION
### Description

CLOSES #8208 

I have finished the three layout issues in exporting HTML (subscriptions and feeds).

Specifically, the current layouts are like this:

<img width="4482" height="3147" alt="Picture1" src="https://github.com/user-attachments/assets/b7341820-1cf8-4709-8f60-6a18f5e939db" />



### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ x ] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [ x ] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [ x ] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [ x ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
