### PR TITLE
Fix "Too many inflation attempts" crash from SQLite lock contention

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -382,7 +382,6 @@ public class PodDBAdapter {
         SQLiteDatabase newDb;
         try {
             newDb = dbHelper.getWritableDatabase();
-            newDb.disableWriteAheadLogging();
         } catch (SQLException ex) {
             Log.e(TAG, Log.getStackTraceString(ex));
             newDb = dbHelper.getReadableDatabase();


### PR DESCRIPTION
### Description

Remove the explicit disableWriteAheadLogging() call in PodDBAdapter.openDb(). Without WAL, SQLite allows only one connection at a time, forcing all threads to serialize on a single lock. When multiple UI fragments (ExternalPlayerFragment, CoverFragment, ItemDescriptionFragment, PlaybackHistoryFragment) simultaneously query the database on separate RxJava IO threads, the resulting lock contention on the same monitor exhausts the ART monitor inflation limit, causing a fatal crash (monitor.cc:1125).

Fixes #8338

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
