### PR TITLE
Fix some lint warnings and suppress the others

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -149,8 +149,8 @@ public class AudioPlayerFragment extends Fragment implements
 
         pager = root.findViewById(R.id.pager);
         pager.setAdapter(new AudioPlayerPagerAdapter(this));
-        // Required for getChildAt(int) in ViewPagerBottomSheetBehavior to return the correct page
-        pager.setOffscreenPageLimit((int) NUM_CONTENT_FRAGMENTS);
+        //noinspection WrongConstant
+        pager.setOffscreenPageLimit(NUM_CONTENT_FRAGMENTS);
         pager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override
             public void onPageSelected(int position) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -505,7 +505,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 }
                 if (item.getMedia() != null) {
                     long itemTimeLeft = item.getMedia().getDuration() - item.getMedia().getPosition();
-                    timeLeft += itemTimeLeft / playbackSpeed;
+                    timeLeft += (long) (itemTimeLeft / playbackSpeed);
                 }
             }
             info += " • ";

--- a/common.gradle
+++ b/common.gradle
@@ -40,6 +40,13 @@ android {
         targetCompatibility JavaVersion.VERSION_21
     }
 
+    tasks.withType(JavaCompile) {
+        options.compilerArgs.addAll([
+            "-Xlint:all,-deprecation,-serial,-this-escape,-unchecked,-processing,-classfile",
+            "-Werror",
+        ])
+    }
+
     testOptions {
         animationsDisabled = true
         unitTests {
@@ -73,14 +80,6 @@ tasks.withType(Test).configureEach {
         events "skipped", "passed", "failed"
         showStandardStreams true
         displayGranularity 2
-    }
-}
-
-gradle.projectsEvaluated {
-    tasks.withType(JavaCompile).tap {
-        configureEach {
-            options.compilerArgs << "-Xlint"
-        }
     }
 }
 

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -494,6 +494,11 @@ public class FeedMedia implements Playable {
     }
 
     @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/net/sync/service/src/test/java/de/danoeh/antennapod/net/sync/service/EpisodeActionFilterTest.java
+++ b/net/sync/service/src/test/java/de/danoeh/antennapod/net/sync/service/EpisodeActionFilterTest.java
@@ -59,7 +59,7 @@ public class EpisodeActionFilterTest extends TestCase {
                 .build()
         );
 
-        Map<Pair<String, String>, EpisodeAction> uniqueList = episodeActionFilter
+        Map<Pair<String, String>, EpisodeAction> uniqueList = EpisodeActionFilter
                 .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
         assertSame(1, uniqueList.size());
     }
@@ -104,7 +104,7 @@ public class EpisodeActionFilterTest extends TestCase {
                 .build()
         );
 
-        Map<Pair<String, String>, EpisodeAction> uniqueList = episodeActionFilter
+        Map<Pair<String, String>, EpisodeAction> uniqueList = EpisodeActionFilter
                 .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
         assertSame(0, uniqueList.size());
     }
@@ -142,7 +142,7 @@ public class EpisodeActionFilterTest extends TestCase {
                 .build()
         );
 
-        Map<Pair<String, String>, EpisodeAction> uniqueList = episodeActionFilter
+        Map<Pair<String, String>, EpisodeAction> uniqueList = EpisodeActionFilter
                 .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
         assertEquals(2, uniqueList.size());
     }
@@ -180,7 +180,7 @@ public class EpisodeActionFilterTest extends TestCase {
                 .build()
         );
 
-        Map<Pair<String, String>, EpisodeAction> uniqueList = episodeActionFilter
+        Map<Pair<String, String>, EpisodeAction> uniqueList = EpisodeActionFilter
                 .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
         assertEquals(0, uniqueList.size());
     }
@@ -205,7 +205,7 @@ public class EpisodeActionFilterTest extends TestCase {
                 .build()
         );
 
-        Map<Pair<String, String>, EpisodeAction> uniqueList = episodeActionFilter
+        Map<Pair<String, String>, EpisodeAction> uniqueList = EpisodeActionFilter
                 .getRemoteActionsOverridingLocalActions(remoteActions, episodeActions);
         assertSame(1, uniqueList.size());
     }

--- a/net/sync/service/src/test/java/de/danoeh/antennapod/net/sync/service/EpisodeActionFilterTest.java
+++ b/net/sync/service/src/test/java/de/danoeh/antennapod/net/sync/service/EpisodeActionFilterTest.java
@@ -17,8 +17,6 @@ import de.danoeh.antennapod.net.sync.serviceinterface.EpisodeAction;
 
 public class EpisodeActionFilterTest extends TestCase {
 
-    EpisodeActionFilter episodeActionFilter = new EpisodeActionFilter();
-
     public void testGetRemoteActionsHappeningAfterLocalActions() throws ParseException {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date morning = format.parse("2021-01-01 08:00:00");

--- a/playback/service/build.gradle
+++ b/playback/service/build.gradle
@@ -8,7 +8,7 @@ android {
     namespace "de.danoeh.antennapod.playback.service"
 
     tasks.withType(JavaCompile) {
-        // There is no way to suppress this specific warning, so we have to disable all:
+        // There is no way to suppress this specific warning, so we have to opt out of all:
         // class file for com.google.j2objc.annotations.ReflectionSupport$Level not found
         options.compilerArgs.removeAll { it == "-Werror" }
     }

--- a/playback/service/build.gradle
+++ b/playback/service/build.gradle
@@ -6,6 +6,12 @@ apply from: "../../playFlavor.gradle"
 
 android {
     namespace "de.danoeh.antennapod.playback.service"
+
+    tasks.withType(JavaCompile) {
+        // There is no way to suppress this specific warning, so we have to disable all:
+        // class file for com.google.j2objc.annotations.ReflectionSupport$Level not found
+        options.compilerArgs.removeAll { it == "-Werror" }
+    }
 }
 
 dependencies {

--- a/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/QueueScreen.java
+++ b/ui/echo/src/main/java/de/danoeh/antennapod/ui/echo/screen/QueueScreen.java
@@ -87,7 +87,7 @@ public class QueueScreen extends EchoScreen {
                         }
                         if (item.getMedia() != null) {
                             long itemTimeLeft = item.getMedia().getDuration() - item.getMedia().getPosition();
-                            queueSecondsLeft += itemTimeLeft / playbackSpeed;
+                            queueSecondsLeft += (long) (itemTimeLeft / playbackSpeed);
                         }
                     }
                     queueSecondsLeft /= 1000;

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/downloads/DownloadStatisticsListAdapter.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/downloads/DownloadStatisticsListAdapter.java
@@ -41,7 +41,7 @@ public class DownloadStatisticsListAdapter extends StatisticsListAdapter {
         for (int i = 0; i < statisticsData.size(); i++) {
             StatisticsItem item = statisticsData.get(i);
             dataValues[i] = item.totalDownloadSize;
-            cacheEpisodes += item.episodesDownloadCount;
+            cacheEpisodes += (int) item.episodesDownloadCount;
         }
         return new PieChartView.PieChartData(dataValues);
     }


### PR DESCRIPTION
### Description

Fix some lint warnings and suppress the others. This makes builds easier because IntelliJ no longer jumps to those warnings (and it prevents more from showing up).

Initial prototype: Claude, $1.99

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
