### PR TITLE
Access database sequentially

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -56,7 +56,7 @@ public final class DBReader {
      *      The FeedItem-list can be loaded separately with getFeedItemList().
      */
     @NonNull
-    public static List<Feed> getFeedList() {
+    public static synchronized List<Feed> getFeedList() {
         Log.d(TAG, "Extracting Feedlist");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -77,7 +77,7 @@ public final class DBReader {
      *
      * @return A list of Strings with the download URLs of all feeds.
      */
-    public static List<String> getFeedListDownloadUrls() {
+    public static synchronized List<String> getFeedListDownloadUrls() {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (Cursor cursor = adapter.getFeedCursorDownloadUrls()) {
@@ -101,7 +101,7 @@ public final class DBReader {
      *
      * @param items The FeedItems whose Feed-objects should be loaded.
      */
-    public static void loadFeedDataOfFeedItemList(List<FeedItem> items) {
+    public static synchronized void loadFeedDataOfFeedItemList(List<FeedItem> items) {
         List<Feed> feeds = getFeedList();
 
         Map<Long, Feed> feedIndex = new ArrayMap<>(feeds.size());
@@ -125,8 +125,8 @@ public final class DBReader {
      * @param feed The Feed whose items should be loaded
      * @return A list with the FeedItems of the Feed. The Feed-attribute of the FeedItems will already be set correctly.
      */
-    public static List<FeedItem> getFeedItemList(final Feed feed, final FeedItemFilter filter, SortOrder sortOrder,
-                                                 int offset, int limit) {
+    public static synchronized List<FeedItem> getFeedItemList(final Feed feed,
+                                             final FeedItemFilter filter, SortOrder sortOrder, int offset, int limit) {
         Log.d(TAG, "getFeedItemList() called with: " + "feed = [" + feed + "]");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -159,7 +159,7 @@ public final class DBReader {
      *
      * @return A list of IDs sorted by the same order as the queue.
      */
-    public static LongList getQueueIDList() {
+    public static synchronized LongList getQueueIDList() {
         Log.d(TAG, "getQueueIDList() called");
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -178,7 +178,7 @@ public final class DBReader {
      * Gets the remaining queue size, given a current item, including the current item.
      * If the current item is not found it will return 0.
      */
-    public static int getRemainingQueueSize(long existingId) {
+    public static synchronized int getRemainingQueueSize(long existingId) {
         final LongList wholeQueue = getQueueIDList();
 
         // now try to find the id
@@ -198,7 +198,7 @@ public final class DBReader {
      * @return A list of FeedItems sorted by the same order as the queue.
      */
     @NonNull
-    public static List<FeedItem> getQueue() {
+    public static synchronized List<FeedItem> getQueue() {
         Log.d(TAG, "getQueue() called");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -219,7 +219,8 @@ public final class DBReader {
      * @param filter The filter describing which episodes to filter out.
      */
     @NonNull
-    public static List<FeedItem> getEpisodes(int offset, int limit, FeedItemFilter filter, SortOrder sortOrder) {
+    public static synchronized List<FeedItem> getEpisodes(int offset, int limit,
+                                                          FeedItemFilter filter, SortOrder sortOrder) {
         Log.d(TAG, "getRecentlyPublishedEpisodes() called with: offset=" + offset + ", limit=" + limit);
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -232,7 +233,7 @@ public final class DBReader {
         }
     }
 
-    public static int getTotalEpisodeCount(FeedItemFilter filter) {
+    public static synchronized int getTotalEpisodeCount(FeedItemFilter filter) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (Cursor cursor = adapter.getEpisodeCountCursor(filter)) {
@@ -245,7 +246,7 @@ public final class DBReader {
         }
     }
 
-    public static int getFeedEpisodeCount(long feedId, FeedItemFilter filter) {
+    public static synchronized int getFeedEpisodeCount(long feedId, FeedItemFilter filter) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (Cursor cursor = adapter.getFeedEpisodeCountCursor(feedId, filter)) {
@@ -258,7 +259,7 @@ public final class DBReader {
         }
     }
 
-    public static List<FeedItem> getRandomEpisodes(int limit, int seed) {
+    public static synchronized List<FeedItem> getRandomEpisodes(int limit, int seed) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getRandomEpisodesCursor(limit, seed))) {
@@ -276,7 +277,7 @@ public final class DBReader {
      * @return A list with DownloadStatus objects that represent the download log.
      * The size of the returned list is limited by {@link #DOWNLOAD_LOG_SIZE}.
      */
-    public static List<DownloadResult> getDownloadLog() {
+    public static synchronized List<DownloadResult> getDownloadLog() {
         Log.d(TAG, "getDownloadLog() called");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -299,7 +300,7 @@ public final class DBReader {
      * @return A list with DownloadStatus objects that represent the feed's download log,
      * newest events first.
      */
-    public static List<DownloadResult> getFeedDownloadLog(long feedId, long limit) {
+    public static synchronized List<DownloadResult> getFeedDownloadLog(long feedId, long limit) {
         Log.d(TAG, "getFeedDownloadLog() called with: " + "feed = [" + feedId + "]");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -325,7 +326,7 @@ public final class DBReader {
      *         database and the items-attribute will be set correctly.
      */
     @Nullable
-    public static Feed getFeed(final long feedId, boolean filtered, int offset, int limit) {
+    public static synchronized Feed getFeed(final long feedId, boolean filtered, int offset, int limit) {
         Log.d(TAG, "getFeed() called with: " + "feedId = [" + feedId + "]");
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -358,7 +359,7 @@ public final class DBReader {
      * @return The FeedItem or null if the FeedItem could not be found.
      */
     @Nullable
-    public static FeedItem getFeedItem(final long itemId) {
+    public static synchronized FeedItem getFeedItem(final long itemId) {
         Log.d(TAG, "getFeedItem() called with: " + "itemId = [" + itemId + "]");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -383,7 +384,7 @@ public final class DBReader {
      * @return The FeedItem next in queue or null if the FeedItem could not be found.
      */
     @Nullable
-    public static FeedItem getNextInQueue(FeedItem item) {
+    public static synchronized FeedItem getNextInQueue(FeedItem item) {
         Log.d(TAG, "getNextInQueue() called with: " + "itemId = [" + item.getId() + "]");
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -403,7 +404,7 @@ public final class DBReader {
     }
 
     @NonNull
-    public static List<FeedItem> getPausedQueue(int limit) {
+    public static synchronized List<FeedItem> getPausedQueue(int limit) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getPausedQueueCursor(limit))) {
@@ -423,7 +424,7 @@ public final class DBReader {
      * @return The FeedItem or null if the FeedItem could not be found.
      *          Does NOT load additional attributes like feed.
      */
-    public static FeedItem getFeedItemByGuidOrEpisodeUrl(final String guid, final String episodeUrl) {
+    public static synchronized FeedItem getFeedItemByGuidOrEpisodeUrl(final String guid, final String episodeUrl) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(adapter.getFeedItemCursor(guid, episodeUrl))) {
@@ -442,7 +443,7 @@ public final class DBReader {
      *
      * @param item The FeedItem
      */
-    public static void loadDescriptionOfFeedItem(final FeedItem item) {
+    public static synchronized void loadDescriptionOfFeedItem(final FeedItem item) {
         Log.d(TAG, "loadDescriptionOfFeedItem() called with: " + "item = [" + item + "]");
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -464,7 +465,7 @@ public final class DBReader {
      *
      * @param item The FeedItem
      */
-    public static List<Chapter> loadChaptersOfFeedItem(final FeedItem item) {
+    public static synchronized List<Chapter> loadChaptersOfFeedItem(final FeedItem item) {
         Log.d(TAG, "loadChaptersOfFeedItem() called with: " + "item = [" + item + "]");
 
         PodDBAdapter adapter = PodDBAdapter.getInstance();
@@ -492,7 +493,7 @@ public final class DBReader {
      * @return The found object, or null if it does not exist
      */
     @Nullable
-    public static FeedMedia getFeedMedia(final long mediaId) {
+    public static synchronized FeedMedia getFeedMedia(final long mediaId) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
 
@@ -508,7 +509,7 @@ public final class DBReader {
         }
     }
 
-    public static List<FeedItem> getFeedItemsWithUrl(List<String> urls) {
+    public static synchronized List<FeedItem> getFeedItemsWithUrl(List<String> urls) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedItemCursor itemCursor = new FeedItemCursor(adapter.getFeedItemCursorByUrl(urls))) {
@@ -551,7 +552,7 @@ public final class DBReader {
     }
 
     @NonNull
-    public static List<MonthlyStatisticsItem> getMonthlyTimeStatistics() {
+    public static synchronized List<MonthlyStatisticsItem> getMonthlyTimeStatistics() {
         List<MonthlyStatisticsItem> months = new ArrayList<>();
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -582,7 +583,7 @@ public final class DBReader {
      * @return The list of statistics objects
      */
     @NonNull
-    public static StatisticsResult getStatistics(boolean includeMarkedAsPlayed,
+    public static synchronized StatisticsResult getStatistics(boolean includeMarkedAsPlayed,
                                                  long timeFilterFrom, long timeFilterTo) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -624,7 +625,7 @@ public final class DBReader {
         return result;
     }
 
-    public static long getTimeBetweenReleaseAndPlayback(long timeFilterFrom, long timeFilterTo) {
+    public static synchronized long getTimeBetweenReleaseAndPlayback(long timeFilterFrom, long timeFilterTo) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (Cursor cursor = adapter.getTimeBetweenReleaseAndPlayback(timeFilterFrom, timeFilterTo)) {
@@ -641,7 +642,7 @@ public final class DBReader {
      * items.
      */
     @NonNull
-    public static NavDrawerData getNavDrawerData(@Nullable SubscriptionsFilter subscriptionsFilter,
+    public static synchronized NavDrawerData getNavDrawerData(@Nullable SubscriptionsFilter subscriptionsFilter,
                                                  FeedOrder feedOrder, FeedCounter feedCounter, int feedState) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
@@ -746,7 +747,7 @@ public final class DBReader {
         return result;
     }
 
-    public static List<NavDrawerData.TagItem> getAllTags(int feedState) {
+    public static synchronized List<NavDrawerData.TagItem> getAllTags(int feedState) {
         Map<String, NavDrawerData.TagItem> tags = new HashMap<>();
         List<Feed> allFeeds = getFeedList();
         List<Feed> feeds = new ArrayList<>();
@@ -785,7 +786,7 @@ public final class DBReader {
         return tagsSorted;
     }
 
-    public static List<FeedItem> searchFeedItems(final long feedId, final String query, int state) {
+    public static synchronized List<FeedItem> searchFeedItems(final long feedId, final String query, int state) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedItemCursor searchResult = new FeedItemCursor(adapter.searchItems(feedId, query, state))) {
@@ -797,7 +798,7 @@ public final class DBReader {
         }
     }
 
-    public static List<Feed> searchFeeds(final String query, int state) {
+    public static synchronized List<Feed> searchFeeds(final String query, int state) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedCursor cursor = new FeedCursor(adapter.searchFeeds(query, state))) {


### PR DESCRIPTION
### Description

Access the database sequentially. This will lead to horrible performance but maybe it stops the crashes on Android 16 beta, which have trouble locking SQLite. Unfortunately it is hard to figure out what the problem actually is because Google no longer publishes the Android source code during betas. We tried everything else, this is the last resort.

Closes #8338

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests