### PR TITLE
Move Statistics screen from Subscriptions menu to navigation drawer

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -55,6 +55,7 @@ import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
 import de.danoeh.antennapod.ui.common.IntentUtils;
+import de.danoeh.antennapod.ui.common.NavigationToolbarActivity;
 import de.danoeh.antennapod.ui.common.ThemeSwitcher;
 import de.danoeh.antennapod.ui.common.ThemeUtils;
 import de.danoeh.antennapod.ui.discovery.DiscoveryFragment;
@@ -75,6 +76,7 @@ import de.danoeh.antennapod.ui.screen.preferences.PreferenceActivity;
 import de.danoeh.antennapod.ui.screen.queue.QueueFragment;
 import de.danoeh.antennapod.ui.screen.rating.RatingDialogManager;
 import de.danoeh.antennapod.ui.screen.subscriptions.SubscriptionFragment;
+import de.danoeh.antennapod.ui.statistics.StatisticsFragment;
 import de.danoeh.antennapod.ui.view.BottomSheetBackPressedCallback;
 import de.danoeh.antennapod.ui.view.LockableBottomSheetBehavior;
 import org.apache.commons.lang3.ArrayUtils;
@@ -89,7 +91,7 @@ import java.util.Objects;
 /**
  * The activity that is shown when the user launches the app.
  */
-public class MainActivity extends CastEnabledActivity {
+public class MainActivity extends CastEnabledActivity implements NavigationToolbarActivity {
 
     private static final String TAG = "MainActivity";
     public static final String MAIN_FRAGMENT_TAG = "main";
@@ -313,6 +315,7 @@ public class MainActivity extends CastEnabledActivity {
         }
     }
 
+    @Override
     public void setupToolbarToggle(@NonNull MaterialToolbar toolbar, boolean displayUpArrow) {
         if (drawerLayout != null) { // Tablet layout does not have a drawer
             if (drawerToggle != null) {
@@ -427,6 +430,9 @@ public class MainActivity extends CastEnabledActivity {
                 break;
             case SubscriptionFragment.TAG:
                 fragment = new SubscriptionFragment();
+                break;
+            case StatisticsFragment.TAG:
+                fragment = new StatisticsFragment();
                 break;
             case DiscoveryFragment.TAG:
                 fragment = new DiscoveryFragment();
@@ -765,6 +771,9 @@ public class MainActivity extends CastEnabledActivity {
                         break;
                     case "SUBSCRIPTIONS":
                         loadFragment(SubscriptionFragment.TAG, null);
+                        break;
+                    case "STATISTICS":
+                        loadFragment(StatisticsFragment.TAG, null);
                         break;
                     default:
                         EventBus.getDefault().post(new MessageEvent(getString(R.string.app_action_not_found, feature)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavigationNames.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavigationNames.java
@@ -11,6 +11,7 @@ import de.danoeh.antennapod.ui.screen.download.CompletedDownloadsFragment;
 import de.danoeh.antennapod.ui.screen.home.HomeFragment;
 import de.danoeh.antennapod.ui.screen.queue.QueueFragment;
 import de.danoeh.antennapod.ui.screen.subscriptions.SubscriptionFragment;
+import de.danoeh.antennapod.ui.statistics.StatisticsFragment;
 
 public abstract class NavigationNames {
     public static @DrawableRes int getDrawable(String tag) {
@@ -29,6 +30,8 @@ public abstract class NavigationNames {
                 return R.drawable.ic_history;
             case SubscriptionFragment.TAG:
                 return R.drawable.ic_subscriptions;
+            case StatisticsFragment.TAG:
+                return R.drawable.ic_chart_box;
             case AddFeedFragment.TAG:
                 return R.drawable.ic_add;
             default:
@@ -52,6 +55,8 @@ public abstract class NavigationNames {
                 return R.string.downloads_label;
             case PlaybackHistoryFragment.TAG:
                 return R.string.playback_history_label;
+            case StatisticsFragment.TAG:
+                return R.string.statistics_label;
             case AddFeedFragment.TAG:
                 return R.string.add_feed_label;
             case NavListAdapter.SUBSCRIPTION_LIST_TAG:
@@ -77,6 +82,8 @@ public abstract class NavigationNames {
                 return R.string.downloads_label_short;
             case PlaybackHistoryFragment.TAG:
                 return R.string.playback_history_label_short;
+            case StatisticsFragment.TAG:
+                return R.string.statistics_label_short;
             case AddFeedFragment.TAG:
                 return R.string.add_feed_label_short;
             case NavListAdapter.SUBSCRIPTION_LIST_TAG:
@@ -102,6 +109,8 @@ public abstract class NavigationNames {
                 return R.id.bottom_navigation_addfeed;
             case SubscriptionFragment.TAG:
                 return R.id.bottom_navigation_subscriptions;
+            case StatisticsFragment.TAG:
+                return R.id.bottom_navigation_statistics;
             case HomeFragment.TAG: // fall-through
             default:
                 return R.id.bottom_navigation_home;
@@ -123,6 +132,8 @@ public abstract class NavigationNames {
             return AddFeedFragment.TAG;
         } else if (id == R.id.bottom_navigation_subscriptions) {
             return SubscriptionFragment.TAG;
+        } else if (id == R.id.bottom_navigation_statistics) {
+            return StatisticsFragment.TAG;
         } else if (id == R.id.bottom_navigation_home) {
             return HomeFragment.TAG;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -36,7 +36,7 @@ import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.MenuItemUtils;
 import de.danoeh.antennapod.ui.screen.AddFeedFragment;
 import de.danoeh.antennapod.ui.screen.SearchFragment;
-import de.danoeh.antennapod.ui.statistics.StatisticsFragment;
+
 import de.danoeh.antennapod.ui.view.EmptyViewHandler;
 import de.danoeh.antennapod.ui.view.FloatingSelectMenu;
 import de.danoeh.antennapod.ui.view.ItemOffsetDecoration;
@@ -284,9 +284,6 @@ public class SubscriptionFragment extends Fragment
             } else {
                 ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             }
-            return true;
-        } else if (itemId == R.id.action_statistics) {
-            ((MainActivity) getActivity()).loadChildFragment(new StatisticsFragment());
             return true;
         } else if (itemId == R.id.pref_show_subscription_title) {
             item.setChecked(!item.isChecked());

--- a/app/src/main/res/menu/subscriptions.xml
+++ b/app/src/main/res/menu/subscriptions.xml
@@ -7,11 +7,6 @@
             custom:showAsAction="always"
             android:title="@string/search_label"/>
     <item
-            android:id="@+id/action_statistics"
-            android:icon="@drawable/ic_chart_box"
-            android:title="@string/statistics_label"
-            custom:showAsAction="always" />
-    <item
             android:id="@+id/refresh_item"
             android:title="@string/refresh_label"
             android:menuCategory="container"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -27,6 +27,7 @@
     <item name="bottom_navigation_history" type="id"/>
     <item name="bottom_navigation_addfeed" type="id"/>
     <item name="bottom_navigation_subscriptions" type="id"/>
+    <item name="bottom_navigation_statistics" type="id"/>
     <item name="bottom_navigation_more" type="id"/>
     <item name="bottom_navigation_customize" type="id"/>
     <item name="bottom_navigation_settings" type="id"/>

--- a/storage/preferences/src/main/res/values/arrays.xml
+++ b/storage/preferences/src/main/res/values/arrays.xml
@@ -8,6 +8,7 @@
         <item>EpisodesFragment</item>
         <item>DownloadsFragment</item>
         <item>PlaybackHistoryFragment</item>
+        <item>StatisticsFragment</item>
         <item>AddFeedFragment</item>
         <item>SubscriptionList</item>
     </string-array>

--- a/ui/common/src/main/java/de/danoeh/antennapod/ui/common/NavigationToolbarActivity.java
+++ b/ui/common/src/main/java/de/danoeh/antennapod/ui/common/NavigationToolbarActivity.java
@@ -1,0 +1,7 @@
+package de.danoeh.antennapod.ui.common;
+
+import com.google.android.material.appbar.MaterialToolbar;
+
+public interface NavigationToolbarActivity {
+    void setupToolbarToggle(MaterialToolbar toolbar, boolean displayUpArrow);
+}

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="provider_authority" translatable="false">de.danoeh.antennapod.provider</string>
     <string name="feed_update_receiver_name">Update subscriptions</string>
     <string name="statistics_label">Statistics</string>
+    <string name="statistics_label_short">Stats</string>
     <string name="add_feed_label">Add podcast</string>
     <string name="add_feed_label_short">Add</string>
     <string name="episodes_label">Episodes</string>

--- a/ui/preferences/src/main/res/values/arrays.xml
+++ b/ui/preferences/src/main/res/values/arrays.xml
@@ -267,6 +267,7 @@
         <item>NewEpisodesFragment</item>
         <item>EpisodesFragment</item>
         <item>SubscriptionFragment</item>
+        <item>StatisticsFragment</item>
         <item>remember</item>
     </string-array>
 
@@ -276,6 +277,7 @@
         <item>@string/inbox_label</item>
         <item>@string/episodes_label</item>
         <item>@string/subscriptions_label</item>
+        <item>@string/statistics_label</item>
         <item>@string/remember_last_page</item>
     </string-array>
 </resources>

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
@@ -19,6 +19,7 @@ import androidx.viewpager2.widget.ViewPager2;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import de.danoeh.antennapod.ui.common.ConfirmationDialog;
+import de.danoeh.antennapod.ui.common.NavigationToolbarActivity;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.event.StatisticsEvent;
 import de.danoeh.antennapod.ui.common.PagedToolbarFragment;
@@ -42,7 +43,7 @@ public class StatisticsFragment extends PagedToolbarFragment {
     public static final String PREF_INCLUDE_MARKED_PLAYED = "countAll";
     public static final String PREF_FILTER_FROM = "filterFrom";
     public static final String PREF_FILTER_TO = "filterTo";
-
+    private static final String KEY_UP_ARROW = "up_arrow";
 
     private static final int POS_SUBSCRIPTIONS = 0;
     private static final int POS_YEARS = 1;
@@ -52,6 +53,7 @@ public class StatisticsFragment extends PagedToolbarFragment {
     private TabLayout tabLayout;
     private ViewPager2 viewPager;
     private MaterialToolbar toolbar;
+    private boolean displayUpArrow;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -67,7 +69,15 @@ public class StatisticsFragment extends PagedToolbarFragment {
         if (BuildConfig.DEBUG || EchoConfig.isCurrentlyVisible()) {
             toolbar.getMenu().findItem(R.id.show_echo).setVisible(true);
         }
-        toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
+        displayUpArrow = getParentFragmentManager().getBackStackEntryCount() != 0;
+        if (savedInstanceState != null) {
+            displayUpArrow = savedInstanceState.getBoolean(KEY_UP_ARROW);
+        }
+        if (getActivity() instanceof NavigationToolbarActivity) {
+            ((NavigationToolbarActivity) getActivity()).setupToolbarToggle(toolbar, displayUpArrow);
+        } else {
+            toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
+        }
         viewPager.setAdapter(new StatisticsPagerAdapter(this));
         // Give the TabLayout the ViewPager
         tabLayout = rootView.findViewById(R.id.sliding_tabs);
@@ -88,6 +98,12 @@ public class StatisticsFragment extends PagedToolbarFragment {
             }
         }).attach();
         return rootView;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(KEY_UP_ARROW, displayUpArrow);
+        super.onSaveInstanceState(outState);
     }
 
     @Override


### PR DESCRIPTION
### Description
Make the Statistics screen a top-level navigation destination in the drawer and bottom navigation, instead of being hidden behind the Subscriptions overflow menu. This makes it easier to discover and reflects that statistics aren't just about subscriptions.

Fixes #8310 

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
