### PR TITLE
Move URL edit box from feed info to feed settings

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -1,7 +1,5 @@
 package de.danoeh.antennapod.ui.screen.feed;
 
-import android.content.ActivityNotFoundException;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.LightingColorFilter;
@@ -14,16 +12,12 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.Fragment;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.google.android.material.appbar.MaterialToolbar;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.databinding.FeedinfoBinding;
@@ -31,7 +25,6 @@ import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.storage.database.DBReader;
-import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.common.ClipboardUtils;
 import de.danoeh.antennapod.ui.common.IntentUtils;
@@ -40,11 +33,9 @@ import de.danoeh.antennapod.ui.cleaner.HtmlToPlainText;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedFunding;
 import de.danoeh.antennapod.ui.glide.FastBlurTransformation;
-import de.danoeh.antennapod.ui.screen.feed.preferences.EditUrlSettingsDialog;
 import de.danoeh.antennapod.ui.statistics.StatisticsFragment;
 import de.danoeh.antennapod.ui.statistics.feed.FeedStatisticsDialogFragment;
 import de.danoeh.antennapod.ui.statistics.feed.FeedStatisticsFragment;
-import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeOnSubscribe;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -63,8 +54,6 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
 
     private static final String EXTRA_FEED_ID = "de.danoeh.antennapod.extra.feedId";
     private static final String TAG = "FeedInfoActivity";
-    private final ActivityResultLauncher<Uri> addLocalFolderLauncher =
-            registerForActivityResult(new AddLocalFolder(), this::addLocalFolderResult);
 
     private Feed feed;
     private Disposable disposable;
@@ -270,13 +259,10 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
 
     private void refreshToolbarState() {
         boolean isSubscribed = feed != null && feed.getState() == Feed.STATE_SUBSCRIBED;
-        viewBinding.toolbar.getMenu().findItem(R.id.reconnect_local_folder).setVisible(
-                isSubscribed && feed.isLocalFeed());
         viewBinding.toolbar.getMenu().findItem(R.id.share_item).setVisible(isSubscribed && !feed.isLocalFeed());
         viewBinding.toolbar.getMenu().findItem(R.id.visit_website_item).setVisible(isSubscribed
                 && feed.getLink() != null
                 && IntentUtils.isCallable(getContext(), new Intent(Intent.ACTION_VIEW, Uri.parse(feed.getLink()))));
-        viewBinding.toolbar.getMenu().findItem(R.id.edit_feed_url_item).setVisible(isSubscribed && !feed.isLocalFeed());
     }
 
     @Override
@@ -289,72 +275,10 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
             IntentUtils.openInBrowser(getContext(), feed.getLink());
         } else if (item.getItemId() == R.id.share_item) {
             ShareUtils.shareFeedLink(getContext(), feed);
-        } else if (item.getItemId() == R.id.reconnect_local_folder) {
-            MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(getContext());
-            alert.setMessage(R.string.reconnect_local_folder_warning);
-            alert.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                try {
-                    addLocalFolderLauncher.launch(null);
-                } catch (ActivityNotFoundException e) {
-                    Log.e(TAG, "No activity found. Should never happen...");
-                }
-            });
-            alert.setNegativeButton(android.R.string.cancel, null);
-            alert.show();
-        } else if (item.getItemId() == R.id.edit_feed_url_item) {
-            new EditUrlSettingsDialog(getActivity(), feed) {
-                @Override
-                protected void setUrl(String url) {
-                    feed.setDownloadUrl(url);
-                    viewBinding.urlLabel.setText(feed.getDownloadUrl());
-                    viewBinding.urlLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                            0, 0, R.drawable.ic_paperclip, 0);
-                }
-            }.show();
         } else {
             return false;
         }
         return true;
     }
 
-    private void addLocalFolderResult(final Uri uri) {
-        if (uri == null) {
-            return;
-        }
-        reconnectLocalFolder(uri);
-    }
-
-    private void reconnectLocalFolder(Uri uri) {
-        if (feed == null) {
-            return;
-        }
-
-        Completable.fromAction(() -> {
-            getActivity().getContentResolver()
-                    .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
-                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            DocumentFile documentFile = DocumentFile.fromTreeUri(getContext(), uri);
-            if (documentFile == null) {
-                throw new IllegalArgumentException("Unable to retrieve document tree");
-            }
-            feed.setDownloadUrl(Feed.PREFIX_LOCAL_FOLDER + uri.toString());
-            FeedDatabaseWriter.updateFeed(getContext(), feed, false);
-        })
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        () -> EventBus.getDefault().post(new MessageEvent(getString(android.R.string.ok))),
-                        error -> EventBus.getDefault().post(new MessageEvent(error.getLocalizedMessage())));
-    }
-
-    private static class AddLocalFolder extends ActivityResultContracts.OpenDocumentTree {
-        @NonNull
-        @Override
-        public Intent createIntent(@NonNull final Context context, @Nullable final Uri input) {
-            return super.createIntent(context, input)
-                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
-                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-        }
-    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.ui.screen.feed.preferences;
 
 import android.Manifest;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -13,6 +15,9 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
 import androidx.core.content.ContextCompat;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
@@ -33,9 +38,11 @@ import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
 import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
+import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.screen.synchronization.AuthenticationDialog;
 import de.danoeh.antennapod.ui.screen.feed.RenameFeedDialog;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeOnSubscribe;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -62,6 +69,8 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
     private static final String PREF_NOTIFICATION = "episodeNotification";
     private static final String PREF_RENAME = "rename";
     private static final String PREF_TAGS = "tags";
+    private static final String PREF_EDIT_FEED_URL = "editFeedUrl";
+    private static final String PREF_RECONNECT_LOCAL_FOLDER = "reconnectLocalFolder";
 
     private Feed feed;
     private Disposable disposable;
@@ -74,6 +83,9 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
         fragment.setArguments(arguments);
         return fragment;
     }
+
+    private final ActivityResultLauncher<Uri> addLocalFolderLauncher =
+            registerForActivityResult(new AddLocalFolder(), this::addLocalFolderResult);
 
     boolean notificationPermissionDenied = false;
     private final ActivityResultLauncher<String> enableNotificationsRequestPermissionLauncher =
@@ -130,10 +142,12 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
                     updateAutoDownloadEnabledSummary();
                     updateNewEpisodesActionSummary();
 
+                    findPreference(PREF_RECONNECT_LOCAL_FOLDER).setVisible(feed.isLocalFeed());
                     if (feed.isLocalFeed()) {
                         findPreference(PREF_AUTHENTICATION).setVisible(false);
                         findPreference(PREF_AUTODOWNLOAD).setVisible(false);
                         findPreference(PREF_EPISODE_FILTER).setVisible(false);
+                        findPreference(PREF_EDIT_FEED_URL).setVisible(false);
                     }
 
                     findPreference(PREF_SCREEN).setVisible(true);
@@ -269,6 +283,29 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
             new RenameFeedDialog(getActivity(), feed).show();
             return true;
         });
+        findPreference(PREF_EDIT_FEED_URL).setOnPreferenceClickListener(preference -> {
+            new EditUrlSettingsDialog(getActivity(), feed) {
+                @Override
+                protected void setUrl(String url) {
+                    feed.setDownloadUrl(url);
+                }
+            }.show();
+            return true;
+        });
+        findPreference(PREF_RECONNECT_LOCAL_FOLDER).setOnPreferenceClickListener(preference -> {
+            MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(getContext());
+            alert.setMessage(R.string.reconnect_local_folder_warning);
+            alert.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                try {
+                    addLocalFolderLauncher.launch(null);
+                } catch (ActivityNotFoundException e) {
+                    Log.e(TAG, "No activity found. Should never happen...");
+                }
+            });
+            alert.setNegativeButton(android.R.string.cancel, null);
+            alert.show();
+            return true;
+        });
     }
 
     private void updateAutoDeleteSummary() {
@@ -327,6 +364,42 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
         };
         autoDownloadPreference.setSummary(summary);
         autoDownloadPreference.setValue("" + feedPreferences.getAutoDownload().code);
+    }
+
+    private void addLocalFolderResult(final Uri uri) {
+        if (uri == null) {
+            return;
+        }
+        if (feed == null) {
+            return;
+        }
+        Completable.fromAction(() -> {
+            getActivity().getContentResolver()
+                    .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            DocumentFile documentFile = DocumentFile.fromTreeUri(getContext(), uri);
+            if (documentFile == null) {
+                throw new IllegalArgumentException("Unable to retrieve document tree");
+            }
+            feed.setDownloadUrl(Feed.PREFIX_LOCAL_FOLDER + uri.toString());
+            FeedDatabaseWriter.updateFeed(getContext(), feed, false);
+        })
+                .subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        () -> EventBus.getDefault().post(new MessageEvent(getString(android.R.string.ok))),
+                        error -> EventBus.getDefault().post(new MessageEvent(error.getLocalizedMessage())));
+    }
+
+    private static class AddLocalFolder extends ActivityResultContracts.OpenDocumentTree {
+        @NonNull
+        @Override
+        public Intent createIntent(@NonNull final Context context, @Nullable final Uri input) {
+            return super.createIntent(context, input)
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+        }
     }
 
     private boolean showPlaybackSpeedDialog(Preference preference) {

--- a/app/src/main/res/menu/feedinfo.xml
+++ b/app/src/main/res/menu/feedinfo.xml
@@ -13,12 +13,4 @@
         android:title="@string/share_label"
         android:icon="@drawable/ic_share"
         android:visible="true" />
-    <item
-        android:id="@+id/reconnect_local_folder"
-        custom:showAsAction="collapseActionView"
-        android:title="@string/reconnect_local_folder"
-        android:visible="false" />
-    <item
-        android:id="@+id/edit_feed_url_item"
-        android:title="@string/edit_url_menu" />
 </menu>

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -101,6 +101,18 @@
             android:summary="@string/authentication_descr"
             android:title="@string/authentication_label" />
 
+        <Preference
+            android:icon="@drawable/ic_settings"
+            android:key="editFeedUrl"
+            android:summary="@string/edit_url_menu_summary"
+            android:title="@string/edit_url_menu" />
+
+        <Preference
+            android:icon="@drawable/ic_settings"
+            android:key="reconnectLocalFolder"
+            android:summary="@string/reconnect_local_folder_summary"
+            android:title="@string/reconnect_local_folder" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -856,6 +856,7 @@
     <string name="statistics_years_barchart_description">Time played per month</string>
     <string name="wait_icon" translatable="false">…</string>
     <string name="edit_url_menu">Edit feed URL</string>
+    <string name="edit_url_menu_summary">Risky: can permanently break episodes list, history, and playback state</string>
     <string name="edit_url_confirmation_msg">Changing the RSS address can easily break the playback state and episode listings of the podcast. We do NOT recommend changing it and will NOT provide support if anything goes wrong. This cannot be undone. The broken subscription CANNOT be repaired by simply changing the address back. We recommend creating a backup before continuing.</string>
 
     <!-- Podcast release schedules -->
@@ -895,6 +896,7 @@
     <string name="add_local_folder">Add local folder</string>
     <string name="local_folder">Local folder</string>
     <string name="reconnect_local_folder">Re-connect local folder</string>
+    <string name="reconnect_local_folder_summary">Risky: only re-connect to the exact same folder. Otherwise, you will lose all your playback state.</string>
     <string name="reconnect_local_folder_warning">In case of permission denials, you can use this to re-connect to the exact same folder. Do not select another folder.</string>
     <string name="local_feed_description">This virtual podcast was created by adding a folder to AntennaPod.</string>
     <string name="unable_to_start_system_file_manager">Unable to start system file manager</string>


### PR DESCRIPTION
### Description

Move URL edit box from feed info to feed settings. This really is a setting, not something that should be on the info page in some overflow menu...

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
