### PR TITLE
Reduce number of database queries

### DIFF
--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -136,7 +136,7 @@ public class DbReaderTest {
                     items.add(item);
                 }
             }
-            DBReader.loadAdditionalFeedItemListData(items);
+            DBReader.loadFeedDataOfFeedItemList(items);
             for (int i = 0; i < numFeeds; i++) {
                 for (int j = 0; j < numItems; j++) {
                     FeedItem item = feeds.get(i).getItems().get(j);

--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
@@ -295,7 +295,7 @@ public class SyncService extends Worker {
             updatedItems.add(feedItem);
         }
         DBWriter.removeQueueItem(getApplicationContext(), false, queueToBeRemoved.toArray());
-        DBReader.loadAdditionalFeedItemListData(updatedItems);
+        DBReader.loadFeedDataOfFeedItemList(updatedItems);
         DBWriter.setItemList(updatedItems);
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -95,37 +95,13 @@ public final class DBReader {
     }
 
     /**
-     * Loads additional data in to the feed items from other database queries
-     *
-     * @param items the FeedItems who should have other data loaded
-     */
-    public static void loadAdditionalFeedItemListData(List<FeedItem> items) {
-        loadTagsOfFeedItemList(items);
-        loadFeedDataOfFeedItemList(items);
-    }
-
-    private static void loadTagsOfFeedItemList(List<FeedItem> items) {
-        LongList favoriteIds = getFavoriteIDList();
-        LongList queueIds = getQueueIDList();
-
-        for (FeedItem item : items) {
-            if (favoriteIds.contains(item.getId())) {
-                item.addTag(FeedItem.TAG_FAVORITE);
-            }
-            if (queueIds.contains(item.getId())) {
-                item.addTag(FeedItem.TAG_QUEUE);
-            }
-        }
-    }
-
-    /**
      * Takes a list of FeedItems and loads their corresponding Feed-objects from the database.
      * The feedID-attribute of a FeedItem must be set to the ID of its feed or the method will
      * not find the correct feed of an item.
      *
      * @param items The FeedItems whose Feed-objects should be loaded.
      */
-    private static void loadFeedDataOfFeedItemList(List<FeedItem> items) {
+    public static void loadFeedDataOfFeedItemList(List<FeedItem> items) {
         List<Feed> feeds = getFeedList();
 
         Map<Long, Feed> feedIndex = new ArrayMap<>(feeds.size());
@@ -229,24 +205,8 @@ public final class DBReader {
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getQueueCursor())) {
             List<FeedItem> items = extractItemlistFromCursor(cursor);
-            loadAdditionalFeedItemListData(items);
+            loadFeedDataOfFeedItemList(items);
             return items;
-        } finally {
-            adapter.close();
-        }
-    }
-
-    private static LongList getFavoriteIDList() {
-        Log.d(TAG, "getFavoriteIDList() called");
-
-        PodDBAdapter adapter = PodDBAdapter.getInstance();
-        adapter.open();
-        try (Cursor cursor = adapter.getFavoritesIdsCursor()) {
-            LongList favoriteIDs = new LongList(cursor.getCount());
-            while (cursor.moveToNext()) {
-                favoriteIDs.add(cursor.getLong(0));
-            }
-            return favoriteIDs;
         } finally {
             adapter.close();
         }
@@ -265,7 +225,7 @@ public final class DBReader {
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getEpisodesCursor(offset, limit, filter, sortOrder))) {
             List<FeedItem> items = extractItemlistFromCursor(cursor);
-            loadAdditionalFeedItemListData(items);
+            loadFeedDataOfFeedItemList(items);
             return items;
         } finally {
             adapter.close();
@@ -303,7 +263,7 @@ public final class DBReader {
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getRandomEpisodesCursor(limit, seed))) {
             List<FeedItem> items = extractItemlistFromCursor(cursor);
-            loadAdditionalFeedItemListData(items);
+            loadFeedDataOfFeedItemList(items);
             return items;
         } finally {
             adapter.close();
@@ -380,7 +340,6 @@ public final class DBReader {
                 for (FeedItem item : items) {
                     item.setFeed(feed);
                 }
-                loadTagsOfFeedItemList(items);
                 feed.setItems(items);
             } else {
                 Log.e(TAG, "getFeed could not find feed with id " + feedId);
@@ -408,7 +367,7 @@ public final class DBReader {
             List<FeedItem> list = extractItemlistFromCursor(cursor);
             if (!list.isEmpty()) {
                 FeedItem item = list.get(0);
-                loadAdditionalFeedItemListData(list);
+                loadFeedDataOfFeedItemList(list);
                 return item;
             }
         } finally {
@@ -432,7 +391,7 @@ public final class DBReader {
             List<FeedItem> list = extractItemlistFromCursor(cursor);
             if (!list.isEmpty()) {
                 FeedItem nextItem = list.get(0);
-                loadAdditionalFeedItemListData(list);
+                loadFeedDataOfFeedItemList(list);
                 return nextItem;
             }
             return null;
@@ -449,7 +408,7 @@ public final class DBReader {
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getPausedQueueCursor(limit))) {
             List<FeedItem> items = extractItemlistFromCursor(cursor);
-            loadAdditionalFeedItemListData(items);
+            loadFeedDataOfFeedItemList(items);
             return items;
         } finally {
             adapter.close();
@@ -462,7 +421,7 @@ public final class DBReader {
      * @param guid feed item guid
      * @param episodeUrl the feed item's url
      * @return The FeedItem or null if the FeedItem could not be found.
-     *          Does NOT load additional attributes like feed or queue state.
+     *          Does NOT load additional attributes like feed.
      */
     public static FeedItem getFeedItemByGuidOrEpisodeUrl(final String guid, final String episodeUrl) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -542,7 +501,7 @@ public final class DBReader {
                 return null;
             }
             FeedItem item = itemCursor.getFeedItem();
-            loadAdditionalFeedItemListData(Collections.singletonList(item));
+            loadFeedDataOfFeedItemList(Collections.singletonList(item));
             return item.getMedia();
         } finally {
             adapter.close();
@@ -554,7 +513,7 @@ public final class DBReader {
         adapter.open();
         try (FeedItemCursor itemCursor = new FeedItemCursor(adapter.getFeedItemCursorByUrl(urls))) {
             List<FeedItem> items = extractItemlistFromCursor(itemCursor);
-            loadAdditionalFeedItemListData(items);
+            loadFeedDataOfFeedItemList(items);
             return items;
         } finally {
             adapter.close();
@@ -831,7 +790,7 @@ public final class DBReader {
         adapter.open();
         try (FeedItemCursor searchResult = new FeedItemCursor(adapter.searchItems(feedId, query, state))) {
             List<FeedItem> items = extractItemlistFromCursor(searchResult);
-            loadAdditionalFeedItemListData(items);
+            loadFeedDataOfFeedItemList(items);
             return items;
         } finally {
             adapter.close();

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/NonSubscribedFeedsCleaner.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/NonSubscribedFeedsCleaner.java
@@ -22,7 +22,7 @@ public class NonSubscribedFeedsCleaner {
             }
             DBReader.getFeedItemList(feed, new FeedItemFilter(FeedItemFilter.INCLUDE_NOT_SUBSCRIBED),
                     SortOrder.DATE_NEW_OLD, 0, Integer.MAX_VALUE);
-            DBReader.loadAdditionalFeedItemListData(feed.getItems());
+            DBReader.loadFeedDataOfFeedItemList(feed.getItems());
             if (shouldDelete(feed)) {
                 Log.d(TAG, "Deleting unsubscribed feed " + feed.getTitle());
                 try {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -267,6 +267,8 @@ public class PodDBAdapter {
     public static final String SELECT_KEY_ITEM_ID = "item_id";
     public static final String SELECT_KEY_MEDIA_ID = "media_id";
     public static final String SELECT_KEY_FEED_ID = "feed_id";
+    public static final String SELECT_KEY_IS_FAVORITE = "is_favorite";
+    public static final String SELECT_KEY_IS_IN_QUEUE = "is_in_queue";
 
     private static final String KEYS_FEED_ITEM_WITHOUT_DESCRIPTION =
             TABLE_NAME_FEED_ITEMS + "." + KEY_ID + " AS " + SELECT_KEY_ITEM_ID + ", "
@@ -284,7 +286,11 @@ public class PodDBAdapter {
             + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_CHAPTER_URL + ", "
             + TABLE_NAME_FEED_ITEMS + "." + KEY_SOCIAL_INTERACT_URL + ", "
             + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_TRANSCRIPT_TYPE + ", "
-            + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_TRANSCRIPT_URL;
+            + TABLE_NAME_FEED_ITEMS + "." + KEY_PODCASTINDEX_TRANSCRIPT_URL + ", "
+            + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + " IN (SELECT " + TABLE_NAME_FAVORITES + "." + KEY_FEEDITEM
+            + " FROM " + TABLE_NAME_FAVORITES + ") AS " + SELECT_KEY_IS_FAVORITE + ", "
+            + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + " IN (SELECT " + TABLE_NAME_QUEUE + "." + KEY_FEEDITEM
+            + " FROM " + TABLE_NAME_QUEUE + ") AS " + SELECT_KEY_IS_IN_QUEUE;
 
     private static final String KEYS_FEED_MEDIA =
             TABLE_NAME_FEED_MEDIA + "." + KEY_ID + " AS " + SELECT_KEY_MEDIA_ID + ", "
@@ -1109,12 +1115,6 @@ public class PodDBAdapter {
                     + TABLE_NAME_FEED_MEDIA + "." + KEY_LAST_PLAYED_TIME_STATISTICS + " ELSE 0 END) DESC , "
                 + TABLE_NAME_QUEUE + "." + KEY_ID
                 + " LIMIT " + limit;
-        return db.rawQuery(query, null);
-    }
-
-    public final Cursor getFavoritesIdsCursor() {
-        final String query = "SELECT " + TABLE_NAME_FAVORITES + "." + KEY_FEEDITEM
-                + " FROM " + TABLE_NAME_FAVORITES;
         return db.rawQuery(query, null);
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemCursor.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemCursor.java
@@ -29,6 +29,8 @@ public class FeedItemCursor extends CursorWrapper {
     private final int indexMediaId;
     private final int indexPodcastIndexTranscriptType;
     private final int indexPodcastIndexTranscriptUrl;
+    private final int indexIsFavorite;
+    private final int indexIsInQueue;
 
     public FeedItemCursor(Cursor cursor) {
         super(new FeedMediaCursor(cursor));
@@ -49,6 +51,8 @@ public class FeedItemCursor extends CursorWrapper {
         indexSocialInteractUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_SOCIAL_INTERACT_URL);
         indexPodcastIndexTranscriptType = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_TYPE);
         indexPodcastIndexTranscriptUrl = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_PODCASTINDEX_TRANSCRIPT_URL);
+        indexIsFavorite = cursor.getColumnIndexOrThrow(PodDBAdapter.SELECT_KEY_IS_FAVORITE);
+        indexIsInQueue = cursor.getColumnIndexOrThrow(PodDBAdapter.SELECT_KEY_IS_IN_QUEUE);
     }
 
     /**
@@ -74,6 +78,12 @@ public class FeedItemCursor extends CursorWrapper {
                 getString(indexSocialInteractUrl));
         if (!isNull(indexMediaId)) {
             item.setMedia(feedMediaCursor.getFeedMedia());
+        }
+        if (getInt(indexIsFavorite) > 0) {
+            item.addTag(FeedItem.TAG_FAVORITE);
+        }
+        if (getInt(indexIsInQueue) > 0) {
+            item.addTag(FeedItem.TAG_QUEUE);
         }
         return item;
     }


### PR DESCRIPTION
### Description

Reduce number of database queries. Instead of loading queue and favorites lists in separate queries, let sqlite do the join

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
