### PR TITLE
Build media item stub on main thread and full item on background thread

### DIFF
--- a/playback/base/build.gradle
+++ b/playback/base/build.gradle
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     implementation project(':model')
+    implementation project(':system')
 
     implementation "androidx.media3:media3-exoplayer:$media3Version"
     implementation "androidx.media3:media3-session:$media3Version"

--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
@@ -13,6 +13,7 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.playback.Playable;
+import de.danoeh.antennapod.system.utils.ThreadUtils;
 
 import java.util.List;
 
@@ -20,7 +21,30 @@ public class MediaItemAdapter {
     public static final String MEDIA_ID_FEED_PREFIX = "FeedId:";
     public static final String KEY_STREAM_URL = "stream_url";
 
+    /**
+     * Create a basic media item without attached metadata.
+     * Should be used when initiating playback from outside the service.
+     */
+    public static MediaItem fromPlayableStub(Playable playable) {
+        MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder();
+        metadataBuilder.setIsPlayable(true);
+        metadataBuilder.setIsBrowsable(false);
+        String mediaId = "0";
+        if (playable instanceof FeedMedia) {
+            mediaId = String.valueOf(((FeedMedia) playable).getId());
+        }
+        return new MediaItem.Builder()
+                .setMediaId(mediaId)
+                .setMediaMetadata(metadataBuilder.build())
+                .build();
+    }
+
+    /**
+     * Create a media item and load all its metadata.
+     * Do NOT use this method on the main thread.
+     */
     public static MediaItem fromPlayable(Playable playable) {
+        ThreadUtils.assertNotMainThread();
         MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder();
         metadataBuilder.setTitle(playable.getEpisodeTitle());
         metadataBuilder.setIsPlayable(true);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
+import androidx.core.util.Pair;
 import androidx.media3.common.ForwardingPlayer;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.PlaybackException;
@@ -476,18 +477,22 @@ public class Media3PlaybackService extends MediaLibraryService {
         }
         queueLoaderDisposable = Maybe.fromCallable(() -> {
             FeedItem nextItem = DBReader.getNextInQueue(item);
-            return nextItem != null && nextItem.getMedia() != null ? nextItem.getMedia() : null;
+            if (nextItem != null && nextItem.getMedia() != null) {
+                return new Pair<>(nextItem.getMedia(), MediaItemAdapter.fromPlayable(nextItem.getMedia()));
+            }
+            return null;
         })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        nextMedia -> {
+                        pair -> {
+                            final FeedMedia nextMedia = pair.first;
+                            final MediaItem nextMediaItem = pair.second;
                             currentPlayable = nextMedia;
                             currentPlayable.onPlaybackStart();
-                            MediaItem mediaItem = MediaItemAdapter.fromPlayable(nextMedia);
                             PlaybackPreferences.writeMediaPlaying(nextMedia);
                             player.setPlayWhenReady(UserPreferences.isFollowQueue());
-                            player.setMediaItem(mediaItem);
+                            player.setMediaItem(nextMediaItem);
                             player.seekTo(nextMedia.getPosition());
                             player.prepare();
                         },

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
@@ -53,7 +53,7 @@ public class PlaybackServiceStarter {
                         == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
                     controller.play(); // Casting somehow does not play when not quickly starting the old episode
                 }
-                controller.setMediaItem(MediaItemAdapter.fromPlayable(media));
+                controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media));
                 controller.prepare();
                 controller.play();
             });

--- a/storage/database/build.gradle
+++ b/storage/database/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':net:download:service-interface')
     implementation project(':net:sync:service-interface')
     implementation project(':storage:preferences')
+    implementation project(':system')
     implementation project(':ui:app-start-intent')
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -10,8 +10,6 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.os.Build;
-import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -42,6 +40,7 @@ import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.storage.database.mapper.FeedItemFilterQuery;
 import de.danoeh.antennapod.storage.database.mapper.FeedItemSortQuery;
 
+import de.danoeh.antennapod.system.utils.ThreadUtils;
 import org.apache.commons.io.FileUtils;
 
 import static de.danoeh.antennapod.model.feed.FeedPreferences.SPEED_USE_GLOBAL;
@@ -389,24 +388,8 @@ public class PodDBAdapter {
         return newDb;
     }
 
-    private boolean isTest() {
-        if ("robolectric".equals(Build.FINGERPRINT)) {
-            return true;
-        }
-        try {
-            Class.forName("org.junit.Test");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
-
     public synchronized PodDBAdapter open() {
-        if (BuildConfig.DEBUG) {
-            if (Looper.myLooper() == Looper.getMainLooper() && !isTest()) {
-                throw new RuntimeException("I/O on main thread");
-            }
-        }
+        ThreadUtils.assertNotMainThread();
         // do nothing
         return this;
     }

--- a/system/src/main/java/de/danoeh/antennapod/system/utils/ThreadUtils.java
+++ b/system/src/main/java/de/danoeh/antennapod/system/utils/ThreadUtils.java
@@ -1,0 +1,35 @@
+package de.danoeh.antennapod.system.utils;
+
+import android.os.Build;
+import android.os.Looper;
+import de.danoeh.antennapod.system.BuildConfig;
+
+public final class ThreadUtils {
+    private ThreadUtils() {
+        // Private constructor to prevent instantiation
+    }
+
+    /**
+     * Assert to notify developers that they are not supposed to call a function on the main thread.
+     * If you get an exception in this method, you should move your calls to background threads.
+     */
+    public static void assertNotMainThread() {
+        if (BuildConfig.DEBUG) {
+            if (Looper.myLooper() == Looper.getMainLooper() && !isTest()) {
+                throw new RuntimeException("I/O on main thread");
+            }
+        }
+    }
+
+    private static boolean isTest() {
+        if ("robolectric".equals(Build.FINGERPRINT)) {
+            return true;
+        }
+        try {
+            Class.forName("org.junit.Test");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Description

Build media item stub in main thread and full item in background thread.
We later plan to add more things to load to the main item creation code, which should not run on the main thread.
Contributes to #8261

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
