### PR TITLE
Simplify playback statistics tracking

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.model.feed;
 
-import android.content.Context;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -412,20 +411,6 @@ public class FeedMedia implements Playable {
     public void onPlaybackStart() {
         startPosition = Math.max(position, 0);
         playedDurationWhenStarted = playedDuration;
-    }
-
-    @Override
-    public void onPlaybackPause(Context context) {
-        if (position > startPosition) {
-            playedDuration = playedDurationWhenStarted + position - startPosition;
-            playedDurationWhenStarted = playedDuration;
-        }
-        startPosition = position;
-    }
-
-    @Override
-    public void onPlaybackCompleted(Context context) {
-        startPosition = -1;
     }
 
     @Override

--- a/model/src/main/java/de/danoeh/antennapod/model/playback/Playable.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/playback/Playable.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.model.playback;
 
-import android.content.Context;
 import android.os.Parcelable;
 
 import androidx.annotation.Nullable;
@@ -108,22 +107,6 @@ public interface Playable extends Parcelable, Serializable {
      * Position held by this Playable should be set accurately before a call to this method is made.
      */
     void onPlaybackStart();
-
-    /**
-     * This method should be called every time playback pauses or stops on this object,
-     * including just before a seeking operation is performed, after which a call to
-     * {@link #onPlaybackStart()} should be made. If playback completes, calling this method is not
-     * necessary, as long as a call to {@link #onPlaybackCompleted(Context)} is made.
-     * <p/>
-     * Position held by this Playable should be set accurately before a call to this method is made.
-     */
-    void onPlaybackPause(Context context);
-
-    /**
-     * This method should be called when playback completes for this object.
-     * @param context
-     */
-    void onPlaybackCompleted(Context context);
 
     /**
      * Returns an integer that must be unique among all Playable classes. The

--- a/model/src/main/java/de/danoeh/antennapod/model/playback/RemoteMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/playback/RemoteMedia.java
@@ -1,6 +1,5 @@
 package de.danoeh.antennapod.model.playback;
 
-import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.Nullable;
@@ -200,16 +199,6 @@ public class RemoteMedia implements Playable {
 
     @Override
     public void onPlaybackStart() {
-        // no-op
-    }
-
-    @Override
-    public void onPlaybackPause(Context context) {
-        // no-op
-    }
-
-    @Override
-    public void onPlaybackCompleted(Context context) {
         // no-op
     }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -978,7 +978,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 }
                 SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, false);
             }
-            playable.onPlaybackPause(getApplicationContext());
         }
 
         @Override
@@ -1183,11 +1182,6 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
         if (!(playable instanceof FeedMedia)) {
             Log.d(TAG, "Not doing post-playback processing: media not of type FeedMedia");
-            if (ended) {
-                playable.onPlaybackCompleted(getApplicationContext());
-            } else {
-                playable.onPlaybackPause(getApplicationContext());
-            }
             return;
         }
         FeedMedia media = (FeedMedia) playable;
@@ -1205,14 +1199,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             autoSkipped = true;
         }
 
-        if (ended || almostEnded) {
-            SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, true);
-            media.onPlaybackCompleted(getApplicationContext());
-        } else {
-            SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, false);
-            media.onPlaybackPause(getApplicationContext());
-        }
-
+        SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, ended || almostEnded);
         if (item != null) {
             if (ended || almostEnded
                     || autoSkipped


### PR DESCRIPTION
### Description

Simplify playback statistics tracking to update played duration in a single place (`PlayableUtils.saveCurrentPosition`). Prepares for the new playback service.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
