### PR TITLE
Switch away from JitPack

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,10 +121,9 @@ dependencies {
     annotationProcessor "org.greenrobot:eventbus-annotation-processor:$eventbusVersion"
     implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-
-    implementation 'com.github.ByteHamster:SearchPreference:v2.5.0'
+    implementation 'com.bytehamster:lib.preferencesearch:2.7.3'
     implementation 'com.github.skydoves:balloon:1.5.3'
-    implementation 'com.github.xabaras:RecyclerViewSwipeDecorator:1.3'
+    implementation 'it.xabaras.android:recyclerview-swipedecorator:1.4'
 
     testImplementation "androidx.test:core:$testCoreVersion"
     testImplementation "junit:junit:$junitVersion"

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
         mavenLocal()
     }
 }

--- a/ui/preferences/build.gradle
+++ b/ui/preferences/build.gradle
@@ -47,5 +47,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
     implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation 'com.github.ByteHamster:SearchPreference:2.7.3'
+    implementation 'com.bytehamster:lib.preferencesearch:2.7.3'
 }


### PR DESCRIPTION
### Description

JitPack was down a couple of times recently. We can easily switch the last remaining dependencies to mvn central.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
