### PR TITLE
Faster media session item list loading

### DIFF
--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
@@ -86,8 +86,12 @@ public class MediaItemAdapter {
 
     private static Bitmap loadArtworkBitmap(Context context, Playable playable, int iconSize) {
         try {
-            return Glide.with(context).asBitmap().load(playable.getImageLocation())
-                    .submit(iconSize, iconSize).get(500, TimeUnit.MILLISECONDS);
+            return Glide.with(context)
+                    .asBitmap()
+                    .onlyRetrieveFromCache(true)
+                    .load(playable.getImageLocation())
+                    .submit(iconSize, iconSize)
+                    .get(500, TimeUnit.MILLISECONDS);
         } catch (Exception tr1) {
             // fall through to try feed image
         }
@@ -103,8 +107,12 @@ public class MediaItemAdapter {
             return null;
         }
         try {
-            return Glide.with(context).asBitmap().load(fallback)
-                    .submit(iconSize, iconSize).get(500, TimeUnit.MILLISECONDS);
+            return Glide.with(context)
+                    .asBitmap()
+                    .onlyRetrieveFromCache(true)
+                    .load(fallback)
+                    .submit(iconSize, iconSize)
+                    .get(500, TimeUnit.MILLISECONDS);
         } catch (Exception tr2) {
             Log.e(TAG, "Error loading artwork bitmap", tr2);
         }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -336,7 +336,9 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     @NonNull
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> onGetChildren(
             @NonNull MediaLibraryService.MediaLibrarySession session, @NonNull MediaSession.ControllerInfo browser,
-            @NonNull String parentId, int page, int pageSize, @Nullable MediaLibraryService.LibraryParams params) {
+            @NonNull String parentId, int page, int pageSizeRequest,
+            @Nullable MediaLibraryService.LibraryParams params) {
+        final int pageSize = Math.min(100, pageSizeRequest); // Safety limit when calling application wants too much
         SettableFuture<LibraryResult<ImmutableList<MediaItem>>> future = SettableFuture.create();
 
         switch (parentId) {


### PR DESCRIPTION
### Description

Loading all items from network needed too long, especially if one of the servers is broken and times out, and the calling application requests too many episodes at once.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
