### PR TITLE
Show "Import error" instead of "Export error" for import failures

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
@@ -238,6 +238,15 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
         alert.show();
     }
 
+    private void showImportErrorDialog(final Throwable error) {
+        progressDialog.dismiss();
+        final MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(getContext());
+        alert.setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss());
+        alert.setTitle(R.string.import_error_label);
+        alert.setMessage(error.getMessage());
+        alert.show();
+    }
+
     private void restoreDatabaseResult(final ActivityResult result) {
         if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
             return;
@@ -250,7 +259,7 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
                 .subscribe(() -> {
                     showDatabaseImportSuccessDialog();
                     progressDialog.dismiss();
-                }, this::showExportErrorDialog);
+                }, this::showImportErrorDialog);
     }
 
     private void backupDatabaseResult(final Uri uri) {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -688,6 +688,7 @@
     <string name="successful_import_label">Import successful</string>
     <string name="import_ok">Please press OK to restart AntennaPod</string>
     <string name="import_no_downgrade">This database was exported with a newer version of AntennaPod. Your current installation does not yet know how to handle this file.</string>
+    <string name="import_error_label">Import error</string>
     <string name="favorites_export_label">Favorites export</string>
     <string name="favorites_export_summary">Export saved favorites to file</string>
 


### PR DESCRIPTION
### Description

Fix a bug where import errors re-used the "export error" dialog, causing user confusion.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
