### PR TITLE
Delete stale WAL/SHM files before moving imported database into place

### DIFF
--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/DatabaseExporter.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/DatabaseExporter.java
@@ -88,6 +88,8 @@ public class DatabaseExporter {
             if (!success) {
                 throw new IOException("Unable to delete old database");
             }
+            new File(currentDB.getAbsolutePath() + "-wal").delete();
+            new File(currentDB.getAbsolutePath() + "-shm").delete();
             FileUtils.moveFile(tempDB, currentDB);
         } catch (IOException | SQLiteException e) {
             Log.e(TAG, Log.getStackTraceString(e));


### PR DESCRIPTION
When SQLite runs in WAL mode, it creates companion -wal and -shm files alongside the main database file. During database import, we delete the old database and move the imported file into its place. However, the old -wal and -shm files were left behind. If they contained data from the previous WAL session, SQLite could replay stale WAL entries on top of the freshly imported database, leading to corruption or unexpected state.

This adds explicit deletion of -wal and -shm files after removing the old database but before moving the imported one in. File.delete() is a safe no-op if the files don't exist, so this works regardless of whether WAL mode was previously active.

### Description
Fixes #8347

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
