### PR TITLE
More efficient chapter parser dispatch

### DIFF
--- a/parser/media/src/main/java/de/danoeh/antennapod/parser/media/MediaFormatDetector.java
+++ b/parser/media/src/main/java/de/danoeh/antennapod/parser/media/MediaFormatDetector.java
@@ -11,43 +11,33 @@ public final class MediaFormatDetector {
     }
 
     public enum Format {
-        ID3,
-        OGG,
-        M4A,
-        UNKNOWN
+        ID3, OGG, M4A, UNKNOWN
     }
 
     public static Result detect(InputStream input) throws IOException {
         byte[] prefix = new byte[PREFIX_READ_LIMIT];
         int bytesRead = input.read(prefix);
-
         if (bytesRead > 0) {
             prefix = Arrays.copyOf(prefix, bytesRead);
+            return new Result(detectFormat(prefix), prefix);
         } else {
-            prefix = new byte[0];
+            return new Result(Format.UNKNOWN, new byte[0]);
         }
-
-        return new Result(detectFormat(prefix), prefix);
     }
 
     static Format detectFormat(byte[] prefix) {
         if (prefix.length >= 3
                 && prefix[0] == 0x49 && prefix[1] == 0x44 && prefix[2] == 0x33) {
             return Format.ID3;
-        }
-
-        if (prefix.length >= 4
+        } else if (prefix.length >= 4
                 && prefix[0] == 0x4F && prefix[1] == 0x67
                 && prefix[2] == 0x67 && prefix[3] == 0x53) {
             return Format.OGG;
-        }
-
-        if (prefix.length >= 8
+        } else if (prefix.length >= 8
                 && prefix[4] == 0x66 && prefix[5] == 0x74
                 && prefix[6] == 0x79 && prefix[7] == 0x70) {
             return Format.M4A;
         }
-
         return Format.UNKNOWN;
     }
 

--- a/parser/media/src/main/java/de/danoeh/antennapod/parser/media/MediaFormatDetector.java
+++ b/parser/media/src/main/java/de/danoeh/antennapod/parser/media/MediaFormatDetector.java
@@ -1,0 +1,63 @@
+package de.danoeh.antennapod.parser.media;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+public final class MediaFormatDetector {
+    private static final int PREFIX_READ_LIMIT = 64;
+
+    private MediaFormatDetector() {
+    }
+
+    public enum Format {
+        ID3,
+        OGG,
+        M4A,
+        UNKNOWN
+    }
+
+    public static Result detect(InputStream input) throws IOException {
+        byte[] prefix = new byte[PREFIX_READ_LIMIT];
+        int bytesRead = input.read(prefix);
+
+        if (bytesRead > 0) {
+            prefix = Arrays.copyOf(prefix, bytesRead);
+        } else {
+            prefix = new byte[0];
+        }
+
+        return new Result(detectFormat(prefix), prefix);
+    }
+
+    static Format detectFormat(byte[] prefix) {
+        if (prefix.length >= 3
+                && prefix[0] == 0x49 && prefix[1] == 0x44 && prefix[2] == 0x33) {
+            return Format.ID3;
+        }
+
+        if (prefix.length >= 4
+                && prefix[0] == 0x4F && prefix[1] == 0x67
+                && prefix[2] == 0x67 && prefix[3] == 0x53) {
+            return Format.OGG;
+        }
+
+        if (prefix.length >= 8
+                && prefix[4] == 0x66 && prefix[5] == 0x74
+                && prefix[6] == 0x79 && prefix[7] == 0x70) {
+            return Format.M4A;
+        }
+
+        return Format.UNKNOWN;
+    }
+
+    public static class Result {
+        public final Format format;
+        public final byte[] bytes;
+
+        Result(Format format, byte[] bytes) {
+            this.format = format;
+            this.bytes = bytes;
+        }
+    }
+}

--- a/parser/media/src/test/java/de/danoeh/antennapod/parser/media/MediaFormatDetectorTest.java
+++ b/parser/media/src/test/java/de/danoeh/antennapod/parser/media/MediaFormatDetectorTest.java
@@ -1,0 +1,52 @@
+package de.danoeh.antennapod.parser.media;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+
+import org.junit.Test;
+
+public class MediaFormatDetectorTest {
+
+    @Test
+    public void testMagicId3_detectsId3() throws Exception {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {0x49, 0x44, 0x33})).format);
+    }
+
+    @Test
+    public void testMagicOgg_detectsOgg() throws Exception {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {0x4F, 0x67, 0x67, 0x53})).format);
+    }
+
+    @Test
+    public void testMagicM4a_detectsM4a() throws Exception {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70})).format);
+    }
+
+    @Test
+    public void testMagicZeroed_detectsUnknown() throws Exception {
+        assertEquals(MediaFormatDetector.Format.UNKNOWN,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {0, 0, 0, 0, 0, 0, 0, 0})).format);
+    }
+
+    @Test
+    public void testMagicEmpty_detectsUnknown() throws Exception {
+        assertEquals(MediaFormatDetector.Format.UNKNOWN,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {})).format);
+    }
+
+    @Test
+    public void testMagicShort_detectsUnknown() throws Exception {
+        assertEquals(MediaFormatDetector.Format.UNKNOWN,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {0x66, 0x74, 0x79})).format);
+    }
+
+    @Test
+    public void testRawMp3FrameMagic_detectsUnknown() throws Exception {
+        assertEquals(MediaFormatDetector.Format.UNKNOWN,
+                MediaFormatDetector.detect(new ByteArrayInputStream(new byte[] {(byte) 0xFF, (byte) 0xFB, 0x00, 0x00})).format);
+    }
+}

--- a/ui/chapters/build.gradle
+++ b/ui/chapters/build.gradle
@@ -6,6 +6,10 @@ apply from: "../../playFlavor.gradle"
 
 android {
     namespace "de.danoeh.antennapod.ui.chapters"
+
+    sourceSets {
+        test.resources.srcDir "../../parser/media/src/test/resources"
+    }
 }
 
 dependencies {
@@ -20,4 +24,8 @@ dependencies {
     implementation libs.commons.io
     implementation libs.commons.lang3
     implementation libs.okhttp
+
+    testImplementation libs.androidx.test.core
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/ui/chapters/src/main/java/de/danoeh/antennapod/ui/chapters/ChapterUtils.java
+++ b/ui/chapters/src/main/java/de/danoeh/antennapod/ui/chapters/ChapterUtils.java
@@ -70,7 +70,6 @@ public class ChapterUtils {
                     chaptersFromPodcastIndex = ChapterUtils.loadChaptersFromUrl(
                             feedMedia.getItem().getPodcastIndexChapterUrl(), forceRefresh);
                 }
-
             }
 
             List<Chapter> chaptersFromMediaFile = ChapterUtils.loadChaptersFromMediaFile(playable, context);
@@ -90,36 +89,29 @@ public class ChapterUtils {
 
     public static List<Chapter> loadChaptersFromMediaFile(Playable playable, Context context)
             throws InterruptedIOException {
+        // Load the first few bytes to detect the format.
+        // Then stitch the format back onto the stream and pass it to the chapter reader.
+        // If we were unable to detect the format, we stitch and send it to the first reader,
+        // then we try again with a fresh stream for the remaining two readers.
+        // This reduces the number of times we have to open a new stream as much as possible.
         MediaFormatDetector.Format format = MediaFormatDetector.Format.UNKNOWN;
         MediaFormatDetector.Format hint = MediaFormatDetector.Format.UNKNOWN;
         try (CountingInputStream sniffStream = openStream(playable, context)) {
             MediaFormatDetector.Result detection = MediaFormatDetector.detect(sniffStream);
             format = detection.format;
-
             if (format == MediaFormatDetector.Format.UNKNOWN) {
-                String url = playable.getStreamUrl();
-
-                String mime = null;
-                if (playable instanceof FeedMedia) {
-                    mime = ((FeedMedia) playable).getMimeType();
-                }
-
-                hint = detectHintFromMetadata(mime, url);
+                hint = detectHintFromMetadata(
+                        ((FeedMedia) playable).getMimeType(), playable.getStreamUrl());
             }
-
             InputStream reconstructed = new SequenceInputStream(
-                    new ByteArrayInputStream(detection.bytes),
-                    sniffStream
-            );
-
+                    new ByteArrayInputStream(detection.bytes), sniffStream);
             if (format != MediaFormatDetector.Format.UNKNOWN) {
                 CountingInputStream input = new CountingInputStream(reconstructed);
                 List<Chapter> chapters = readChaptersFromInputStream(input, format);
                 hasLoadedChapters(chapters);
                 return chapters;
-            }
-
-            if (hint == MediaFormatDetector.Format.ID3 || hint == MediaFormatDetector.Format.UNKNOWN) {
+            } else if (hint == MediaFormatDetector.Format.ID3
+                    || hint == MediaFormatDetector.Format.UNKNOWN) {
                 List<Chapter> chapters = readId3ChaptersFrom(new CountingInputStream(reconstructed));
                 if (hasLoadedChapters(chapters)) {
                     return chapters;
@@ -157,17 +149,15 @@ public class ChapterUtils {
     static MediaFormatDetector.Format detectHintFromMetadata(String mime, String url) {
         MediaFormatDetector.Format format = MediaFormatDetector.Format.UNKNOWN;
         if (mime != null) {
-            String m = mime.trim().toLowerCase(Locale.US);
-            if (m.equals("audio/mpeg") || m.equals("audio/mp3") || m.equals("audio/x-mp3")) {
-                format = MediaFormatDetector.Format.ID3;
-            } else if (m.equals("audio/ogg") || m.equals("application/ogg")
-                    || m.equals("audio/opus") || m.equals("application/opus")) {
-                format = MediaFormatDetector.Format.OGG;
-            } else if (m.equals("audio/mp4") || m.equals("audio/x-m4a")
-                    || m.equals("audio/m4a") || m.equals("video/mp4")
-                    || m.equals("audio/x-m4b") || m.equals("audio/m4b")) {
-                format = MediaFormatDetector.Format.M4A;
-            }
+            format = switch (mime.trim().toLowerCase(Locale.US)) {
+                case "audio/mpeg", "audio/mp3", "audio/x-mp3"
+                        -> MediaFormatDetector.Format.ID3;
+                case "audio/ogg", "application/ogg", "audio/opus", "application/opus"
+                        -> MediaFormatDetector.Format.OGG;
+                case "audio/mp4", "audio/x-m4a", "audio/m4a", "video/mp4", "audio/x-m4b", "audio/m4b"
+                        -> MediaFormatDetector.Format.M4A;
+                default -> format;
+            };
         }
 
         if (format == MediaFormatDetector.Format.UNKNOWN && url != null) {
@@ -176,13 +166,12 @@ public class ChapterUtils {
                 int dot = filename.lastIndexOf('.');
                 if (dot != -1 && dot < filename.length() - 1) {
                     String ext = filename.substring(dot + 1).toLowerCase(Locale.US);
-                    if (ext.equals("mp3")) {
-                        format = MediaFormatDetector.Format.ID3;
-                    } else if (ext.equals("ogg") || ext.equals("opus")) {
-                        format = MediaFormatDetector.Format.OGG;
-                    } else if (ext.equals("m4a") || ext.equals("mp4") || ext.equals("m4b")) {
-                        format = MediaFormatDetector.Format.M4A;
-                    }
+                    format = switch (ext) {
+                        case "mp3" -> MediaFormatDetector.Format.ID3;
+                        case "ogg", "opus" -> MediaFormatDetector.Format.OGG;
+                        case "m4a", "mp4", "m4b" -> MediaFormatDetector.Format.M4A;
+                        default -> format;
+                    };
                 }
             }
         }
@@ -190,39 +179,25 @@ public class ChapterUtils {
     }
 
     static MediaFormatDetector.Format[] getFallbackOrder(MediaFormatDetector.Format hint) {
-        if (hint == MediaFormatDetector.Format.OGG) {
-            return new MediaFormatDetector.Format[] {
-                    MediaFormatDetector.Format.ID3,
-                    MediaFormatDetector.Format.M4A
-            };
-        }
-
-        if (hint == MediaFormatDetector.Format.M4A) {
-            return new MediaFormatDetector.Format[] {
-                    MediaFormatDetector.Format.ID3,
-                    MediaFormatDetector.Format.OGG
-            };
-        }
-
-        return new MediaFormatDetector.Format[] {
-                MediaFormatDetector.Format.OGG,
-                MediaFormatDetector.Format.M4A
+        return switch (hint) {
+            case OGG -> new MediaFormatDetector.Format[]{
+                    MediaFormatDetector.Format.ID3, MediaFormatDetector.Format.M4A};
+            case M4A -> new MediaFormatDetector.Format[]{
+                    MediaFormatDetector.Format.ID3, MediaFormatDetector.Format.OGG};
+            default -> new MediaFormatDetector.Format[]{
+                    MediaFormatDetector.Format.OGG, MediaFormatDetector.Format.M4A};
         };
     }
 
     private static List<Chapter> readChaptersFromInputStream(
             CountingInputStream input, MediaFormatDetector.Format format)
             throws IOException, ID3ReaderException, VorbisCommentReaderException {
-        switch (format) {
-            case ID3:
-                return readId3ChaptersFrom(input);
-            case OGG:
-                return readOggChaptersFromInputStream(input);
-            case M4A:
-                return readM4AChaptersFromInputStream(input);
-            default:
-                return Collections.emptyList();
-        }
+        return switch (format) {
+            case ID3 -> readId3ChaptersFrom(input);
+            case OGG -> readOggChaptersFromInputStream(input);
+            case M4A -> readM4AChaptersFromInputStream(input);
+            default -> Collections.emptyList();
+        };
     }
 
     private static boolean hasLoadedChapters(List<Chapter> chapters) {

--- a/ui/chapters/src/main/java/de/danoeh/antennapod/ui/chapters/ChapterUtils.java
+++ b/ui/chapters/src/main/java/de/danoeh/antennapod/ui/chapters/ChapterUtils.java
@@ -5,10 +5,13 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
+import android.webkit.URLUtil;
+
 import androidx.annotation.NonNull;
 import de.danoeh.antennapod.model.feed.Chapter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.common.AntennapodHttpClient;
+import de.danoeh.antennapod.parser.media.MediaFormatDetector;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.parser.feed.PodcastIndexChapterParser;
 import de.danoeh.antennapod.parser.media.id3.ChapterReader;
@@ -23,14 +26,17 @@ import okhttp3.Response;
 import org.apache.commons.io.input.CountingInputStream;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
+import java.io.SequenceInputStream;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Utility class for getting chapter data from media files.
@@ -84,43 +90,159 @@ public class ChapterUtils {
 
     public static List<Chapter> loadChaptersFromMediaFile(Playable playable, Context context)
             throws InterruptedIOException {
-        try (CountingInputStream in = openStream(playable, context)) {
-            List<Chapter> chapters = readId3ChaptersFrom(in);
-            if (!chapters.isEmpty()) {
-                Log.i(TAG, "Chapters loaded");
+        MediaFormatDetector.Format format = MediaFormatDetector.Format.UNKNOWN;
+        MediaFormatDetector.Format hint = MediaFormatDetector.Format.UNKNOWN;
+        try (CountingInputStream sniffStream = openStream(playable, context)) {
+            MediaFormatDetector.Result detection = MediaFormatDetector.detect(sniffStream);
+            format = detection.format;
+
+            if (format == MediaFormatDetector.Format.UNKNOWN) {
+                String url = playable.getStreamUrl();
+
+                String mime = null;
+                if (playable instanceof FeedMedia) {
+                    mime = ((FeedMedia) playable).getMimeType();
+                }
+
+                hint = detectHintFromMetadata(mime, url);
+            }
+
+            InputStream reconstructed = new SequenceInputStream(
+                    new ByteArrayInputStream(detection.bytes),
+                    sniffStream
+            );
+
+            if (format != MediaFormatDetector.Format.UNKNOWN) {
+                CountingInputStream input = new CountingInputStream(reconstructed);
+                List<Chapter> chapters = readChaptersFromInputStream(input, format);
+                hasLoadedChapters(chapters);
                 return chapters;
+            }
+
+            if (hint == MediaFormatDetector.Format.ID3 || hint == MediaFormatDetector.Format.UNKNOWN) {
+                List<Chapter> chapters = readId3ChaptersFrom(new CountingInputStream(reconstructed));
+                if (hasLoadedChapters(chapters)) {
+                    return chapters;
+                }
+            } else if (hint == MediaFormatDetector.Format.OGG) {
+                List<Chapter> chapters = readOggChaptersFromInputStream(
+                        new CountingInputStream(reconstructed));
+                if (hasLoadedChapters(chapters)) {
+                    return chapters;
+                }
+            } else {
+                List<Chapter> chapters = readM4AChaptersFromInputStream(
+                        new CountingInputStream(reconstructed));
+                if (hasLoadedChapters(chapters)) {
+                    return chapters;
+                }
             }
         } catch (InterruptedIOException e) {
             throw e;
-        } catch (IOException | ID3ReaderException e) {
-            Log.e(TAG, "Unable to load ID3 chapters: " + e.getMessage());
+        } catch (IOException | ID3ReaderException | VorbisCommentReaderException e) {
+            Log.e(TAG, "Unable to load chapters: " + e.getMessage());
         }
 
-        try (CountingInputStream in = openStream(playable, context)) {
-            List<Chapter> chapters = readOggChaptersFromInputStream(in);
-            if (!chapters.isEmpty()) {
-                Log.i(TAG, "Chapters loaded");
-                return chapters;
+        if (format == MediaFormatDetector.Format.UNKNOWN) {
+            for (MediaFormatDetector.Format fallbackFormat : getFallbackOrder(hint)) {
+                List<Chapter> chapters = tryFreshStreamParser(playable, context, fallbackFormat);
+                if (hasLoadedChapters(chapters)) {
+                    return chapters;
+                }
             }
-        } catch (InterruptedIOException e) {
-            throw e;
-        } catch (IOException | VorbisCommentReaderException e) {
-            Log.e(TAG, "Unable to load vorbis chapters: " + e.getMessage());
         }
-
-        try (CountingInputStream in = openStream(playable, context)) {
-            List<Chapter> chapters = readM4AChaptersFromInputStream(in);
-            if (!chapters.isEmpty()) {
-                Log.i(TAG, "Chapters loaded");
-                return chapters;
-            }
-        } catch (InterruptedIOException e) {
-            throw e;
-        } catch (IOException e) {
-            Log.e(TAG, "Unable to open stream " + e.getMessage());
-        }
-
         return null;
+    }
+
+    static MediaFormatDetector.Format detectHintFromMetadata(String mime, String url) {
+        MediaFormatDetector.Format format = MediaFormatDetector.Format.UNKNOWN;
+        if (mime != null) {
+            String m = mime.trim().toLowerCase(Locale.US);
+            if (m.equals("audio/mpeg") || m.equals("audio/mp3") || m.equals("audio/x-mp3")) {
+                format = MediaFormatDetector.Format.ID3;
+            } else if (m.equals("audio/ogg") || m.equals("application/ogg")
+                    || m.equals("audio/opus") || m.equals("application/opus")) {
+                format = MediaFormatDetector.Format.OGG;
+            } else if (m.equals("audio/mp4") || m.equals("audio/x-m4a")
+                    || m.equals("audio/m4a") || m.equals("video/mp4")
+                    || m.equals("audio/x-m4b") || m.equals("audio/m4b")) {
+                format = MediaFormatDetector.Format.M4A;
+            }
+        }
+
+        if (format == MediaFormatDetector.Format.UNKNOWN && url != null) {
+            String filename = URLUtil.guessFileName(url, null, mime);
+            if (!TextUtils.isEmpty(filename)) {
+                int dot = filename.lastIndexOf('.');
+                if (dot != -1 && dot < filename.length() - 1) {
+                    String ext = filename.substring(dot + 1).toLowerCase(Locale.US);
+                    if (ext.equals("mp3")) {
+                        format = MediaFormatDetector.Format.ID3;
+                    } else if (ext.equals("ogg") || ext.equals("opus")) {
+                        format = MediaFormatDetector.Format.OGG;
+                    } else if (ext.equals("m4a") || ext.equals("mp4") || ext.equals("m4b")) {
+                        format = MediaFormatDetector.Format.M4A;
+                    }
+                }
+            }
+        }
+        return format;
+    }
+
+    static MediaFormatDetector.Format[] getFallbackOrder(MediaFormatDetector.Format hint) {
+        if (hint == MediaFormatDetector.Format.OGG) {
+            return new MediaFormatDetector.Format[] {
+                    MediaFormatDetector.Format.ID3,
+                    MediaFormatDetector.Format.M4A
+            };
+        }
+
+        if (hint == MediaFormatDetector.Format.M4A) {
+            return new MediaFormatDetector.Format[] {
+                    MediaFormatDetector.Format.ID3,
+                    MediaFormatDetector.Format.OGG
+            };
+        }
+
+        return new MediaFormatDetector.Format[] {
+                MediaFormatDetector.Format.OGG,
+                MediaFormatDetector.Format.M4A
+        };
+    }
+
+    private static List<Chapter> readChaptersFromInputStream(
+            CountingInputStream input, MediaFormatDetector.Format format)
+            throws IOException, ID3ReaderException, VorbisCommentReaderException {
+        switch (format) {
+            case ID3:
+                return readId3ChaptersFrom(input);
+            case OGG:
+                return readOggChaptersFromInputStream(input);
+            case M4A:
+                return readM4AChaptersFromInputStream(input);
+            default:
+                return Collections.emptyList();
+        }
+    }
+
+    private static boolean hasLoadedChapters(List<Chapter> chapters) {
+        if (chapters != null && !chapters.isEmpty()) {
+            Log.i(TAG, "Chapters loaded");
+            return true;
+        }
+        return false;
+    }
+
+    private static List<Chapter> tryFreshStreamParser(Playable playable, Context context,
+                                                      MediaFormatDetector.Format format) throws InterruptedIOException {
+        try (CountingInputStream in = openStream(playable, context)) {
+            return readChaptersFromInputStream(in, format);
+        } catch (InterruptedIOException e) {
+            throw e;
+        } catch (IOException | ID3ReaderException | VorbisCommentReaderException e) {
+            Log.e(TAG, "Unable to load chapters (" + format + "): " + e.getMessage());
+            return null;
+        }
     }
 
     private static CountingInputStream openStream(Playable playable, Context context) throws IOException {
@@ -184,13 +306,7 @@ public class ChapterUtils {
         ChapterReader reader = new ChapterReader(in);
         reader.readInputStream();
         List<Chapter> chapters = reader.getChapters();
-        Collections.sort(chapters, new ChapterStartTimeComparator());
-        enumerateEmptyChapterTitles(chapters);
-        if (!chaptersValid(chapters)) {
-            Log.e(TAG, "Chapter data was invalid");
-            return Collections.emptyList();
-        }
-        return chapters;
+        return processChapters(chapters);
     }
 
     @NonNull
@@ -198,15 +314,7 @@ public class ChapterUtils {
         VorbisCommentChapterReader reader = new VorbisCommentChapterReader(new BufferedInputStream(input));
         reader.readInputStream();
         List<Chapter> chapters = reader.getChapters();
-        if (chapters == null) {
-            return Collections.emptyList();
-        }
-        Collections.sort(chapters, new ChapterStartTimeComparator());
-        enumerateEmptyChapterTitles(chapters);
-        if (chaptersValid(chapters)) {
-            return chapters;
-        }
-        return Collections.emptyList();
+        return processChapters(chapters);
     }
 
     @NonNull
@@ -214,6 +322,10 @@ public class ChapterUtils {
         M4AChapterReader reader = new M4AChapterReader(new BufferedInputStream(input));
         reader.readInputStream();
         List<Chapter> chapters = reader.getChapters();
+        return processChapters(chapters);
+    }
+
+    private static List<Chapter> processChapters(List<Chapter> chapters) {
         if (chapters == null) {
             return Collections.emptyList();
         }
@@ -222,6 +334,7 @@ public class ChapterUtils {
         if (chaptersValid(chapters)) {
             return chapters;
         }
+        Log.e(TAG, "Chapter data was invalid");
         return Collections.emptyList();
     }
 

--- a/ui/chapters/src/test/java/de/danoeh/antennapod/ui/chapters/ChapterUtilsTest.java
+++ b/ui/chapters/src/test/java/de/danoeh/antennapod/ui/chapters/ChapterUtilsTest.java
@@ -1,0 +1,205 @@
+package de.danoeh.antennapod.ui.chapters;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+import java.util.List;
+
+import de.danoeh.antennapod.model.feed.Chapter;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.parser.media.MediaFormatDetector;
+
+@RunWith(RobolectricTestRunner.class)
+public class ChapterUtilsTest {
+
+    @Test
+    public void testMimeMpeg_selectsId3() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.detectHintFromMetadata("audio/mpeg", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeMp3_selectsId3() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.detectHintFromMetadata("audio/mp3", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeXMp3_selectsId3() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.detectHintFromMetadata("audio/x-mp3", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeOgg_selectsOgg() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.detectHintFromMetadata("audio/ogg", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeApplicationOgg_selectsOgg() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.detectHintFromMetadata("application/ogg", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeOpus_selectsOgg() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.detectHintFromMetadata("audio/opus", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeApplicationOpus_selectsOgg() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.detectHintFromMetadata("application/opus", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeM4a_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata("audio/mp4", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeVideoMp4_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata("video/mp4", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeM4b_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata("audio/m4b", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimeXM4b_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata("audio/x-m4b", "http://example.com/file?token=abc"));
+    }
+
+    @Test
+    public void testMimePreferredOverExtension() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.detectHintFromMetadata("audio/mpeg", "http://example.com/file.m4a?token=abc"));
+    }
+
+    @Test
+    public void testExtensionMp3_selectsId3() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.mp3?token=abc"));
+    }
+
+    @Test
+    public void testExtensionOgg_selectsOgg() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.ogg?token=abc"));
+    }
+
+    @Test
+    public void testExtensionOpus_selectsOgg() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.opus?token=abc"));
+    }
+
+    @Test
+    public void testExtensionM4a_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.m4a?token=abc"));
+    }
+
+    @Test
+    public void testExtensionMp4_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.mp4?token=abc"));
+    }
+
+    @Test
+    public void testExtensionM4b_selectsM4a() {
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.m4b?token=abc"));
+    }
+
+    @Test
+    public void testUnknownMetadata_detectsUnknown() {
+        assertEquals(MediaFormatDetector.Format.UNKNOWN,
+                ChapterUtils.detectHintFromMetadata(null, "http://example.com/file.unknown?token=abc"));
+    }
+
+    @Test
+    public void testFallbackOrderOggHint_skipsOgg() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.getFallbackOrder(MediaFormatDetector.Format.OGG)[0]);
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.getFallbackOrder(MediaFormatDetector.Format.OGG)[1]);
+    }
+
+    @Test
+    public void testFallbackOrderM4aHint_skipsM4a() {
+        assertEquals(MediaFormatDetector.Format.ID3,
+                ChapterUtils.getFallbackOrder(MediaFormatDetector.Format.M4A)[0]);
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.getFallbackOrder(MediaFormatDetector.Format.M4A)[1]);
+    }
+
+    @Test
+    public void testFallbackOrderUnknownHint_skipsId3BecauseAlreadyTried() {
+        assertEquals(MediaFormatDetector.Format.OGG,
+                ChapterUtils.getFallbackOrder(MediaFormatDetector.Format.UNKNOWN)[0]);
+        assertEquals(MediaFormatDetector.Format.M4A,
+                ChapterUtils.getFallbackOrder(MediaFormatDetector.Format.UNKNOWN)[1]);
+    }
+
+    @Test
+    public void testLoadChaptersFromMediaFile_stitchedMp3_readsChapters() throws Exception {
+        List<Chapter> chapters = loadFixtureChapters("auphonic.mp3", "audio/mpeg");
+
+        assertEquals(4, chapters.size());
+        assertEquals(0, chapters.get(0).getStart());
+        assertEquals("Chapter 1 - ❤️😊", chapters.get(0).getTitle());
+    }
+
+    @Test
+    public void testLoadChaptersFromMediaFile_magicBytesOverrideMetadataHint() throws Exception {
+        List<Chapter> chapters = loadFixtureChapters("auphonic.mp3", "audio/ogg");
+
+        assertEquals(4, chapters.size());
+        assertEquals(0, chapters.get(0).getStart());
+        assertEquals("Chapter 1 - ❤️😊", chapters.get(0).getTitle());
+    }
+
+    @Test
+    public void testLoadChaptersFromMediaFile_stitchedOgg_readsChapters() throws Exception {
+        List<Chapter> chapters = loadFixtureChapters("auphonic.ogg", "audio/ogg");
+
+        assertEquals(4, chapters.size());
+        assertEquals(0, chapters.get(0).getStart());
+        assertEquals("Chapter 1 - ❤️😊", chapters.get(0).getTitle());
+    }
+
+    @Test
+    public void testLoadChaptersFromMediaFile_stitchedM4a_readsChapters() throws Exception {
+        List<Chapter> chapters = loadFixtureChapters("nero-chapters.m4a", "audio/mp4");
+
+        assertEquals(4, chapters.size());
+        assertEquals(0, chapters.get(0).getStart());
+        assertEquals("Chapter 1 - ❤️😊", chapters.get(0).getTitle());
+    }
+
+    private List<Chapter> loadFixtureChapters(String filename, String mimeType) throws Exception {
+        Context context = ApplicationProvider.getApplicationContext();
+        String path = new File(getClass().getClassLoader().getResource(filename).toURI()).getPath();
+
+        FeedMedia media = new FeedMedia(1, null, 0, 0, 0, mimeType,
+                path, "http://example.com/" + filename, 1, null, 0, 0);
+        return ChapterUtils.loadChaptersFromMediaFile(media, context);
+    }
+}


### PR DESCRIPTION
## Description

This PR reduces avoidable per-parser stream opens during chapter loading by introducing parser dispatch based on bounded magic-byte detection with hint-based fallback ordering.

The implementation evolved during review from the original MIME-first dispatch approach into a parser-neutral, magic-byte-first detection flow that preserves compatibility behavior for unknown streams while eliminating unnecessary parser probing for confidently detected formats.

Addresses part 1 of issue #8352.

---

## What Changed

For recognized embedded-chapter container formats:

- ID3
- OGG
- M4A/MP4

chapter loading now:

- opens the stream once
- performs a bounded 64-byte sniff
- detects the container from stream contents
- reconstructs the logical parser stream using:
  - `ByteArrayInputStream`
  - `SequenceInputStream`
- dispatches directly to the matching parser

For confidently detected formats:

- unrelated parsers are no longer attempted
- empty chapter results do not trigger brute-force fallback probing

Parser-neutral detection was moved into `:parser:media` via `MediaFormatDetector`, which now owns:

- ID3 detection
- OGG detection
- M4A/MP4 detection (`ftyp` at offset 4)
- bounded sniff-byte extraction

Playback/UI integration intentionally remains in `:ui:chapters`, including:

- `Playable`
- `FeedMedia`
- `openStream(...)`
- MIME/URL metadata handling
- parser dispatch orchestration

---

## Metadata Handling

MIME type and URL extension metadata are now treated only as fallback hints.

Because podcast feeds may provide incorrect metadata:

- confirmed magic-byte detection always wins
- metadata never overrides confirmed stream detection
- metadata hint only influences fallback ordering when detection remains `UNKNOWN`

If metadata points to the wrong parser:

- that parser attempt can fail or return no chapters
- remaining fallback parser paths are still tried
- UNKNOWN-format compatibility behavior is preserved

---

## UNKNOWN-format Compatibility

UNKNOWN streams intentionally preserve backward-compatible probing behavior.

Current UNKNOWN flow:

- bounded sniff once
- first fallback attempt uses the reconstructed stream with metadata-informed ordering
- remaining fallback parsers open fresh streams as needed

This preserves existing parser assumptions while still reducing unnecessary duplication in the common recognized-format case.

This PR intentionally does NOT introduce:

- repeated-loader coordination
- caching/coalescing
- playback lifecycle synchronization
- persistent parser state
- full-file buffering

Part 2 of #8352 (repeated chapter loading across playback/event transitions) remains separate follow-up work and is intentionally out of scope for this PR.

---

## Verification

Verified with:

- targeted parser/media detector tests
- ChapterUtils integration-style tests
- stitched-stream parser dispatch tests
- streamed playback reproduction on `freeDebug`
- real-world streamed media verification, including raw MP3 frame-sync fallback behavior

Added coverage for:

- ID3 magic detection
- OGG magic detection
- M4A magic detection
- empty input
- short input
- zeroed input
- raw MP3 frame-sync UNKNOWN behavior (`FF FB`)
- stitched-stream parser dispatch
- misleading metadata override protection
- fallback-order behavior

Runtime verification confirmed:

- recognized formats dispatch exactly once
- stitched-stream parser dispatch worked correctly for tested formats
- unrelated parser paths are skipped for known formats
- UNKNOWN compatibility fallback remains functional

---

## Scope / Issue Tracking

This PR addresses part 1 of #8352 only:
per-parser stream duplication during chapter loading.

Repeated chapter parsing across playback/event transitions remains intentionally separate follow-up work.

For that reason, this PR references #8352 but intentionally does not use a closing keyword.

---

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests