### PR TITLE
Fix sleep timer hint text wrapping

### DIFF
--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -48,12 +48,9 @@
             <TextView
                 android:id="@+id/sleepTimerHintText"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
+                android:layout_height="wrap_content"
                 android:visibility="visible"
-                android:layout_weight="1"
-                android:selectAllOnFocus="true"
                 android:layout_margin="8dp"
-                android:ems="2"
                 android:text="@string/multiple_sleep_episodes_while_continuous_playback_disabled" />
 
             <Button


### PR DESCRIPTION
### Description

Closes: #8199

Updates the sleep timer dialog hint text so it uses `wrap_content` height instead of a weighted zero-height layout. This lets the disabled-continuous-playback warning expand to its full text instead of being constrained to a single line.

This follows the layout cleanup suggested by the maintainer in the issue thread.

### Checklist

- [x] I have read the contribution guidelines
- [x] I have performed a self-review of my code
- [ ] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project
- [x] I have mentioned the corresponding issue and the relevant keyword in the description
- [x] If it is a core feature, I have added automated tests

Validation performed:

- `xmllint --noout app/src/main/res/layout/time_dialog.xml`
- `git diff --check`

Gradle validation attempted:

- `./gradlew :app:lintPlayDebug` could not run because the Android SDK is not configured in this environment (`ANDROID_HOME` / `sdk.dir` missing).