### PR TITLE
Animate subscription selection

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/subscriptions/SubscriptionsRecyclerAdapter.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.ui.screen.subscriptions;
 
+import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
@@ -94,14 +95,7 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
                 holder.gradient.setVisibility(View.GONE);
             }
         }
-        if (holder.selectIcon != null) {
-            FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) holder.card.getLayoutParams();
-            params.leftMargin = cardMargin;
-            params.topMargin = cardMargin;
-            params.rightMargin = cardMargin;
-            params.bottomMargin = cardMargin;
-            holder.card.setLayoutParams(params);
-        }
+        animateCardMargin(holder, cardMargin);
 
         holder.itemView.setOnLongClickListener(v -> {
             if (!inActionMode()) {
@@ -118,6 +112,52 @@ public class SubscriptionsRecyclerAdapter extends SelectableAdapter<Subscription
                 mainActivityRef.get().loadChildFragment(fragment);
             }
         });
+    }
+
+    @Override
+    protected void toggleSelection(int pos) {
+        setSelected(pos, !isSelected(pos));
+        notifyItemChanged(pos, Boolean.TRUE);
+        if (getSelectedCount() == 0) {
+            endSelectMode();
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull SubscriptionViewHolder holder, int position,
+                                 @NonNull List<Object> payloads) {
+        if (payloads.isEmpty() || holder.selectIcon == null) {
+            super.onBindViewHolder(holder, position, payloads);
+            return;
+        }
+        holder.itemView.setSelected(isSelected(position));
+        holder.selectIcon.setImageResource(isSelected(position)
+                ? R.drawable.circle_checked : R.drawable.circle_unchecked);
+        int targetMargin = isSelected(position)
+                ? (int) convertDpToPixel(holder.itemView.getContext(), 12f) : 0;
+        animateCardMargin(holder, targetMargin);
+    }
+
+    private void animateCardMargin(@NonNull SubscriptionViewHolder holder, int targetMargin) {
+        if (holder.selectIcon == null) {
+            return;
+        }
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) holder.card.getLayoutParams();
+        int startMargin = params.leftMargin;
+        if (startMargin == targetMargin) {
+            return;
+        }
+        ValueAnimator animator = ValueAnimator.ofInt(startMargin, targetMargin);
+        animator.setDuration(100);
+        animator.addUpdateListener(a -> {
+            int margin = (int) a.getAnimatedValue();
+            params.leftMargin = margin;
+            params.topMargin = margin;
+            params.rightMargin = margin;
+            params.bottomMargin = margin;
+            holder.card.setLayoutParams(params);
+        });
+        animator.start();
     }
 
     @Override

--- a/app/src/main/java/de/danoeh/antennapod/ui/view/FloatingSelectMenu.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/view/FloatingSelectMenu.java
@@ -80,11 +80,19 @@ public class FloatingSelectMenu extends FrameLayout {
 
     @Override
     public void setVisibility(int visibility) {
-        if (getVisibility() != View.VISIBLE && visibility == View.VISIBLE) {
+        if (visibility == View.VISIBLE && getVisibility() != View.VISIBLE) {
             announceForAccessibility(getContext().getString(R.string.multi_select_started_talkback));
+            viewBinding.scrollView.scrollTo(0, 0);
+            updateItemVisibility();
+            setAlpha(0f);
+            super.setVisibility(View.VISIBLE);
+            animate().alpha(1f).setDuration(100).start();
+        } else if (visibility != View.VISIBLE && getVisibility() == View.VISIBLE && isAttachedToWindow()) {
+            animate().alpha(0f).setDuration(100).withEndAction(() -> super.setVisibility(visibility)).start();
+        } else {
+            super.setVisibility(visibility);
+            viewBinding.scrollView.scrollTo(0, 0);
+            updateItemVisibility();
         }
-        super.setVisibility(visibility);
-        viewBinding.scrollView.scrollTo(0, 0);
-        updateItemVisibility();
     }
 }


### PR DESCRIPTION
### Description

Animate subscription selection. Instead of jumping to the larger margin, animate to it. Feels much more natural

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
