### PR TITLE
Validate RSS URL before closing the AddViaUrlDialog

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
@@ -49,7 +49,6 @@ import de.danoeh.antennapod.ui.view.LiftOnScrollListener;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import org.apache.commons.lang3.StringUtils;
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.Collections;
@@ -156,12 +155,8 @@ public class AddFeedFragment extends Fragment {
 
         alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener((view) -> {
             Editable inputText = dialogBinding.textInput.getText();
-            if (StringUtils.isBlank(inputText)) {
-                dialogBinding.textInput.setError(getText(R.string.rss_address_empty));
-                return;
-            }
             if (!inputText.toString().matches(Patterns.WEB_URL.pattern())) {
-                dialogBinding.textInput.setError(getText(R.string.rss_address_not_url));
+                dialogBinding.textInputLayout.setError(getText(R.string.rss_address_invalid));
                 return;
             }
             addUrl(inputText.toString());

--- a/app/src/main/res/layout/edit_text_dialog.xml
+++ b/app/src/main/res/layout/edit_text_dialog.xml
@@ -7,6 +7,7 @@
     android:padding="16dp">
 
     <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/textInputLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -867,8 +867,7 @@
     <string name="search_fyyd_label">Search fyyd</string>
     <string name="add_podcast_by_url">Add podcast by RSS address</string>
     <string name="rss_address">RSS address</string>
-    <string name="rss_address_empty">Please provide a RSS address</string>
-    <string name="rss_address_not_url">The RSS address you entered is not a valid URL.</string>
+    <string name="rss_address_invalid">The RSS address you entered is not valid.</string>
     <string name="discover">Discover</string>
     <string name="discover_hide">Hide</string>
     <string name="discover_is_hidden">You selected to hide suggestions.</string>


### PR DESCRIPTION
### Description
Closes #8216 by checking, if the input is empty or not a valid URL. Otherwise show an appropriate error.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
