### PR TITLE
Remove 'pause on focus loss' setting

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/ui/PreferencesTest.java
@@ -216,18 +216,6 @@ public class PreferencesTest {
     }
 
     @Test
-    public void testPauseForInterruptions() {
-        clickPreference(R.string.playback_pref);
-        final boolean pauseForFocusLoss = UserPreferences.shouldPauseForFocusLoss();
-        clickPreference(R.string.pref_pausePlaybackForFocusLoss_title);
-        Awaitility.await().atMost(1000, MILLISECONDS)
-                .until(() -> pauseForFocusLoss != UserPreferences.shouldPauseForFocusLoss());
-        clickPreference(R.string.pref_pausePlaybackForFocusLoss_title);
-        Awaitility.await().atMost(1000, MILLISECONDS)
-                .until(() -> pauseForFocusLoss == UserPreferences.shouldPauseForFocusLoss());
-    }
-
-    @Test
     public void testSetEpisodeCache() {
         String[] entries = res.getStringArray(R.array.episode_cache_size_entries);
         String[] values = res.getStringArray(R.array.episode_cache_size_values);

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -782,8 +782,6 @@
     <string name="choose_data_directory">Choose data folder</string>
     <string name="choose_data_directory_message">Please choose the base of your data folder. AntennaPod will create the appropriate subdirectories.</string>
     <string name="choose_data_directory_available_space">%1$s of %2$s free</string>
-    <string name="pref_pausePlaybackForFocusLoss_sum">Pause playback instead of lowering volume when another app wants to play sounds</string>
-    <string name="pref_pausePlaybackForFocusLoss_title">Pause for interruptions</string>
 
     <!-- Rating dialog -->
     <string name="rating_tagline">Since %1$s, you played %2$s%3$d%4$s hours of podcasts.</string>

--- a/ui/preferences/src/main/res/xml/preferences_playback.xml
+++ b/ui/preferences/src/main/res/xml/preferences_playback.xml
@@ -25,12 +25,6 @@
                 android:summary="@string/pref_unpauseOnBluetoothReconnect_sum"
                 android:title="@string/pref_unpauseOnBluetoothReconnect_title"
                 search:ignore="true" />
-        <SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:enabled="true"
-                android:key="prefPauseForFocusLoss"
-                android:summary="@string/pref_pausePlaybackForFocusLoss_sum"
-                android:title="@string/pref_pausePlaybackForFocusLoss_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/playback_control">


### PR DESCRIPTION
### Description

Remove 'pause on focus loss' setting. The setting is non-functional with the new playback service, which always pauses (and never ducks) when on media type speech. This aligns with the Android system defaults and media3 behavior.

Closes #8390

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
