### PR TITLE
Shorten queue subtitle

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -497,24 +497,20 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
     }
 
     private void refreshInfoBar() {
-        String info = getResources().getQuantityString(R.plurals.num_episodes, queue.size(), queue.size());
-        if (!queue.isEmpty()) {
-            long timeLeft = 0;
-            for (FeedItem item : queue) {
-                float playbackSpeed = 1;
-                if (UserPreferences.timeRespectsSpeed()) {
-                    playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(item.getMedia());
-                }
-                if (item.getMedia() != null) {
-                    long itemTimeLeft = item.getMedia().getDuration() - item.getMedia().getPosition();
-                    timeLeft += (long) (itemTimeLeft / playbackSpeed);
-                }
+        long timeLeft = 0;
+        for (FeedItem item : queue) {
+            float playbackSpeed = 1;
+            if (UserPreferences.timeRespectsSpeed()) {
+                playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(item.getMedia());
             }
-            info += " • ";
-            info += getString(R.string.time_left_label);
-            info += Converter.getDurationStringLocalized(getResources(), timeLeft, false);
+            if (item.getMedia() != null) {
+                long itemTimeLeft = item.getMedia().getDuration() - item.getMedia().getPosition();
+                timeLeft += (long) (itemTimeLeft / playbackSpeed);
+            }
         }
-        infoBar.setText(info);
+        String episodes = getResources().getQuantityString(R.plurals.num_episodes, queue.size(), queue.size());
+        String time = Converter.getDurationStringLocalized(getResources(), timeLeft, false);
+        infoBar.setText(getString(R.string.queue_time_left_label, episodes, time));
 
         if (recyclerAdapter.inActionMode()) {
             infoBar.setVisibility(View.INVISIBLE);

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -419,7 +419,7 @@
     <string name="smart_shuffle">Smart shuffle</string>
     <string name="size">Size</string>
     <string name="clear_queue_confirmation_msg">Please confirm that you want to remove ALL episodes from the queue.</string>
-    <string name="time_left_label">Time left:\u0020</string>
+    <string name="queue_time_left_label">%1$s • %2$s left</string>
 
     <!--  Variable Speed -->
     <string name="speed_presets">Presets</string>


### PR DESCRIPTION
### Description

Shorten queue subtitle. In German, it sometimes broke to two lines, which looked super messy

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
