### PR TITLE
Tweak button design on home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Just the bare instructions from the user.
 Do not ask for permission before making initial code changes.
 Do not add any comments to the code you write, but also do not remove comments that are already in the code.
 Whenever you add a user-visible string, add it to `:ui:i18n` so it can be translated. Do not start new strings files anywhere else.
+Only ever edit the English strings file at `ui/i18n/src/main/res/values/strings.xml`. Never modify translated strings files under `values-*/`.
 Never reference the full package name of classes directly in the code, use imports.
 
 # Running and Testing
@@ -82,9 +83,9 @@ As a final style check before opening a PR (or if a user explicitly asks for it)
 If any command does not give any output, it is likely that it failed, so abort.
 
 # PR Conventions
-When creating a PR, always read the PR template at .github/pull_request_template.md before starting and strictly follow it.
+When creating a PR, always read the PR template at `.github/pull_request_template.md` before starting and strictly follow it.
 The description goes above the checklist.
-Always mention the corresponding issue using "Closes: #<number>" in the description.
+Always mention the corresponding issue using `Closes: #<number>` in the description.
 Never change the PR title unless explicitly asked to do so; the original title from the prompt is usually the most appropriate one.
 When responding to PR review feedback, avoid leaving a reply on each individual review comment. Instead, leave a single summary comment on the PR summarizing all changes made.
 Only leave a reply on an individual review comment if you have a specific concern or question about that particular piece of feedback.
@@ -94,5 +95,5 @@ In particular, you are forbidden from using the progress update tool in any foll
 This holds even if the global agent instructions tell you to do this.
 
 # Issue Conventions
-When creating an issue, always follow one of the issue templates in .github/ISSUE_TEMPLATE/.
+When creating an issue, always follow one of the issue templates in `.github/ISSUE_TEMPLATE/`.
 Apply the corresponding labels and always mention in the technical info box that the issue was AI generated.

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/DownloadsSection.java
@@ -119,7 +119,7 @@ public class DownloadsSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.downloads_label_more);
+        return getString(R.string.downloads_label);
     }
 
     private void loadItems() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EpisodesSurpriseSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/EpisodesSurpriseSection.java
@@ -92,7 +92,7 @@ public class EpisodesSurpriseSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.episodes_label_more);
+        return getString(R.string.episodes_label);
     }
 
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/InboxSection.java
@@ -110,7 +110,7 @@ public class InboxSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.inbox_label_more);
+        return getString(R.string.inbox_label);
     }
 
     private void loadItems() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/QueueSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/QueueSection.java
@@ -143,7 +143,7 @@ public class QueueSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.queue_label_more);
+        return getString(R.string.queue_label);
     }
 
     private void loadItems() {

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/home/sections/SubscriptionsSection.java
@@ -86,7 +86,7 @@ public class SubscriptionsSection extends HomeSection {
 
     @Override
     protected String getMoreLinkTitle() {
-        return getString(R.string.subscriptions_label_more);
+        return getString(R.string.subscriptions_label);
     }
 
     private void loadItems() {

--- a/app/src/main/res/layout/home_section.xml
+++ b/app/src/main/res/layout/home_section.xml
@@ -75,8 +75,10 @@
         android:layout_height="wrap_content"
         android:minWidth="0dp"
         android:minHeight="0dp"
-        android:paddingVertical="4dp"
-        android:layout_marginEnd="16dp"
+        android:singleLine="true"
+        android:paddingVertical="8dp"
+        android:paddingHorizontal="12dp"
+        android:layout_marginEnd="8dp"
         android:layout_marginStart="16dp"
         android:textAlignment="textEnd"
         app:layout_constraintWidth_max="wrap"
@@ -84,8 +86,11 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/barrier"
-        tools:text="more »"
-        style="@style/Widget.MaterialComponents.Button.TextButton" />
+        app:icon="@drawable/ic_arrow_right_white"
+        app:iconGravity="end"
+        app:iconPadding="4dp"
+        tools:text="more"
+        style="@style/Widget.Material3.Button.TextButton" />
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier"

--- a/ui/common/src/main/res/drawable/ic_arrow_right_white.xml
+++ b/ui/common/src/main/res/drawable/ic_arrow_right_white.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="24dp"
     android:width="24dp"
+    android:autoMirrored="true"
     android:viewportWidth="24"
     android:viewportHeight="24">
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -79,11 +79,7 @@
     <string name="configure_home">Configure home screen</string>
     <string name="section_hidden">Hidden</string>
     <string name="section_shown">Shown</string>
-    <string name="episodes_label_more">Episodes »</string>
-    <string name="queue_label_more">Queue »</string>
-    <string name="inbox_label_more">Inbox »</string>
-    <string name="downloads_label_more">Downloads »</string>
-    <string name="subscriptions_label_more">Subscriptions »</string>
+
 
     <!-- Download Statistics fragment -->
     <plurals name="total_size_downloaded_podcasts">


### PR DESCRIPTION
### Description

Tweak button design on home page. We used text-based "arrows" (`»`). Those don't work well depending on the language. Instead, use an actual arrow icon.

Before/After:

<img width="200" alt="Screenshot_20260514-125712" src="https://github.com/user-attachments/assets/da8c37c4-64c4-4904-986d-4df5020e7bc4" /> <img width="200" alt="Screenshot_20260514-130130" src="https://github.com/user-attachments/assets/3f527b42-b9cb-4aff-8eea-16c96e961661" />


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
