### PR TITLE
Fix issue where sleep timer is marked as active after events are fired

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ClockSleepTimer.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ClockSleepTimer.java
@@ -98,15 +98,14 @@ public class ClockSleepTimer implements SleepTimer {
         // mark the sleep timer as active before firing the events
         // the event processors may immediately check if the sleep timer is active
         isRunning = true;
+        lastTick = System.currentTimeMillis();
 
         // make sure we've registered for events first
         EventBus.getDefault().register(this);
         final TimerValue left = getTimeLeft();
         EventBus.getDefault().post(SleepTimerUpdatedEvent.justEnabled(left));
 
-        lastTick = System.currentTimeMillis();
         EventBus.getDefault().postSticky(SleepTimerUpdatedEvent.updated(left));
-
     }
 
     @Override


### PR DESCRIPTION
### Description
Fix issue where sleep timer is marked as active after events are fired, instead of before.

closes #8207 

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
