### PR TITLE
Show feed covers more reliably in media session callback

### DIFF
--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
@@ -106,16 +106,32 @@ public class MediaItemAdapter {
             return Glide.with(context).asBitmap().load(fallback)
                     .submit(iconSize, iconSize).get(500, TimeUnit.MILLISECONDS);
         } catch (Exception tr2) {
-            Log.e(TAG, "Error loading artwork bitmap", tr2);
+            Log.e(TAG, "Skipping to load artwork bitmap: " + tr2.getMessage());
         }
         return null;
     }
 
-
-    public static MediaItem fromFeed(Feed feed) {
+    public static MediaItem fromFeed(Context context, Feed feed) {
         MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder();
         metadataBuilder.setTitle(feed.getTitle());
-        if (feed.getImageUrl() != null && feed.getImageUrl().startsWith("http")) {
+
+        Bitmap bitmap = null;
+        try {
+            int iconSize = (int) (128 * context.getResources().getDisplayMetrics().density);
+            bitmap = Glide.with(context)
+                    .asBitmap()
+                    .onlyRetrieveFromCache(true)
+                    .load(feed.getImageUrl())
+                    .submit(iconSize, iconSize)
+                    .get(500, TimeUnit.MILLISECONDS);
+        } catch (Exception exception) {
+            Log.e(TAG, "Skipping to load artwork bitmap:" + exception.getMessage());
+        }
+        if (bitmap != null) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, bos);
+            metadataBuilder.setArtworkData(bos.toByteArray(), MediaMetadata.PICTURE_TYPE_FRONT_COVER);
+        } else if (feed.getImageUrl() != null && feed.getImageUrl().startsWith("http")) {
             metadataBuilder.setArtworkUri(Uri.parse(feed.getImageUrl()));
         }
         metadataBuilder.setSubtitle(feed.getAuthor());

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -359,7 +359,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                                     ImmutableList.Builder<MediaItem> builder = new ImmutableList.Builder<>();
                                     for (Feed feed : items) {
                                         if (feed.getState() == Feed.STATE_SUBSCRIBED) {
-                                            builder.add(MediaItemAdapter.fromFeed(feed));
+                                            builder.add(MediaItemAdapter.fromFeed(context, feed));
                                         }
                                     }
                                     future.set(LibraryResult.ofItemList(builder.build(), params));
@@ -447,7 +447,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
         if (id.startsWith(MediaItemAdapter.MEDIA_ID_FEED_PREFIX)) {
             long feedId = Long.parseLong(id.split(":")[1]);
             Feed feed = DBReader.getFeed(feedId, false, 0, 0);
-            return MediaItemAdapter.fromFeed(feed);
+            return MediaItemAdapter.fromFeed(context, feed);
         }
         switch (id) {
             case MEDIA_ID_ROOT:


### PR DESCRIPTION
### Description

Show feed covers more reliably in media session callback. Similarly to the episode covers, we can use our cache and pass it as bitmap to ensure that the receiving application can show them even if it does not have network connection.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
