### PR TITLE
Migrate Gradle dependencies to version catalogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ Never update the PR description after the initial creation, even if you have new
 The user might have updated the description in the meantime and this would overwrite their work.
 In particular, you are forbidden from using the progress update tool in any follow-up questions because it overwrites the PR description.
 This holds even if the global agent instructions tell you to do this.
+Never create commits directly on the `develop` or `master` branch. Always checkout a new branch for that.
 
 # Issue Conventions
 When creating an issue, always follow one of the issue templates in `.github/ISSUE_TEMPLATE/`.

--- a/app-wearos/build.gradle
+++ b/app-wearos/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("org.jlleitschuh.gradle.ktlint")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ktlint)
 }
 apply from: "../common.gradle"
 apply from: "../playFlavor.gradle"
@@ -66,18 +66,18 @@ dependencies {
     implementation project(":net:sync:wear-interface")
 
     // NOTE: DO NOT INCLUDE a dependency on androidx.compose.material:material, the watch version is a replacement
-    implementation "androidx.wear:wear:$wearVersion"
-    implementation "com.google.android.gms:play-services-wearable:$wearableVersion"
-    implementation "androidx.wear.compose:compose-foundation:$wearComposeVersion"
-    implementation "androidx.wear.compose:compose-material3:$wearComposeVersion"
-    implementation "androidx.compose.ui:ui:$composeVersion"
-    implementation "androidx.compose.runtime:runtime:$composeVersion"
-    implementation "androidx.lifecycle:lifecycle-runtime-compose:$lifecycleRuntimeComposeVersion"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleRuntimeComposeVersion"
-    implementation "androidx.core:core-ktx:$coreKtxVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0"
-    implementation "androidx.activity:activity-compose:$activityComposeVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation libs.androidx.wear
+    implementation libs.google.play.services.wearable
+    implementation libs.androidx.wear.compose.foundation
+    implementation libs.androidx.wear.compose.material3
+    implementation libs.androidx.compose.ui
+    implementation libs.androidx.compose.runtime
+    implementation libs.androidx.lifecycle.runtime.compose
+    implementation libs.androidx.lifecycle.viewmodel.ktx
+    implementation libs.androidx.core.ktx
+    implementation libs.kotlinx.coroutines.play.services
+    implementation libs.androidx.activity.compose
+    implementation libs.androidx.appcompat
 
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id('com.android.application')
-    id('com.github.triplet.play') version '3.9.0' apply false
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.triplet.play) apply false
 }
 apply from: "../common.gradle"
 apply from: "../playFlavor.gradle"
@@ -88,50 +88,50 @@ dependencies {
     implementation project(':ui:chapters')
     implementation project(':ui:transcript')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation "androidx.core:core:$coreVersion"
-    implementation "androidx.fragment:fragment:$fragmentVersion"
-    implementation 'androidx.gridlayout:gridlayout:1.0.0'
-    implementation "androidx.media:media:$mediaVersion"
-    implementation "androidx.palette:palette:$paletteVersion"
-    implementation "androidx.preference:preference:$preferenceVersion"
-    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
-    implementation "androidx.viewpager2:viewpager2:$viewPager2Version"
-    implementation "androidx.work:work-runtime:$workManagerVersion"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation "androidx.drawerlayout:drawerlayout:1.2.0"
-    implementation "androidx.media3:media3-common:$media3Version"
-    implementation "androidx.media3:media3-session:$media3Version"
-    implementation "androidx.media3:media3-ui:$media3Version"
-    playImplementation "com.google.android.gms:play-services-wearable:$wearableVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.coordinatorlayout
+    implementation libs.androidx.core
+    implementation libs.androidx.fragment
+    implementation libs.androidx.gridlayout
+    implementation libs.androidx.media
+    implementation libs.androidx.palette
+    implementation libs.androidx.preference
+    implementation libs.androidx.recyclerview
+    implementation libs.androidx.viewpager2
+    implementation libs.androidx.work.runtime
+    implementation libs.google.material
+    implementation libs.androidx.drawerlayout
+    implementation libs.androidx.media3.common
+    implementation libs.androidx.media3.session
+    implementation libs.androidx.media3.ui
+    playImplementation libs.google.play.services.wearable
 
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.jsoup:jsoup:$jsoupVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation 'com.bytehamster:lib.preferencesearch:2.7.3'
-    implementation 'com.github.skydoves:balloon:1.5.3'
-    implementation 'it.xabaras.android:recyclerview-swipedecorator:1.4'
+    implementation libs.commons.lang3
+    implementation libs.commons.io
+    implementation libs.jsoup
+    implementation libs.glide
+    implementation libs.okhttp
+    implementation libs.okhttp.urlconnection
+    implementation libs.eventbus
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.preferencesearch
+    implementation libs.balloon
+    implementation libs.recyclerview.swipedecorator
 
-    testImplementation "androidx.test:core:$testCoreVersion"
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 
-    androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    androidTestImplementation 'com.nanohttpd:nanohttpd:2.1.1'
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
-    androidTestImplementation "androidx.test:runner:$runnerVersion"
-    androidTestImplementation "androidx.test:rules:$rulesVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation libs.awaitility
+    androidTestImplementation libs.nanohttpd
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.androidx.test.espresso.contrib
+    androidTestImplementation libs.androidx.test.espresso.intents
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.ext.junit
 }
 
 if (project.hasProperty("antennaPodPlayPublisherCredentials")) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,63 +1,9 @@
-buildscript {
-    ext.agpVersion = "8.11.0"
-    ext.kotlin_version = '2.3.20'
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-    repositories {
-        mavenCentral()
-    }
-}
 plugins {
-    id 'com.android.application' version "$agpVersion" apply false
-    id 'com.android.library' version "$agpVersion" apply false
-    id 'com.github.spotbugs' version '4.8.0' apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.spotbugs) apply false
     id 'checkstyle'
-    id 'org.jlleitschuh.gradle.ktlint' version '12.3.0' apply false
-    id 'org.jetbrains.kotlin.plugin.compose' version "$kotlin_version" apply false
-}
-
-project.ext {
-    // AndroidX
-    annotationVersion = "1.9.1"
-    appcompatVersion = "1.7.1"
-    coreVersion = "1.16.0"
-    fragmentVersion = "1.8.9"
-    mediaVersion = "1.6.0"
-    media3Version = "1.9.0"
-    paletteVersion = "1.0.0"
-    preferenceVersion = "1.2.1"
-    recyclerViewVersion = "1.4.0"
-    viewPager2Version = "1.1.0"
-    workManagerVersion = "2.10.3"
-    googleMaterialVersion = "1.12.0"
-
-    // Wear OS
-    wearableVersion = "19.0.0"
-    wearVersion = "1.3.0"
-    wearComposeVersion = "1.6.0"
-    composeVersion = "1.7.5"
-    lifecycleRuntimeComposeVersion = "2.8.7"
-    coreKtxVersion = "1.18.0"
-    activityComposeVersion = "1.9.3"
-
-    // Third-party
-    commonslangVersion = "3.18.0"
-    commonsioVersion = "2.5" // Recent versions cause ClassNotFoundException on Android 6
-    jsoupVersion = "1.15.1"
-    glideVersion = "4.16.0"
-    okhttpVersion = "4.12.0"
-    eventbusVersion = "3.3.1"
-    rxAndroidVersion = "3.0.2"
-    rxJavaVersion = "3.1.5"
-
-    //Tests
-    awaitilityVersion = "3.1.6"
-    junitVersion = "4.13"
-    robolectricVersion = "4.16"
-    espressoVersion = "3.5.0"
-    runnerVersion = "1.5.0"
-    rulesVersion = "1.5.0"
-    testCoreVersion = "1.5.0"
-    mockitoVersion = "5.15.2"
+    alias(libs.plugins.ktlint) apply false
 }

--- a/common.gradle
+++ b/common.gradle
@@ -71,7 +71,7 @@ android {
 dependencies {
     // align all versions of kotlin transitive dependencies, see
     // https://youtrack.jetbrains.com/issue/KT-55297/kotlin-stdlib-should-declare-constraints-on-kotlin-stdlib-jdk8-and-kotlin-stdlib-jdk7
-    implementation platform("org.jetbrains.kotlin:kotlin-bom:1.9.24")
+    implementation platform(libs.kotlin.bom)
 }
 
 tasks.withType(Test).configureEach {

--- a/event/build.gradle
+++ b/event/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../common.gradle"
 
@@ -9,7 +9,7 @@ android {
 
 dependencies {
     implementation project(':model')
-    implementation "androidx.core:core:$coreVersion"
+    implementation libs.androidx.core
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,87 @@
+[versions]
+agp = "8.11.0"
+kotlin = "2.3.20"
+media3 = "1.9.0"
+wear-compose = "1.6.0"
+compose = "1.7.5"
+lifecycle-runtime-compose = "2.8.7"
+glide = "4.16.0"
+okhttp = "4.12.0"
+espresso = "3.5.0"
+androidx-test = "1.5.0"
+
+[libraries]
+androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
+androidx-coordinatorlayout = { module = "androidx.coordinatorlayout:coordinatorlayout", version = "1.1.0" }
+androidx-core = { module = "androidx.core:core", version = "1.16.0" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.18.0" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.0.0" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version = "1.0.1" }
+androidx-drawerlayout = { module = "androidx.drawerlayout:drawerlayout", version = "1.2.0" }
+androidx-fragment = { module = "androidx.fragment:fragment", version = "1.8.9" }
+androidx-gridlayout = { module = "androidx.gridlayout:gridlayout", version = "1.0.0" }
+androidx-media = { module = "androidx.media:media", version = "1.6.0" }
+androidx-media3-common = { module = "androidx.media3:media3-common", version.ref = "media3" }
+androidx-media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
+androidx-mediarouter = { module = "androidx.mediarouter:mediarouter", version = "1.3.0" }
+androidx-palette = { module = "androidx.palette:palette", version = "1.0.0" }
+androidx-preference = { module = "androidx.preference:preference", version = "1.2.1" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.4.0" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-test-espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "espresso" }
+androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version = "1.1.1" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
+androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.1.0" }
+androidx-wear = { module = "androidx.wear:wear", version = "1.3.0" }
+androidx-wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
+androidx-wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose" }
+androidx-work-runtime = { module = "androidx.work:work-runtime", version = "2.10.3" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle-runtime-compose" }
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle-runtime-compose" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.3" }
+androidx-car-app = { module = "androidx.car.app:app", version = "1.4.0-rc02" }
+google-material = { module = "com.google.android.material:material", version = "1.12.0" }
+google-play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version = "19.0.0" }
+google-play-services-base = { module = "com.google.android.gms:play-services-base", version = "17.5.0" }
+google-play-services-cast-framework = { module = "com.google.android.gms:play-services-cast-framework", version = "21.2.0" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version = "1.9.24" }
+kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version = "1.9.0" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.18.0" }
+commons-io = { module = "commons-io:commons-io", version = "2.5" }
+jsoup = { module = "org.jsoup:jsoup", version = "1.15.1" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+glide-okhttp3-integration = { module = "com.github.bumptech.glide:okhttp3-integration", version.ref = "glide" }
+glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-urlconnection = { module = "com.squareup.okhttp3:okhttp-urlconnection", version.ref = "okhttp" }
+eventbus = { module = "org.greenrobot:eventbus", version = "3.3.1" }
+rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version = "3.0.2" }
+rxjava = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.5" }
+guava = { module = "com.google.guava:guava", version = "31.0.1-android" }
+conscrypt-android = { module = "org.conscrypt:conscrypt-android", version = "2.5.3" }
+preferencesearch = { module = "com.bytehamster:lib.preferencesearch", version = "2.7.3" }
+balloon = { module = "com.github.skydoves:balloon", version = "1.5.3" }
+recyclerview-swipedecorator = { module = "it.xabaras.android:recyclerview-swipedecorator", version = "1.4" }
+nanohttpd = { module = "com.nanohttpd:nanohttpd", version = "2.1.1" }
+awaitility = { module = "org.awaitility:awaitility", version = "3.1.6" }
+junit = { module = "junit:junit", version = "4.13" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.16" }
+mockito-core = { module = "org.mockito:mockito-core", version = "5.15.2" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+spotbugs = { id = "com.github.spotbugs", version = "4.8.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.3.0" }
+triplet-play = { id = "com.github.triplet.play", version = "3.9.0" }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../common.gradle"
 
@@ -12,11 +12,11 @@ android {
 }
 
 dependencies {
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.media:media:$mediaVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.media
+    implementation libs.commons.lang3
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.test:core:$testCoreVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation libs.junit
+    testImplementation libs.androidx.test.core
+    testImplementation libs.mockito.core
 }

--- a/net/common/build.gradle
+++ b/net/common/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -17,10 +17,10 @@ dependencies {
     implementation project(':net:ssl')
     implementation project(':storage:preferences')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.okhttp
+    implementation libs.okhttp.urlconnection
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/net/discovery/build.gradle
+++ b/net/discovery/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -24,9 +24,9 @@ dependencies {
     implementation project(':storage:preferences')
     implementation project(':ui:i18n')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.okhttp
 }

--- a/net/download/service-interface/build.gradle
+++ b/net/download/service-interface/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
     id("java-test-fixtures")
 }
 apply from: "../../../common.gradle"
@@ -18,10 +18,10 @@ dependencies {
     implementation project(':net:common')
     implementation project(':storage:preferences')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.commons.lang3
+    implementation libs.commons.io
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/net/download/service/build.gradle
+++ b/net/download/service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
     id("java-test-fixtures")
 }
 apply from: "../../../common.gradle"
@@ -24,25 +24,25 @@ dependencies {
     implementation project(':ui:chapters')
     implementation project(':ui:transcript')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation "androidx.work:work-runtime:$workManagerVersion"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.core
+    implementation libs.androidx.documentfile
+    implementation libs.androidx.work.runtime
+    implementation libs.google.material
 
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "com.google.guava:guava:31.0.1-android"
+    implementation libs.okhttp
+    implementation libs.okhttp.urlconnection
+    implementation libs.commons.io
+    implementation libs.commons.lang3
+    implementation libs.eventbus
+    implementation libs.glide
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.guava
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "androidx.preference:preference:$preferenceVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.awaitility
+    testImplementation libs.mockito.core
+    testImplementation libs.androidx.preference
 }

--- a/net/ssl/build.gradle
+++ b/net/ssl/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -9,12 +9,12 @@ android {
 }
 
 dependencies {
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
 
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    implementation libs.okhttp
 
-    playImplementation 'com.google.android.gms:play-services-base:17.5.0'
+    playImplementation libs.google.play.services.base
     // This version should be updated regularly.
-    freeImplementation 'org.conscrypt:conscrypt-android:2.5.3'
+    freeImplementation libs.conscrypt.android
 }

--- a/net/sync/gpoddernet/build.gradle
+++ b/net/sync/gpoddernet/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../../common.gradle"
 
@@ -10,14 +10,14 @@ android {
 dependencies {
     implementation project(':net:sync:service-interface')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
 
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
+    implementation libs.okhttp
+    implementation libs.commons.lang3
+    implementation libs.commons.io
+    implementation libs.rxandroid
+    implementation libs.rxjava
 
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit
 }

--- a/net/sync/service-interface/build.gradle
+++ b/net/sync/service-interface/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../../common.gradle"
 
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':model')
     implementation project(':storage:preferences')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.rxandroid
+    implementation libs.rxjava
 }

--- a/net/sync/service/build.gradle
+++ b/net/sync/service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../../common.gradle"
 apply from: "../../../playFlavor.gradle"
@@ -20,16 +20,16 @@ dependencies {
     implementation project(':ui:i18n')
     implementation project(':net:download:service-interface')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation "androidx.work:work-runtime:$workManagerVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.core
+    implementation libs.androidx.work.runtime
 
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "com.google.guava:guava:31.0.1-android"
+    implementation libs.eventbus
+    implementation libs.commons.lang3
+    implementation libs.okhttp
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.guava
 
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit
 }

--- a/net/sync/wear-interface/build.gradle
+++ b/net/sync/wear-interface/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../../common.gradle"
 
@@ -10,9 +10,9 @@ android {
 dependencies {
     implementation project(':model')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "com.google.android.gms:play-services-wearable:$wearableVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.google.play.services.wearable
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/parser/feed/build.gradle
+++ b/parser/feed/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -10,14 +10,14 @@ android {
 dependencies {
     implementation project(':model')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 
-    implementation "androidx.core:core:$coreVersion"
+    implementation libs.androidx.core
 
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.jsoup:jsoup:$jsoupVersion"
+    implementation libs.commons.lang3
+    implementation libs.commons.io
+    implementation libs.jsoup
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/parser/media/build.gradle
+++ b/parser/media/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -10,10 +10,10 @@ android {
 dependencies {
     implementation project(':model')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 
-    implementation "commons-io:commons-io:$commonsioVersion"
+    implementation libs.commons.io
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/parser/transcript/build.gradle
+++ b/parser/transcript/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -10,14 +10,14 @@ android {
 dependencies {
     implementation project(':model')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 
-    implementation "androidx.core:core:$coreVersion"
+    implementation libs.androidx.core
 
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.jsoup:jsoup:$jsoupVersion"
+    implementation libs.commons.lang3
+    implementation libs.commons.io
+    implementation libs.jsoup
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.robolectric
 }

--- a/playback/base/build.gradle
+++ b/playback/base/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -13,10 +13,10 @@ dependencies {
     implementation project(':system')
     implementation project(':net:common')
 
-    implementation "androidx.media3:media3-exoplayer:$media3Version"
-    implementation "androidx.media3:media3-session:$media3Version"
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
+    implementation libs.androidx.media3.exoplayer
+    implementation libs.androidx.media3.session
+    annotationProcessor libs.androidx.annotation
+    implementation libs.glide
 
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit
 }

--- a/playback/cast/build.gradle
+++ b/playback/cast/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -14,12 +14,12 @@ dependencies {
     implementation project(':playback:base')
     implementation project(':ui:episodes')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.eventbus
 
-    playApi 'androidx.mediarouter:mediarouter:1.3.0'
-    playApi 'com.google.android.gms:play-services-cast-framework:21.2.0'
-    implementation "androidx.media3:media3-exoplayer:$media3Version"
-    playImplementation "androidx.media3:media3-cast:$media3Version"
+    playApi libs.androidx.mediarouter
+    playApi libs.google.play.services.cast.framework
+    implementation libs.androidx.media3.exoplayer
+    playImplementation libs.androidx.media3.cast
 }

--- a/playback/service/build.gradle
+++ b/playback/service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -31,21 +31,21 @@ dependencies {
     implementation project(':ui:widget')
     implementation project(':ui:chapters')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.car.app:app:1.4.0-rc02"
-    implementation "androidx.core:core:$coreVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "androidx.media:media:$mediaVersion"
-    implementation "androidx.media3:media3-exoplayer:$media3Version"
-    implementation "androidx.media3:media3-session:$media3Version"
-    implementation "androidx.media3:media3-ui:$media3Version"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.car.app
+    implementation libs.androidx.core
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.media
+    implementation libs.androidx.media3.exoplayer
+    implementation libs.androidx.media3.session
+    implementation libs.androidx.media3.ui
 
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.eventbus
+    implementation libs.glide
+    implementation libs.commons.lang3
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation libs.junit
+    testImplementation libs.mockito.core
 }

--- a/storage/database-maintenance-service/build.gradle
+++ b/storage/database-maintenance-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -12,8 +12,8 @@ dependencies {
     implementation project(':storage:database')
     implementation project(':ui:notifications')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation "androidx.work:work-runtime:$workManagerVersion"
-    implementation "com.google.guava:guava:31.0.1-android"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.core
+    implementation libs.androidx.work.runtime
+    implementation libs.guava
 }

--- a/storage/database/build.gradle
+++ b/storage/database/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -21,17 +21,17 @@ dependencies {
     implementation project(':system')
     implementation project(':ui:app-start-intent')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation 'androidx.documentfile:documentfile:1.0.1'
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.core
+    implementation libs.androidx.documentfile
 
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "com.google.guava:guava:31.0.1-android"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
+    implementation libs.commons.io
+    implementation libs.eventbus
+    implementation libs.guava
+    implementation libs.commons.lang3
 
     testImplementation project(':parser:feed')
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.test:core:$testCoreVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.androidx.test.core
+    testImplementation libs.robolectric
 }

--- a/storage/importexport/build.gradle
+++ b/storage/importexport/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -17,18 +17,18 @@ dependencies {
     implementation project(':model')
     implementation project(':net:download:service-interface')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation "androidx.work:work-runtime:$workManagerVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.core
+    implementation libs.androidx.documentfile
+    implementation libs.androidx.work.runtime
 
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "com.google.guava:guava:31.0.1-android"
+    implementation libs.commons.io
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.eventbus
+    implementation libs.guava
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.test:core:$testCoreVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.junit
+    testImplementation libs.androidx.test.core
+    testImplementation libs.robolectric
 }

--- a/storage/preferences/build.gradle
+++ b/storage/preferences/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -14,7 +14,7 @@ android {
 dependencies {
     implementation project(':model')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.fragment:fragment:$fragmentVersion"
-    implementation "androidx.preference:preference:$preferenceVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.fragment
+    implementation libs.androidx.preference
 }

--- a/system/build.gradle
+++ b/system/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.library'
+    alias(libs.plugins.android.library)
 }
 apply from: "../common.gradle"
 
@@ -10,5 +10,5 @@ android {
 dependencies {
     implementation project(":storage:preferences")
 
-    implementation "commons-io:commons-io:$commonsioVersion"
+    implementation libs.commons.io
 }

--- a/ui/app-start-intent/build.gradle
+++ b/ui/app-start-intent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -8,5 +8,5 @@ android {
 }
 
 dependencies {
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 }

--- a/ui/chapters/build.gradle
+++ b/ui/chapters/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -16,8 +16,8 @@ dependencies {
     implementation project(':parser:transcript')
     implementation project(':storage:database')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.commons.io
+    implementation libs.commons.lang3
+    implementation libs.okhttp
 }

--- a/ui/common/build.gradle
+++ b/ui/common/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -15,13 +15,13 @@ dependencies {
     implementation project(":storage:preferences")
     implementation project(":ui:i18n")
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "androidx.viewpager2:viewpager2:$viewPager2Version"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation "androidx.core:core-splashscreen:1.0.0"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.viewpager2
+    implementation libs.google.material
+    implementation libs.androidx.core.splashscreen
+    implementation libs.commons.lang3
+    implementation libs.commons.io
 
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit
 }

--- a/ui/discovery/build.gradle
+++ b/ui/discovery/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -16,11 +16,11 @@ dependencies {
     implementation project(':ui:app-start-intent')
     implementation project(':ui:common')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.google.material
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.glide
+    implementation libs.eventbus
 }

--- a/ui/echo/build.gradle
+++ b/ui/echo/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -19,10 +19,10 @@ dependencies {
     implementation project(':ui:common')
     implementation project(':ui:episodes')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.google.material
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.glide
 }

--- a/ui/episodes/build.gradle
+++ b/ui/episodes/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -12,8 +12,8 @@ dependencies {
     implementation project(":storage:preferences")
     implementation project(":ui:common")
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.core
+    implementation libs.google.material
 }

--- a/ui/glide/build.gradle
+++ b/ui/glide/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -12,11 +12,11 @@ dependencies {
     implementation project(":model")
     implementation project(':net:common')
 
-    implementation "androidx.palette:palette:$paletteVersion"
+    implementation libs.androidx.palette
 
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "com.github.bumptech.glide:okhttp3-integration:$glideVersion@aar"
-    annotationProcessor "com.github.bumptech.glide:compiler:$glideVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "commons-io:commons-io:$commonsioVersion"
+    implementation libs.glide
+    implementation libs.glide.okhttp3.integration
+    annotationProcessor libs.glide.compiler
+    implementation libs.okhttp
+    implementation libs.commons.io
 }

--- a/ui/i18n/build.gradle
+++ b/ui/i18n/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    annotationProcessor libs.androidx.annotation
 }

--- a/ui/notifications/build.gradle
+++ b/ui/notifications/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 
@@ -16,6 +16,6 @@ dependencies {
     implementation project(':storage:preferences')
     implementation project(':ui:i18n')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.core:core:$coreVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.core
 }

--- a/ui/preferences/build.gradle
+++ b/ui/preferences/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -34,18 +34,18 @@ dependencies {
     implementation project(':net:sync:service-interface')
     implementation project(':net:sync:service')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "androidx.fragment:fragment:$fragmentVersion"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
-    implementation "androidx.preference:preference:$preferenceVersion"
-    implementation "androidx.work:work-runtime:$workManagerVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.fragment
+    implementation libs.google.material
+    implementation libs.androidx.preference
+    implementation libs.androidx.work.runtime
 
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttpVersion"
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation 'com.bytehamster:lib.preferencesearch:2.7.3'
+    implementation libs.rxandroid
+    implementation libs.rxjava
+    implementation libs.glide
+    implementation libs.okhttp
+    implementation libs.okhttp.urlconnection
+    implementation libs.eventbus
+    implementation libs.preferencesearch
 }

--- a/ui/statistics/build.gradle
+++ b/ui/statistics/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -20,16 +20,16 @@ dependencies {
     implementation project(":ui:common")
     implementation project(":ui:echo")
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "androidx.core:core:$coreVersion"
-    implementation "androidx.fragment:fragment:$fragmentVersion"
-    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
-    implementation "androidx.viewpager2:viewpager2:$viewPager2Version"
-    implementation "com.google.android.material:material:$googleMaterialVersion"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.core
+    implementation libs.androidx.fragment
+    implementation libs.androidx.recyclerview
+    implementation libs.androidx.viewpager2
+    implementation libs.google.material
 
-    implementation "org.greenrobot:eventbus:$eventbusVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
+    implementation libs.eventbus
+    implementation libs.glide
+    implementation libs.rxandroid
+    implementation libs.rxjava
 }

--- a/ui/transcript/build.gradle
+++ b/ui/transcript/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -14,7 +14,7 @@ dependencies {
     implementation project(':parser:media')
     implementation project(':parser:transcript')
 
-    implementation "commons-io:commons-io:$commonsioVersion"
-    implementation "org.apache.commons:commons-lang3:$commonslangVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    implementation libs.commons.io
+    implementation libs.commons.lang3
+    implementation libs.okhttp
 }

--- a/ui/widget/build.gradle
+++ b/ui/widget/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
@@ -28,9 +28,9 @@ dependencies {
     implementation project(':ui:i18n')
     implementation project(':ui:glide')
 
-    annotationProcessor "androidx.annotation:annotation:$annotationVersion"
-    implementation "androidx.appcompat:appcompat:$appcompatVersion"
-    implementation "androidx.work:work-runtime:$workManagerVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation "com.google.guava:guava:31.0.1-android"
+    annotationProcessor libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.work.runtime
+    implementation libs.glide
+    implementation libs.guava
 }


### PR DESCRIPTION
### Description

Migrate Gradle dependencies to version catalogs. This is the modern style of managing dependencies. Confirmed with diff on `./gradlew :app:dependencies` that no versions changed.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
