### PR TITLE
Work around incorrect redirects duplicating subscriptions on sync

### DIFF
--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SyncService.java
@@ -166,6 +166,12 @@ public class SyncService extends Worker {
                         || queuedRemovedFeeds.contains(redirectedUrl))) {
                 continue;
             }
+            // If the creator redirected their feed incorrectly, we still try to avoid duplicated subscriptions
+            String finalUrl = RedirectChecker.getFinalUrl(downloadUrl);
+            if (UrlChecker.containsUrl(localSubscriptions, finalUrl)
+                    || queuedRemovedFeeds.contains(finalUrl)) {
+                continue;
+            }
 
             Feed feed = new Feed(downloadUrl, null, "Unknown podcast");
             feed.setItems(Collections.emptyList());


### PR DESCRIPTION
### Description

Work around incorrect redirects duplicating subscriptions on sync. We already had handling for proper redirects. Note that we still subscribe to the non-redirected url, so sync status might be inconsistent until the podcast creator fixes their feed. However, that is better than duplicated subscriptions.

Closes #8382

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
