### PR TITLE
Fix mixing up media id and feed item id

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
@@ -25,6 +25,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
+import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.ui.common.Keyboard;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -85,8 +86,10 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
         controller.init();
         EventBus.getDefault().register(this);
 
-        disposable = Single.fromCallable(() ->
-                        DBReader.getRemainingQueueSize(PlaybackPreferences.getCurrentlyPlayingFeedMediaId()))
+        disposable = Single.fromCallable(() -> {
+            FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+            return DBReader.getRemainingQueueSize(media.getItemId());
+        })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> currentQueueSize = result);


### PR DESCRIPTION
### Description

Fix comparing feed item ids (from the queue) with feed media ids (from the currently playing media). Root cause found by @eblis in #8177
Closes #8177

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
