### PR TITLE
Hide persistent playback controls preference on Android 11+

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -69,6 +69,8 @@ public class PreferencesTest {
 
     @Test
     public void testEnablePersistentPlaybackControls() {
+        // Preference is hidden on Android 11+ where the system controls notification persistence.
+        assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.R);
         final boolean persistNotify = UserPreferences.isPersistNotify();
         clickPreference(R.string.user_interface_label);
         clickPreference(R.string.pref_persistNotify_title);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/UserInterfacePreferencesFragment.java
@@ -96,6 +96,10 @@ public class UserInterfacePreferencesFragment extends AnimatedPreferenceFragment
             findPreference(UserPreferences.PREF_EXPANDED_NOTIFICATION).setVisible(false);
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            findPreference(UserPreferences.PREF_PERSISTENT_NOTIFICATION).setVisible(false);
+        }
+
         findPreference(UserPreferences.PREF_BOTTOM_NAVIGATION).setOnPreferenceChangeListener((preference, newValue) -> {
             if (newValue instanceof Boolean && !(Boolean) newValue) {
                 new MaterialAlertDialogBuilder(getContext())

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/UserPreferences.java
@@ -54,7 +54,7 @@ public abstract class UserPreferences {
     public static final String PREF_EXPANDED_NOTIFICATION = "prefExpandNotify";
     public static final String PREF_USE_EPISODE_COVER = "prefEpisodeCover";
     public static final String PREF_SHOW_TIME_LEFT = "showTimeLeft";
-    private static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
+    public static final String PREF_PERSISTENT_NOTIFICATION = "prefPersistNotify";
     public static final String PREF_FULL_NOTIFICATION_BUTTONS = "prefFullNotificationButtons";
     private static final String PREF_SHOW_DOWNLOAD_REPORT = "prefShowDownloadReport";
     public static final String PREF_DEFAULT_PAGE = "prefDefaultPage";


### PR DESCRIPTION
### Description

Hides the "Persistent playback controls" preference from the User Interface settings screen when running on Android 11 (API 30) or newer. Starting with Android 11, notification persistence for media sessions is handled system-wide, so the app-level toggle is a no-op on modern devices and can be confusing to users.

The change follows the existing pattern used for `PREF_EXPANDED_NOTIFICATION`, which is hidden on API 26+ for the same reason (notification channels superseded it).

On Android < 11 the preference remains visible and functional. On Android 11+, `isPersistNotify()` continues to return its default (`true`), so no behavioral regression for existing users.

One incidental change: `PREF_PERSISTENT_NOTIFICATION` was previously `private` in `UserPreferences`; I changed it to `public` so `UserInterfacePreferencesFragment` can reference it for visibility control (matches the visibility of the adjacent `PREF_EXPANDED_NOTIFICATION` constant).

Closes: #6809

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using \`./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug\`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests — N/A, visibility-only change based on `Build.VERSION.SDK_INT`; behavior is framework-gated and not meaningfully unit-testable.