### PR TITLE
Add support for searching queue only

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
@@ -74,7 +74,8 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     protected FeedItemFilter getFilter() {
         FeedItemFilter filter = new FeedItemFilter(UserPreferences.getPrefFilterAllEpisodes());
         if (filter.showIsFavorite) {
-            return new FeedItemFilter(filter, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            return new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
+                    FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
         } else {
             return filter;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/AllEpisodesFragment.java
@@ -74,8 +74,7 @@ public class AllEpisodesFragment extends EpisodesListFragment {
     protected FeedItemFilter getFilter() {
         FeedItemFilter filter = new FeedItemFilter(UserPreferences.getPrefFilterAllEpisodes());
         if (filter.showIsFavorite) {
-            return new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
-                    FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            return new FeedItemFilter(filter, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
         } else {
             return filter;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/FavoritesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/FavoritesFragment.java
@@ -19,7 +19,8 @@ import java.util.List;
 public class FavoritesFragment extends EpisodesListFragment {
     public static final String TAG = "FavoritesFragment";
     private static final FeedItemFilter FILTER_FAVORITES = new FeedItemFilter(
-            FeedItemFilter.IS_FAVORITE, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            FeedItemFilter.IS_FAVORITE, FeedItemFilter.INCLUDE_SUBSCRIBED,
+            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
     private static Pair<Integer, Integer> scrollPosition = null;
 
     @NonNull

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/FavoritesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/FavoritesFragment.java
@@ -19,8 +19,7 @@ import java.util.List;
 public class FavoritesFragment extends EpisodesListFragment {
     public static final String TAG = "FavoritesFragment";
     private static final FeedItemFilter FILTER_FAVORITES = new FeedItemFilter(
-            FeedItemFilter.IS_FAVORITE, FeedItemFilter.INCLUDE_SUBSCRIBED,
-            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            FeedItemFilter.IS_FAVORITE, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
     private static Pair<Integer, Integer> scrollPosition = null;
 
     @NonNull

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
@@ -26,7 +26,8 @@ import java.util.List;
 public class PlaybackHistoryFragment extends EpisodesListFragment {
     public static final String TAG = "PlaybackHistoryFragment";
     private static final FeedItemFilter FILTER_HISTORY = new FeedItemFilter(
-            FeedItemFilter.IS_IN_HISTORY, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            FeedItemFilter.IS_IN_HISTORY, FeedItemFilter.INCLUDE_SUBSCRIBED,
+            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
     private static Pair<Integer, Integer> scrollPosition = null;
 
     @NonNull

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/PlaybackHistoryFragment.java
@@ -26,8 +26,7 @@ import java.util.List;
 public class PlaybackHistoryFragment extends EpisodesListFragment {
     public static final String TAG = "PlaybackHistoryFragment";
     private static final FeedItemFilter FILTER_HISTORY = new FeedItemFilter(
-            FeedItemFilter.IS_IN_HISTORY, FeedItemFilter.INCLUDE_SUBSCRIBED,
-            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            FeedItemFilter.IS_IN_HISTORY, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
     private static Pair<Integer, Integer> scrollPosition = null;
 
     @NonNull

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/SearchFragment.java
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.chip.Chip;
+import com.google.android.material.chip.ChipGroup;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
@@ -35,6 +36,7 @@ import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.ui.episodeslist.EpisodeMultiSelectActionHandler;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.ui.episodeslist.FeedItemMenuHandler;
 import de.danoeh.antennapod.net.discovery.CombinedSearcher;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -67,7 +69,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     private static final String ARG_QUERY = "query";
     private static final String ARG_FEED = "feed";
     private static final String ARG_FEED_NAME = "feedName";
-    private static final String ARG_ARCHIVED = "archived";
+    private static final String ARG_FILTER = "filter";
     private static final int SEARCH_DEBOUNCE_INTERVAL = 1500;
 
     private EpisodeItemListAdapter adapter;
@@ -78,7 +80,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     private EmptyViewHandler emptyViewHandler;
     private EpisodeItemListRecyclerView recyclerView;
     private List<FeedItem> results;
-    private Chip chip;
+    private ChipGroup chipGroup;
     private SearchView searchView;
     private FloatingSelectMenu floatingSelectMenu;
     private Handler automaticSearchDebouncer;
@@ -93,6 +95,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         SearchFragment fragment = new SearchFragment();
         Bundle args = new Bundle();
         args.putLong(ARG_FEED, 0);
+        args.putSerializable(ARG_FILTER, FeedItemFilter.unfiltered());
         fragment.setArguments(args);
         return fragment;
     }
@@ -116,9 +119,9 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         return fragment;
     }
 
-    public static SearchFragment newInstanceArchive() {
+    public static SearchFragment newInstance(FeedItemFilter filter) {
         SearchFragment fragment = newInstance();
-        fragment.getArguments().putBoolean(ARG_ARCHIVED, true);
+        fragment.getArguments().putSerializable(ARG_FILTER, filter);
         return fragment;
     }
 
@@ -200,12 +203,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
         emptyViewHandler.setTitle(R.string.type_to_search);
         EventBus.getDefault().register(this);
 
-        chip = layout.findViewById(R.id.feed_title_chip);
-        chip.setOnCloseIconClickListener(v -> {
-            getArguments().putLong(ARG_FEED, 0);
-            getArguments().putBoolean(ARG_ARCHIVED, false);
-            searchWithProgressBar();
-        });
+        chipGroup = layout.findViewById(R.id.filter_chips);
         updateChipVisibility();
         if (getArguments().getString(ARG_QUERY, null) != null) {
             search();
@@ -380,14 +378,36 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
     }
 
     private void updateChipVisibility() {
-        chip.setVisibility(View.GONE);
-        if (getArguments().getBoolean(ARG_ARCHIVED, false)) {
-            chip.setVisibility(View.VISIBLE);
-            chip.setText(R.string.archive_feed_label_noun);
-        } else if (getArguments().getLong(ARG_FEED, 0) != 0) {
-            chip.setVisibility(View.VISIBLE);
-            chip.setText(getArguments().getString(ARG_FEED_NAME, ""));
+        chipGroup.removeAllViews();
+        FeedItemFilter filter = (FeedItemFilter) getArguments().getSerializable(ARG_FILTER);
+        if (filter != null && filter.showQueued) {
+            addChip(getString(R.string.queue_label), v -> {
+                getArguments().putSerializable(ARG_FILTER, filter.without(FeedItemFilter.QUEUED));
+                searchWithProgressBar();
+            });
         }
+        if (filter != null && filter.includeArchived && !filter.includeSubscribed && !filter.includeNotSubscribed) {
+            addChip(getString(R.string.archive_feed_label_noun), v -> {
+                getArguments().putSerializable(ARG_FILTER, filter.without(FeedItemFilter.INCLUDE_ARCHIVED));
+                searchWithProgressBar();
+            });
+        }
+        if (getArguments().getLong(ARG_FEED, 0) != 0) {
+            addChip(getArguments().getString(ARG_FEED_NAME, ""), v -> {
+                getArguments().putLong(ARG_FEED, 0);
+                searchWithProgressBar();
+            });
+        }
+        chipGroup.setVisibility(chipGroup.getChildCount() > 0 ? View.VISIBLE : View.GONE);
+    }
+
+    private void addChip(String text, View.OnClickListener closeListener) {
+        Chip chip = (Chip) getLayoutInflater().inflate(R.layout.item_tag_chip, chipGroup, false);
+        chip.setText(text);
+        chip.setCheckable(false);
+        chip.setCloseIconVisible(true);
+        chip.setOnCloseIconClickListener(closeListener);
+        chipGroup.addView(chip);
     }
 
     private void search() {
@@ -398,21 +418,38 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
             disposableEpisodes.dispose();
         }
         long feed = getArguments().getLong(ARG_FEED, 0);
+        FeedItemFilter filter = (FeedItemFilter) getArguments().getSerializable(ARG_FILTER);
+        if (filter == null) {
+            filter = FeedItemFilter.unfiltered();
+        }
+        for (String value : filter.getValues()) {
+            if (!value.isEmpty()
+                    && !value.equals(FeedItemFilter.QUEUED)
+                    && !value.equals(FeedItemFilter.INCLUDE_ARCHIVED)
+                    && !value.equals(FeedItemFilter.INCLUDE_SUBSCRIBED)
+                    && !value.equals(FeedItemFilter.INCLUDE_NOT_SUBSCRIBED)) {
+                throw new IllegalArgumentException("SearchFragment does not support filter: " + value);
+            }
+        }
+        final FeedItemFilter activeFilter = filter;
+        boolean hasEpisodeFilter = activeFilter.showQueued || activeFilter.showPlayed || activeFilter.showUnplayed
+                || activeFilter.showNew || activeFilter.showDownloaded || activeFilter.showIsFavorite
+                || activeFilter.showInHistory || activeFilter.showPaused;
         boolean isSearchingFeed = feed != 0;
         updateChipVisibility();
-        adapterFeeds.setEndButton(R.string.search_online, isSearchingFeed ? null : this::searchOnline);
+        adapterFeeds.setEndButton(R.string.search_online,
+                (isSearchingFeed || hasEpisodeFilter) ? null : this::searchOnline);
 
         String query = searchView.getQuery().toString();
         if (query.isEmpty()) {
             emptyViewHandler.setTitle(R.string.type_to_search);
             return;
         }
-        final int state = getArguments().getBoolean(ARG_ARCHIVED, false) ? Feed.STATE_ARCHIVED : Feed.STATE_SUBSCRIBED;
-        if (feed != 0) {
-            // Search within a feed
+        if (feed != 0 || hasEpisodeFilter) {
+            // Search within a feed or with episode-level filters: don't show subscription results
             adapterFeeds.updateData(Collections.emptyList());
         } else {
-            disposableFeeds = Observable.fromCallable(() -> DBReader.searchFeeds(query, state))
+            disposableFeeds = Observable.fromCallable(() -> DBReader.searchFeeds(query, activeFilter))
                     .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(results -> {
@@ -421,7 +458,7 @@ public class SearchFragment extends Fragment implements EpisodeItemListAdapter.O
                         emptyViewHandler.setTitle(getString(R.string.no_results_for_query, query));
                     }, error -> Log.e(TAG, Log.getStackTraceString(error)));
         }
-        disposableEpisodes = Observable.fromCallable(() -> DBReader.searchFeedItems(feed, query, state))
+        disposableEpisodes = Observable.fromCallable(() -> DBReader.searchFeedItems(feed, query, activeFilter))
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(results -> {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -190,7 +190,8 @@ public class CompletedDownloadsFragment extends Fragment
                 public void onConfirmButtonPressed(DialogInterface clickedDialog) {
                     clickedDialog.dismiss();
                     Observable.fromCallable(() -> DBReader.getEpisodes(0, Integer.MAX_VALUE,
-                                    new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED,
+                                    new FeedItemFilter(FeedItemFilter.DOWNLOADED,
+                                            FeedItemFilter.INCLUDE_ALL_FEED_STATES,
                                             FeedItemFilter.PLAYED), SortOrder.DATE_OLD_NEW))
                             .subscribeOn(Schedulers.computation())
                             .observeOn(AndroidSchedulers.mainThread())
@@ -311,8 +312,7 @@ public class CompletedDownloadsFragment extends Fragment
         disposable = Observable.fromCallable(() -> {
             SortOrder sortOrder = UserPreferences.getDownloadsSortedOrder();
             List<FeedItem> downloadedItems = DBReader.getEpisodes(0, Integer.MAX_VALUE,
-                    new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_SUBSCRIBED,
-                            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED), sortOrder);
+                    new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_ALL_FEED_STATES), sortOrder);
 
             List<String> mediaUrls = new ArrayList<>();
             if (runningDownloads == null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/download/CompletedDownloadsFragment.java
@@ -311,7 +311,8 @@ public class CompletedDownloadsFragment extends Fragment
         disposable = Observable.fromCallable(() -> {
             SortOrder sortOrder = UserPreferences.getDownloadsSortedOrder();
             List<FeedItem> downloadedItems = DBReader.getEpisodes(0, Integer.MAX_VALUE,
-                    new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED), sortOrder);
+                    new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_SUBSCRIBED,
+                            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED), sortOrder);
 
             List<String> mediaUrls = new ArrayList<>();
             if (runningDownloads == null) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -40,7 +40,8 @@ public class DownloadsSection extends HomeSection {
     public static final String TAG = "DownloadsSection";
     private static final int NUM_EPISODES = 2;
     private static final FeedItemFilter FILTER_DOWNLOADED = new FeedItemFilter(
-            FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_SUBSCRIBED,
+            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
     private EpisodeItemListAdapter adapter;
     private List<FeedItem> items;
     private Disposable disposable;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -40,8 +40,7 @@ public class DownloadsSection extends HomeSection {
     public static final String TAG = "DownloadsSection";
     private static final int NUM_EPISODES = 2;
     private static final FeedItemFilter FILTER_DOWNLOADED = new FeedItemFilter(
-            FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_SUBSCRIBED,
-            FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+            FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
     private EpisodeItemListAdapter adapter;
     private List<FeedItem> items;
     private Disposable disposable;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -314,8 +314,7 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
         } else if (itemId == R.id.action_search) {
             ((MainActivity) getActivity()).loadChildFragment(
                     SearchFragment.newInstance(new FeedItemFilter(FeedItemFilter.QUEUED,
-                            FeedItemFilter.INCLUDE_SUBSCRIBED, FeedItemFilter.INCLUDE_ARCHIVED,
-                            FeedItemFilter.INCLUDE_NOT_SUBSCRIBED)));
+                            FeedItemFilter.INCLUDE_ALL_FEED_STATES)));
             return true;
         }
         return false;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -312,7 +312,10 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             conDialog.createNewDialog().show();
             return true;
         } else if (itemId == R.id.action_search) {
-            ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
+            ((MainActivity) getActivity()).loadChildFragment(
+                    SearchFragment.newInstance(new FeedItemFilter(FeedItemFilter.QUEUED,
+                            FeedItemFilter.INCLUDE_SUBSCRIBED, FeedItemFilter.INCLUDE_ARCHIVED,
+                            FeedItemFilter.INCLUDE_NOT_SUBSCRIBED)));
             return true;
         }
         return false;

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionFragment.java
@@ -27,6 +27,7 @@ import de.danoeh.antennapod.event.FeedItemEvent;
 import de.danoeh.antennapod.event.FeedListUpdateEvent;
 import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.model.feed.SubscriptionsFilter;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
@@ -280,7 +281,8 @@ public class SubscriptionFragment extends Fragment
             return true;
         } else if (itemId == R.id.action_search) {
             if (stateToShow == Feed.STATE_ARCHIVED) {
-                ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstanceArchive());
+                ((MainActivity) getActivity()).loadChildFragment(
+                        SearchFragment.newInstance(new FeedItemFilter(FeedItemFilter.INCLUDE_ARCHIVED)));
             } else {
                 ((MainActivity) getActivity()).loadChildFragment(SearchFragment.newInstance());
             }

--- a/app/src/main/res/layout/search_fragment.xml
+++ b/app/src/main/res/layout/search_fragment.xml
@@ -24,15 +24,14 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <com.google.android.material.chip.Chip
-        android:id="@+id/feed_title_chip"
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/filter_chips"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/appbar"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="0dp"
-        android:visibility="gone"
-        app:closeIconVisible="true" />
+        android:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/progressBar"
@@ -47,7 +46,7 @@
         android:id="@+id/recyclerViewFeeds"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/feed_title_chip"
+        android:layout_below="@id/filter_chips"
         android:paddingLeft="12dp"
         android:paddingRight="12dp"
         android:clipToPadding="false" />

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItemFilter.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItemFilter.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.model.feed;
 
-import android.text.TextUtils;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,15 +52,16 @@ public class FeedItemFilter implements Serializable {
     }
 
     public FeedItemFilter(String properties) {
-        this(TextUtils.split(properties, ","));
+        this(properties.isEmpty() ? new String[0] : properties.split(","));
     }
 
     public FeedItemFilter(FeedItemFilter filter, String... additionalProperties) {
-        this(TextUtils.join(",", filter.getValues()) + "," + TextUtils.join(",", additionalProperties));
+        this(String.join(",", filter.getValues()) + "," + String.join(",", additionalProperties));
     }
 
     public FeedItemFilter(String... properties) {
-        this.properties = TextUtils.split(TextUtils.join(",", properties), ",");
+        String joined = String.join(",", properties);
+        this.properties = joined.isEmpty() ? new String[0] : joined.split(",");
 
         // see R.arrays.feed_filter_values
         showUnplayed = hasProperty(UNPLAYED);

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItemFilter.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItemFilter.java
@@ -3,6 +3,7 @@ package de.danoeh.antennapod.model.feed;
 import android.text.TextUtils;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,6 +25,8 @@ public class FeedItemFilter implements Serializable {
     public final boolean showIsFavorite;
     public final boolean showNotFavorite;
     public final boolean showInHistory;
+    public final boolean includeSubscribed;
+    public final boolean includeArchived;
     public final boolean includeNotSubscribed;
 
     public static final String PLAYED = "played";
@@ -40,10 +43,12 @@ public class FeedItemFilter implements Serializable {
     public static final String DOWNLOADED = "downloaded";
     public static final String NOT_DOWNLOADED = "not_downloaded";
     public static final String IS_IN_HISTORY = "is_in_history";
+    public static final String INCLUDE_SUBSCRIBED = "include_subscribed";
+    public static final String INCLUDE_ARCHIVED = "include_archived";
     public static final String INCLUDE_NOT_SUBSCRIBED = "include_not_subscribed";
 
     public static FeedItemFilter unfiltered() {
-        return new FeedItemFilter("");
+        return new FeedItemFilter();
     }
 
     public FeedItemFilter(String properties) {
@@ -72,6 +77,8 @@ public class FeedItemFilter implements Serializable {
         showNotFavorite = hasProperty(NOT_FAVORITE);
         showNew = hasProperty(NEW);
         showInHistory = hasProperty(IS_IN_HISTORY);
+        includeSubscribed = hasProperty(INCLUDE_SUBSCRIBED);
+        includeArchived = hasProperty(INCLUDE_ARCHIVED);
         includeNotSubscribed = hasProperty(INCLUDE_NOT_SUBSCRIBED);
     }
 
@@ -85,6 +92,12 @@ public class FeedItemFilter implements Serializable {
 
     public List<String> getValuesList() {
         return Arrays.asList(properties);
+    }
+
+    public FeedItemFilter without(String property) {
+        List<String> newValues = new ArrayList<>(Arrays.asList(properties));
+        newValues.remove(property);
+        return new FeedItemFilter(newValues.toArray(new String[0]));
     }
 
     public boolean matches(FeedItem item) {
@@ -119,9 +132,20 @@ public class FeedItemFilter implements Serializable {
         } else if (showInHistory && item.getMedia() != null
                 && item.getMedia().getLastPlayedTimeHistory().getTime() == 0) {
             return false;
-        } else if (!includeNotSubscribed && item.getFeed() != null
-                && item.getFeed().getState() == Feed.STATE_NOT_SUBSCRIBED) {
-            return false;
+        }
+        if (item.getFeed() != null) {
+            int state = item.getFeed().getState();
+            if (includeSubscribed || includeArchived || includeNotSubscribed) {
+                if (state == Feed.STATE_SUBSCRIBED && !includeSubscribed) {
+                    return false;
+                } else if (state == Feed.STATE_ARCHIVED && !includeArchived) {
+                    return false;
+                } else if (state == Feed.STATE_NOT_SUBSCRIBED && !includeNotSubscribed) {
+                    return false;
+                }
+            } else if (state != Feed.STATE_SUBSCRIBED) {
+                return false;
+            }
         }
         return true;
     }

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItemFilter.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedItemFilter.java
@@ -46,6 +46,8 @@ public class FeedItemFilter implements Serializable {
     public static final String INCLUDE_SUBSCRIBED = "include_subscribed";
     public static final String INCLUDE_ARCHIVED = "include_archived";
     public static final String INCLUDE_NOT_SUBSCRIBED = "include_not_subscribed";
+    public static final String INCLUDE_ALL_FEED_STATES =
+            INCLUDE_SUBSCRIBED + "," + INCLUDE_ARCHIVED + "," + INCLUDE_NOT_SUBSCRIBED;
 
     public static FeedItemFilter unfiltered() {
         return new FeedItemFilter();
@@ -60,7 +62,7 @@ public class FeedItemFilter implements Serializable {
     }
 
     public FeedItemFilter(String... properties) {
-        this.properties = properties;
+        this.properties = TextUtils.split(TextUtils.join(",", properties), ",");
 
         // see R.arrays.feed_filter_values
         showUnplayed = hasProperty(UNPLAYED);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -1913,7 +1913,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
                 return;
             }
 
-            List<FeedItem> results = DBReader.searchFeedItems(0, query, Feed.STATE_SUBSCRIBED);
+            List<FeedItem> results = DBReader.searchFeedItems(0, query, FeedItemFilter.unfiltered());
             if (results.size() > 0 && results.get(0).getMedia() != null) {
                 FeedMedia media = results.get(0).getMedia();
                 startPlaying(media, false);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -413,7 +413,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
             @NonNull String query, int page, int pageSize, @Nullable MediaLibraryService.LibraryParams params) {
         SettableFuture<LibraryResult<ImmutableList<MediaItem>>> future = SettableFuture.create();
         disposables.add(Single.fromCallable(() ->
-                        DBReader.searchFeedItems(0, query, Feed.STATE_SUBSCRIBED))
+                        DBReader.searchFeedItems(0, query, FeedItemFilter.unfiltered()))
                 .subscribeOn(Schedulers.io())
                 .subscribe(items -> future.set(LibraryResult.ofItemList(
                                 MediaItemAdapter.fromItemList(context, items), params)),

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -336,8 +336,7 @@ public final class DBReader {
                 feed = cursor.getFeed();
                 FeedItemFilter filter = (filtered && feed.getItemFilter() != null)
                         ? feed.getItemFilter() : FeedItemFilter.unfiltered();
-                filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
-                        FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+                filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
                 List<FeedItem> items = getFeedItemList(feed, filter, feed.getSortOrder(), offset, limit);
                 for (FeedItem item : items) {
                     item.setFeed(feed);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -336,7 +336,8 @@ public final class DBReader {
                 feed = cursor.getFeed();
                 FeedItemFilter filter = (filtered && feed.getItemFilter() != null)
                         ? feed.getItemFilter() : FeedItemFilter.unfiltered();
-                filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+                filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
+                        FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
                 List<FeedItem> items = getFeedItemList(feed, filter, feed.getSortOrder(), offset, limit);
                 for (FeedItem item : items) {
                     item.setFeed(feed);
@@ -786,10 +787,11 @@ public final class DBReader {
         return tagsSorted;
     }
 
-    public static List<FeedItem> searchFeedItems(final long feedId, final String query, int state) {
+    public static List<FeedItem> searchFeedItems(final long feedId, final String query,
+                                                  FeedItemFilter filter) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        try (FeedItemCursor searchResult = new FeedItemCursor(adapter.searchItems(feedId, query, state))) {
+        try (FeedItemCursor searchResult = new FeedItemCursor(adapter.searchItems(feedId, query, filter))) {
             List<FeedItem> items = extractItemlistFromCursor(searchResult);
             loadFeedDataOfFeedItemList(items);
             return items;
@@ -798,10 +800,10 @@ public final class DBReader {
         }
     }
 
-    public static List<Feed> searchFeeds(final String query, int state) {
+    public static List<Feed> searchFeeds(final String query, FeedItemFilter filter) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
-        try (FeedCursor cursor = new FeedCursor(adapter.searchFeeds(query, state))) {
+        try (FeedCursor cursor = new FeedCursor(adapter.searchFeeds(query, filter))) {
             List<Feed> items = new ArrayList<>();
             while (cursor.moveToNext()) {
                 items.add(cursor.getFeed());

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -23,6 +23,7 @@ import de.danoeh.antennapod.model.feed.FeedFunding;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -357,7 +358,7 @@ public class PodDBAdapter {
             "SELECT " + KEYS_FEED_ITEM_WITHOUT_DESCRIPTION + ", " + KEYS_FEED_MEDIA
             + " FROM " + TABLE_NAME_FEED_ITEMS
             + JOIN_FEED_ITEM_AND_MEDIA;
-    public static final String SELECT_WHERE_FEED_IS_SUBSCRIBED = TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
+    private static final String SELECT_WHERE_FEED_IS_SUBSCRIBED = TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
             + " IN (SELECT " + KEY_ID + " FROM " + TABLE_NAME_FEEDS
             + " WHERE " + KEY_STATE + "=" + Feed.STATE_SUBSCRIBED + ")";
 
@@ -1010,6 +1011,8 @@ public class PodDBAdapter {
     public final Cursor getItemsOfFeedCursor(final Feed feed, FeedItemFilter filter, SortOrder sortOrder,
                                              int offset, int limit) {
         String orderByQuery = FeedItemSortQuery.generateFrom(sortOrder);
+        filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
+                FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
         String filterQuery = FeedItemFilterQuery.generateFrom(filter);
         String whereClauseAnd = "".equals(filterQuery) ? "" : " AND " + filterQuery;
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
@@ -1132,6 +1135,8 @@ public class PodDBAdapter {
     }
 
     public final Cursor getFeedEpisodeCountCursor(long feedId, FeedItemFilter filter) {
+        filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
+                FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
         String filterQuery = FeedItemFilterQuery.generateFrom(filter);
         String whereAndClause = "".equals(filterQuery) ? "" : " AND " + filterQuery;
         final String query = "SELECT count(" + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + ") FROM " + TABLE_NAME_FEED_ITEMS
@@ -1416,7 +1421,7 @@ public class PodDBAdapter {
      *
      * @return A cursor with all search results in SEL_FI_EXTRA selection.
      */
-    public Cursor searchItems(long feedID, String searchQuery, int state) {
+    public Cursor searchItems(long feedID, String searchQuery, FeedItemFilter filter) {
         final String[] queryWords = prepareSearchQuery(searchQuery);
 
         String queryFeedId;
@@ -1429,8 +1434,11 @@ public class PodDBAdapter {
         }
 
         String queryStart = SELECT_FEED_ITEMS_AND_MEDIA_WITH_DESCRIPTION + " WHERE " + queryFeedId;
-        if (state == Feed.STATE_SUBSCRIBED && feedID == 0) {
-            queryStart += " AND " + SELECT_WHERE_FEED_IS_SUBSCRIBED;
+        if (feedID == 0) {
+            String filterQuery = FeedItemFilterQuery.generateFrom(filter);
+            if (!filterQuery.isEmpty()) {
+                queryStart += " AND " + filterQuery;
+            }
         }
         queryStart += " AND (";
         StringBuilder sb = new StringBuilder(queryStart);
@@ -1458,10 +1466,23 @@ public class PodDBAdapter {
      *
      * @return A cursor with all search results in SEL_FI_EXTRA selection.
      */
-    public Cursor searchFeeds(String searchQuery, int state) {
+    public Cursor searchFeeds(String searchQuery, FeedItemFilter filter) {
         final String[] queryWords = prepareSearchQuery(searchQuery);
+        List<String> allowedStates = new ArrayList<>();
+        if (filter.includeSubscribed) {
+            allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
+        }
+        if (filter.includeArchived) {
+            allowedStates.add(String.valueOf(Feed.STATE_ARCHIVED));
+        }
+        if (filter.includeNotSubscribed) {
+            allowedStates.add(String.valueOf(Feed.STATE_NOT_SUBSCRIBED));
+        }
+        if (allowedStates.isEmpty()) {
+            allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
+        }
         String queryStart = "SELECT " + KEYS_FEED + " FROM " + TABLE_NAME_FEEDS
-                + " WHERE " + KEY_STATE + " = " + state;
+                + " WHERE " + KEY_STATE + " IN (" + TextUtils.join(",", allowedStates) + ")";
         StringBuilder sb = new StringBuilder(queryStart);
 
         for (int i = 0; i < queryWords.length; i++) {

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1011,8 +1011,7 @@ public class PodDBAdapter {
     public final Cursor getItemsOfFeedCursor(final Feed feed, FeedItemFilter filter, SortOrder sortOrder,
                                              int offset, int limit) {
         String orderByQuery = FeedItemSortQuery.generateFrom(sortOrder);
-        filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
-                FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+        filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
         String filterQuery = FeedItemFilterQuery.generateFrom(filter);
         String whereClauseAnd = "".equals(filterQuery) ? "" : " AND " + filterQuery;
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
@@ -1135,8 +1134,7 @@ public class PodDBAdapter {
     }
 
     public final Cursor getFeedEpisodeCountCursor(long feedId, FeedItemFilter filter) {
-        filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_SUBSCRIBED,
-                FeedItemFilter.INCLUDE_ARCHIVED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED);
+        filter = new FeedItemFilter(filter, FeedItemFilter.INCLUDE_ALL_FEED_STATES);
         String filterQuery = FeedItemFilterQuery.generateFrom(filter);
         String whereAndClause = "".equals(filterQuery) ? "" : " AND " + filterQuery;
         final String query = "SELECT count(" + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + ") FROM " + TABLE_NAME_FEED_ITEMS
@@ -1434,11 +1432,12 @@ public class PodDBAdapter {
         }
 
         String queryStart = SELECT_FEED_ITEMS_AND_MEDIA_WITH_DESCRIPTION + " WHERE " + queryFeedId;
-        if (feedID == 0) {
-            String filterQuery = FeedItemFilterQuery.generateFrom(filter);
-            if (!filterQuery.isEmpty()) {
-                queryStart += " AND " + filterQuery;
-            }
+        FeedItemFilter effectiveFilter = feedID != 0
+                ? new FeedItemFilter(filter, FeedItemFilter.INCLUDE_ALL_FEED_STATES)
+                : filter;
+        String filterQuery = FeedItemFilterQuery.generateFrom(effectiveFilter);
+        if (!filterQuery.isEmpty()) {
+            queryStart += " AND " + filterQuery;
         }
         queryStart += " AND (";
         StringBuilder sb = new StringBuilder(queryStart);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
@@ -1,5 +1,7 @@
 package de.danoeh.antennapod.storage.database.mapper;
 
+import android.text.TextUtils;
+import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.storage.database.PodDBAdapter;
 
@@ -66,9 +68,22 @@ public class FeedItemFilterQuery {
         if (filter.showInHistory) {
             statements.add(keyCompletionDate + " > 0 ");
         }
-        if (!filter.includeNotSubscribed) {
-            statements.add(PodDBAdapter.SELECT_WHERE_FEED_IS_SUBSCRIBED);
+        List<String> allowedStates = new ArrayList<>();
+        if (filter.includeSubscribed) {
+            allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
         }
+        if (filter.includeArchived) {
+            allowedStates.add(String.valueOf(Feed.STATE_ARCHIVED));
+        }
+        if (filter.includeNotSubscribed) {
+            allowedStates.add(String.valueOf(Feed.STATE_NOT_SUBSCRIBED));
+        }
+        if (allowedStates.isEmpty()) {
+            allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
+        }
+        statements.add(PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_FEED
+                + " IN (SELECT " + PodDBAdapter.KEY_ID + " FROM " + PodDBAdapter.TABLE_NAME_FEEDS
+                + " WHERE " + PodDBAdapter.KEY_STATE + " IN (" + TextUtils.join(",", allowedStates) + "))");
 
         if (statements.isEmpty()) {
             return "";

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedItemFilterQuery.java
@@ -68,22 +68,25 @@ public class FeedItemFilterQuery {
         if (filter.showInHistory) {
             statements.add(keyCompletionDate + " > 0 ");
         }
-        List<String> allowedStates = new ArrayList<>();
-        if (filter.includeSubscribed) {
-            allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
+        boolean allStatesAllowed = filter.includeSubscribed && filter.includeArchived && filter.includeNotSubscribed;
+        if (!allStatesAllowed) {
+            List<String> allowedStates = new ArrayList<>();
+            if (filter.includeSubscribed) {
+                allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
+            }
+            if (filter.includeArchived) {
+                allowedStates.add(String.valueOf(Feed.STATE_ARCHIVED));
+            }
+            if (filter.includeNotSubscribed) {
+                allowedStates.add(String.valueOf(Feed.STATE_NOT_SUBSCRIBED));
+            }
+            if (allowedStates.isEmpty()) {
+                allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
+            }
+            statements.add(PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_FEED
+                    + " IN (SELECT " + PodDBAdapter.KEY_ID + " FROM " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " WHERE " + PodDBAdapter.KEY_STATE + " IN (" + TextUtils.join(",", allowedStates) + "))");
         }
-        if (filter.includeArchived) {
-            allowedStates.add(String.valueOf(Feed.STATE_ARCHIVED));
-        }
-        if (filter.includeNotSubscribed) {
-            allowedStates.add(String.valueOf(Feed.STATE_NOT_SUBSCRIBED));
-        }
-        if (allowedStates.isEmpty()) {
-            allowedStates.add(String.valueOf(Feed.STATE_SUBSCRIBED));
-        }
-        statements.add(PodDBAdapter.TABLE_NAME_FEED_ITEMS + "." + PodDBAdapter.KEY_FEED
-                + " IN (SELECT " + PodDBAdapter.KEY_ID + " FROM " + PodDBAdapter.TABLE_NAME_FEEDS
-                + " WHERE " + PodDBAdapter.KEY_STATE + " IN (" + TextUtils.join(",", allowedStates) + "))");
 
         if (statements.isEmpty()) {
             return "";


### PR DESCRIPTION
### Description

The search icon in the queue now searches the queue only. A chip indicates that this is the case. This lays the groundwork for adding other filters as well.

Contributes to #4374

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
