### PR TITLE
Fix crash when device does not support loudness enhancer

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerWrapper.java
@@ -402,20 +402,20 @@ public class ExoPlayerWrapper {
             return;
         }
 
-        LoudnessEnhancer newEnhancer = new LoudnessEnhancer(audioStreamId);
         LoudnessEnhancer oldEnhancer = this.loudnessEnhancer;
         if (oldEnhancer != null) {
             try {
+                LoudnessEnhancer newEnhancer = new LoudnessEnhancer(audioStreamId);
                 newEnhancer.setEnabled(oldEnhancer.getEnabled());
                 if (oldEnhancer.getEnabled()) {
                     newEnhancer.setTargetGain((int) oldEnhancer.getTargetGain());
                 }
                 oldEnhancer.release();
+                this.loudnessEnhancer = newEnhancer;
             } catch (Exception e) {
                 Log.d(TAG, e.toString());
+                this.loudnessEnhancer = null;
             }
         }
-
-        this.loudnessEnhancer = newEnhancer;
     }
 }


### PR DESCRIPTION
### Description

Fix crash when device does not support loudness enhancer. This fixes the old playback service, which is mostly non-functional by now. This still documents how to fix the loudness enhancer in case it is ported to the new service at some point.
Closes #8294

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
