### PR TITLE
Remove hidden setting from search

### DIFF
--- a/ui/preferences/src/main/res/xml/preferences_playback.xml
+++ b/ui/preferences/src/main/res/xml/preferences_playback.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch">
 
     <PreferenceCategory android:title="@string/interruptions">
         <SwitchPreferenceCompat
@@ -14,14 +15,16 @@
                 android:dependency="prefPauseOnHeadsetDisconnect"
                 android:key="prefUnpauseOnHeadsetReconnect"
                 android:summary="@string/pref_unpauseOnHeadsetReconnect_sum"
-                android:title="@string/pref_unpauseOnHeadsetReconnect_title"/>
+                android:title="@string/pref_unpauseOnHeadsetReconnect_title"
+                search:ignore="true" />
         <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
                 android:dependency="prefPauseOnHeadsetDisconnect"
                 android:key="prefUnpauseOnBluetoothReconnect"
                 android:summary="@string/pref_unpauseOnBluetoothReconnect_sum"
-                android:title="@string/pref_unpauseOnBluetoothReconnect_title"/>
+                android:title="@string/pref_unpauseOnBluetoothReconnect_title"
+                search:ignore="true" />
         <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:enabled="true"


### PR DESCRIPTION
### Description

The resume playback settings are hidden on recent Android versions. Hide them from search as well.
Closes #8314

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
