### PR TITLE
Reduce number of feed item events

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/CancelDownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/CancelDownloadActionButton.java
@@ -33,6 +33,6 @@ public class CancelDownloadActionButton extends ItemActionButton {
         FeedMedia media = item.getMedia();
         DownloadServiceInterface.get().cancel(context, media);
         item.disableAutoDownload();
-        DBWriter.setFeedItem(item);
+        DBWriter.setFeedItem(item, false);
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/MarkAsPlayedActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/MarkAsPlayedActionButton.java
@@ -9,6 +9,8 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.storage.database.DBWriter;
 
+import java.util.Collections;
+
 public class MarkAsPlayedActionButton extends ItemActionButton {
 
     public MarkAsPlayedActionButton(FeedItem item) {
@@ -30,7 +32,7 @@ public class MarkAsPlayedActionButton extends ItemActionButton {
     @Override
     public void onClick(Context context) {
         if (!item.isPlayed()) {
-            DBWriter.markItemPlayed(FeedItem.PLAYED, true, item);
+            DBWriter.markItemsPlayed(FeedItem.PLAYED, true, Collections.singletonList(item));
         }
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/PlayActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/PlayActionButton.java
@@ -15,6 +15,8 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.playback.MediaType;
 import org.greenrobot.eventbus.EventBus;
 
+import java.util.Collections;
+
 public class PlayActionButton extends ItemActionButton {
     private static final String TAG = "PlayActionButton";
 
@@ -45,7 +47,7 @@ public class PlayActionButton extends ItemActionButton {
             media.setDownloaded(false, 0);
             media.setLocalFileUrl(null);
             DBWriter.setMediaDownloadInformation(media);
-            EventBus.getDefault().post(FeedItemEvent.updated(media.getItem()));
+            EventBus.getDefault().post(new FeedItemEvent(Collections.singletonList(media.getItem()), false));
             EventBus.getDefault().post(new MessageEvent(context.getString(R.string.error_file_not_found)));
             return;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -96,14 +96,13 @@ public class EpisodeMultiSelectActionHandler {
                 markUnplayed.add(episode);
             }
         }
-        DBWriter.markItemPlayed(FeedItem.UNPLAYED, false, markUnplayed.toArray(new FeedItem[0]));
+        DBWriter.markItemsPlayed(FeedItem.UNPLAYED, false, markUnplayed);
         showMessage(R.plurals.removed_from_inbox_batch_label, markUnplayed.size());
     }
 
     private void markedCheckedPlayed(List<FeedItem> items) {
         for (FeedItem item : items) {
             item.setPlayed(true);
-            DBWriter.markItemPlayed(FeedItem.PLAYED, true, item);
             if (!item.getFeed().isLocalFeed() && item.getFeed().getState() != Feed.STATE_NOT_SUBSCRIBED
                     && SynchronizationSettings.isProviderConnected()) {
                 FeedMedia media = item.getMedia();
@@ -119,13 +118,13 @@ public class EpisodeMultiSelectActionHandler {
                 }
             }
         }
+        DBWriter.markItemsPlayed(FeedItem.PLAYED, true, items);
         showMessage(R.plurals.marked_as_played_message, items.size());
     }
 
     private void markedCheckedUnplayed(List<FeedItem> items) {
         for (FeedItem item : items) {
             item.setPlayed(false);
-            DBWriter.markItemPlayed(FeedItem.UNPLAYED, false, item);
             if (!item.getFeed().isLocalFeed() && item.getMedia() != null
                     && item.getFeed().getState() != Feed.STATE_NOT_SUBSCRIBED) {
                 SynchronizationQueue.getInstance().enqueueEpisodeAction(
@@ -134,6 +133,7 @@ public class EpisodeMultiSelectActionHandler {
                                 .build());
             }
         }
+        DBWriter.markItemsPlayed(FeedItem.UNPLAYED, false, items);
         showMessage(R.plurals.marked_as_unplayed_message, items.size());
     }
 
@@ -170,10 +170,10 @@ public class EpisodeMultiSelectActionHandler {
         int count = 0;
         for (FeedItem episode : items) {
             if (!episode.isTagged(FeedItem.TAG_FAVORITE)) {
-                DBWriter.addFavoriteItem(episode);
                 count++;
             }
         }
+        DBWriter.addFavoriteItems(items);
         showMessage(R.plurals.added_to_favorites_message, count);
     }
 
@@ -181,15 +181,15 @@ public class EpisodeMultiSelectActionHandler {
         int count = 0;
         for (FeedItem episode : items) {
             if (episode.isTagged(FeedItem.TAG_FAVORITE)) {
-                DBWriter.removeFavoriteItem(episode);
                 count++;
             }
         }
+        DBWriter.removeFavoriteItems(items);
         showMessage(R.plurals.removed_from_favorites_message, count);
     }
 
     private void resetPositionChecked(List<FeedItem> items) {
-        int count = 0;
+        List<FeedItem> toReset = new ArrayList<>();
         for (FeedItem episode : items) {
             if (!episode.hasMedia() || episode.getMedia().getPosition() == 0) {
                 continue;
@@ -199,10 +199,10 @@ public class EpisodeMultiSelectActionHandler {
                 PlaybackPreferences.writeNoMediaPlaying();
                 IntentUtils.sendLocalBroadcast(activity, PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
             }
-            DBWriter.markItemPlayed(FeedItem.UNPLAYED, true, episode);
-            count++;
+            toReset.add(episode);
         }
-        showMessage(R.plurals.reset_position_message, count);
+        DBWriter.markItemsPlayed(FeedItem.UNPLAYED, true, toReset);
+        showMessage(R.plurals.reset_position_message, toReset.size());
     }
 
     private void shareChecked(List<FeedItem> items) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodesListFragment.java
@@ -43,7 +43,6 @@ import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.ui.swipeactions.SwipeActions;
 import de.danoeh.antennapod.model.feed.FeedItem;
@@ -329,6 +328,10 @@ public abstract class EpisodesListFragment extends Fragment
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            loadItems();
+            return;
+        }
         for (FeedItem item : event.items) {
             int pos = FeedItemEvent.indexOfItemWithId(episodes, item.getId());
             if (pos >= 0) {
@@ -339,6 +342,10 @@ public abstract class EpisodesListFragment extends Fragment
                 } else {
                     listAdapter.notifyItemRemoved(pos);
                 }
+            } else if (getFilter().matches(item)) {
+                // Found something new
+                loadItems();
+                return;
             }
         }
     }
@@ -383,11 +390,6 @@ public abstract class EpisodesListFragment extends Fragment
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusChanged(PlayerStatusEvent event) {
-        loadItems();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
         loadItems();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -201,16 +201,16 @@ public class FeedItemMenuHandler {
         } else if (menuItemId == R.id.remove_from_queue_item) {
             DBWriter.removeQueueItem(context, true, selectedItem);
         } else if (menuItemId == R.id.add_to_favorites_item) {
-            DBWriter.addFavoriteItem(selectedItem);
+            DBWriter.addFavoriteItems(Collections.singletonList(selectedItem));
         } else if (menuItemId == R.id.remove_from_favorites_item) {
-            DBWriter.removeFavoriteItem(selectedItem);
+            DBWriter.removeFavoriteItems(Collections.singletonList(selectedItem));
         } else if (menuItemId == R.id.reset_position) {
             selectedItem.getMedia().setPosition(0);
             if (PlaybackPreferences.getCurrentlyPlayingFeedMediaId() == selectedItem.getMedia().getId()) {
                 PlaybackPreferences.writeNoMediaPlaying();
                 IntentUtils.sendLocalBroadcast(context, PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
             }
-            DBWriter.markItemPlayed(FeedItem.UNPLAYED, true, selectedItem);
+            DBWriter.markItemsPlayed(FeedItem.UNPLAYED, true, Collections.singletonList(selectedItem));
         } else if (menuItemId == R.id.visit_website_item) {
             IntentUtils.openInBrowser(context, selectedItem.getLinkWithFallback());
         } else if (menuItemId == R.id.open_social_interact_url) {
@@ -249,7 +249,7 @@ public class FeedItemMenuHandler {
         Log.d(TAG, "markReadWithUndo(" + item.getId() + ")");
         // we're marking it as unplayed since the user didn't actually play it
         // but they don't want it considered 'NEW' anymore
-        DBWriter.markItemPlayed(playState, false, item);
+        DBWriter.markItemsPlayed(playState, false, Collections.singletonList(item));
 
         Context context = fragment.requireContext();
         final Handler h = new Handler(context.getMainLooper());
@@ -290,7 +290,7 @@ public class FeedItemMenuHandler {
         if (showSnackbar) {
             EventBus.getDefault().post(new MessageEvent(message,
                     ctx -> {
-                        DBWriter.markItemPlayed(item.getPlayState(), false, item);
+                        DBWriter.markItemsPlayed(item.getPlayState(), false, Collections.singletonList(item));
                         // don't forget to cancel the thing that's going to remove the media
                         h.removeCallbacks(r);
                     }, fragment.getString(R.string.undo)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -32,7 +32,6 @@ import de.danoeh.antennapod.event.EpisodeDownloadEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeMultiSelectActionHandler;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
@@ -320,13 +319,12 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        search();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            search();
+            return;
+        }
         if (results == null) {
             return;
         } else if (adapter == null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -32,7 +32,6 @@ import de.danoeh.antennapod.ui.screen.feed.ItemSortDialog;
 import de.danoeh.antennapod.event.EpisodeDownloadEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeMultiSelectActionHandler;
 import de.danoeh.antennapod.ui.swipeactions.SwipeActions;
@@ -251,6 +250,10 @@ public class CompletedDownloadsFragment extends Fragment
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            loadItems();
+            return;
+        }
         if (items == null) {
             return;
         } else if (adapter == null) {
@@ -292,11 +295,6 @@ public class CompletedDownloadsFragment extends Fragment
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onDownloadLogChanged(DownloadLogEvent event) {
-        loadItems();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
         loadItems();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/BottomNavigation.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/BottomNavigation.java
@@ -14,8 +14,8 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.internal.ViewUtils;
 import com.google.android.material.navigation.NavigationBarView;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
@@ -163,8 +163,10 @@ public class BottomNavigation {
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        updateBottomNavigationBadgeIfNeeded();
+    public void onUnreadItemsChanged(FeedItemEvent event) {
+        if (event.unreadStatusChanged) {
+            updateBottomNavigationBadgeIfNeeded();
+        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/drawer/NavDrawerFragment.java
@@ -59,9 +59,9 @@ import de.danoeh.antennapod.storage.database.NavDrawerData;
 import de.danoeh.antennapod.ui.screen.feed.RemoveFeedDialog;
 import de.danoeh.antennapod.ui.screen.feed.RenameFeedDialog;
 import de.danoeh.antennapod.ui.screen.subscriptions.SubscriptionsFilterDialog;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.QueueEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
@@ -251,10 +251,11 @@ public class NavDrawerFragment extends Fragment implements SharedPreferences.OnS
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        loadData();
+    public void onUnreadItemsChanged(FeedItemEvent event) {
+        if (event.unreadStatusChanged) {
+            loadData();
+        }
     }
-
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onFeedListChanged(FeedListUpdateEvent event) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -41,7 +41,6 @@ import de.danoeh.antennapod.event.EpisodeDownloadEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
@@ -68,6 +67,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -203,7 +203,7 @@ public class ItemFragment extends Fragment {
         positiveButton.setOnClickListener(v1 -> {
             UserPreferences.setStreamOverDownload(offerStreaming);
             // Update all visible lists to reflect new streaming action button
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+            EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
             EventBus.getDefault().post(new MessageEvent(getString(R.string.on_demand_config_setting_changed)));
             balloon.dismiss();
         });
@@ -365,6 +365,10 @@ public class ItemFragment extends Fragment {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            load();
+            return;
+        }
         for (FeedItem item : event.items) {
             if (this.item.getId() == item.getId()) {
                 load();
@@ -389,11 +393,6 @@ public class ItemFragment extends Fragment {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusChanged(PlayerStatusEvent event) {
         updateButtons();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        load();
     }
 
     private void load() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemPagerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemPagerFragment.java
@@ -13,7 +13,6 @@ import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
@@ -165,6 +164,10 @@ public class ItemPagerFragment extends Fragment implements MaterialToolbar.OnMen
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            refreshToolbarState();
+            return;
+        }
         for (FeedItem item : event.items) {
             if (this.item != null && this.item.getId() == item.getId()) {
                 this.item = item;
@@ -172,11 +175,6 @@ public class ItemPagerFragment extends Fragment implements MaterialToolbar.OnMen
                 return;
             }
         }
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onEventMainThread(UnreadItemsUpdateEvent event) {
-        refreshToolbarState();
     }
 
     private void openPodcast() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -28,7 +28,6 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.databinding.FeedItemListFragmentBinding;
 import de.danoeh.antennapod.event.EpisodeDownloadEvent;
-import de.danoeh.antennapod.event.FavoritesEvent;
 import de.danoeh.antennapod.event.FeedEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
@@ -36,7 +35,6 @@ import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.event.QueueEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.model.download.DownloadResult;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -401,6 +399,10 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            updateUi();
+            return;
+        }
         if (feed == null || feed.getItems() == null) {
             return;
         }
@@ -411,6 +413,10 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                 feed.getItems().remove(pos);
                 feed.getItems().add(pos, item);
                 adapter.notifyItemChangedCompat(pos);
+            } else if (item.getFeedId() == feedID) {
+                // Filtered-out item of this feed was touched, reload all
+                updateUi();
+                return;
             }
         }
     }
@@ -441,11 +447,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void favoritesChanged(FavoritesEvent event) {
-        updateUi();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onQueueChanged(QueueEvent event) {
         updateUi();
     }
@@ -471,11 +472,6 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusChanged(PlayerStatusEvent event) {
-        updateUi();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
         updateUi();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -15,7 +15,6 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.DownloadLogEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
@@ -110,11 +109,6 @@ public class DownloadsSection extends HomeSection {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusChanged(PlayerStatusEvent event) {
-        loadItems();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsUpdateEvent(UnreadItemsUpdateEvent event) {
         loadItems();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
@@ -25,7 +25,6 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.event.EpisodeDownloadEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -82,11 +81,6 @@ public class InboxSection extends HomeSection {
     @Override
     protected void handleMoreClick() {
         ((MainActivity) requireActivity()).loadChildFragment(new InboxFragment());
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        loadItems();
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -487,7 +487,7 @@ public class AudioPlayerFragment extends Fragment implements
     public void setupOptionsMenu() {
         toolbar.getMenu().findItem(R.id.open_feed_item).setVisible(true);
         FeedItemMenuHandler.onPrepareMenu(toolbar.getMenu(),
-                Collections.singletonList(((FeedMedia) currentMedia).getItem()));
+                Collections.singletonList(currentMedia.getItem()));
         ((CastEnabledActivity) getActivity()).requestCastButton(toolbar.getMenu());
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -249,7 +249,7 @@ public class AudioPlayerFragment extends Fragment implements
             AudioPlayerFragment.this.loadMediaInfo(false);
         }
         if (event.items.isEmpty()) {
-            // The unread update update event is sometimes abused to trigger UI updates
+            // The unread update event is sometimes abused to trigger UI updates
             updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(),
                     currentMedia.getDuration()));
         }
@@ -485,12 +485,9 @@ public class AudioPlayerFragment extends Fragment implements
     }
 
     public void setupOptionsMenu() {
-        boolean isFeedMedia = currentMedia instanceof FeedMedia;
-        toolbar.getMenu().findItem(R.id.open_feed_item).setVisible(isFeedMedia);
-        if (isFeedMedia) {
-            FeedItemMenuHandler.onPrepareMenu(toolbar.getMenu(),
-                    Collections.singletonList(((FeedMedia) currentMedia).getItem()));
-        }
+        toolbar.getMenu().findItem(R.id.open_feed_item).setVisible(true);
+        FeedItemMenuHandler.onPrepareMenu(toolbar.getMenu(),
+                Collections.singletonList(((FeedMedia) currentMedia).getItem()));
         ((CastEnabledActivity) getActivity()).requestCastButton(toolbar.getMenu());
     }
 
@@ -500,8 +497,7 @@ public class AudioPlayerFragment extends Fragment implements
             return false;
         }
 
-        final @Nullable FeedItem feedItem = (currentMedia instanceof FeedMedia)
-                ? ((FeedMedia) currentMedia).getItem() : null;
+        final @Nullable FeedItem feedItem = currentMedia.getItem();
         if (feedItem != null && FeedItemMenuHandler.onMenuItemClicked(this, item.getItemId(), feedItem)) {
             return true;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -55,10 +55,9 @@ import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.ui.common.Converter;
 import de.danoeh.antennapod.ui.screen.feed.preferences.SkipPreferenceDialog;
-import de.danoeh.antennapod.event.FavoritesEvent;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.PlayerErrorEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.playback.BufferUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.event.playback.PlaybackServiceEvent;
@@ -102,7 +101,7 @@ public class AudioPlayerFragment extends Fragment implements
     private CardView cardViewSeek;
     private TextView txtvSeek;
 
-    private Playable currentMedia;
+    private FeedMedia currentMedia;
     private Disposable disposable;
     private boolean showTimeLeft;
     private boolean seekedToChapterStart = false;
@@ -242,12 +241,18 @@ public class AudioPlayerFragment extends Fragment implements
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsUpdate(UnreadItemsUpdateEvent event) {
+    public void onItemsUpdate(FeedItemEvent event) {
         if (currentMedia == null) {
             return;
         }
-        updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(),
-                currentMedia.getDuration()));
+        if (FeedItemEvent.indexOfItemWithId(event.items, currentMedia.getItemId()) != -1) {
+            AudioPlayerFragment.this.loadMediaInfo(false);
+        }
+        if (event.items.isEmpty()) {
+            // The unread update update event is sometimes abused to trigger UI updates
+            updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(),
+                    currentMedia.getDuration()));
+        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -280,8 +285,8 @@ public class AudioPlayerFragment extends Fragment implements
         if (disposable != null) {
             disposable.dispose();
         }
-        disposable = Maybe.<Playable>create(emitter -> {
-            Playable media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+        disposable = Maybe.<FeedMedia>create(emitter -> {
+            FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
             if (media != null) {
                 if (includingChapters) {
                     ChapterUtils.loadChapters(media, getContext(), false);
@@ -401,11 +406,6 @@ public class AudioPlayerFragment extends Fragment implements
             float progress = ((float) event.getPosition()) / event.getDuration();
             sbPosition.setProgress((int) (progress * sbPosition.getMax()));
         }
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void favoritesChanged(FavoritesEvent event) {
-        AudioPlayerFragment.this.loadMediaInfo(false);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/Media3VideoPlayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/Media3VideoPlayerActivity.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.databinding.Media3VideoPlayerActivityBinding;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.playback.service.Media3PlaybackService;
 import de.danoeh.antennapod.playback.service.PlaybackController;
@@ -38,7 +39,6 @@ import de.danoeh.antennapod.ui.screen.playback.TranscriptDialogFragment;
 import de.danoeh.antennapod.ui.screen.playback.VariableSpeedDialog;
 import de.danoeh.antennapod.ui.screen.playback.PlaybackControlsDialog;
 import de.danoeh.antennapod.ui.share.ShareDialog;
-import de.danoeh.antennapod.event.FavoritesEvent;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -299,9 +299,9 @@ public class Media3VideoPlayerActivity extends AppCompatActivity implements Tool
         }
 
         if (item.getItemId() == R.id.add_to_favorites_item) {
-            DBWriter.addFavoriteItem(currentMedia.getItem());
+            DBWriter.addFavoriteItems(Collections.singletonList(currentMedia.getItem()));
         } else if (item.getItemId() == R.id.remove_from_favorites_item) {
-            DBWriter.removeFavoriteItem(currentMedia.getItem());
+            DBWriter.removeFavoriteItems(Collections.singletonList(currentMedia.getItem()));
         } else if (item.getItemId() == R.id.open_feed_item) {
             new MainActivityStarter(this).withOpenFeed(currentMedia.getItem().getFeedId())
                     .withClearTop().start();
@@ -316,8 +316,10 @@ public class Media3VideoPlayerActivity extends AppCompatActivity implements Tool
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void favoritesChanged(FavoritesEvent event) {
-        loadMediaInfo();
+    public void itemChanged(FeedItemEvent event) {
+        if (currentMedia != null && event.items.contains(currentMedia.getItem())) {
+            loadMediaInfo();
+        }
     }
 
     private static String getWebsiteLinkWithFallback(FeedMedia media) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/Media3VideoPlayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/Media3VideoPlayerActivity.java
@@ -317,7 +317,7 @@ public class Media3VideoPlayerActivity extends AppCompatActivity implements Tool
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void itemChanged(FeedItemEvent event) {
-        if (currentMedia != null && event.items.contains(currentMedia.getItem())) {
+        if (currentMedia != null && FeedItemEvent.indexOfItemWithId(event.items, currentMedia.getItemId()) != -1) {
             loadMediaInfo();
         }
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/VideoplayerActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/video/VideoplayerActivity.java
@@ -470,9 +470,9 @@ public class VideoplayerActivity extends CastEnabledActivity
         }
         final @Nullable FeedItem feedItem = getFeedItem(media);
         if (item.getItemId() == R.id.add_to_favorites_item && feedItem != null) {
-            DBWriter.addFavoriteItem(feedItem);
+            DBWriter.addFavoriteItems(Collections.singletonList(feedItem));
         } else if (item.getItemId() == R.id.remove_from_favorites_item && feedItem != null) {
-            DBWriter.removeFavoriteItem(feedItem);
+            DBWriter.removeFavoriteItems(Collections.singletonList(feedItem));
         } else if (item.getItemId() == R.id.disable_sleeptimer_item
                 || item.getItemId() == R.id.set_sleeptimer_item) {
             new SleepTimerDialog().show(getSupportFragmentManager(), "SleepTimerDialog");

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
@@ -12,8 +12,8 @@ import androidx.preference.Preference;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.storage.preferences.UsageStatistics;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
@@ -22,6 +22,7 @@ import de.danoeh.antennapod.ui.screen.subscriptions.EpisodeListGlobalDefaultSort
 
 import org.greenrobot.eventbus.EventBus;
 
+import java.util.Collections;
 import java.util.List;
 
 public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment {
@@ -56,7 +57,7 @@ public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment
                 .setOnPreferenceChangeListener(
                         (preference, newValue) -> {
                             UserPreferences.setShowRemainTimeSetting((Boolean) newValue);
-                            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+                            EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
                             EventBus.getDefault().post(new PlayerStatusEvent());
                             return true;
                         });
@@ -86,7 +87,7 @@ public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment
         findPreference(UserPreferences.PREF_STREAM_OVER_DOWNLOAD)
                 .setOnPreferenceChangeListener((preference, newValue) -> {
                     // Update all visible lists to reflect new streaming action button
-                    EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+                    EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
                     // User consciously decided whether to prefer the streaming button, disable suggestion
                     UsageStatistics.doNotAskAgain(UsageStatistics.ACTION_STREAM);
                     return true;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -56,7 +56,6 @@ import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.event.QueueEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeMultiSelectActionHandler;
 import de.danoeh.antennapod.ui.swipeactions.SwipeActions;
@@ -180,6 +179,11 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(FeedItemEvent event) {
         Log.d(TAG, "onEventMainThread() called with: " + "event = [" + event + "]");
+        if (event.unreadStatusChanged && event.items.isEmpty()) {
+            loadItems();
+            refreshToolbarState();
+            return;
+        }
         if (queue == null) {
             return;
         } else if (recyclerAdapter == null) {
@@ -195,6 +199,9 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 recyclerAdapter.notifyItemChangedCompat(pos);
                 refreshInfoBar();
             }
+        }
+        if (event.unreadStatusChanged) {
+            refreshToolbarState();
         }
     }
 
@@ -227,13 +234,6 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusChanged(PlayerStatusEvent event) {
-        loadItems();
-        refreshToolbarState();
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        // Sent when playback position is reset
         loadItems();
         refreshToolbarState();
     }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedCounterDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedCounterDialog.java
@@ -3,12 +3,13 @@ package de.danoeh.antennapod.ui.screen.subscriptions;
 import android.content.Context;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.model.feed.FeedCounter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class FeedCounterDialog {
@@ -28,7 +29,7 @@ public class FeedCounterDialog {
                 UserPreferences.setFeedCounterSetting(
                         FeedCounter.fromOrdinal(Integer.parseInt(entryValues.get(which))));
                 //Update subscriptions
-                EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+                EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
             }
             d.dismiss();
         });

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedSortDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/FeedSortDialog.java
@@ -8,10 +8,11 @@ import de.danoeh.antennapod.model.feed.FeedOrder;
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import de.danoeh.antennapod.R;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 
 public class FeedSortDialog {
@@ -30,7 +31,7 @@ public class FeedSortDialog {
             if (selectedIndex != which) {
                 UserPreferences.setFeedOrder(FeedOrder.fromOrdinal(Integer.parseInt(entryValues.get(which))));
                 //Update subscriptions
-                EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+                EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
             }
             d.dismiss();
         });

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -23,9 +23,9 @@ import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.model.feed.SubscriptionsFilter;
@@ -473,8 +473,10 @@ public class SubscriptionFragment extends Fragment
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onUnreadItemsChanged(UnreadItemsUpdateEvent event) {
-        loadSubscriptionsAndTags();
+    public void onUnreadItemsChanged(FeedItemEvent event) {
+        if (event.unreadStatusChanged) {
+            loadSubscriptionsAndTags();
+        }
     }
 
     private void setCollapsingToolbarFlags(int flags) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsFilterDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsFilterDialog.java
@@ -18,7 +18,7 @@ import com.google.android.material.button.MaterialButtonToggleGroup;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.databinding.FilterDialogBinding;
 import de.danoeh.antennapod.databinding.FilterDialogRowBinding;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
+import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.model.feed.SubscriptionsFilter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import org.greenrobot.eventbus.EventBus;
@@ -127,6 +127,6 @@ public class SubscriptionsFilterDialog extends BottomSheetDialogFragment {
     private static void updateFilter(Set<String> filterValues) {
         SubscriptionsFilter subscriptionsFilter = new SubscriptionsFilter(filterValues.toArray(new String[0]));
         UserPreferences.setSubscriptionsFilter(subscriptionsFilter);
-        EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+        EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
     }
 }

--- a/event/src/main/java/de/danoeh/antennapod/event/FavoritesEvent.java
+++ b/event/src/main/java/de/danoeh/antennapod/event/FavoritesEvent.java
@@ -1,7 +1,0 @@
-package de.danoeh.antennapod.event;
-
-public class FavoritesEvent {
-
-    public FavoritesEvent() {
-    }
-}

--- a/event/src/main/java/de/danoeh/antennapod/event/FeedItemEvent.java
+++ b/event/src/main/java/de/danoeh/antennapod/event/FeedItemEvent.java
@@ -3,24 +3,17 @@ package de.danoeh.antennapod.event;
 
 import androidx.annotation.NonNull;
 
-import java.util.Arrays;
 import java.util.List;
 
 import de.danoeh.antennapod.model.feed.FeedItem;
 
 public class FeedItemEvent {
     @NonNull public final List<FeedItem> items;
+    public final boolean unreadStatusChanged;
 
-    public FeedItemEvent(@NonNull List<FeedItem> items) {
+    public FeedItemEvent(@NonNull List<FeedItem> items, boolean unreadStatusChanged) {
         this.items = items;
-    }
-
-    public static FeedItemEvent updated(List<FeedItem> items) {
-        return new FeedItemEvent(items);
-    }
-
-    public static FeedItemEvent updated(FeedItem... items) {
-        return new FeedItemEvent(Arrays.asList(items));
+        this.unreadStatusChanged = unreadStatusChanged;
     }
 
     public static int indexOfItemWithId(List<FeedItem> items, long id) {

--- a/event/src/main/java/de/danoeh/antennapod/event/UnreadItemsUpdateEvent.java
+++ b/event/src/main/java/de/danoeh/antennapod/event/UnreadItemsUpdateEvent.java
@@ -1,6 +1,0 @@
-package de.danoeh.antennapod.event;
-
-public class UnreadItemsUpdateEvent {
-    public UnreadItemsUpdateEvent() {
-    }
-}

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItem.java
@@ -294,6 +294,10 @@ public class FeedItem implements Serializable {
         return state;
     }
 
+    public void setPlayState(int state) {
+        this.state = state;
+    }
+
     public void setNew() {
         state = NEW;
     }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/MediaDownloadedHandler.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/MediaDownloadedHandler.java
@@ -11,13 +11,11 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
 import de.danoeh.antennapod.ui.chapters.ChapterUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.greenrobot.eventbus.EventBus;
 
 import java.io.File;
 import java.io.InterruptedIOException;
 import java.util.concurrent.ExecutionException;
 
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.model.download.DownloadRequest;
 import de.danoeh.antennapod.model.download.DownloadResult;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -101,10 +99,7 @@ public class MediaDownloadedHandler implements Runnable {
                 // setFeedItem() signals (via EventBus) that the item has been updated,
                 // so we do it after the enclosing media has been updated above,
                 // to ensure subscribers will get the updated FeedMedia as well
-                DBWriter.setFeedItem(item).get();
-                if (broadcastUnreadStateUpdate) {
-                    EventBus.getDefault().post(new UnreadItemsUpdateEvent());
-                }
+                DBWriter.setFeedItem(item, broadcastUnreadStateUpdate).get();
             }
         } catch (InterruptedException e) {
             Log.e(TAG, "MediaHandlerThread was interrupted");

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbWriterTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbWriterTest.java
@@ -108,7 +108,7 @@ public class DbWriterTest {
                 "dummy path", "download_url", System.currentTimeMillis(), null, 0, 0);
         item.setMedia(media);
 
-        DBWriter.setFeedItem(item).get(TIMEOUT, TimeUnit.SECONDS);
+        DBWriter.setFeedItem(item, false).get(TIMEOUT, TimeUnit.SECONDS);
 
         media.setPosition(position);
         media.setLastPlayedTimeStatistics(lastPlayedTimeStatistics);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -70,6 +70,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -485,7 +486,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, almostEnded);
         if (almostEnded) {
             if (item != null) {
-                DBWriter.markItemPlayed(FeedItem.PLAYED, true, item);
+                DBWriter.markItemsPlayed(FeedItem.PLAYED, true, Collections.singletonList(item));
                 DBWriter.removeQueueItem(this, true, item);
                 FeedPreferences.AutoDeleteAction action = item.getFeed().getPreferences().getCurrentAutoDelete();
                 boolean autoDeleteEnabledGlobally = UserPreferences.isAutoDelete()

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
@@ -398,7 +398,7 @@ public abstract class PlaybackController {
         } else if (playable instanceof FeedMedia) {
             FeedMedia media = (FeedMedia) playable;
             media.setPosition(time);
-            DBWriter.setFeedItem(media.getItem());
+            DBWriter.setFeedItem(media.getItem(), false);
             EventBus.getDefault().post(new PlaybackPositionEvent(time, playable.getDuration()));
         }
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1210,7 +1210,8 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                     || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
                 // only mark the item as played if we're not keeping it anyways
                 positionJustResetAfterPlayback = item.getIdentifyingValue();
-                DBWriter.markItemPlayed(FeedItem.PLAYED, ended || (skipped && almostEnded), item);
+                DBWriter.markItemsPlayed(FeedItem.PLAYED, ended || (skipped && almostEnded),
+                        Collections.singletonList(item));
                 // don't know if it actually matters to not autodownload when smart mark as played is triggered
                 DBWriter.removeQueueItem(PlaybackService.this, ended, item);
                 // Delete episode if enabled

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlayableUtils.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/PlayableUtils.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.playback.service.internal;
 
+import java.util.Collections;
 import java.util.Date;
 
 import de.danoeh.antennapod.storage.database.DBWriter;
@@ -26,7 +27,7 @@ public abstract class PlayableUtils {
             media.setLastPlayedTimeHistory(new Date(timestamp));
             FeedItem item = media.getItem();
             if (item != null && item.isNew()) {
-                DBWriter.markItemPlayed(FeedItem.UNPLAYED, false, item);
+                DBWriter.markItemsPlayed(FeedItem.UNPLAYED, false, Collections.singletonList(item));
             }
             if (media.getStartPosition() >= 0 && playable.getPosition() > media.getStartPosition()) {
                 media.setPlayedDuration(media.getPlayedDurationWhenStarted()

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -107,7 +107,8 @@ public class DBWriter {
                 return;
             }
             deleteFeedMediaSynchronous(context, media);
-            EventBus.getDefault().post(new FeedItemEvent(Collections.singletonList(media.getItem()), false));
+            EventBus.getDefault().post(new FeedItemEvent(media.getItem() != null
+                    ? Collections.singletonList(media.getItem()) : Collections.emptyList(), false));
             if (UserPreferences.shouldDeleteRemoveFromQueue()) {
                 DBWriter.removeQueueItemSynchronous(context, false, media.getItemId());
             }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -307,16 +307,14 @@ public class DBWriter {
      * @param date LastPlayedTimeHistory for <code>media</code>
      */
     public static Future<?> addItemToPlaybackHistory(final FeedMedia media, Date date) {
+        media.setLastPlayedTimeHistory(date);
         return runOnDbThread(() -> {
             Log.d(TAG, "Adding item to playback history");
-            media.setLastPlayedTimeHistory(date);
-
             PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
             adapter.setFeedMediaLastPlayedTimeHistory(media);
             adapter.close();
             EventBus.getDefault().post(PlaybackHistoryEvent.listUpdated());
-
         });
     }
 
@@ -460,7 +458,6 @@ public class DBWriter {
             adapter.open();
             adapter.clearQueue();
             adapter.close();
-
             EventBus.getDefault().post(QueueEvent.cleared());
         });
     }
@@ -537,25 +534,25 @@ public class DBWriter {
     }
 
     public static Future<?> addFavoriteItems(final List<FeedItem> items) {
+        for (FeedItem item : items) {
+            item.addTag(FeedItem.TAG_FAVORITE);
+        }
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance().open();
             adapter.addFavoriteItems(items);
             adapter.close();
-            for (FeedItem item : items) {
-                item.addTag(FeedItem.TAG_FAVORITE);
-            }
             EventBus.getDefault().post(new FeedItemEvent(items, false));
         });
     }
 
     public static Future<?> removeFavoriteItems(final List<FeedItem> items) {
+        for (FeedItem item : items) {
+            item.removeTag(FeedItem.TAG_FAVORITE);
+        }
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance().open();
             adapter.removeFavoriteItems(items);
             adapter.close();
-            for (FeedItem item : items) {
-                item.removeTag(FeedItem.TAG_FAVORITE);
-            }
             EventBus.getDefault().post(new FeedItemEvent(items, false));
         });
     }
@@ -653,18 +650,17 @@ public class DBWriter {
      */
     @NonNull
     public static Future<?> markItemsPlayed(int played, boolean resetMediaPosition, List<FeedItem> items) {
+        for (FeedItem item : items) {
+            if (item.hasMedia() && resetMediaPosition) {
+                item.getMedia().setPosition(0);
+            }
+            item.setPlayState(played);
+        }
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
             adapter.setFeedItemsRead(played, resetMediaPosition, items);
             adapter.close();
-
-            for (FeedItem item : items) {
-                if (item.hasMedia() && resetMediaPosition) {
-                    item.getMedia().setPosition(0);
-                }
-                item.setPlayState(played);
-            }
             EventBus.getDefault().post(new FeedItemEvent(items, true));
         });
     }
@@ -680,7 +676,6 @@ public class DBWriter {
             adapter.open();
             adapter.setFeedItems(FeedItem.NEW, FeedItem.UNPLAYED, feedId);
             adapter.close();
-
             EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
         });
     }
@@ -694,7 +689,6 @@ public class DBWriter {
             adapter.open();
             adapter.setFeedItems(FeedItem.NEW, FeedItem.UNPLAYED);
             adapter.close();
-
             EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
         });
     }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBWriter.java
@@ -35,12 +35,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 
-import de.danoeh.antennapod.event.FavoritesEvent;
 import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.playback.PlaybackHistoryEvent;
 import de.danoeh.antennapod.event.QueueEvent;
-import de.danoeh.antennapod.event.UnreadItemsUpdateEvent;
 import de.danoeh.antennapod.event.FeedEvent;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
@@ -108,14 +106,15 @@ public class DBWriter {
             if (media == null) {
                 return;
             }
-            boolean result = deleteFeedMediaSynchronous(context, media);
-            if (result && UserPreferences.shouldDeleteRemoveFromQueue()) {
+            deleteFeedMediaSynchronous(context, media);
+            EventBus.getDefault().post(new FeedItemEvent(Collections.singletonList(media.getItem()), false));
+            if (UserPreferences.shouldDeleteRemoveFromQueue()) {
                 DBWriter.removeQueueItemSynchronous(context, false, media.getItemId());
             }
         });
     }
 
-    private static boolean deleteFeedMediaSynchronous(@NonNull Context context, @NonNull FeedMedia media) {
+    private static void deleteFeedMediaSynchronous(@NonNull Context context, @NonNull FeedMedia media) {
         Log.i(TAG, String.format(Locale.US, "Requested to delete FeedMedia [id=%d, title=%s, downloaded=%s",
                 media.getId(), media.getEpisodeTitle(), media.isDownloaded()));
         boolean localDelete = false;
@@ -165,10 +164,7 @@ public class DBWriter {
                             .currentTimestamp()
                             .build());
             }
-
-            EventBus.getDefault().post(FeedItemEvent.updated(media.getItem()));
         }
-        return true;
     }
 
     /**
@@ -215,6 +211,7 @@ public class DBWriter {
     private static void deleteFeedItemsSynchronous(@NonNull Context context, @NonNull List<FeedItem> items) {
         List<FeedItem> queue = DBReader.getQueue();
         List<FeedItem> removedFromQueue = new ArrayList<>();
+        List<FeedItem> deleted = new ArrayList<>();
         for (FeedItem item : items) {
             if (queue.remove(item)) {
                 removedFromQueue.add(item);
@@ -231,6 +228,7 @@ public class DBWriter {
                     }
                     if (item.getMedia().isDownloaded()) {
                         deleteFeedMediaSynchronous(context, item.getMedia());
+                        deleted.add(item);
                     }
                 }
             }
@@ -247,6 +245,7 @@ public class DBWriter {
         for (FeedItem item : removedFromQueue) {
             EventBus.getDefault().post(QueueEvent.irreversibleRemoved(item));
         }
+        EventBus.getDefault().post(new FeedItemEvent(deleted, false));
 
         // we assume we also removed download log entries for the feed or its media files.
         // especially important if download or refresh failed, as the user should not be able
@@ -358,9 +357,9 @@ public class DBWriter {
                     adapter.setQueue(queue);
                     item.addTag(FeedItem.TAG_QUEUE);
                     EventBus.getDefault().post(QueueEvent.added(item, index));
-                    EventBus.getDefault().post(FeedItemEvent.updated(item));
+                    EventBus.getDefault().post(new FeedItemEvent(Collections.singletonList(item), false));
                     if (item.isNew()) {
-                        DBWriter.markItemPlayed(FeedItem.UNPLAYED, false, item);
+                        DBWriter.markItemsPlayed(FeedItem.UNPLAYED, false, Collections.singletonList(item));
                     }
                 }
             }
@@ -416,10 +415,8 @@ public class DBWriter {
                 for (QueueEvent event : events) {
                     EventBus.getDefault().post(event);
                 }
-                EventBus.getDefault().post(FeedItemEvent.updated(updatedItems));
-                if (markAsUnplayed.size() > 0) {
-                    DBWriter.markItemPlayed(FeedItem.UNPLAYED, false, markAsUnplayed.toArray(new FeedItem[0]));
-                }
+                EventBus.getDefault().post(new FeedItemEvent(updatedItems, false));
+                DBWriter.markItemsPlayed(FeedItem.UNPLAYED, false, markAsUnplayed);
             }
             adapter.close();
             AutoDownloadManager.getInstance().autodownloadUndownloadedItems(context);
@@ -520,7 +517,7 @@ public class DBWriter {
             for (QueueEvent event : events) {
                 EventBus.getDefault().post(event);
             }
-            EventBus.getDefault().post(FeedItemEvent.updated(updatedItems));
+            EventBus.getDefault().post(new FeedItemEvent(updatedItems, false));
         } else {
             Log.w(TAG, "Queue was not modified by call to removeQueueItem");
         }
@@ -532,31 +529,33 @@ public class DBWriter {
 
     public static Future<?> toggleFavoriteItem(final FeedItem item) {
         if (item.isTagged(FeedItem.TAG_FAVORITE)) {
-            return removeFavoriteItem(item);
+            return removeFavoriteItems(Collections.singletonList(item));
         } else {
-            return addFavoriteItem(item);
+            return addFavoriteItems(Collections.singletonList(item));
         }
     }
 
-    public static Future<?> addFavoriteItem(final FeedItem item) {
+    public static Future<?> addFavoriteItems(final List<FeedItem> items) {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance().open();
-            adapter.addFavoriteItem(item);
+            adapter.addFavoriteItems(items);
             adapter.close();
-            item.addTag(FeedItem.TAG_FAVORITE);
-            EventBus.getDefault().post(new FavoritesEvent());
-            EventBus.getDefault().post(FeedItemEvent.updated(item));
+            for (FeedItem item : items) {
+                item.addTag(FeedItem.TAG_FAVORITE);
+            }
+            EventBus.getDefault().post(new FeedItemEvent(items, false));
         });
     }
 
-    public static Future<?> removeFavoriteItem(final FeedItem item) {
+    public static Future<?> removeFavoriteItems(final List<FeedItem> items) {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance().open();
-            adapter.removeFavoriteItem(item);
+            adapter.removeFavoriteItems(items);
             adapter.close();
-            item.removeTag(FeedItem.TAG_FAVORITE);
-            EventBus.getDefault().post(new FavoritesEvent());
-            EventBus.getDefault().post(FeedItemEvent.updated(item));
+            for (FeedItem item : items) {
+                item.removeTag(FeedItem.TAG_FAVORITE);
+            }
+            EventBus.getDefault().post(new FeedItemEvent(items, false));
         });
     }
 
@@ -652,14 +651,20 @@ public class DBWriter {
      * @param items              The FeedItem objects to be updated
      */
     @NonNull
-    public static Future<?> markItemPlayed(int played, boolean resetMediaPosition, FeedItem... items) {
+    public static Future<?> markItemsPlayed(int played, boolean resetMediaPosition, List<FeedItem> items) {
         return runOnDbThread(() -> {
             final PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
-            adapter.setFeedItemRead(played, resetMediaPosition, items);
+            adapter.setFeedItemsRead(played, resetMediaPosition, items);
             adapter.close();
 
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+            for (FeedItem item : items) {
+                if (item.hasMedia() && resetMediaPosition) {
+                    item.getMedia().setPosition(0);
+                }
+                item.setPlayState(played);
+            }
+            EventBus.getDefault().post(new FeedItemEvent(items, true));
         });
     }
 
@@ -675,7 +680,7 @@ public class DBWriter {
             adapter.setFeedItems(FeedItem.NEW, FeedItem.UNPLAYED, feedId);
             adapter.close();
 
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+            EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
         });
     }
 
@@ -689,7 +694,7 @@ public class DBWriter {
             adapter.setFeedItems(FeedItem.NEW, FeedItem.UNPLAYED);
             adapter.close();
 
-            EventBus.getDefault().post(new UnreadItemsUpdateEvent());
+            EventBus.getDefault().post(new FeedItemEvent(Collections.emptyList(), true));
         });
     }
 
@@ -726,7 +731,7 @@ public class DBWriter {
             adapter.open();
             adapter.storeFeedItemlist(items);
             adapter.close();
-            EventBus.getDefault().post(FeedItemEvent.updated(items));
+            EventBus.getDefault().post(new FeedItemEvent(items, false));
         });
     }
 
@@ -779,14 +784,15 @@ public class DBWriter {
      * the content of FeedComponent-attributes.
      *
      * @param item The FeedItem object.
+     * @param unreadStatusChanged Whether the unread status of this item or related items has changed.
      */
-    public static Future<?> setFeedItem(final FeedItem item) {
+    public static Future<?> setFeedItem(final FeedItem item, final boolean unreadStatusChanged) {
         return runOnDbThread(() -> {
             PodDBAdapter adapter = PodDBAdapter.getInstance();
             adapter.open();
             adapter.setSingleFeedItem(item);
             adapter.close();
-            EventBus.getDefault().post(FeedItemEvent.updated(item));
+            EventBus.getDefault().post(new FeedItemEvent(Collections.singletonList(item), unreadStatusChanged));
         });
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -754,7 +754,7 @@ public class PodDBAdapter {
      *
      * @param played             New read status of items. See @FeedItem
      * @param resetMediaPosition Should the postition of the media item be reset?
-     * @param items              Array of items to upgrade
+     * @param items              List of items to upgrade
      */
     public void setFeedItemsRead(int played, boolean resetMediaPosition, List<FeedItem> items) {
         try {
@@ -869,6 +869,9 @@ public class PodDBAdapter {
      * Adds the item to favorites
      */
     public void addFavoriteItems(List<FeedItem> items) {
+        if (items.isEmpty()) {
+            return;
+        }
         db.execSQL("INSERT INTO " + TABLE_NAME_FAVORITES + " (" + KEY_FEEDITEM + ", " + KEY_FEED + ")"
                 + " SELECT " + KEY_ID + ", " + KEY_FEED
                 + " FROM " + TABLE_NAME_FEED_ITEMS
@@ -877,16 +880,11 @@ public class PodDBAdapter {
     }
 
     public void removeFavoriteItems(List<FeedItem> items) {
+        if (items.isEmpty()) {
+            return;
+        }
         db.execSQL("DELETE FROM " + TABLE_NAME_FAVORITES
                 + " WHERE " + KEY_FEEDITEM + " IN (" + getItemIds(items) + ")");
-    }
-
-    private boolean isItemInFavorites(FeedItem item) {
-        String query = String.format(Locale.US, "SELECT %s from %s WHERE %s=%d",
-                KEY_ID, TABLE_NAME_FAVORITES, KEY_FEEDITEM, item.getId());
-        try (Cursor c = db.rawQuery(query, null)) {
-            return c.getCount() > 0;
-        }
     }
 
     public void setQueue(List<FeedItem> queue) {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -756,7 +756,7 @@ public class PodDBAdapter {
      * @param resetMediaPosition Should the postition of the media item be reset?
      * @param items              Array of items to upgrade
      */
-    public void setFeedItemRead(int played, boolean resetMediaPosition, FeedItem... items) {
+    public void setFeedItemsRead(int played, boolean resetMediaPosition, List<FeedItem> items) {
         try {
             db.beginTransactionNonExclusive();
             ContentValues values = new ContentValues();
@@ -868,20 +868,17 @@ public class PodDBAdapter {
     /**
      * Adds the item to favorites
      */
-    public void addFavoriteItem(FeedItem item) {
-        // don't add an item that's already there...
-        if (isItemInFavorites(item)) {
-            Log.d(TAG, "item already in favorites");
-            return;
-        }
-        ContentValues values = new ContentValues();
-        values.put(KEY_FEEDITEM, item.getId());
-        values.put(KEY_FEED, item.getFeedId());
-        db.insert(TABLE_NAME_FAVORITES, null, values);
+    public void addFavoriteItems(List<FeedItem> items) {
+        db.execSQL("INSERT INTO " + TABLE_NAME_FAVORITES + " (" + KEY_FEEDITEM + ", " + KEY_FEED + ")"
+                + " SELECT " + KEY_ID + ", " + KEY_FEED
+                + " FROM " + TABLE_NAME_FEED_ITEMS
+                + " WHERE " + KEY_ID + " IN (" + getItemIds(items) + ")"
+                + " AND " + KEY_ID + " NOT IN (SELECT " + KEY_FEEDITEM + " FROM " + TABLE_NAME_FAVORITES + ")");
     }
 
-    public void removeFavoriteItem(FeedItem item) {
-        db.execSQL("DELETE FROM " + TABLE_NAME_FAVORITES + " WHERE " + KEY_FEEDITEM + "=" + item.getId());
+    public void removeFavoriteItems(List<FeedItem> items) {
+        db.execSQL("DELETE FROM " + TABLE_NAME_FAVORITES
+                + " WHERE " + KEY_FEEDITEM + " IN (" + getItemIds(items) + ")");
     }
 
     private boolean isItemInFavorites(FeedItem item) {
@@ -1485,6 +1482,17 @@ public class PodDBAdapter {
         sb.append(" ORDER BY " + KEY_TITLE + " ASC LIMIT 300");
 
         return db.rawQuery(sb.toString(), null);
+    }
+
+    private String getItemIds(List<FeedItem> items) {
+        StringBuilder itemIds = new StringBuilder();
+        for (FeedItem item : items) {
+            if (itemIds.length() != 0) {
+                itemIds.append(",");
+            }
+            itemIds.append(item.getId());
+        }
+        return itemIds.toString();
     }
 
     /**

--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriterTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriterTest.java
@@ -93,7 +93,7 @@ public class FeedDatabaseWriterTest {
         feed = FeedDatabaseWriter.updateFeed(context, feed, false);
         DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(),
                 SortOrder.EPISODE_TITLE_A_Z, 0, Integer.MAX_VALUE);
-        DBWriter.markItemPlayed(FeedItem.PLAYED, false, feed.getItems().get(2)).get();
+        DBWriter.markItemsPlayed(FeedItem.PLAYED, false, Collections.singletonList(feed.getItems().get(2))).get();
 
         Feed updatedFeed = createFeed();
         updatedFeed.setId(feed.getId());

--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/NonSubscribedFeedsCleanerTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/NonSubscribedFeedsCleanerTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -141,7 +142,7 @@ public class NonSubscribedFeedsCleanerTest {
         nonSubscribedFeedFavorite.getItems().add(createItem(nonSubscribedFeedFavorite));
 
         DBWriter.setCompleteFeed(subscribedFeed, nonSubscribedFeedFavorite, nonSubscribedFeed).get();
-        DBWriter.addFavoriteItem(nonSubscribedFeedFavorite.getItems().get(0)).get();
+        DBWriter.addFavoriteItems(Collections.singletonList(nonSubscribedFeedFavorite.getItems().get(0))).get();
 
         NonSubscribedFeedsCleaner.deleteOldNonSubscribedFeeds(context);
 


### PR DESCRIPTION
### Description

Reduce number of feed item events. Only have one type of event, instead of item update AND unread update AND favorite update. This means that on most screens, instead of receiving 2 events when marking something as favorite, we receive only one event with that episode. This means we query the database less frequently.

Additionally, for multi-select and similar batch tasks, instead of sending one event per episode, send one combined event for all episodes together. Again, this reduces the number of events we send and therefore the number of database calls we make. Using multi-select to remove/add all favorites feels noticeably faster.

Initial prototype: Claude, $2.59

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
