### PR TITLE
Run checkstyle in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,18 +43,3 @@ project.ext {
     testCoreVersion = "1.5.0"
     mockitoVersion = "5.15.2"
 }
-
-checkstyle {
-    toolVersion '10.3.1'
-}
-
-tasks.register('checkstyle', Checkstyle) {
-    minHeapSize = "200m"
-    maxHeapSize = "2g"
-    classpath = files()
-    source "${project.rootDir}"
-    exclude("**/generated-sources/**")
-    exclude("**/gen/**")
-    exclude("**/build/**")
-    exclude("**/generated/**")
-}

--- a/common.gradle
+++ b/common.gradle
@@ -128,3 +128,25 @@ def parseSpotBugsXml(task, xmlFile) {
                 new Exception("SpotBugs violations were found. See output above for details."))
     }
 }
+
+apply plugin: 'checkstyle'
+
+checkstyle {
+    toolVersion = '10.12.0'
+    configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+    ignoreFailures = false
+    showViolations = true
+}
+
+tasks.register('checkstyle', Checkstyle) {
+    group = "verification"
+
+    classpath = files()
+    source = fileTree('src/main/java') { include '**/*.java' }
+    if (file("src/free/java").exists()) source += fileTree("src/free/java") { include '**/*.java' }
+    if (file("src/play/java").exists()) source += fileTree("src/play/java") { include '**/*.java' }
+
+    exclude '**/gen/**'
+    exclude '**/R.java'
+    exclude '**/BuildConfig.java'
+}

--- a/parser/media/src/main/java/de/danoeh/antennapod/parser/media/vorbis/VorbisCommentChapterReader.java
+++ b/parser/media/src/main/java/de/danoeh/antennapod/parser/media/vorbis/VorbisCommentChapterReader.java
@@ -95,7 +95,6 @@ public class VorbisCommentChapterReader extends VorbisCommentReader {
      * Return the id of a vorbiscomment chapter from a string like CHAPTERxxx*
      *
      * @return the id of the chapter key or -1 if the id couldn't be read.
-     * @throws VorbisCommentReaderException
      * */
     private static int getIdFromKey(String key) throws VorbisCommentReaderException {
         if (key.length() >= CHAPTERXXX_LENGTH) { // >= CHAPTERxxx


### PR DESCRIPTION
### Description

Make `./gradlew checkstyle` much faster by registering a task for each module and letting Gradle run those in parallel.

Before: 27 seconds, every time you run it (no caching)
After: 18 seconds, 2s on subsequent runs (if only a few code files were touched)

Also, upgrade checkstyle version

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
