### PR TITLE
Offer to fix stale download markers after database import

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
+++ b/app/src/main/java/de/danoeh/antennapod/actionbutton/DownloadActionButton.java
@@ -61,7 +61,8 @@ public class DownloadActionButton extends ItemActionButton {
                     TIMEOUT_NETWORK_WARN_SECONDS / 60, TIMEOUT_NETWORK_WARN_SECONDS / 60), Toast.LENGTH_LONG).show();
         }
         if (NetworkUtils.isEpisodeDownloadAllowed() || shouldBypass) {
-            DownloadServiceInterface.get().downloadNow(context, item, bypassCellularNetworkType == BYPASS_TYPE_NOW);
+            DownloadServiceInterface.get().downloadNow(context, item,
+                    bypassCellularNetworkType == BYPASS_TYPE_NOW, false);
         } else {
             MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context)
                     .setTitle(R.string.confirm_mobile_download_dialog_title)
@@ -69,13 +70,13 @@ public class DownloadActionButton extends ItemActionButton {
                             (d, w) -> {
                                 bypassCellularNetworkType = BYPASS_TYPE_LATER;
                                 bypassCellularNetworkWarningTimer = System.currentTimeMillis() / 1000;
-                                DownloadServiceInterface.get().downloadNow(context, item, false);
+                                DownloadServiceInterface.get().downloadNow(context, item, false, false);
                             })
                     .setNeutralButton(R.string.confirm_mobile_download_dialog_allow_this_time,
                             (d, w) -> {
                                 bypassCellularNetworkType = BYPASS_TYPE_NOW;
                                 bypassCellularNetworkWarningTimer = System.currentTimeMillis() / 1000;
-                                DownloadServiceInterface.get().downloadNow(context, item, true);
+                                DownloadServiceInterface.get().downloadNow(context, item, true, false);
                             })
                     .setNegativeButton(R.string.cancel_label, null);
             if (NetworkUtils.isNetworkRestricted() && NetworkUtils.isVpnOverWifi()) {

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -44,6 +44,7 @@ import de.danoeh.antennapod.event.FeedUpdateRunningEvent;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.StreamingConfirmationEvent;
 import de.danoeh.antennapod.model.download.DownloadStatus;
+import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.download.service.feed.FeedUpdateManagerImpl;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
@@ -52,8 +53,10 @@ import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
 import de.danoeh.antennapod.playback.cast.CastEnabledActivity;
 import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.playback.service.PlaybackServiceInterface;
+import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.databasemaintenanceservice.DatabaseMaintenanceWorker;
 import de.danoeh.antennapod.storage.importexport.AutomaticDatabaseExportWorker;
+import de.danoeh.antennapod.storage.importexport.StaleDownloadMarkers;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.TransitionEffect;
@@ -86,12 +89,17 @@ import de.danoeh.antennapod.ui.screen.subscriptions.SubscriptionFragment;
 import de.danoeh.antennapod.ui.statistics.StatisticsFragment;
 import de.danoeh.antennapod.ui.view.BottomSheetBackPressedCallback;
 import de.danoeh.antennapod.ui.view.LockableBottomSheetBehavior;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.apache.commons.lang3.ArrayUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -732,6 +740,52 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
                 .show();
     }
 
+    private void checkMissingFilesAfterImport() {
+        Single.fromCallable(() -> {
+            StaleDownloadMarkers.clearStaleDownloadsFromUnsubscribedFeeds();
+            return StaleDownloadMarkers.findMissingMediaIds();
+        })
+                .subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::showMissingFilesDialog,
+                        error -> Log.e(TAG, Log.getStackTraceString(error)));
+    }
+
+    private void showMissingFilesDialog(List<Long> missingMediaIds) {
+        if (missingMediaIds.isEmpty()) {
+            return;
+        }
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this);
+        builder.setTitle(getResources().getQuantityString(R.plurals.import_missing_files_title,
+                missingMediaIds.size(), missingMediaIds.size()));
+        builder.setMessage(getString(R.string.import_missing_files_message));
+        builder.setCancelable(false);
+        builder.setPositiveButton(R.string.import_redownload_label, (dialog, which) ->
+                redownloadItems(missingMediaIds));
+        builder.setNegativeButton(R.string.import_ignore_label, (dialog, which) ->
+                clearDownloadStateForItems(missingMediaIds));
+        builder.show();
+    }
+
+    private void redownloadItems(List<Long> mediaIds) {
+        Completable.fromAction(() -> {
+            for (Long mediaId : mediaIds) {
+                FeedMedia media = DBReader.getFeedMedia(mediaId);
+                if (media != null && media.getItem() != null) {
+                    DownloadServiceInterface.get().download(this, media.getItem(), true);
+                }
+            }
+        })
+                .subscribeOn(Schedulers.computation())
+                .subscribe(() -> { }, error -> Log.e(TAG, Log.getStackTraceString(error)));
+    }
+
+    private void clearDownloadStateForItems(List<Long> mediaIds) {
+        Completable.fromAction(() -> StaleDownloadMarkers.clearDownloadStateForItems(mediaIds))
+                .subscribeOn(Schedulers.computation())
+                .subscribe(() -> { }, error -> Log.e(TAG, Log.getStackTraceString(error)));
+    }
+
     private void handleNavIntent() {
         Log.d(TAG, "handleNavIntent()");
         Intent intent = getIntent();
@@ -776,6 +830,9 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
         }
         if (intent.getBooleanExtra(MainActivityStarter.EXTRA_OPEN_DOWNLOAD_LOGS, false)) {
             new DownloadLogFragment().show(getSupportFragmentManager(), DownloadLogFragment.TAG);
+        }
+        if (intent.getBooleanExtra(MainActivityStarter.EXTRA_CHECK_MISSING_FILES_AFTER_IMPORT, false)) {
+            checkMissingFilesAfterImport();
         }
         if (intent.getBooleanExtra(EXTRA_REFRESH_ON_START, false)) {
             FeedUpdateManager.getInstance().runOnceOrAsk(this);

--- a/app/src/main/java/de/danoeh/antennapod/activity/SplashActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/SplashActivity.java
@@ -36,6 +36,7 @@ public class SplashActivity extends Activity {
                 .subscribe(
                     () -> {
                         Intent intent = new Intent(SplashActivity.this, MainActivity.class);
+                        intent.putExtras(getIntent());
                         startActivity(intent);
                         overridePendingTransition(0, 0);
                         finish();

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -142,7 +142,7 @@ public class EpisodeMultiSelectActionHandler {
         int downloaded = 0;
         for (FeedItem episode : items) {
             if (episode.hasMedia() && !episode.isDownloaded()) {
-                DownloadServiceInterface.get().download(activity, episode);
+                DownloadServiceInterface.get().download(activity, episode, false);
                 downloaded++;
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
@@ -37,6 +37,7 @@ import de.danoeh.antennapod.storage.importexport.FavoritesWriter;
 import de.danoeh.antennapod.storage.importexport.HtmlWriter;
 import de.danoeh.antennapod.storage.importexport.OpmlWriter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
@@ -390,7 +391,10 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
     private void forceRestart() {
         PackageManager pm = getContext().getPackageManager();
         Intent intent = pm.getLaunchIntentForPackage(getContext().getPackageName());
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.putExtra(MainActivityStarter.EXTRA_CHECK_MISSING_FILES_AFTER_IMPORT, true);
+        // CLEAR_TASK is required: without it, AMS routes this launcher intent to the existing
+        // task and discards our extras, so the missing-files dialog never appears after restart.
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         getContext().getApplicationContext().startActivity(intent);
         Runtime.getRuntime().exit(0);
     }

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterface.java
@@ -31,13 +31,22 @@ public abstract class DownloadServiceInterface {
 
     /**
      * Download immediately after user action.
+     *
+     * @param skipQueue if true, the item is not added to the playback queue even when
+     *                  {@code UserPreferences.enqueueDownloadedEpisodes()} would normally do so.
+     *                  Use this for post-import re-downloads that should not modify the user's queue.
      */
-    public abstract void downloadNow(Context context, FeedItem item, boolean ignoreConstraints);
+    public abstract void downloadNow(Context context, FeedItem item,
+                                     boolean ignoreConstraints, boolean skipQueue);
 
     /**
      * Download when device seems fit.
+     *
+     * @param skipQueue if true, the item is not added to the playback queue even when
+     *                  {@code UserPreferences.enqueueDownloadedEpisodes()} would normally do so.
+     *                  Use this for post-import re-downloads that should not modify the user's queue.
      */
-    public abstract void download(Context context, FeedItem item);
+    public abstract void download(Context context, FeedItem item, boolean skipQueue);
 
     public abstract void cancel(Context context, FeedMedia media);
 

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterfaceStub.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/DownloadServiceInterfaceStub.java
@@ -7,11 +7,11 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 public class DownloadServiceInterfaceStub extends DownloadServiceInterface {
 
     @Override
-    public void downloadNow(Context context, FeedItem item, boolean ignoreConstraints) {
+    public void downloadNow(Context context, FeedItem item, boolean ignoreConstraints, boolean skipQueue) {
     }
 
     @Override
-    public void download(Context context, FeedItem item) {
+    public void download(Context context, FeedItem item, boolean skipQueue) {
     }
 
     @Override

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
@@ -104,7 +104,7 @@ public class AutomaticDownloadAlgorithm {
                     Log.d(TAG, "Enqueueing " + itemsToDownload.size() + " items for download");
 
                     for (FeedItem episode : itemsToDownload) {
-                        DownloadServiceInterface.get().download(context, episode);
+                        DownloadServiceInterface.get().download(context, episode, false);
                     }
                 }
             }

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/DownloadServiceInterfaceImpl.java
@@ -24,8 +24,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
-    public void downloadNow(Context context, FeedItem item, boolean ignoreConstraints) {
-        OneTimeWorkRequest.Builder workRequest = getRequest(context, item);
+    public void downloadNow(Context context, FeedItem item, boolean ignoreConstraints, boolean skipQueue) {
+        OneTimeWorkRequest.Builder workRequest = getRequest(context, item, skipQueue);
         workRequest.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST);
         if (ignoreConstraints) {
             workRequest.setConstraints(new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build());
@@ -36,22 +36,22 @@ public class DownloadServiceInterfaceImpl extends DownloadServiceInterface {
                 ExistingWorkPolicy.KEEP, workRequest.build());
     }
 
-    public void download(Context context, FeedItem item) {
+    public void download(Context context, FeedItem item, boolean skipQueue) {
         if (item.isDownloaded()) {
             return;
         }
-        OneTimeWorkRequest.Builder workRequest = getRequest(context, item);
+        OneTimeWorkRequest.Builder workRequest = getRequest(context, item, skipQueue);
         workRequest.setConstraints(getConstraints());
         WorkManager.getInstance(context).enqueueUniqueWork(item.getMedia().getDownloadUrl(),
                 ExistingWorkPolicy.KEEP, workRequest.build());
     }
 
-    private static OneTimeWorkRequest.Builder getRequest(Context context, FeedItem item) {
+    private static OneTimeWorkRequest.Builder getRequest(Context context, FeedItem item, boolean skipQueue) {
         OneTimeWorkRequest.Builder workRequest = new OneTimeWorkRequest.Builder(EpisodeDownloadWorker.class)
                 .setInitialDelay(0L, TimeUnit.MILLISECONDS)
                 .addTag(DownloadServiceInterface.WORK_TAG)
                 .addTag(DownloadServiceInterface.WORK_TAG_EPISODE_URL + item.getMedia().getDownloadUrl());
-        if (!item.isTagged(FeedItem.TAG_QUEUE) && UserPreferences.enqueueDownloadedEpisodes()) {
+        if (!skipQueue && !item.isTagged(FeedItem.TAG_QUEUE) && UserPreferences.enqueueDownloadedEpisodes()) {
             DBWriter.addQueueItem(context, item);
             workRequest.addTag(DownloadServiceInterface.WORK_DATA_WAS_QUEUED);
         }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -24,6 +24,7 @@ import de.danoeh.antennapod.model.feed.FeedFunding;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -579,6 +580,31 @@ public class PodDBAdapter {
                     new String[]{String.valueOf(media.getId())});
         } else {
             Log.e(TAG, "setMediaDownloadInformation: ID of media was 0");
+        }
+    }
+
+    /**
+     * Clears the local file URL and sets the download date for every FeedMedia row whose ID is in
+     * the given list, in a single SQL UPDATE. Used for bulk reconciliation of stale download
+     * markers (post-import cleanup, etc.).
+     */
+    public void setDownloadStateForMediaIds(List<Long> mediaIds, long downloadDate) {
+        if (mediaIds.isEmpty()) {
+            return;
+        }
+        ContentValues values = new ContentValues();
+        values.putNull(KEY_FILE_URL);
+        values.put(KEY_DOWNLOAD_DATE, downloadDate);
+        // SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999; chunk well below that.
+        final int chunkSize = 500;
+        for (int start = 0; start < mediaIds.size(); start += chunkSize) {
+            List<Long> chunk = mediaIds.subList(start, Math.min(start + chunkSize, mediaIds.size()));
+            String placeholders = TextUtils.join(",", Collections.nCopies(chunk.size(), "?"));
+            String[] args = new String[chunk.size()];
+            for (int i = 0; i < chunk.size(); i++) {
+                args[i] = String.valueOf(chunk.get(i));
+            }
+            db.update(TABLE_NAME_FEED_MEDIA, values, KEY_ID + " IN (" + placeholders + ")", args);
         }
     }
 

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/StaleDownloadMarkers.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/StaleDownloadMarkers.java
@@ -1,0 +1,66 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import de.danoeh.antennapod.model.feed.SortOrder;
+import de.danoeh.antennapod.storage.database.DBReader;
+import de.danoeh.antennapod.storage.database.PodDBAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helpers for detecting and clearing stale download markers: episodes the database thinks are
+ * downloaded but whose files are missing from disk. Typically used after a database import.
+ */
+public class StaleDownloadMarkers {
+
+    private StaleDownloadMarkers() {
+    }
+
+    public static List<Long> findMissingMediaIds() {
+        List<FeedItem> downloadedItems = DBReader.getEpisodes(0, Integer.MAX_VALUE,
+                new FeedItemFilter(FeedItemFilter.DOWNLOADED), SortOrder.DATE_NEW_OLD);
+        List<Long> missingIds = new ArrayList<>();
+        for (FeedItem item : downloadedItems) {
+            if (item.getMedia() != null && !item.getMedia().fileExists()) {
+                missingIds.add(item.getMedia().getId());
+            }
+        }
+        return missingIds;
+    }
+
+    /**
+     * Reconcile download markers for episodes whose feed is not subscribed (i.e. removed or
+     * archived) and whose file is missing on disk. We don't want to re-download  these,
+     * so we silently clear the marker. We leave items alone if the file still exists.
+     */
+    public static void clearStaleDownloadsFromUnsubscribedFeeds() {
+        List<FeedItem> downloadedItems = DBReader.getEpisodes(0, Integer.MAX_VALUE,
+                new FeedItemFilter(FeedItemFilter.DOWNLOADED, FeedItemFilter.INCLUDE_NOT_SUBSCRIBED),
+                SortOrder.DATE_NEW_OLD);
+        List<Long> missingIds = new ArrayList<>();
+        for (FeedItem item : downloadedItems) {
+            if (item.getFeed() == null || item.getFeed().getState() == Feed.STATE_SUBSCRIBED) {
+                continue;
+            }
+            if (item.getMedia() != null && !item.getMedia().fileExists()) {
+                missingIds.add(item.getMedia().getId());
+            }
+        }
+        if (!missingIds.isEmpty()) {
+            clearDownloadStateForItems(missingIds);
+        }
+    }
+
+    public static void clearDownloadStateForItems(List<Long> mediaIds) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        try {
+            adapter.setDownloadStateForMediaIds(mediaIds, 0);
+        } finally {
+            adapter.close();
+        }
+    }
+}

--- a/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MainActivityStarter.java
+++ b/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MainActivityStarter.java
@@ -19,6 +19,7 @@ public class MainActivityStarter {
     public static final String EXTRA_OPEN_DRAWER = "open_drawer";
     public static final String EXTRA_OPEN_DOWNLOAD_LOGS = "open_download_logs";
     public static final String EXTRA_FRAGMENT_ARGS = "fragment_args";
+    public static final String EXTRA_CHECK_MISSING_FILES_AFTER_IMPORT = "check_missing_files_after_import";
 
     private final Intent intent;
     private final Context context;

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -684,6 +684,13 @@
     <string name="import_ok">Please press OK to restart AntennaPod</string>
     <string name="import_no_downgrade">This database was exported with a newer version of AntennaPod. Your current installation does not yet know how to handle this file.</string>
     <string name="import_error_label">Import error</string>
+    <plurals name="import_missing_files_title">
+        <item quantity="one">%1$d episode missing after import</item>
+        <item quantity="other">%1$d episodes missing after import</item>
+    </plurals>
+    <string name="import_missing_files_message">These episodes are marked as downloaded, but their files were not found on this device.</string>
+    <string name="import_ignore_label">Ignore</string>
+    <string name="import_redownload_label">Re-download</string>
     <string name="favorites_export_label">Favorites export</string>
     <string name="favorites_export_summary">Export saved favorites to file</string>
 


### PR DESCRIPTION
### Description

The database holds information about what episodes have been downloaded.  After a database import (for instance, on a new phone), that information is out-of-date. This change offers to update it by marking as not-downloaded any episodes that don't currently exist on disk.

This doesn't precisely fix #3037, because what users actually want is to re-download the episodes. That'll come next.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
