### PR TITLE
Add screenshot mode that hides cover images with unclear licenses

### DIFF
--- a/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/FeedDiscoverAdapter.java
+++ b/ui/discovery/src/main/java/de/danoeh/antennapod/ui/discovery/FeedDiscoverAdapter.java
@@ -58,13 +58,17 @@ public class FeedDiscoverAdapter extends BaseAdapter {
             holder = (Holder) convertView.getTag();
         }
 
-
         final PodcastSearchResult podcast = getItem(position);
         holder.imageView.setContentDescription(podcast.title);
+        String imageUrl = podcast.imageUrl;
+        if (context.getSharedPreferences("MainActivityPrefs", Context.MODE_PRIVATE)
+                .getBoolean("screenshot_mode", false)) {
+            imageUrl = "https://picsum.photos/400/400?random=" + position;
+        }
 
         float radius = 8 * context.getResources().getDisplayMetrics().density;
         Glide.with(context)
-                .load(podcast.imageUrl)
+                .load(imageUrl)
                 .apply(new RequestOptions()
                         .placeholder(ImagePlaceholder.getDrawable(context, radius))
                         .transform(new FitCenter(), new RoundedCorners((int) radius))


### PR DESCRIPTION
### Description

Add screenshot mode that hides cover images with unclear licenses

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
