### PR TITLE
Fix media session browsing

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaItemAdapter.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaItemAdapter.java
@@ -29,7 +29,9 @@ public class MediaItemAdapter {
             FeedMedia feedMedia = (FeedMedia) playable;
             mediaId = String.valueOf(feedMedia.getId());
             metadataBuilder.setSubtitle(feedMedia.getFeedTitle());
-            metadataBuilder.setArtworkUri(Uri.parse(feedMedia.getImageLocation()));
+            if (feedMedia.getImageLocation() != null && feedMedia.getImageLocation().startsWith("http")) {
+                metadataBuilder.setArtworkUri(Uri.parse(feedMedia.getImageLocation()));
+            }
         }
         String uriString = playable.localFileAvailable() ? playable.getLocalFileUrl() : playable.getStreamUrl();
         return new MediaItem.Builder()
@@ -43,7 +45,9 @@ public class MediaItemAdapter {
     public static MediaItem fromFeed(Feed feed) {
         MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder();
         metadataBuilder.setTitle(feed.getTitle());
-        metadataBuilder.setArtworkUri(Uri.parse(feed.getImageUrl()));
+        if (feed.getImageUrl() != null && feed.getImageUrl().startsWith("http")) {
+            metadataBuilder.setArtworkUri(Uri.parse(feed.getImageUrl()));
+        }
         metadataBuilder.setSubtitle(feed.getAuthor());
         metadataBuilder.setIsBrowsable(true);
         metadataBuilder.setIsPlayable(false);
@@ -79,7 +83,9 @@ public class MediaItemAdapter {
     public static ImmutableList<MediaItem> fromItemList(List<FeedItem> feedItems) {
         ImmutableList.Builder<MediaItem> itemsBuilder = ImmutableList.builder();
         for (FeedItem item : feedItems) {
-            itemsBuilder.add(MediaItemAdapter.fromPlayable(item.getMedia()));
+            if (item.getMedia() != null) {
+                itemsBuilder.add(MediaItemAdapter.fromPlayable(item.getMedia()));
+            }
         }
         return itemsBuilder.build();
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -284,6 +284,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
         switch (parentId) {
             case MEDIA_ID_ROOT:
                 disposables.add(Single.fromCallable(() -> ImmutableList.of(
+                                createBrowsableMediaItem(MEDIA_ID_CURRENT),
                                 createBrowsableMediaItem(MEDIA_ID_QUEUE),
                                 createBrowsableMediaItem(MEDIA_ID_DOWNLOADS),
                                 createBrowsableMediaItem(MEDIA_ID_EPISODES),
@@ -299,7 +300,9 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                                 items -> {
                                     ImmutableList.Builder<MediaItem> builder = new ImmutableList.Builder<>();
                                     for (Feed feed : items) {
-                                        builder.add(MediaItemAdapter.fromFeed(feed));
+                                        if (feed.getState() == Feed.STATE_SUBSCRIBED) {
+                                            builder.add(MediaItemAdapter.fromFeed(feed));
+                                        }
                                     }
                                     future.set(LibraryResult.ofItemList(builder.build(), params));
                                 },


### PR DESCRIPTION
### Description

Fix media session browsing:
- Show only subscribed feeds
- Fix crash when image is null or cannot be loaded
- Re-add "current" section to main screen
- Fix trying to show items without media

Closes #8272

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
