### PR TITLE
Fix trying to load local files over http

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/MediaSizeLoader.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/MediaSizeLoader.java
@@ -36,7 +36,7 @@ public abstract class MediaSizeLoader {
                 // only query the network if we haven't already checked
 
                 String url = media.getDownloadUrl();
-                if (TextUtils.isEmpty(url)) {
+                if (TextUtils.isEmpty(url) || !url.startsWith("http")) {
                     emitter.onSuccess(0L);
                     return;
                 }

--- a/net/common/src/main/java/de/danoeh/antennapod/net/common/RedirectChecker.java
+++ b/net/common/src/main/java/de/danoeh/antennapod/net/common/RedirectChecker.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.net.common;
 
+import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.Nullable;
 import okhttp3.Request;
@@ -53,8 +54,8 @@ public abstract class RedirectChecker {
 
     @Nullable
     public static String getFinalUrl(String url) {
-        if (url == null) {
-            return null;
+        if (TextUtils.isEmpty(url) || !url.startsWith("http")) {
+            return url;
         }
         try {
             Request httpReq = new Request.Builder().url(url).head().build();


### PR DESCRIPTION
### Description

Fix trying to load local files over http.
Closes #8449

```
E  java.lang.IllegalArgumentException: Expected URL scheme 'http' or 'https' but was 'content'
	at okhttp3.HttpUrl$Builder.parse$okhttp(HttpUrl.kt:1254)
	at okhttp3.HttpUrl$Companion.get(HttpUrl.kt:1634)
	at okhttp3.Request$Builder.url(Request.kt:184)
	at de.danoeh.antennapod.ui.episodeslist.MediaSizeLoader.lambda$getFeedMediaSizeObservable$0(MediaSizeLoader.java:46)
	at de.danoeh.antennapod.ui.episodeslist.MediaSizeLoader$$ExternalSyntheticLambda0.subscribe(D8$$SyntheticClass:0)
	at io.reactivex.rxjava3.internal.operators.single.SingleCreate.subscribeActual(SingleCreate.java:40)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4855)
	at io.reactivex.rxjava3.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89)
	at io.reactivex.rxjava3.core.Scheduler$DisposeTask.run(Scheduler.java:644)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:65)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:56)
	at java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:348)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1154)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:652)
	at java.lang.Thread.run(Thread.java:1564)

```

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
