### PR TITLE
Add Android Auto "For You" mix of in-progress and newest episodes

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -54,11 +54,11 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     private static final String MEDIA_ID_EPISODES = "episodes";
     private static final String MEDIA_ID_SUBSCRIPTIONS = "subscriptions";
     private static final String MEDIA_ID_CURRENT = "current";
-    private static final String MEDIA_ID_FOR_YOU = "for_you";
-    private static final int FOR_YOU_LIMIT = 30;
+    private static final String MEDIA_ID_RECOMMENDATIONS = "recommendations";
+    private static final int RECOMMENDATIONS_LIMIT = 30;
     private static final ImmutableList<String> BROWSABLE_MEDIA_IDS = ImmutableList.of(
             MEDIA_ID_ROOT, MEDIA_ID_QUEUE, MEDIA_ID_DOWNLOADS, MEDIA_ID_EPISODES,
-            MEDIA_ID_SUBSCRIPTIONS, MEDIA_ID_CURRENT, MEDIA_ID_FOR_YOU);
+            MEDIA_ID_SUBSCRIPTIONS, MEDIA_ID_CURRENT, MEDIA_ID_RECOMMENDATIONS);
 
     protected static final SessionCommand SESSION_COMMAND_REWIND
             = new SessionCommand("rewind", Bundle.EMPTY);
@@ -319,8 +319,8 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 .setExtras(rootExtras).build();
         if ("com.google.android.googlequicksearchbox".equals(browser.getPackageName())) {
             // Android Auto "for you" screen
-            String autoRootId = UserPreferences.isAndroidAutoForYouEnabled()
-                    ? MEDIA_ID_FOR_YOU : MEDIA_ID_CURRENT;
+            String autoRootId = UserPreferences.isAndroidAutoRecommendationsEnabled()
+                    ? MEDIA_ID_RECOMMENDATIONS : MEDIA_ID_CURRENT;
             return Futures.immediateFuture(LibraryResult.ofItem(
                     createBrowsableMediaItem(autoRootId), libraryParams));
         }
@@ -352,8 +352,8 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
 
         switch (parentId) {
             case MEDIA_ID_ROOT:
-                String topItemId = UserPreferences.isAndroidAutoForYouEnabled()
-                        ? MEDIA_ID_FOR_YOU : MEDIA_ID_CURRENT;
+                String topItemId = UserPreferences.isAndroidAutoRecommendationsEnabled()
+                        ? MEDIA_ID_RECOMMENDATIONS : MEDIA_ID_CURRENT;
                 disposables.add(Single.fromCallable(() -> ImmutableList.of(
                                 createBrowsableMediaItem(topItemId),
                                 createBrowsableMediaItem(MEDIA_ID_QUEUE),
@@ -394,14 +394,14 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                                 }
                         ));
                 return future;
-            case MEDIA_ID_FOR_YOU:
-                disposables.add(Single.fromCallable(this::buildForYouList)
+            case MEDIA_ID_RECOMMENDATIONS:
+                disposables.add(Single.fromCallable(this::buildRecommendationsList)
                         .subscribeOn(Schedulers.io())
                         .subscribe(
                                 items -> future.set(LibraryResult.ofItemList(
                                         MediaItemAdapter.fromItemList(items), params)),
                                 error -> {
-                                    Log.e(TAG, "Failed to load For You items", error);
+                                    Log.e(TAG, "Failed to load recommendations", error);
                                     future.set(LibraryResult.ofItemList(ImmutableList.of(), params));
                                 }
                         ));
@@ -455,12 +455,12 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     }
 
     @WorkerThread
-    private List<FeedItem> buildForYouList() {
+    private List<FeedItem> buildRecommendationsList() {
         List<FeedItem> result = new ArrayList<>();
         Set<Long> seenIds = new HashSet<>();
 
         // First: in-progress episodes (started but not finished), most recently played first
-        List<FeedItem> inProgress = DBReader.getEpisodes(0, FOR_YOU_LIMIT,
+        List<FeedItem> inProgress = DBReader.getEpisodes(0, RECOMMENDATIONS_LIMIT,
                 new FeedItemFilter(FeedItemFilter.PAUSED, FeedItemFilter.HAS_MEDIA),
                 SortOrder.COMPLETION_DATE_NEW_OLD);
         for (FeedItem item : inProgress) {
@@ -470,13 +470,13 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
         }
 
         // Second: newest episodes across all subscriptions, filling up to the limit
-        if (result.size() < FOR_YOU_LIMIT) {
-            int remaining = FOR_YOU_LIMIT - result.size();
+        if (result.size() < RECOMMENDATIONS_LIMIT) {
+            int remaining = RECOMMENDATIONS_LIMIT - result.size();
             List<FeedItem> newest = DBReader.getEpisodes(0, remaining + result.size(),
                     new FeedItemFilter(FeedItemFilter.HAS_MEDIA),
                     SortOrder.DATE_NEW_OLD);
             for (FeedItem item : newest) {
-                if (result.size() >= FOR_YOU_LIMIT) {
+                if (result.size() >= RECOMMENDATIONS_LIMIT) {
                     break;
                 }
                 if (seenIds.add(item.getId())) {
@@ -523,9 +523,9 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
             case MEDIA_ID_CURRENT:
                 return MediaItemAdapter.from(context, MEDIA_ID_CURRENT,
                         context.getString(R.string.current_playing_episode), R.drawable.ic_play_48dp_black, null);
-            case MEDIA_ID_FOR_YOU:
-                return MediaItemAdapter.from(context, MEDIA_ID_FOR_YOU,
-                        context.getString(R.string.for_you_label), R.drawable.ic_play_48dp_black, null);
+            case MEDIA_ID_RECOMMENDATIONS:
+                return MediaItemAdapter.from(context, MEDIA_ID_RECOMMENDATIONS,
+                        context.getString(R.string.recommendations_label), R.drawable.ic_play_48dp_black, null);
             default:
                 throw new IllegalArgumentException("ID not known: " + id);
         }

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -90,7 +90,7 @@ public abstract class UserPreferences {
     public static final String PREF_PAUSE_PLAYBACK_FOR_FOCUS_LOSS = "prefPauseForFocusLoss";
     private static final String PREF_TIME_RESPECTS_SPEED = "prefPlaybackTimeRespectsSpeed";
     public static final String PREF_STREAM_OVER_DOWNLOAD = "prefStreamOverDownload";
-    public static final String PREF_ANDROID_AUTO_FOR_YOU = "prefAndroidAutoForYou";
+    public static final String PREF_ANDROID_AUTO_RECOMMENDATIONS = "prefAndroidAutoRecommendations";
 
     // Network
     private static final String PREF_ENQUEUE_DOWNLOADED = "prefEnqueueDownloaded";
@@ -398,8 +398,8 @@ public abstract class UserPreferences {
         return prefs.getBoolean(PREF_FOLLOW_QUEUE, true);
     }
 
-    public static boolean isAndroidAutoForYouEnabled() {
-        return prefs.getBoolean(PREF_ANDROID_AUTO_FOR_YOU, false);
+    public static boolean isAndroidAutoRecommendationsEnabled() {
+        return prefs.getBoolean(PREF_ANDROID_AUTO_RECOMMENDATIONS, false);
     }
 
     /**

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -36,10 +36,10 @@
     <string name="years_statistics_label">Years</string>
     <string name="notification_pref_fragment">Notifications</string>
     <string name="current_playing_episode">Current</string>
-    <string name="for_you_label">For You</string>
+    <string name="recommendations_label">Recommendations</string>
     <string name="android_auto_label">Android Auto</string>
-    <string name="pref_android_auto_for_you_title">\"For You\" mix</string>
-    <string name="pref_android_auto_for_you_sum">Show a mix of in-progress and newest episodes instead of only the current episode in Android Auto</string>
+    <string name="pref_android_auto_recommendations_title">\"For You\" recommendations</string>
+    <string name="pref_android_auto_recommendations_sum">Show a mix of in-progress and newest episodes instead of only the current episode in Android Auto\'s \"For You\" tab</string>
 
     <!-- Google Assistant -->
     <string name="app_action_not_found">\"%1$s\" not found</string>

--- a/ui/preferences/src/main/res/xml/preferences_playback.xml
+++ b/ui/preferences/src/main/res/xml/preferences_playback.xml
@@ -100,8 +100,8 @@
         <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:enabled="true"
-                android:key="prefAndroidAutoForYou"
-                android:summary="@string/pref_android_auto_for_you_sum"
-                android:title="@string/pref_android_auto_for_you_title"/>
+                android:key="prefAndroidAutoRecommendations"
+                android:summary="@string/pref_android_auto_recommendations_sum"
+                android:title="@string/pref_android_auto_recommendations_title"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
### Description

Changes what AntennaPod returns to Android Auto's existing "For You" recommendation tab (and Google Assistant media suggestions). Currently it only returns the single currently-playing episode. With this change enabled, it returns a mix of in-progress (paused) episodes sorted by most recently played, followed by the newest episodes across all subscriptions (up to 30 items, deduplicated).

The main browse tree (Queue, Downloads, Episodes, Subscriptions) is unchanged.

Gated behind a new toggle in **Settings > Playback > Android Auto** (default: off, preserving existing behavior).

Closes: #8326

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests