### PR TITLE
Fix dismissing miniplayer on media3 service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ If you have to use shell commands, prefer dedicated tools (such as `jq` for json
 AntennaPod uses a highly modularized Gradle architecture with modules organized by domain.
 Each module is stored in a folder of the same name (for example `:net:discovery` in `./net/discovery`)
 and contains a `README.md` file with a brief explanation of the module's purpose and internal structure.
+Before looking at code in a module, always read its `README.md` first.
 Several functional areas follow a service-interface/service split: the interface module is depended on by consumers, and the implementation is registered at app startup via `ClientConfigurator`.
 - `:app` - Main application module that integrates all features
 - `:event` - EventBus events used for cross-component communication throughout the app

--- a/app/README.md
+++ b/app/README.md
@@ -2,3 +2,6 @@
 
 The main application module that integrates all features and hosts app-specific UI screens not large enough for their own module.
 `PodcastApp` initializes the app; `ClientConfigurator` registers service implementations (download, sync) at startup.
+
+The miniplayer (the collapsed player bar at the bottom of the screen) is implemented in `ExternalPlayerFragment`.
+It is hosted in `MainActivity` as a bottom sheet. `MainActivity` controls its visibility via `setPlayerVisible()` based on playback state.

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -311,8 +311,8 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
                 bottomSheetBackPressedCallback.setEnabled(true);
             } else if (state == BottomSheetBehavior.STATE_HIDDEN) {
                 PlaybackController.bindToMedia3Service(MainActivity.this, controller -> {
-                    controller.stop();
                     controller.clearMediaItems();
+                    controller.stop();
                 });
                 PlaybackPreferences.writeNoMediaPlaying();
                 setPlayerVisible(false);

--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -51,7 +51,6 @@ import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
 import de.danoeh.antennapod.playback.cast.CastEnabledActivity;
 import de.danoeh.antennapod.playback.service.PlaybackController;
-import de.danoeh.antennapod.playback.service.PlaybackServiceInterface;
 import de.danoeh.antennapod.storage.databasemaintenanceservice.DatabaseMaintenanceWorker;
 import de.danoeh.antennapod.storage.importexport.AutomaticDatabaseExportWorker;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
@@ -59,7 +58,6 @@ import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
-import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.ui.common.NavigationToolbarActivity;
 import de.danoeh.antennapod.ui.common.ThemeSwitcher;
 import de.danoeh.antennapod.ui.common.ThemeUtils;
@@ -312,8 +310,10 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
                 onSlide(view, 1.0f);
                 bottomSheetBackPressedCallback.setEnabled(true);
             } else if (state == BottomSheetBehavior.STATE_HIDDEN) {
-                IntentUtils.sendLocalBroadcast(MainActivity.this,
-                        PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
+                PlaybackController.bindToMedia3Service(MainActivity.this, controller -> {
+                    controller.stop();
+                    controller.clearMediaItems();
+                });
                 PlaybackPreferences.writeNoMediaPlaying();
                 setPlayerVisible(false);
                 bottomSheetBackPressedCallback.setEnabled(false);

--- a/playback/service/README.md
+++ b/playback/service/README.md
@@ -1,3 +1,9 @@
 # :playback:service
 
 The main service doing media playback.
+
+`Media3PlaybackService` is the active implementation, built on AndroidX Media3/ExoPlayer.
+`PlaybackService` is legacy and will throw an exception if started — it exists only during the transition period.
+
+External callers should interact with the service through `PlaybackController`, which provides a
+`bindToMedia3Service()` helper that connects a `MediaController` and runs a callback on it.

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -295,7 +295,12 @@ public class Media3PlaybackService extends MediaLibraryService {
 
         @Override
         public void onMediaItemTransition(@Nullable MediaItem mediaItem, int reason) {
-            ensureCurrentMediaLoaded();
+            if (mediaItem == null) {
+                currentPlayable = null;
+                PlaybackPreferences.writeNoMediaPlaying();
+            } else {
+                ensureCurrentMediaLoaded();
+            }
             EventBus.getDefault().post(new PlayerStatusEvent());
         }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.playback.base.MediaItemAdapter;
@@ -278,8 +279,16 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     public ListenableFuture<MediaSession.MediaItemsWithStartPosition> onPlaybackResumption(
             @NonNull MediaSession mediaSession, @NonNull MediaSession.ControllerInfo controller) {
         SettableFuture<MediaSession.MediaItemsWithStartPosition> future = SettableFuture.create();
-        disposables.add(Single.fromCallable(() ->
-                        DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId()))
+        disposables.add(Single.fromCallable(() -> {
+                    FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+                    if (media == null) {
+                        List<FeedItem> recentQueue = DBReader.getPausedQueue(1);
+                        if (!recentQueue.isEmpty()) {
+                            media = recentQueue.get(0).getMedia();
+                        }
+                    }
+                    return media;
+                })
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         media -> {

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -280,15 +280,15 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
             @NonNull MediaSession mediaSession, @NonNull MediaSession.ControllerInfo controller) {
         SettableFuture<MediaSession.MediaItemsWithStartPosition> future = SettableFuture.create();
         disposables.add(Single.fromCallable(() -> {
-                    FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
-                    if (media == null) {
-                        List<FeedItem> recentQueue = DBReader.getPausedQueue(1);
-                        if (!recentQueue.isEmpty()) {
-                            media = recentQueue.get(0).getMedia();
-                        }
-                    }
-                    return media;
-                })
+            FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+            if (media == null) {
+                List<FeedItem> recentQueue = DBReader.getPausedQueue(1);
+                if (!recentQueue.isEmpty()) {
+                    media = recentQueue.get(0).getMedia();
+                }
+            }
+            return media;
+        })
                 .subscribeOn(Schedulers.io())
                 .subscribe(
                         media -> {


### PR DESCRIPTION
### Description

Fix dismissing miniplayer on media3 service. To make this super nice, we would need resumption support at runtime, but media3 does not support that: https://github.com/androidx/media/issues/770
Closes #8446

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
