### PR TITLE
Clarify that new episodes action cannot be changed when autodownload is enabled

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.databinding.PlaybackSpeedFeedSettingDialogBinding;
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.settings.SkipIntroEndingChangedEvent;
 import de.danoeh.antennapod.event.settings.SpeedPresetChangedEvent;
 import de.danoeh.antennapod.event.settings.VolumeAdaptionChangedEvent;
@@ -213,6 +214,14 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
             EventBus.getDefault().post(new VolumeAdaptionChangedEvent(newSetting, feed.getId()));
             return false;
         });
+        findPreference(PREF_NEW_EPISODES_ACTION).setOnPreferenceClickListener(preference -> {
+            boolean isAutoDownload = feed.getPreferences().isAutoDownload(UserPreferences.isEnableAutodownloadGlobal());
+            if (isAutoDownload && !feed.isLocalFeed()) {
+                EventBus.getDefault().post(new MessageEvent(getString(R.string.feed_new_episodes_action_snackbar)));
+                return true;
+            }
+            return false;
+        });
         findPreference(PREF_NEW_EPISODES_ACTION).setOnPreferenceChangeListener((preference, newValue) -> {
             int code = Integer.parseInt((String) newValue);
             feedPreferences.setNewEpisodesAction(FeedPreferences.NewEpisodesAction.fromCode(code));
@@ -284,7 +293,6 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
         ListPreference newEpisodesAction = findPreference(PREF_NEW_EPISODES_ACTION);
         boolean isAutoDownload = feed.getPreferences().isAutoDownload(UserPreferences.isEnableAutodownloadGlobal());
         if (isAutoDownload && !feed.isLocalFeed()) {
-            newEpisodesAction.setEnabled(false);
             newEpisodesAction.setSummary(R.string.feed_new_episodes_action_summary_autodownload);
             return;
         }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="feed_new_episodes_action_add_to_queue">Add to queue</string>
     <string name="feed_new_episodes_action_nothing">Nothing</string>
     <string name="feed_new_episodes_action_summary_autodownload">Automatic download enabled. Episodes are added to the inbox and then moved to the queue once downloaded.</string>
+    <string name="feed_new_episodes_action_snackbar">Cannot be changed when automatic download is enabled.</string>
     <string name="episode_cleanup_never">Never</string>
     <string name="episode_cleanup_except_favorite_removal">When not favorited</string>
     <string name="episode_cleanup_queue_removal">When not in queue</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/preference/MaterialListPreference.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/preference/MaterialListPreference.java
@@ -17,6 +17,9 @@ public class MaterialListPreference extends ListPreference {
 
     @Override
     protected void onClick() {
+        if (getOnPreferenceClickListener() != null && getOnPreferenceClickListener().onPreferenceClick(this)) {
+            return;
+        }
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(getContext());
         builder.setTitle(getTitle());
         builder.setIcon(getDialogIcon());


### PR DESCRIPTION
### Description

Clarify that new episodes action cannot be changed when autodownload is enabled
Closes #8224

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
