### PR TITLE
Implement auto-rewind on resume in Media3PlaybackService

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -393,9 +393,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 return;
                             }
                             allowStreamingThisTime = false;
-                            long savedPosition = media.getPosition();
-                            currentPlayable.setPosition((int) savedPosition);
-                            player.seekTo(savedPosition);
+                            currentPlayable.setPosition((int) player.getCurrentPosition());
                             currentPlayable.onPlaybackStart();
                             if (currentPlayable.getItem() != null
                                     && !currentPlayable.getItem().isTagged(FeedItem.TAG_QUEUE)) {
@@ -616,10 +614,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                             }
                             player.setPlayWhenReady(UserPreferences.isFollowQueue());
                             player.setMediaItem(nextMediaItem);
-                            long startPosition = SkipUtils.skipIntroIfNecessary(this, nextMedia);
-                            startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
-                                    (int) startPosition, nextMedia.getLastPlayedTimeStatistics());
-                            player.seekTo(startPosition);
+                            player.seekTo(SkipUtils.skipIntroIfNecessary(this, nextMedia));
                             player.prepare();
                         },
                         error -> Log.e(TAG, "Failed to load next queue item", error),

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -30,6 +30,7 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.playback.base.MediaItemAdapter;
+import de.danoeh.antennapod.playback.base.RewindAfterPauseUtils;
 import de.danoeh.antennapod.playback.service.R;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
@@ -238,6 +239,8 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 .subscribeOn(Schedulers.io())
                 .subscribe(result -> {
                     long startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
+                    startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
+                            (int) startPosition, result.second.getLastPlayedTimeStatistics());
                     future.set(new MediaSession.MediaItemsWithStartPosition(result.first, index, startPosition));
                 }, error -> {
                     Log.e(TAG, "Failed to load media", error);
@@ -285,10 +288,13 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         media -> {
+                            long startPosition = SkipUtils.skipIntroIfNecessary(context, media);
+                            startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
+                                    (int) startPosition, media.getLastPlayedTimeStatistics());
                             MediaSession.MediaItemsWithStartPosition result =
                                     new MediaSession.MediaItemsWithStartPosition(
                                             Collections.singletonList(MediaItemAdapter.fromPlayable(context, media)),
-                                            0, SkipUtils.skipIntroIfNecessary(context, media));
+                                            0, startPosition);
                             future.set(result);
                         },
                         future::setException


### PR DESCRIPTION
### Description

This PR fixes the missing auto-rewind feature after the Media3 migration. 
To solve this, I used the existing `RewindAfterPauseUtils.calculatePositionWithRewind()` to get the correct rewind time based on the user's settings and pause duration.

Closes #8268

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` *(Note: local build was successful)*
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)