### PR TITLE
Remove EventBus annotation processor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,6 @@ android {
         // "1.2.3"          -> 1020395
         versionCode 3110395
         versionName "3.11.3"
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments = [eventBusIndex: 'de.danoeh.antennapod.ApEventBusIndex']
-            }
-        }
     }
 
     signingConfigs {
@@ -118,7 +112,6 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
     implementation "org.greenrobot:eventbus:$eventbusVersion"
-    annotationProcessor "org.greenrobot:eventbus-annotation-processor:$eventbusVersion"
     implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
     implementation 'com.bytehamster:lib.preferencesearch:2.7.3'

--- a/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
+++ b/app/src/main/java/de/danoeh/antennapod/PodcastApp.java
@@ -21,7 +21,6 @@ public class PodcastApp extends Application {
         try {
             // Robolectric calls onCreate for every test, which causes problems with static members
             EventBus.builder()
-                    .addIndex(new ApEventBusIndex())
                     .logNoSubscriberMessages(false)
                     .sendNoSubscriberEvent(false)
                     .installDefaultEventBus();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TranscriptAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/TranscriptAdapter.java
@@ -26,8 +26,6 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.jsoup.internal.StringUtil;
 
 public class TranscriptAdapter extends RecyclerView.Adapter<TranscriptViewholder> {
-
-    public String tag = "TranscriptAdapter";
     private final SegmentClickListener segmentClickListener;
     private final Context context;
     private FeedMedia media;

--- a/playback/cast/build.gradle
+++ b/playback/cast/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "org.greenrobot:eventbus:$eventbusVersion"
-    annotationProcessor "org.greenrobot:eventbus-annotation-processor:$eventbusVersion"
 
     playApi 'androidx.mediarouter:mediarouter:1.3.0'
     playApi 'com.google.android.gms:play-services-cast-framework:21.2.0'


### PR DESCRIPTION
### Description

Remove EventBus annotation processor. This breaks reproducible builds without really helping with performance.

See also https://verification.f-droid.org/packages/de.danoeh.antennapod/

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
