### PR TITLE
Follow all redirects before giving stream url to ExoPlayer

### DIFF
--- a/net/common/src/main/java/de/danoeh/antennapod/net/common/RedirectChecker.java
+++ b/net/common/src/main/java/de/danoeh/antennapod/net/common/RedirectChecker.java
@@ -50,4 +50,20 @@ public abstract class RedirectChecker {
         }
         return null;
     }
+
+    @Nullable
+    public static String getFinalUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+        try {
+            Request httpReq = new Request.Builder().url(url).head().build();
+            Response response = AntennapodHttpClient.getHttpClient().newCall(httpReq).execute();
+            response.close();
+            return response.request().url().toString();
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to follow redirects for " + url + ": " + e.getMessage());
+            return url;
+        }
+    }
 }

--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import de.danoeh.antennapod.net.common.HttpCredentialEncoder;
+import de.danoeh.antennapod.net.common.RedirectChecker;
 import android.util.Log;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.Nullable;
@@ -80,7 +81,12 @@ public class MediaItemAdapter {
         Bundle extras = new Bundle();
         extras.putString(KEY_STREAM_URL, playable.getStreamUrl());
         metadataBuilder.setExtras(extras);
-        String localPlaybackUri = playable.localFileAvailable() ? playable.getLocalFileUrl() : playable.getStreamUrl();
+        String localPlaybackUri;
+        if (playable.localFileAvailable()) {
+            localPlaybackUri = playable.getLocalFileUrl();
+        } else {
+            localPlaybackUri = RedirectChecker.getFinalUrl(playable.getStreamUrl());
+        }
         Bundle requestExtras = new Bundle();
         if (!playable.localFileAvailable() && playable instanceof FeedMedia) {
             FeedMedia feedMedia = (FeedMedia) playable;


### PR DESCRIPTION
### Description

Follow all redirects before giving stream url to ExoPlayer. This is an attempt to reduce the impact of dynamic ad insertion changing the media file while AntennaPod is still playing it.

Contributes to #7409

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint spotbugsPlayDebug spotbugsDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
