### PR TITLE
Move database calls from Schedulers.io to Schedulers.computation

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/OpmlImportActivity.java
@@ -104,7 +104,7 @@ public class OpmlImportActivity extends ToolbarActivity {
                 }
                 FeedUpdateManager.getInstance().runOnce(this);
             })
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
                             () -> {
@@ -224,7 +224,7 @@ public class OpmlImportActivity extends ToolbarActivity {
             reader.close();
             return result;
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         result -> {

--- a/app/src/main/java/de/danoeh/antennapod/activity/SelectSubscriptionActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/SelectSubscriptionActivity.java
@@ -125,7 +125,7 @@ public class SelectSubscriptionActivity extends AppCompatActivity {
             disposable.dispose();
         }
         disposable = Observable.fromCallable(DBReader::getFeedList)
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         result -> {

--- a/app/src/main/java/de/danoeh/antennapod/activity/SplashActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/SplashActivity.java
@@ -31,7 +31,7 @@ public class SplashActivity extends Activity {
             PodDBAdapter.getInstance().close();
             subscriber.onComplete();
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     () -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -253,7 +253,7 @@ public abstract class EpisodesListFragment extends Fragment
                         } while (nextPage.size() == EPISODES_PER_PAGE);
                     }
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> listAdapter.endSelectMode(),
                         error -> Log.e(TAG, Log.getStackTraceString(error)));
@@ -282,7 +282,7 @@ public abstract class EpisodesListFragment extends Fragment
         listAdapter.setDummyViews(1);
         listAdapter.notifyItemInserted(listAdapter.getItemCount() - 1);
         disposable = Observable.fromCallable(() -> loadMoreData(page))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         data -> {
@@ -401,7 +401,7 @@ public abstract class EpisodesListFragment extends Fragment
             disposable.dispose();
         }
         disposable = Observable.fromCallable(() -> new Pair<>(loadData(), loadTotalItemCount()))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         data -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AddFeedFragment.java
@@ -181,7 +181,7 @@ public class AddFeedFragment extends Fragment {
             return;
         }
         Observable.fromCallable(() -> addLocalFolder(uri))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         feed -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -415,7 +415,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
             adapterFeeds.updateData(Collections.emptyList());
         } else {
             disposableFeeds = Observable.fromCallable(() -> DBReader.searchFeeds(query, state))
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(results -> {
                         progressBar.setVisibility(View.GONE);
@@ -424,7 +424,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
                     }, error -> Log.e(TAG, Log.getStackTraceString(error)));
         }
         disposableEpisodes = Observable.fromCallable(() -> DBReader.searchFeedItems(feed, query, state))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(results -> {
                     progressBar.setVisibility(View.GONE);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/chapter/ChaptersFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/chapter/ChaptersFragment.java
@@ -146,7 +146,7 @@ public class ChaptersFragment extends AppCompatDialogFragment {
                 emitter.onComplete();
             }
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(media -> onMediaChanged((Playable) media),
                 error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -193,7 +193,7 @@ public class CompletedDownloadsFragment extends Fragment
                     Observable.fromCallable(() -> DBReader.getEpisodes(0, Integer.MAX_VALUE,
                                     new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED,
                                             FeedItemFilter.PLAYED), SortOrder.DATE_OLD_NEW))
-                            .subscribeOn(Schedulers.io())
+                            .subscribeOn(Schedulers.computation())
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe(items -> new EpisodeMultiSelectActionHandler(getActivity(), R.id.remove_item)
                                     .handleAction(items), error -> Log.e(TAG, Log.getStackTraceString(error)));
@@ -329,7 +329,7 @@ public class CompletedDownloadsFragment extends Fragment
             currentDownloads.addAll(downloadedItems);
             return currentDownloads;
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
                 result -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogDetailsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogDetailsDialog.java
@@ -125,7 +125,7 @@ public class DownloadLogDetailsDialog extends DialogFragment {
             }
             emitter.onSuccess(true);
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(obj -> updateUi(),
                         error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/DownloadLogFragment.java
@@ -110,7 +110,7 @@ public class DownloadLogFragment extends BottomSheetDialogFragment
             disposable.dispose();
         }
         disposable = Observable.fromCallable(DBReader::getDownloadLog)
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     if (result != null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/BottomNavigation.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/BottomNavigation.java
@@ -74,7 +74,7 @@ public class BottomNavigation {
         }
         bottomNavigationBadgeLoader = Observable.fromCallable(
                         () -> DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     BadgeDrawable badge = bottomNavigationView.getOrCreateBadge(R.id.bottom_navigation_inbox);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
@@ -430,7 +430,7 @@ public class NavDrawerFragment extends Fragment implements SharedPreferences.OnS
                     reclaimableSpace = EpisodeCleanupAlgorithmFactory.build().getReclaimableItems();
                     return new Pair<>(data, makeFlatDrawerData(data.tags, data.feedCounters));
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         result -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -405,7 +405,7 @@ public class ItemFragment extends Fragment {
             viewBinding.progbarLoading.setVisibility(View.VISIBLE);
         }
         disposable = Observable.fromCallable(this::loadInBackground)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(result -> {
                 viewBinding.progbarLoading.setVisibility(View.GONE);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemPagerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemPagerFragment.java
@@ -133,7 +133,7 @@ public class ItemPagerFragment extends Fragment implements MaterialToolbar.OnMen
         }
 
         disposable = Observable.fromCallable(() -> DBReader.getFeedItem(itemId))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     item = result;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -145,7 +145,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                 emitter.onComplete();
             }
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     feed = result;
@@ -353,7 +353,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
             feed.setDownloadUrl(Feed.PREFIX_LOCAL_FOLDER + uri.toString());
             FeedDatabaseWriter.updateFeed(getContext(), feed, false);
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         () -> EventBus.getDefault().post(new MessageEvent(getString(android.R.string.ok))),

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -208,7 +208,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             EpisodeMultiSelectActionHandler handler
                     = new EpisodeMultiSelectActionHandler(getActivity(), menuItem.getItemId());
             Completable.fromAction(() -> handleActionForAllSelectedItems(handler))
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(() -> adapter.endSelectMode(),
                             error -> Log.e(TAG, Log.getStackTraceString(error)));
@@ -621,7 +621,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                     }
                     return feedDownloadLog.get(0);
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     downloadStatus -> DownloadLogDetailsDialog.newInstance(downloadStatus, false)
@@ -676,7 +676,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                     int count = DBReader.getFeedEpisodeCount(feed.getId(), feed.getItemFilter());
                     return new Pair<>(feed, count);
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     result -> {
@@ -708,7 +708,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         adapter.setDummyViews(1);
         adapter.notifyItemInserted(adapter.getItemCount() - 1);
         disposable = Observable.fromCallable(() -> loadMoreData(page))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         items -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/RemoveFeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/RemoveFeedDialog.java
@@ -131,7 +131,7 @@ public class RemoveFeedDialog extends BottomSheetDialogFragment {
                         DBWriter.deleteFeed(context, feed.getId()).get();
                     }
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         () -> {
@@ -162,7 +162,7 @@ public class RemoveFeedDialog extends BottomSheetDialogFragment {
                         DBWriter.setFeedState(context, feed, Feed.STATE_ARCHIVED).get();
                     }
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         () -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsFragment.java
@@ -59,7 +59,7 @@ public class FeedSettingsFragment extends Fragment {
                 emitter.onComplete();
             }
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> toolbar.setSubtitle(result.getTitle()),
                         error -> Log.d(TAG, Log.getStackTraceString(error)),

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -117,7 +117,7 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
                 emitter.onComplete();
             }
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     feed = result;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/TagSettingsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/TagSettingsDialog.java
@@ -125,7 +125,7 @@ public class TagSettingsDialog extends DialogFragment {
                     }
                     return folders;
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         result -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/HomeFragment.java
@@ -164,7 +164,7 @@ public class HomeFragment extends Fragment implements Toolbar.OnMenuItemClickLis
             disposable.dispose();
         }
         disposable = Observable.fromCallable(() -> DBReader.getTotalEpisodeCount(FeedItemFilter.unfiltered()))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(numEpisodes -> {
                     boolean hasEpisodes = numEpisodes != 0;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -134,7 +134,7 @@ public class DownloadsSection extends HomeSection {
         }
         SortOrder sortOrder = UserPreferences.getDownloadsSortedOrder();
         disposable = Observable.fromCallable(() -> DBReader.getEpisodes(0, NUM_EPISODES, FILTER_DOWNLOADED, sortOrder))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(downloads -> {
                     items = downloads;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EchoSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EchoSection.java
@@ -52,7 +52,7 @@ public class EchoSection extends Fragment {
                 }
                 return totalTime;
             })
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(totalTime -> {
                 boolean shouldShow = (totalTime >= 3600 * 10);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EpisodesSurpriseSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EpisodesSurpriseSection.java
@@ -150,7 +150,7 @@ public class EpisodesSurpriseSection extends HomeSection {
             disposable.dispose();
         }
         disposable = Observable.fromCallable(() -> DBReader.getRandomEpisodes(NUM_EPISODES, seed))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(episodes -> {
                     this.episodes = episodes;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
@@ -127,7 +127,7 @@ public class InboxSection extends HomeSection {
                         new Pair<>(DBReader.getEpisodes(0, NUM_EPISODES,
                                 new FeedItemFilter(FeedItemFilter.NEW), UserPreferences.getInboxSortedOrder()),
                                 DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW))))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(data -> {
                     items = data.first;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/QueueSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/QueueSection.java
@@ -151,7 +151,7 @@ public class QueueSection extends HomeSection {
             disposable.dispose();
         }
         disposable = Observable.fromCallable(() -> DBReader.getPausedQueue(NUM_EPISODES))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(queue -> {
                     this.queue = queue;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
@@ -97,7 +97,7 @@ public class SubscriptionsSection extends HomeSection {
         long threeYearsAgo = System.currentTimeMillis() - 3L * 365L * 24L * 60L * 60L * 1000L;
         disposable = Observable.fromCallable(() ->
                         DBReader.getStatistics(includeMarkedAsPlayed, threeYearsAgo, Long.MAX_VALUE).feedTime)
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(statisticsData -> {
                     Collections.sort(statisticsData, (item1, item2) ->

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/onlinefeedview/OnlineFeedViewActivity.java
@@ -232,7 +232,7 @@ public class OnlineFeedViewActivity extends AppCompatActivity {
             }
             return null;
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(subscribedFeed -> {
             if (subscribedFeed.getState() == Feed.STATE_NOT_SUBSCRIBED) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
@@ -87,7 +87,7 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
 
         disposable = Single.fromCallable(() ->
                         DBReader.getRemainingQueueSize(PlaybackPreferences.getCurrentlyPlayingFeedMediaId()))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> currentQueueSize = result);
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TranscriptDialogFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TranscriptDialogFragment.java
@@ -181,7 +181,7 @@ public class TranscriptDialogFragment extends DialogFragment
                 emitter.onComplete();
             }
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(media -> onMediaChanged((Playable) media),
                 error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/VariableSpeedDialog.java
@@ -87,7 +87,7 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
             // Make sure the media is loaded in case getCurrentPlaybackSpeedMultiplier has to access it
             return controller.getMedia();
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(pair -> {
                     if (controller == null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -262,7 +262,7 @@ public class AudioPlayerFragment extends Fragment implements
                 emitter.onComplete();
             }
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(media -> {
             updateUi(media);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
@@ -104,7 +104,7 @@ public class CoverFragment extends Fragment {
             } else {
                 emitter.onComplete();
             }
-        }).subscribeOn(Schedulers.io())
+        }).subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(media -> {
                     this.media = media;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -181,7 +181,7 @@ public class ExternalPlayerFragment extends Fragment {
             disposable.dispose();
         }
         disposable = Maybe.fromCallable(() -> controller.getMedia())
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::updateUi,
                         error -> Log.e(TAG, Log.getStackTraceString(error)),

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ItemDescriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ItemDescriptionFragment.java
@@ -109,7 +109,7 @@ public class ItemDescriptionFragment extends Fragment {
                     context, media.getDescription(), media.getDuration());
             emitter.onSuccess(shownotesCleaner.processShownotes());
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(data -> {
                     webvDescription.loadDataWithBaseURL("https://127.0.0.1", data, "text/html",

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/VideoplayerActivity.java
@@ -289,7 +289,7 @@ public class VideoplayerActivity extends CastEnabledActivity
             }
             emitter.onSuccess(new Pair<>(media, feedItem));
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         result -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
@@ -245,7 +245,7 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
         final Uri uri = result.getData().getData();
         progressDialog.show();
         disposable = Completable.fromAction(() -> DatabaseExporter.importBackup(uri, getContext()))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> {
                     showDatabaseImportSuccessDialog();
@@ -259,7 +259,7 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
         }
         progressDialog.show();
         disposable = Completable.fromAction(() -> DatabaseExporter.exportToDocument(uri, getContext()))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> {
                     showExportSuccessSnackbar(uri, "application/x-sqlite3");
@@ -306,7 +306,7 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
                         subscriber.onError(e);
                     }
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(outputFile -> {
                     progressDialog.dismiss();
@@ -332,7 +332,7 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
                         subscriber.onError(e);
                     }
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(ignore -> {
                     progressDialog.dismiss();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -533,7 +533,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             boolean displayGoToInboxButton = DBReader.getTotalEpisodeCount(new FeedItemFilter(FeedItemFilter.NEW)) > 0;
             return new Pair<>(DBReader.getQueue(), displayGoToInboxButton);
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(itemsAndDisplayButton -> {
                     final boolean restoreScrollPosition = queue == null || queue.isEmpty();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/rating/RatingDialogManager.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/rating/RatingDialogManager.java
@@ -52,7 +52,7 @@ public class RatingDialogManager {
                     }
                     return new Pair<>(totalTime, statisticsData.oldestDate);
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     long totalTime = result.getFirst();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedMenuHandler.java
@@ -42,7 +42,7 @@ public abstract class FeedMenuHandler {
                 public void onConfirmButtonPressed(DialogInterface clickedDialog) {
                     clickedDialog.dismiss();
                     Observable.fromCallable((Callable<Future>) () -> DBWriter.removeFeedNewFlag(selectedFeed.getId()))
-                            .subscribeOn(Schedulers.io())
+                            .subscribeOn(Schedulers.computation())
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe(result -> {
                                 if (removeFromInboxCallback != null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -372,7 +372,7 @@ public class SubscriptionFragment extends Fragment
                             List<NavDrawerData.TagItem> tags = DBReader.getAllTags(stateToShow);
                             return new Pair<>(navDrawerData, tags);
                         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     result -> {

--- a/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/FyydPodcastSearcher.java
+++ b/net/discovery/src/main/java/de/danoeh/antennapod/net/discovery/FyydPodcastSearcher.java
@@ -32,7 +32,7 @@ public class FyydPodcastSearcher implements PodcastSearcher {
 
             subscriber.onSuccess(searchResults);
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread());
     }
 

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
@@ -78,8 +78,8 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
         String tag = WORK_TAG_EPISODE_URL + media.getDownloadUrl();
         Future<List<WorkInfo>> future = WorkManager.getInstance(context).getWorkInfosByTag(tag);
         Observable.fromFuture(future)
-                .subscribeOn(Schedulers.io())
-                .observeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
+                .observeOn(Schedulers.computation())
                 .subscribe(
                     workInfos -> {
                         for (WorkInfo info : workInfos) {

--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/LockingAsyncExecutor.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/LockingAsyncExecutor.java
@@ -28,7 +28,7 @@ public class LockingAsyncExecutor {
                 } finally {
                     lock.unlock();
                 }
-            }).subscribeOn(Schedulers.io())
+            }).subscribeOn(Schedulers.computation())
                     .subscribe();
         }
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -372,7 +372,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             }
             emitter.onSuccess(queueItems);
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(queueItems -> mediaSession.setQueue(queueItems), Throwable::printStackTrace);
         singleShotDisposables.add(d);
@@ -432,7 +432,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
             result.sendResult(loadChildrenSynchronous(parentId));
             emitter.onComplete();
         })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     () -> {
@@ -574,7 +574,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                             return playable;
                         }
                     })
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
                             loadedPlayable -> startPlaying(loadedPlayable, allowStreamThisTime),
@@ -771,7 +771,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
 
     private void startPlayingFromPreferences() {
         Disposable d = Observable.fromCallable(() -> DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId()))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         playable -> startPlaying(playable, false),

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlaybackServiceTaskManager.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlaybackServiceTaskManager.java
@@ -160,7 +160,7 @@ public class PlaybackServiceTaskManager {
                 ChapterUtils.loadChapters(media, context, false);
                 emitter.onComplete();
             })
-                    .subscribeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(() -> callback.onChapterLoaded(media),
                             throwable -> Log.d(TAG, "Error loading chapters: " + Log.getStackTraceString(throwable)));

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/EchoActivity.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/EchoActivity.java
@@ -88,7 +88,7 @@ public class EchoActivity extends AppCompatActivity {
     protected void onStart() {
         super.onStart();
         redrawTimer = Flowable.timer(20, TimeUnit.MILLISECONDS)
-                .observeOn(Schedulers.io())
+                .observeOn(Schedulers.computation())
                 .repeat()
                 .subscribe(i -> {
                     if (progressPaused) {
@@ -143,7 +143,7 @@ public class EchoActivity extends AppCompatActivity {
                             Long.compare(item2.timePlayed, item1.timePlayed));
                     return statisticsData;
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     for (EchoScreen screen : screens) {

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/FinalShareScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/FinalShareScreen.java
@@ -119,7 +119,7 @@ public class FinalShareScreen extends EchoScreen {
                     }
                     return statisticsData;
                 })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(result -> { },
                 error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/QueueScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/QueueScreen.java
@@ -76,7 +76,7 @@ public class QueueScreen extends EchoScreen {
             disposable.dispose();
         }
         disposable = Observable.fromCallable(DBReader::getQueue)
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(queue -> {
                     long queueSecondsLeft = 0;

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/TimeReleasePlayScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/TimeReleasePlayScreen.java
@@ -58,7 +58,7 @@ public class TimeReleasePlayScreen extends EchoScreen {
         }
         disposable = Observable.fromCallable(() ->
                         DBReader.getTimeBetweenReleaseAndPlayback(EchoConfig.jan1(), Long.MAX_VALUE))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::display, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/DevelopersFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/DevelopersFragment.java
@@ -40,7 +40,7 @@ public class DevelopersFragment extends ListFragment {
             }
             emitter.onSuccess(developers);
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
                 developers -> setListAdapter(new SimpleIconListAdapter<>(getContext(), developers)),

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/LicensesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/LicensesFragment.java
@@ -62,7 +62,7 @@ public class LicensesFragment extends ListFragment {
             }
             emitter.onSuccess(licenses);
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
                 developers -> setListAdapter(new SimpleIconListAdapter<LicenseItem>(getContext(), developers)),

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/SpecialThanksFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/SpecialThanksFragment.java
@@ -40,7 +40,7 @@ public class SpecialThanksFragment extends ListFragment {
             }
             emitter.onSuccess(specialMembers);
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
                 translators -> setListAdapter(new SimpleIconListAdapter<>(getContext(), translators)),

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/TranslatorsFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/about/TranslatorsFragment.java
@@ -36,7 +36,7 @@ public class TranslatorsFragment extends ListFragment {
             }
             emitter.onSuccess(translators);
         })
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(
                 translators -> setListAdapter(new SimpleIconListAdapter<>(getContext(), translators)),

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/bugreport/BugReportViewModel.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/bugreport/BugReportViewModel.java
@@ -173,7 +173,7 @@ public class BugReportViewModel extends AndroidViewModel {
         super(application);
         // Does file I/O, so we have to use a background thread
         this.disposable = Observable.fromCallable(() -> new UiState(application))
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .subscribe(this.uiState::postValue);
     }
 

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
@@ -124,7 +124,7 @@ public class StatisticsFragment extends PagedToolbarFragment {
                 .apply();
 
         Disposable disposable = Completable.fromFuture(DBWriter.resetStatistics())
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> EventBus.getDefault().post(new StatisticsEvent()),
                         error -> Log.e(TAG, Log.getStackTraceString(error)));

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/downloads/DownloadStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/downloads/DownloadStatisticsFragment.java
@@ -79,7 +79,7 @@ public class DownloadStatisticsFragment extends Fragment {
                             Long.compare(item2.totalDownloadSize, item1.totalDownloadSize));
                     return statisticsData;
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     listAdapter.update(result.feedTime);

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/feed/FeedStatisticsFragment.java
@@ -95,7 +95,7 @@ public class FeedStatisticsFragment extends Fragment {
                     }
                     return null;
                 })
-                        .subscribeOn(Schedulers.io())
+                        .subscribeOn(Schedulers.computation())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(this::showStats, Throwable::printStackTrace);
     }

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/subscriptions/SubscriptionStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/subscriptions/SubscriptionStatisticsFragment.java
@@ -121,7 +121,7 @@ public class SubscriptionStatisticsFragment extends Fragment {
                             Long.compare(item2.timePlayed, item1.timePlayed));
                     return statisticsData;
                 })
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     statisticsResult = result;

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/years/YearsStatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/years/YearsStatisticsFragment.java
@@ -86,7 +86,7 @@ public class YearsStatisticsFragment extends Fragment {
             disposable.dispose();
         }
         disposable = Observable.fromCallable(DBReader::getMonthlyTimeStatistics)
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
                     listAdapter.update(result);


### PR DESCRIPTION
### Description

Move database calls from `Schedulers.io` to `Schedulers.computation`. The io scheduler is unbounded, starting an arbitrary number of threads. This might be a reason for the lock inflation failing. In contrast, the `compute` scheduler is limited by the number of available threads.

Contributes to #8338

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
