### PR TITLE
Implement mini rewind after interruption

### DIFF
--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/RewindAfterPauseUtils.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/RewindAfterPauseUtils.java
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This class calculates the proper rewind time after the pause and resume.
  * <p>
- * User might loose context if he/she pauses and resumes the media after longer time.
+ * User might lose context if he/she pauses and resumes the media after longer time.
  * Media file should be "rewinded" x seconds after user resumes the playback.
  */
 public abstract class RewindAfterPauseUtils {
@@ -13,7 +13,8 @@ public abstract class RewindAfterPauseUtils {
     public static final long ELAPSED_TIME_FOR_MEDIUM_REWIND = TimeUnit.HOURS.toMillis(1);
     public static final long ELAPSED_TIME_FOR_LONG_REWIND = TimeUnit.DAYS.toMillis(1);
 
-    public static final long SHORT_REWIND =  TimeUnit.SECONDS.toMillis(3);
+    public static final long MINIMUM_REWIND = TimeUnit.MILLISECONDS.toMillis(800);
+    public static final long SHORT_REWIND = TimeUnit.SECONDS.toMillis(3);
     public static final long MEDIUM_REWIND = TimeUnit.SECONDS.toMillis(10);
     public static final long LONG_REWIND = TimeUnit.SECONDS.toMillis(20);
 
@@ -33,6 +34,8 @@ public abstract class RewindAfterPauseUtils {
                 rewindTime = MEDIUM_REWIND;
             } else if (elapsedTime > ELAPSED_TIME_FOR_SHORT_REWIND) {
                 rewindTime = SHORT_REWIND;
+            } else if (elapsedTime > 0) {
+                rewindTime = MINIMUM_REWIND;
             }
 
             int newPosition = currentPosition - (int) rewindTime;

--- a/playback/base/src/test/java/de/danoeh/antennapod/playback/base/RewindAfterPauseUtilTest.java
+++ b/playback/base/src/test/java/de/danoeh/antennapod/playback/base/RewindAfterPauseUtilTest.java
@@ -19,6 +19,15 @@ public class RewindAfterPauseUtilTest {
     }
 
     @Test
+    public void testCalculatePositionWithRewindMinimalRewind() {
+        final int ORIGINAL_POSITION = 10000;
+        long lastPlayed = System.currentTimeMillis() - 500;
+        int position = RewindAfterPauseUtils.calculatePositionWithRewind(ORIGINAL_POSITION, lastPlayed);
+
+        assertEquals(ORIGINAL_POSITION - RewindAfterPauseUtils.MINIMUM_REWIND, position);
+    }
+
+    @Test
     public void testCalculatePositionWithRewindSmallRewind() {
         final int ORIGINAL_POSITION = 10000;
         long lastPlayed = System.currentTimeMillis() - RewindAfterPauseUtils.ELAPSED_TIME_FOR_SHORT_REWIND - 1000;

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -205,6 +205,27 @@ public class Media3PlaybackService extends MediaLibraryService {
 
     @UnstableApi
     private final Player.Listener playerListener = new Player.Listener() {
+        private boolean wasTemporarilySuspended = false;
+
+        @Override
+        public void onPlaybackSuppressionReasonChanged(int playbackSuppressionReason) {
+            if (playbackSuppressionReason
+                    == Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS) {
+                wasTemporarilySuspended = true;
+            } else if (playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_NONE
+                    && wasTemporarilySuspended && currentPlayable != null) {
+                wasTemporarilySuspended = false;
+                long savedPosition = player.getCurrentPosition();
+                long startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
+                        (int) savedPosition, currentPlayable.getLastPlayedTimeStatistics());
+                if (startPosition != savedPosition) {
+                    player.seekTo(startPosition);
+                }
+            } else {
+                wasTemporarilySuspended = false;
+            }
+        }
+
         @Override
         public void onPlaybackStateChanged(int playbackState) {
             if (playbackState == Player.STATE_BUFFERING) {


### PR DESCRIPTION
### Description

This PR adds a short (800ms) rewind after audio focus is lost.  Fixes https://github.com/AntennaPod/AntennaPod/issues/2739.

The value of 800ms was chosen by actually driving in my car with a podcast playing and trying different values.  At 800ms I can comfortably understand the word being spoken, but it doesn't feel like I'm hopping back unnecessarily.  Crucially, 800ms is short enough to not cause problems in [Adarma's scenario](https://github.com/AntennaPod/AntennaPod/issues/2739#issuecomment-2521352493).  At most after multiple interruptions you wind up back a couple words.

I have added a unit test to RewindAfterPauseUtils, but I don't see any existing tests for Media3PlaybackService, so I have not added any tests there.  I have run the code checks etc as indicated below.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [X] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [X] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [X] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
