### PR TITLE
Avoid duplicate media notification when casting

### DIFF
--- a/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastOptionsProvider.java
+++ b/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastOptionsProvider.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import com.google.android.gms.cast.framework.CastOptions;
 import com.google.android.gms.cast.framework.OptionsProvider;
 import com.google.android.gms.cast.framework.SessionProvider;
+import com.google.android.gms.cast.framework.media.CastMediaOptions;
 
 import java.util.List;
 
@@ -16,8 +17,13 @@ public class CastOptionsProvider implements OptionsProvider {
     @NonNull
     public CastOptions getCastOptions(@NonNull Context context) {
         return new CastOptions.Builder()
-            .setReceiverApplicationId("BEBC1DB1")
-            .build();
+                .setReceiverApplicationId("BEBC1DB1")
+                .setCastMediaOptions(
+                        new CastMediaOptions.Builder()
+                                .setMediaSessionEnabled(false)
+                                .setNotificationOptions(null)
+                                .build())
+                .build();
     }
 
     @Override


### PR DESCRIPTION
### Description

Tell the cast options provider that we manage the notification ourselves.
Closes #5728
Contributes to #8265

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
