### PR TITLE
Fix crash when opening Sleep Timer dialog due to main-thread DB access

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
@@ -73,6 +73,7 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
     private TimeDialogBinding viewBinding;
     private Disposable disposable;
     private volatile Integer currentQueueSize = null;
+    private volatile FeedMedia currentMedia = null;
 
     public SleepTimerDialog() {
     }
@@ -90,6 +91,7 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
 
         disposable = Single.fromCallable(() -> {
             FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+            currentMedia = media;
             if (media == null || media.getItem() == null) {
                 return 0;
             }
@@ -97,8 +99,13 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
         })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(result -> currentQueueSize = result,
-                        error -> currentQueueSize = 0);
+                .subscribe(result -> {
+                    currentQueueSize = result;
+                    refreshUiState();
+                }, error -> {
+                    currentQueueSize = 0;
+                    refreshUiState();
+                });
     }
 
     @Override
@@ -349,8 +356,9 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
                 }
             } else {
                 // for time sleep timers check if the selected value exceeds the remaining play time in the episode
-                final int remaining = controller != null ? controller.getDuration() - controller.getPosition() :
-                        Integer.MAX_VALUE;
+                final int remaining = (controller != null && currentMedia != null)
+                        ? currentMedia.getDuration() - currentMedia.getPosition()
+                        : Integer.MAX_VALUE;
                 final long timer = TimeUnit.MINUTES.toMillis(selectedSleepTime);
                 if ((timer > remaining) && !UserPreferences.isFollowQueue()) {
                     final int remainingMinutes = Math.toIntExact(TimeUnit.MILLISECONDS.toMinutes(remaining));


### PR DESCRIPTION
### Description

Fix a crash when opening the Sleep Timer dialog caused by main-thread database access.

`SleepTimerDialog.refreshUiState()` reads playback timing via
`PlaybackController.getDuration()` and `getPosition()`. These methods can
fall back to `getMedia()`, which lazily loads media from the database.

This results in disk I/O on the main thread and triggers a crash in
debug builds ("I/O on main thread").

Load the currently playing media asynchronously when the dialog opens
and use it for remaining-time validation instead of triggering a lazy
DB lookup.

Closes: #8360

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description
- [ ] If it is a core feature, I have added automated tests