### PR TITLE
More 'expressive' item backgrounds

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListAdapter.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemListAdapter.java
@@ -15,7 +15,6 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
 
 import de.danoeh.antennapod.ui.SelectableAdapter;
-import de.danoeh.antennapod.ui.common.ThemeUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -121,14 +120,11 @@ public class EpisodeItemListAdapter extends SelectableAdapter<EpisodeItemViewHol
 
         holder.itemView.setSelected(false);
         if (inActionMode()) {
+            holder.itemView.setActivated(false);
             holder.secondaryActionButton.setOnClickListener(
                     v -> toggleSelection(holder.getBindingAdapterPosition()));
             if (isSelected(pos)) {
                 holder.itemView.setSelected(true);
-                holder.itemView.setBackgroundColor(0x88000000
-                        + (0xffffff & ThemeUtils.getColorFromAttr(mainActivityRef.get(), R.attr.colorAccent)));
-            } else {
-                holder.itemView.setBackgroundResource(android.R.color.transparent);
             }
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeItemViewHolder.java
@@ -14,7 +14,6 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.android.material.elevation.SurfaceColors;
 
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.model.feed.Feed;
@@ -32,7 +31,6 @@ import de.danoeh.antennapod.ui.common.Converter;
 import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.ui.common.CircularProgressBar;
-import de.danoeh.antennapod.ui.common.ThemeUtils;
 import de.danoeh.antennapod.ui.episodes.ImageResourceUtils;
 
 /**
@@ -41,7 +39,7 @@ import de.danoeh.antennapod.ui.episodes.ImageResourceUtils;
 public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
     private static final String TAG = "EpisodeItemViewHolder";
 
-    private final View container;
+    public final View container;
     public final ImageView dragHandle;
     public final TextView placeholder;
     public final ImageView cover;
@@ -121,7 +119,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
             progressBar.setVisibility(View.GONE);
             duration.setVisibility(View.GONE);
             position.setVisibility(View.GONE);
-            itemView.setBackgroundResource(ThemeUtils.getDrawableFromAttr(activity, R.attr.selectableItemBackground));
+            itemView.setActivated(false);
         }
 
         if (coverHolder.getVisibility() == View.VISIBLE) {
@@ -138,12 +136,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
         isVideo.setVisibility(media.getMediaType() == MediaType.VIDEO ? View.VISIBLE : View.GONE);
         duration.setVisibility(media.getDuration() > 0 ? View.VISIBLE : View.GONE);
 
-        if (PlaybackStatus.isCurrentlyPlaying(media)) {
-            float density = activity.getResources().getDisplayMetrics().density;
-            itemView.setBackgroundColor(SurfaceColors.getColorForElevation(activity, 8 * density));
-        } else {
-            itemView.setBackgroundResource(ThemeUtils.getDrawableFromAttr(activity, R.attr.selectableItemBackground));
-        }
+        itemView.setActivated(PlaybackStatus.isCurrentlyPlaying(media));
 
         if (DownloadServiceInterface.get().isDownloadingEpisode(media.getDownloadUrl())) {
             float percent = 0.01f * DownloadServiceInterface.get().getProgress(media.getDownloadUrl());
@@ -218,7 +211,7 @@ public class EpisodeItemViewHolder extends RecyclerView.ViewHolder {
         position.setVisibility(View.GONE);
         dragHandle.setVisibility(View.GONE);
         size.setText("");
-        itemView.setBackgroundResource(ThemeUtils.getDrawableFromAttr(activity, R.attr.selectableItemBackground));
+        itemView.setActivated(false);
         placeholder.setText("");
         if (coverHolder.getVisibility() == View.VISIBLE) {
             new CoverLoader()

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/HorizontalItemViewHolder.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/HorizontalItemViewHolder.java
@@ -74,7 +74,7 @@ public class HorizontalItemViewHolder extends RecyclerView.ViewHolder {
             setProgressBar(false, 0);
         } else {
             if (PlaybackStatus.isCurrentlyPlaying(media)) {
-                card.setCardBackgroundColor(ThemeUtils.getColorFromAttr(activity, R.attr.colorSurfaceVariant));
+                card.setCardBackgroundColor(ThemeUtils.getColorFromAttr(activity, R.attr.colorSecondaryContainer));
             }
 
             if (item.getMedia().getDuration() > 0 && item.getMedia().getPosition() > 0) {

--- a/app/src/main/res/drawable/bg_episode_list_item.xml
+++ b/app/src/main/res/drawable/bg_episode_list_item.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="8dp"
+    android:insetRight="8dp"
+    android:insetTop="2dp"
+    android:insetBottom="2dp">
+    <ripple android:color="?attr/colorControlHighlight">
+        <item android:id="@android:id/mask">
+            <shape android:shape="rectangle">
+                <solid android:color="@android:color/black"/>
+                <corners android:radius="12dp"/>
+            </shape>
+        </item>
+        <item>
+            <selector>
+                <item android:state_activated="true">
+                    <shape android:shape="rectangle">
+                        <solid android:color="?attr/colorSecondaryContainer"/>
+                        <corners android:radius="12dp"/>
+                    </shape>
+                </item>
+                <item android:state_selected="true">
+                    <shape android:shape="rectangle">
+                        <solid android:color="?attr/colorSecondaryContainer"/>
+                        <corners android:radius="12dp"/>
+                    </shape>
+                </item>
+                <item android:drawable="@android:color/transparent"/>
+            </selector>
+        </item>
+    </ripple>
+</inset>

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -109,7 +109,7 @@
             android:layout_marginRight="16dp"
             android:layout_alignParentBottom="true"
             app:cardBackgroundColor="@color/non_square_icon_background"
-            app:cardCornerRadius="8dp"
+            app:cardCornerRadius="16dp"
             app:cardPreventCornerOverlap="false"
             app:cardElevation="0dp">
 

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -20,6 +20,8 @@
         android:baselineAligned="false"
         android:paddingStart="12dp"
         android:paddingEnd="0dp"
+        android:background="@drawable/bg_episode_list_item"
+        android:duplicateParentState="true"
         tools:ignore="UselessParent">
 
         <LinearLayout
@@ -48,7 +50,7 @@
             android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
             android:layout_marginEnd="@dimen/listitem_threeline_textleftpadding"
             app:cardBackgroundColor="@color/non_square_icon_background"
-            app:cardCornerRadius="4dp"
+            app:cardCornerRadius="8dp"
             app:cardPreventCornerOverlap="false"
             app:cardElevation="0dp">
 

--- a/app/src/main/res/layout/horizontal_itemlist_item.xml
+++ b/app/src/main/res/layout/horizontal_itemlist_item.xml
@@ -17,7 +17,7 @@
         android:layout_margin="4dp"
         app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardCornerRadius="12dp"
-        app:cardElevation="1dp">
+        app:cardElevation="0dp">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/ui/common/src/main/res/values/colors.xml
+++ b/ui/common/src/main/res/values/colors.xml
@@ -22,8 +22,8 @@
     <color name="text_color_secondary_dark">#cccccc</color>
     <color name="color_surface_variant_light">#D3DCE0</color>
     <color name="color_surface_variant_dark">#2F3B4F</color>
-    <color name="color_secondary_container_light">#A5B8C0</color>
-    <color name="color_secondary_container_dark">#4D5F80</color>
+    <color name="color_secondary_container_light">#C8D8DE</color>
+    <color name="color_secondary_container_dark">#3C4E68</color>
 
     <color name="accent_light">#0078C2</color>
     <color name="accent_dark">#3D8BFF</color>

--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -10,6 +10,7 @@
     </style>
 
     <style name="Theme.Base.AntennaPod.Dynamic.Light" parent="Theme.Material3.DynamicColors.Light">
+        <item name="linearProgressIndicatorStyle">@style/Widget.AntennaPod.LinearProgressIndicator</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="background_color">@color/background_light</item>
@@ -68,6 +69,7 @@
     </style>
 
     <style name="Theme.Base.AntennaPod.Dynamic.Dark" parent="Theme.Material3.DynamicColors.Dark">
+        <item name="linearProgressIndicatorStyle">@style/Widget.AntennaPod.LinearProgressIndicator</item>
         <item name="background_color">@color/background_darktheme</item>
         <item name="background_elevated">@color/background_elevated_darktheme</item>
         <item name="action_icon_color">@color/white</item>
@@ -314,6 +316,10 @@
         <item name="fastScrollHorizontalTrackDrawable">@drawable/scrollbar_track</item>
         <item name="fastScrollVerticalThumbDrawable">?attr/scrollbar_thumb</item>
         <item name="fastScrollVerticalTrackDrawable">@drawable/scrollbar_track</item>
+    </style>
+
+    <style name="Widget.AntennaPod.LinearProgressIndicator" parent="Widget.Material3.LinearProgressIndicator">
+        <item name="trackColor">#18000000</item>
     </style>
 
     <style name="Widget.AntennaPod.ActionBar" parent="Widget.Material3.Light.ActionBar.Solid">


### PR DESCRIPTION
### Description

Material 3 "expressive" uses a lot more bold color. Make the currently playing item background a bit more expressive by using a stronger color.

Before/After:
<img width="200" alt="Screenshot_20260514-135531" src="https://github.com/user-attachments/assets/6571f48c-333b-4c3b-b4e5-799e10a3cf84" /> <img width="200" alt="Screenshot_20260514-135455" src="https://github.com/user-attachments/assets/c709a9d8-a5bb-4c9e-bade-b805f68e3788" />


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
