### PR TITLE
Filter out non-subscribed feeds from GPodder subscription sync

### DIFF
--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -115,7 +115,7 @@ public class DbReaderTest {
         @Test
         public void testFeedListDownloadUrls() {
             List<Feed> feeds = saveFeedlist(10, 0, false);
-            List<String> urls = DBReader.getFeedListDownloadUrls();
+            List<String> urls = DBReader.getFeedListDownloadUrls(false);
             assertNotNull(urls);
             assertEquals(feeds.size(), urls.size());
             for (int i = 0; i < urls.size(); i++) {

--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
@@ -144,7 +144,7 @@ public class SyncService extends Worker {
     private void syncSubscriptions(ISyncService syncServiceImpl) throws SyncServiceException {
         final long lastSync = SynchronizationSettings.getLastSubscriptionSynchronizationTimestamp();
         EventBus.getDefault().postSticky(new SyncServiceEvent(R.string.sync_status_subscriptions));
-        final List<String> localSubscriptions = DBReader.getFeedListDownloadUrls();
+        final List<String> localSubscriptions = DBReader.getFeedListDownloadUrls(true);
         SubscriptionChanges subscriptionChanges = syncServiceImpl.getSubscriptionChanges(lastSync);
         long newTimeStamp = subscriptionChanges.getTimestamp();
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -73,14 +73,15 @@ public final class DBReader {
     }
 
     /**
-     * Returns a list with the download URLs of all feeds.
+     * Returns a list with the download URLs of feeds.
      *
-     * @return A list of Strings with the download URLs of all feeds.
+     * @param subscribedOnly If true, only return feeds with {@link Feed#STATE_SUBSCRIBED}.
+     * @return A list of Strings with the download URLs of matching feeds.
      */
-    public static List<String> getFeedListDownloadUrls() {
+    public static List<String> getFeedListDownloadUrls(boolean subscribedOnly) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        try (Cursor cursor = adapter.getFeedCursorDownloadUrls()) {
+        try (Cursor cursor = adapter.getFeedCursorDownloadUrls(subscribedOnly)) {
             List<String> result = new ArrayList<>(cursor.getCount());
             while (cursor.moveToNext()) {
                 String url = cursor.getString(1);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -965,7 +965,7 @@ public class DBWriter {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         long feedId = 0;
-        try (Cursor cursor = adapter.getFeedCursorDownloadUrls()) {
+        try (Cursor cursor = adapter.getFeedCursorDownloadUrls(false)) {
             if (cursor.moveToFirst()) {
                 do {
                     if (cursor.getString(1).equals(downloadUrl)) {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1001,8 +1001,9 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getFeedCursorDownloadUrls() {
-        return db.query(TABLE_NAME_FEEDS, new String[]{KEY_ID, KEY_DOWNLOAD_URL}, null, null, null, null, null);
+    public final Cursor getFeedCursorDownloadUrls(boolean subscribedOnly) {
+        String selection = subscribedOnly ? KEY_STATE + "=" + Feed.STATE_SUBSCRIBED : null;
+        return db.query(TABLE_NAME_FEEDS, new String[]{KEY_ID, KEY_DOWNLOAD_URL}, selection, null, null, null, null);
     }
 
     /**


### PR DESCRIPTION
### Description

Previewed feeds (with `STATE_NOT_SUBSCRIBED`) were being synced to GPodder-compatible servers as though they were real subscriptions. This caused previewed feeds to appear as subscribed on other devices after sync.

The fix adds a `subscribedOnly` parameter to `getFeedListDownloadUrls` and `getFeedCursorDownloadUrls`. The sync service passes `true` so only actually subscribed feeds are uploaded.

Closes: #8361

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests