### PR TITLE
Fix drawer counters not shown until counter setting is changed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
@@ -477,7 +477,7 @@ public class NavDrawerFragment extends Fragment implements SharedPreferences.OnS
     }
 
     private int feedCounter(Feed feed, Map<Long, Integer> feedCounters) {
-        if (navDrawerData == null || feedCounters == null) {
+        if (feedCounters == null) {
             return 0;
         }
         return feedCounters.containsKey(feed.getId()) ? feedCounters.get(feed.getId()) : 0;


### PR DESCRIPTION
### Description


**Fixes #8283**

**Root cause**

loadData() builds the flat drawer list inside Observable.fromCallable() before the subscribe callback assigns navDrawerData. On first load, feedCounter() returned 0 because it checked navDrawerData == null, so counters were not shown until a later reload.

**Fix**

Remove the navDrawerData null check from feedCounter() and rely only on feedCounters passed from freshly loaded data. This allows counters to be computed correctly during initial drawer list construction.

**Testing**

Cold start: counters are visible immediately in drawer

Restart app: counters remain visible

Changing counter type still updates correctly

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests


