### PR TITLE
Fix player bar jitters and lag when jumping forwards/backwards

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -263,11 +263,11 @@ public class AudioPlayerFragment extends Fragment implements
     }
 
     private void applyUiSeekSettle(int targetPosition, int duration) {
-        float playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia);
-        TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
+        final float playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia);
         uiSeekGenerationCounter++;
         activeUiSeekGeneration = uiSeekGenerationCounter;
         lastUiSeekTimestampMs = System.currentTimeMillis();
+        TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         lastUiSeekTargetDisplayPosition = converter.convert(targetPosition);
         currentMedia.setPosition(targetPosition);
         updatePosition(new PlaybackPositionEvent(targetPosition, duration));
@@ -414,7 +414,6 @@ public class AudioPlayerFragment extends Fragment implements
         float playbackSpeed = currentMedia != null ? PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia) : 1.0f;
         TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         int convertedPosition = converter.convert(event.getPosition());
-        int convertedDuration = converter.convert(event.getDuration());
         if (activeUiSeekGeneration > 0 && lastUiSeekTargetDisplayPosition != Playable.INVALID_TIME) {
             long elapsed = System.currentTimeMillis() - lastUiSeekTimestampMs;
             boolean positionCloseToTarget = Math.abs(convertedPosition - lastUiSeekTargetDisplayPosition)
@@ -426,6 +425,7 @@ public class AudioPlayerFragment extends Fragment implements
                 lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
             }
         }
+        int convertedDuration = converter.convert(event.getDuration());
         int remainingTime = converter.convert(Math.max(event.getDuration() - event.getPosition(), 0));
         if (currentMedia != null) {
             currentChapterIndex = Chapter.getAfterPosition(currentMedia.getChapters(), convertedPosition);
@@ -515,31 +515,29 @@ public class AudioPlayerFragment extends Fragment implements
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), controller ->
-                        {
-                            int duration = (int) controller.getDuration();
-                            if (duration <= 0) {
-                                duration = currentMedia.getDuration();
-                            }
-                            if (duration > 0) {
-                                int targetPosition = (int) (duration * prog);
-                                applyUiSeekSettle(targetPosition, duration);
-                                controller.seekTo(targetPosition);
-                            }
-                        });
+                PlaybackController.bindToMedia3Service(getContext(), controller -> {
+                    int duration = (int) controller.getDuration();
+                    if (duration <= 0) {
+                        duration = currentMedia.getDuration();
+                    }
+                    if (duration > 0) {
+                        int targetPosition = (int) (duration * prog);
+                        applyUiSeekSettle(targetPosition, duration);
+                        controller.seekTo(targetPosition);
+                    }
+                });
             } else {
-                PlaybackController.bindToService(getActivity(), playbackService ->
-                        {
-                            int duration = playbackService.getDuration();
-                            if (duration <= 0) {
-                                duration = currentMedia.getDuration();
-                            }
-                            if (duration > 0) {
-                                int targetPosition = (int) (duration * prog);
-                                applyUiSeekSettle(targetPosition, duration);
-                                playbackService.seekTo(targetPosition);
-                            }
-                        });
+                PlaybackController.bindToService(getActivity(), playbackService -> {
+                    int duration = playbackService.getDuration();
+                    if (duration <= 0) {
+                        duration = currentMedia.getDuration();
+                    }
+                    if (duration > 0) {
+                        int targetPosition = (int) (duration * prog);
+                        applyUiSeekSettle(targetPosition, duration);
+                        playbackService.seekTo(targetPosition);
+                    }
+                });
             }
         }
         cardViewSeek.setScaleX(1f);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -112,7 +112,6 @@ public class AudioPlayerFragment extends Fragment implements
     private long activeUiSeekGeneration = 0;
     private long lastUiSeekTimestampMs = 0;
     private int lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
-    private int lastUiSeekTargetPosition = Playable.INVALID_TIME;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -195,29 +194,10 @@ public class AudioPlayerFragment extends Fragment implements
 
     private void setupControlButtons() {
         butRev.setOnClickListener(v -> {
+            seekRelativeInUi(-UserPreferences.getRewindSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), controller -> {
-                    int basePosition = (int) controller.getCurrentPosition();
-                    if (activeUiSeekGeneration > 0
-                            && lastUiSeekTargetPosition != Playable.INVALID_TIME
-                            && System.currentTimeMillis() - lastUiSeekTimestampMs <= UI_SEEK_SETTLE_WINDOW_MS) {
-                        basePosition = lastUiSeekTargetPosition;
-                    }
-                    int targetPosition = Math.max(0, basePosition - UserPreferences.getRewindSecs() * 1000);
-                    int duration = (int) controller.getDuration();
-                    if (duration <= 0 && currentMedia != null) {
-                        duration = currentMedia.getDuration();
-                    }
-                    if (duration > 0) {
-                        targetPosition = Math.min(targetPosition, duration);
-                        applyUiSeekSettle(targetPosition, duration);
-                    } else if (currentMedia != null) {
-                        currentMedia.setPosition(targetPosition);
-                    }
-                    controller.seekTo(targetPosition);
-                });
+                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekBack);
             } else {
-                seekRelativeInUi(-UserPreferences.getRewindSecs() * 1000);
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo(playbackService.getCurrentPosition()
                                 - UserPreferences.getRewindSecs() * 1000));
@@ -244,29 +224,10 @@ public class AudioPlayerFragment extends Fragment implements
             }
         });
         butFF.setOnClickListener(v -> {
+            seekRelativeInUi(UserPreferences.getFastForwardSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), controller -> {
-                    int basePosition = (int) controller.getCurrentPosition();
-                    if (activeUiSeekGeneration > 0
-                            && lastUiSeekTargetPosition != Playable.INVALID_TIME
-                            && System.currentTimeMillis() - lastUiSeekTimestampMs <= UI_SEEK_SETTLE_WINDOW_MS) {
-                        basePosition = lastUiSeekTargetPosition;
-                    }
-                    int targetPosition = Math.max(0, basePosition + UserPreferences.getFastForwardSecs() * 1000);
-                    int duration = (int) controller.getDuration();
-                    if (duration <= 0 && currentMedia != null) {
-                        duration = currentMedia.getDuration();
-                    }
-                    if (duration > 0) {
-                        targetPosition = Math.min(targetPosition, duration);
-                        applyUiSeekSettle(targetPosition, duration);
-                    } else if (currentMedia != null) {
-                        currentMedia.setPosition(targetPosition);
-                    }
-                    controller.seekTo(targetPosition);
-                });
+                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekForward);
             } else {
-                seekRelativeInUi(UserPreferences.getFastForwardSecs() * 1000);
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo(playbackService.getCurrentPosition()
                                 + UserPreferences.getFastForwardSecs() * 1000));
@@ -291,13 +252,7 @@ public class AudioPlayerFragment extends Fragment implements
         if (currentMedia == null) {
             return;
         }
-        int basePosition = currentMedia.getPosition();
-        if (activeUiSeekGeneration > 0
-                && lastUiSeekTargetPosition != Playable.INVALID_TIME
-                && System.currentTimeMillis() - lastUiSeekTimestampMs <= UI_SEEK_SETTLE_WINDOW_MS) {
-            basePosition = lastUiSeekTargetPosition;
-        }
-        int newPosition = Math.max(0, basePosition + deltaMs);
+        int newPosition = Math.max(0, currentMedia.getPosition() + deltaMs);
         int duration = currentMedia.getDuration();
         if (duration > 0) {
             newPosition = Math.min(newPosition, duration);
@@ -314,7 +269,6 @@ public class AudioPlayerFragment extends Fragment implements
         lastUiSeekTimestampMs = System.currentTimeMillis();
         TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         lastUiSeekTargetDisplayPosition = converter.convert(targetPosition);
-        lastUiSeekTargetPosition = targetPosition;
         currentMedia.setPosition(targetPosition);
         updatePosition(new PlaybackPositionEvent(targetPosition, duration));
     }
@@ -380,9 +334,6 @@ public class AudioPlayerFragment extends Fragment implements
         .subscribe(media -> {
             boolean mediaChanged = currentMedia == null || currentMedia.getId() != media.getId();
             currentMedia = media;
-            if (!mediaChanged && activeUiSeekGeneration > 0 && lastUiSeekTargetPosition != Playable.INVALID_TIME) {
-                currentMedia.setPosition(lastUiSeekTargetPosition);
-            }
             updateUi(mediaChanged);
             if (media.getChapters() == null && !includingChapters) {
                 loadMediaInfo(true);
@@ -472,7 +423,6 @@ public class AudioPlayerFragment extends Fragment implements
             } else {
                 activeUiSeekGeneration = 0;
                 lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
-                lastUiSeekTargetPosition = Playable.INVALID_TIME;
             }
         }
         int convertedDuration = converter.convert(event.getDuration());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -188,7 +188,6 @@ public class AudioPlayerFragment extends Fragment implements
 
     private void setupControlButtons() {
         butRev.setOnClickListener(v -> {
-            seekRelativeInUi(-UserPreferences.getRewindSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), MediaController::seekBack);
             } else {
@@ -218,7 +217,6 @@ public class AudioPlayerFragment extends Fragment implements
             }
         });
         butFF.setOnClickListener(v -> {
-            seekRelativeInUi(UserPreferences.getFastForwardSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), MediaController::seekForward);
             } else {
@@ -240,21 +238,6 @@ public class AudioPlayerFragment extends Fragment implements
                         MediaButtonStarter.createIntent(getContext(), KeyEvent.KEYCODE_MEDIA_NEXT));
             }
         });
-    }
-
-    private void seekRelativeInUi(int deltaMs) {
-        if (currentMedia == null) {
-            return;
-        }
-        int newPosition = Math.max(0, currentMedia.getPosition() + deltaMs);
-        int duration = currentMedia.getDuration();
-        if (duration > 0) {
-            newPosition = Math.min(newPosition, duration);
-            currentMedia.setPosition(newPosition);
-            updatePosition(new PlaybackPositionEvent(newPosition, duration));
-        } else {
-            currentMedia.setPosition(newPosition);
-        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -316,22 +299,19 @@ public class AudioPlayerFragment extends Fragment implements
         .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(media -> {
-            boolean mediaChanged = currentMedia == null || currentMedia.getId() != media.getId();
             currentMedia = media;
-            updateUi(mediaChanged);
+            updateUi();
             if (media.getChapters() == null && !includingChapters) {
                 loadMediaInfo(true);
             }
         }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 
-    private void updateUi(boolean updatePositionFromMedia) {
+    private void updateUi() {
         if (currentMedia == null) {
             return;
         }
-        if (updatePositionFromMedia) {
-            updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(), currentMedia.getDuration()));
-        }
+        updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(), currentMedia.getDuration()));
         updatePlaybackSpeedButton(new SpeedChangedEvent(PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia)));
         setChapterDividers();
         setupOptionsMenu();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -18,8 +18,6 @@ import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
 import androidx.media3.session.MediaController;
-import androidx.media3.session.SessionCommand;
-import androidx.media3.common.util.Util;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -188,6 +188,7 @@ public class AudioPlayerFragment extends Fragment implements
 
     private void setupControlButtons() {
         butRev.setOnClickListener(v -> {
+            seekRelativeInUi(-UserPreferences.getRewindSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), MediaController::seekBack);
             } else {
@@ -217,6 +218,7 @@ public class AudioPlayerFragment extends Fragment implements
             }
         });
         butFF.setOnClickListener(v -> {
+            seekRelativeInUi(UserPreferences.getFastForwardSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), MediaController::seekForward);
             } else {
@@ -238,6 +240,21 @@ public class AudioPlayerFragment extends Fragment implements
                         MediaButtonStarter.createIntent(getContext(), KeyEvent.KEYCODE_MEDIA_NEXT));
             }
         });
+    }
+
+    private void seekRelativeInUi(int deltaMs) {
+        if (currentMedia == null) {
+            return;
+        }
+        int newPosition = Math.max(0, currentMedia.getPosition() + deltaMs);
+        int duration = currentMedia.getDuration();
+        if (duration > 0) {
+            newPosition = Math.min(newPosition, duration);
+            currentMedia.setPosition(newPosition);
+            updatePosition(new PlaybackPositionEvent(newPosition, duration));
+        } else {
+            currentMedia.setPosition(newPosition);
+        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -299,19 +316,22 @@ public class AudioPlayerFragment extends Fragment implements
         .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(media -> {
+            boolean mediaChanged = currentMedia == null || currentMedia.getId() != media.getId();
             currentMedia = media;
-            updateUi();
+            updateUi(mediaChanged);
             if (media.getChapters() == null && !includingChapters) {
                 loadMediaInfo(true);
             }
         }, error -> Log.e(TAG, Log.getStackTraceString(error)));
     }
 
-    private void updateUi() {
+    private void updateUi(boolean updatePositionFromMedia) {
         if (currentMedia == null) {
             return;
         }
-        updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(), currentMedia.getDuration()));
+        if (updatePositionFromMedia) {
+            updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(), currentMedia.getDuration()));
+        }
         updatePlaybackSpeedButton(new SpeedChangedEvent(PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia)));
         setChapterDividers();
         setupOptionsMenu();

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -84,6 +84,8 @@ public class AudioPlayerFragment extends Fragment implements
     public static final int POS_COVER = 0;
     public static final int POS_DESCRIPTION = 1;
     private static final int NUM_CONTENT_FRAGMENTS = 2;
+    private static final long UI_SEEK_SETTLE_WINDOW_MS = 1200;
+    private static final int UI_SEEK_SETTLE_TOLERANCE_MS = 1500;
 
     private TextView txtvPlaybackSpeed;
     private ViewPager2 pager;
@@ -106,6 +108,10 @@ public class AudioPlayerFragment extends Fragment implements
     private boolean showTimeLeft;
     private boolean seekedToChapterStart = false;
     private int currentChapterIndex = -1;
+    private long uiSeekGenerationCounter = 0;
+    private long activeUiSeekGeneration = 0;
+    private long lastUiSeekTimestampMs = 0;
+    private int lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -250,11 +256,21 @@ public class AudioPlayerFragment extends Fragment implements
         int duration = currentMedia.getDuration();
         if (duration > 0) {
             newPosition = Math.min(newPosition, duration);
-            currentMedia.setPosition(newPosition);
-            updatePosition(new PlaybackPositionEvent(newPosition, duration));
+            applyUiSeekSettle(newPosition, duration);
         } else {
             currentMedia.setPosition(newPosition);
         }
+    }
+
+    private void applyUiSeekSettle(int targetPosition, int duration) {
+        float playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia);
+        TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
+        uiSeekGenerationCounter++;
+        activeUiSeekGeneration = uiSeekGenerationCounter;
+        lastUiSeekTimestampMs = System.currentTimeMillis();
+        lastUiSeekTargetDisplayPosition = converter.convert(targetPosition);
+        currentMedia.setPosition(targetPosition);
+        updatePosition(new PlaybackPositionEvent(targetPosition, duration));
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -399,6 +415,17 @@ public class AudioPlayerFragment extends Fragment implements
         TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         int convertedPosition = converter.convert(event.getPosition());
         int convertedDuration = converter.convert(event.getDuration());
+        if (activeUiSeekGeneration > 0 && lastUiSeekTargetDisplayPosition != Playable.INVALID_TIME) {
+            long elapsed = System.currentTimeMillis() - lastUiSeekTimestampMs;
+            boolean positionCloseToTarget = Math.abs(convertedPosition - lastUiSeekTargetDisplayPosition)
+                    <= UI_SEEK_SETTLE_TOLERANCE_MS;
+            if (elapsed <= UI_SEEK_SETTLE_WINDOW_MS && !positionCloseToTarget) {
+                convertedPosition = lastUiSeekTargetDisplayPosition;
+            } else {
+                activeUiSeekGeneration = 0;
+                lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
+            }
+        }
         int remainingTime = converter.convert(Math.max(event.getDuration() - event.getPosition(), 0));
         if (currentMedia != null) {
             currentChapterIndex = Chapter.getAfterPosition(currentMedia.getChapters(), convertedPosition);
@@ -423,7 +450,7 @@ public class AudioPlayerFragment extends Fragment implements
         }
 
         if (!sbPosition.isPressed()) {
-            float progress = ((float) event.getPosition()) / event.getDuration();
+            float progress = convertedDuration > 0 ? ((float) convertedPosition) / convertedDuration : 0;
             sbPosition.setProgress((int) (progress * sbPosition.getMax()));
         }
     }
@@ -487,6 +514,11 @@ public class AudioPlayerFragment extends Fragment implements
             seekedToChapterStart = false;
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
+            int duration = currentMedia.getDuration();
+            if (duration > 0) {
+                int targetPosition = (int) (duration * prog);
+                applyUiSeekSettle(targetPosition, duration);
+            }
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), controller ->
                         controller.seekTo((long) (controller.getDuration() * prog)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -204,10 +204,10 @@ public class AudioPlayerFragment extends Fragment implements
                         basePosition = lastUiSeekTargetPosition;
                     }
                     int targetPosition = Math.max(0, basePosition - UserPreferences.getRewindSecs() * 1000);
-                    int duration = (int) controller.getDuration();
-                    if (duration <= 0 && currentMedia != null) {
-                        duration = currentMedia.getDuration();
-                    }
+                    long controllerDuration = controller.getDuration();
+                    int duration = controllerDuration > 0 && controllerDuration <= Integer.MAX_VALUE
+                            ? (int) controllerDuration
+                            : (currentMedia != null ? currentMedia.getDuration() : Playable.INVALID_TIME);
                     if (duration > 0) {
                         targetPosition = Math.min(targetPosition, duration);
                         applyUiSeekSettle(targetPosition, duration);
@@ -253,10 +253,10 @@ public class AudioPlayerFragment extends Fragment implements
                         basePosition = lastUiSeekTargetPosition;
                     }
                     int targetPosition = Math.max(0, basePosition + UserPreferences.getFastForwardSecs() * 1000);
-                    int duration = (int) controller.getDuration();
-                    if (duration <= 0 && currentMedia != null) {
-                        duration = currentMedia.getDuration();
-                    }
+                    long controllerDuration = controller.getDuration();
+                    int duration = controllerDuration > 0 && controllerDuration <= Integer.MAX_VALUE
+                            ? (int) controllerDuration
+                            : (currentMedia != null ? currentMedia.getDuration() : Playable.INVALID_TIME);
                     if (duration > 0) {
                         targetPosition = Math.min(targetPosition, duration);
                         applyUiSeekSettle(targetPosition, duration);
@@ -566,10 +566,10 @@ public class AudioPlayerFragment extends Fragment implements
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), controller -> {
-                    int duration = (int) controller.getDuration();
-                    if (duration <= 0) {
-                        duration = currentMedia.getDuration();
-                    }
+                    long controllerDuration = controller.getDuration();
+                    int duration = controllerDuration > 0 && controllerDuration <= Integer.MAX_VALUE
+                            ? (int) controllerDuration
+                            : currentMedia.getDuration();
                     if (duration > 0) {
                         int targetPosition = (int) (duration * prog);
                         applyUiSeekSettle(targetPosition, duration);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -109,6 +109,9 @@ public class AudioPlayerFragment extends Fragment implements
     private boolean seekedToChapterStart = false;
     private int currentChapterIndex = -1;
     private long currentMediaId = -1;
+    private int latestLivePosition = Playable.INVALID_TIME;
+    private int latestLiveDuration = Playable.INVALID_TIME;
+    private long latestLiveMediaId = -1;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -317,7 +320,15 @@ public class AudioPlayerFragment extends Fragment implements
         if (currentMedia == null) {
             return;
         }
-        updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(), currentMedia.getDuration()));
+        int position = currentMedia.getPosition();
+        int duration = currentMedia.getDuration();
+        if (currentMedia.getId() == latestLiveMediaId
+                && latestLivePosition != Playable.INVALID_TIME
+                && latestLiveDuration != Playable.INVALID_TIME) {
+            position = latestLivePosition;
+            duration = latestLiveDuration;
+        }
+        updatePosition(new PlaybackPositionEvent(position, duration));
         updatePlaybackSpeedButton(new SpeedChangedEvent(PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia)));
         setChapterDividers();
         setupOptionsMenu();
@@ -333,7 +344,9 @@ public class AudioPlayerFragment extends Fragment implements
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusEvent(PlayerStatusEvent event) {
         long playingMediaId = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
-        if (currentMedia == null || currentMediaId != playingMediaId) {
+        boolean sameOrUnknownPlayingMedia = currentMedia != null
+                && (playingMediaId <= 0 || currentMediaId == playingMediaId);
+        if (currentMedia == null || !sameOrUnknownPlayingMedia) {
             loadMediaInfo(false);
         } else {
             updatePlayButton();
@@ -386,6 +399,9 @@ public class AudioPlayerFragment extends Fragment implements
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void updatePosition(PlaybackPositionEvent event) {
+        latestLiveMediaId = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
+        latestLivePosition = event.getPosition();
+        latestLiveDuration = event.getDuration();
         if (txtvPosition == null || txtvLength == null || sbPosition == null) {
             return;
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -514,32 +514,17 @@ public class AudioPlayerFragment extends Fragment implements
             seekedToChapterStart = false;
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
+            int duration = currentMedia.getDuration();
+            if (duration > 0) {
+                int targetPosition = (int) (duration * prog);
+                applyUiSeekSettle(targetPosition, duration);
+            }
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), controller ->
-                        {
-                            int duration = (int) controller.getDuration();
-                            if (duration <= 0) {
-                                duration = currentMedia.getDuration();
-                            }
-                            if (duration > 0) {
-                                int targetPosition = (int) (duration * prog);
-                                applyUiSeekSettle(targetPosition, duration);
-                                controller.seekTo(targetPosition);
-                            }
-                        });
+                        controller.seekTo((long) (controller.getDuration() * prog)));
             } else {
                 PlaybackController.bindToService(getActivity(), playbackService ->
-                        {
-                            int duration = playbackService.getDuration();
-                            if (duration <= 0) {
-                                duration = currentMedia.getDuration();
-                            }
-                            if (duration > 0) {
-                                int targetPosition = (int) (duration * prog);
-                                applyUiSeekSettle(targetPosition, duration);
-                                playbackService.seekTo(targetPosition);
-                            }
-                        });
+                        playbackService.seekTo((int) (playbackService.getDuration() * prog)));
             }
         }
         cardViewSeek.setScaleX(1f);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -84,8 +84,6 @@ public class AudioPlayerFragment extends Fragment implements
     public static final int POS_COVER = 0;
     public static final int POS_DESCRIPTION = 1;
     private static final int NUM_CONTENT_FRAGMENTS = 2;
-    private static final long UI_SEEK_SETTLE_WINDOW_MS = 1200;
-    private static final int UI_SEEK_SETTLE_TOLERANCE_MS = 1500;
 
     private TextView txtvPlaybackSpeed;
     private ViewPager2 pager;
@@ -108,10 +106,6 @@ public class AudioPlayerFragment extends Fragment implements
     private boolean showTimeLeft;
     private boolean seekedToChapterStart = false;
     private int currentChapterIndex = -1;
-    private long uiSeekGenerationCounter = 0;
-    private long activeUiSeekGeneration = 0;
-    private long lastUiSeekTimestampMs = 0;
-    private int lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -256,21 +250,11 @@ public class AudioPlayerFragment extends Fragment implements
         int duration = currentMedia.getDuration();
         if (duration > 0) {
             newPosition = Math.min(newPosition, duration);
-            applyUiSeekSettle(newPosition, duration);
+            currentMedia.setPosition(newPosition);
+            updatePosition(new PlaybackPositionEvent(newPosition, duration));
         } else {
             currentMedia.setPosition(newPosition);
         }
-    }
-
-    private void applyUiSeekSettle(int targetPosition, int duration) {
-        float playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia);
-        TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
-        uiSeekGenerationCounter++;
-        activeUiSeekGeneration = uiSeekGenerationCounter;
-        lastUiSeekTimestampMs = System.currentTimeMillis();
-        lastUiSeekTargetDisplayPosition = converter.convert(targetPosition);
-        currentMedia.setPosition(targetPosition);
-        updatePosition(new PlaybackPositionEvent(targetPosition, duration));
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -415,17 +399,6 @@ public class AudioPlayerFragment extends Fragment implements
         TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         int convertedPosition = converter.convert(event.getPosition());
         int convertedDuration = converter.convert(event.getDuration());
-        if (activeUiSeekGeneration > 0 && lastUiSeekTargetDisplayPosition != Playable.INVALID_TIME) {
-            long elapsed = System.currentTimeMillis() - lastUiSeekTimestampMs;
-            boolean positionCloseToTarget = Math.abs(convertedPosition - lastUiSeekTargetDisplayPosition)
-                    <= UI_SEEK_SETTLE_TOLERANCE_MS;
-            if (elapsed <= UI_SEEK_SETTLE_WINDOW_MS && !positionCloseToTarget) {
-                convertedPosition = lastUiSeekTargetDisplayPosition;
-            } else {
-                activeUiSeekGeneration = 0;
-                lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
-            }
-        }
         int remainingTime = converter.convert(Math.max(event.getDuration() - event.getPosition(), 0));
         if (currentMedia != null) {
             currentChapterIndex = Chapter.getAfterPosition(currentMedia.getChapters(), convertedPosition);
@@ -450,7 +423,7 @@ public class AudioPlayerFragment extends Fragment implements
         }
 
         if (!sbPosition.isPressed()) {
-            float progress = convertedDuration > 0 ? ((float) convertedPosition) / convertedDuration : 0;
+            float progress = ((float) event.getPosition()) / event.getDuration();
             sbPosition.setProgress((int) (progress * sbPosition.getMax()));
         }
     }
@@ -514,11 +487,6 @@ public class AudioPlayerFragment extends Fragment implements
             seekedToChapterStart = false;
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
-            int duration = currentMedia.getDuration();
-            if (duration > 0) {
-                int targetPosition = (int) (duration * prog);
-                applyUiSeekSettle(targetPosition, duration);
-            }
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), controller ->
                         controller.seekTo((long) (controller.getDuration() * prog)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -112,6 +112,7 @@ public class AudioPlayerFragment extends Fragment implements
     private long activeUiSeekGeneration = 0;
     private long lastUiSeekTimestampMs = 0;
     private int lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
+    private int lastUiSeekTargetPosition = Playable.INVALID_TIME;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -194,10 +195,29 @@ public class AudioPlayerFragment extends Fragment implements
 
     private void setupControlButtons() {
         butRev.setOnClickListener(v -> {
-            seekRelativeInUi(-UserPreferences.getRewindSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekBack);
+                PlaybackController.bindToMedia3Service(getContext(), controller -> {
+                    int basePosition = (int) controller.getCurrentPosition();
+                    if (activeUiSeekGeneration > 0
+                            && lastUiSeekTargetPosition != Playable.INVALID_TIME
+                            && System.currentTimeMillis() - lastUiSeekTimestampMs <= UI_SEEK_SETTLE_WINDOW_MS) {
+                        basePosition = lastUiSeekTargetPosition;
+                    }
+                    int targetPosition = Math.max(0, basePosition - UserPreferences.getRewindSecs() * 1000);
+                    int duration = (int) controller.getDuration();
+                    if (duration <= 0 && currentMedia != null) {
+                        duration = currentMedia.getDuration();
+                    }
+                    if (duration > 0) {
+                        targetPosition = Math.min(targetPosition, duration);
+                        applyUiSeekSettle(targetPosition, duration);
+                    } else if (currentMedia != null) {
+                        currentMedia.setPosition(targetPosition);
+                    }
+                    controller.seekTo(targetPosition);
+                });
             } else {
+                seekRelativeInUi(-UserPreferences.getRewindSecs() * 1000);
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo(playbackService.getCurrentPosition()
                                 - UserPreferences.getRewindSecs() * 1000));
@@ -224,10 +244,29 @@ public class AudioPlayerFragment extends Fragment implements
             }
         });
         butFF.setOnClickListener(v -> {
-            seekRelativeInUi(UserPreferences.getFastForwardSecs() * 1000);
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekForward);
+                PlaybackController.bindToMedia3Service(getContext(), controller -> {
+                    int basePosition = (int) controller.getCurrentPosition();
+                    if (activeUiSeekGeneration > 0
+                            && lastUiSeekTargetPosition != Playable.INVALID_TIME
+                            && System.currentTimeMillis() - lastUiSeekTimestampMs <= UI_SEEK_SETTLE_WINDOW_MS) {
+                        basePosition = lastUiSeekTargetPosition;
+                    }
+                    int targetPosition = Math.max(0, basePosition + UserPreferences.getFastForwardSecs() * 1000);
+                    int duration = (int) controller.getDuration();
+                    if (duration <= 0 && currentMedia != null) {
+                        duration = currentMedia.getDuration();
+                    }
+                    if (duration > 0) {
+                        targetPosition = Math.min(targetPosition, duration);
+                        applyUiSeekSettle(targetPosition, duration);
+                    } else if (currentMedia != null) {
+                        currentMedia.setPosition(targetPosition);
+                    }
+                    controller.seekTo(targetPosition);
+                });
             } else {
+                seekRelativeInUi(UserPreferences.getFastForwardSecs() * 1000);
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo(playbackService.getCurrentPosition()
                                 + UserPreferences.getFastForwardSecs() * 1000));
@@ -252,7 +291,13 @@ public class AudioPlayerFragment extends Fragment implements
         if (currentMedia == null) {
             return;
         }
-        int newPosition = Math.max(0, currentMedia.getPosition() + deltaMs);
+        int basePosition = currentMedia.getPosition();
+        if (activeUiSeekGeneration > 0
+                && lastUiSeekTargetPosition != Playable.INVALID_TIME
+                && System.currentTimeMillis() - lastUiSeekTimestampMs <= UI_SEEK_SETTLE_WINDOW_MS) {
+            basePosition = lastUiSeekTargetPosition;
+        }
+        int newPosition = Math.max(0, basePosition + deltaMs);
         int duration = currentMedia.getDuration();
         if (duration > 0) {
             newPosition = Math.min(newPosition, duration);
@@ -269,6 +314,7 @@ public class AudioPlayerFragment extends Fragment implements
         lastUiSeekTimestampMs = System.currentTimeMillis();
         TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         lastUiSeekTargetDisplayPosition = converter.convert(targetPosition);
+        lastUiSeekTargetPosition = targetPosition;
         currentMedia.setPosition(targetPosition);
         updatePosition(new PlaybackPositionEvent(targetPosition, duration));
     }
@@ -334,6 +380,9 @@ public class AudioPlayerFragment extends Fragment implements
         .subscribe(media -> {
             boolean mediaChanged = currentMedia == null || currentMedia.getId() != media.getId();
             currentMedia = media;
+            if (!mediaChanged && activeUiSeekGeneration > 0 && lastUiSeekTargetPosition != Playable.INVALID_TIME) {
+                currentMedia.setPosition(lastUiSeekTargetPosition);
+            }
             updateUi(mediaChanged);
             if (media.getChapters() == null && !includingChapters) {
                 loadMediaInfo(true);
@@ -423,6 +472,7 @@ public class AudioPlayerFragment extends Fragment implements
             } else {
                 activeUiSeekGeneration = 0;
                 lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
+                lastUiSeekTargetPosition = Playable.INVALID_TIME;
             }
         }
         int convertedDuration = converter.convert(event.getDuration());

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -204,10 +204,10 @@ public class AudioPlayerFragment extends Fragment implements
                         basePosition = lastUiSeekTargetPosition;
                     }
                     int targetPosition = Math.max(0, basePosition - UserPreferences.getRewindSecs() * 1000);
-                    long controllerDuration = controller.getDuration();
-                    int duration = controllerDuration > 0 && controllerDuration <= Integer.MAX_VALUE
-                            ? (int) controllerDuration
-                            : (currentMedia != null ? currentMedia.getDuration() : Playable.INVALID_TIME);
+                    int duration = (int) controller.getDuration();
+                    if (duration <= 0 && currentMedia != null) {
+                        duration = currentMedia.getDuration();
+                    }
                     if (duration > 0) {
                         targetPosition = Math.min(targetPosition, duration);
                         applyUiSeekSettle(targetPosition, duration);
@@ -253,10 +253,10 @@ public class AudioPlayerFragment extends Fragment implements
                         basePosition = lastUiSeekTargetPosition;
                     }
                     int targetPosition = Math.max(0, basePosition + UserPreferences.getFastForwardSecs() * 1000);
-                    long controllerDuration = controller.getDuration();
-                    int duration = controllerDuration > 0 && controllerDuration <= Integer.MAX_VALUE
-                            ? (int) controllerDuration
-                            : (currentMedia != null ? currentMedia.getDuration() : Playable.INVALID_TIME);
+                    int duration = (int) controller.getDuration();
+                    if (duration <= 0 && currentMedia != null) {
+                        duration = currentMedia.getDuration();
+                    }
                     if (duration > 0) {
                         targetPosition = Math.min(targetPosition, duration);
                         applyUiSeekSettle(targetPosition, duration);
@@ -566,10 +566,10 @@ public class AudioPlayerFragment extends Fragment implements
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), controller -> {
-                    long controllerDuration = controller.getDuration();
-                    int duration = controllerDuration > 0 && controllerDuration <= Integer.MAX_VALUE
-                            ? (int) controllerDuration
-                            : currentMedia.getDuration();
+                    int duration = (int) controller.getDuration();
+                    if (duration <= 0) {
+                        duration = currentMedia.getDuration();
+                    }
                     if (duration > 0) {
                         int targetPosition = (int) (duration * prog);
                         applyUiSeekSettle(targetPosition, duration);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -18,6 +18,8 @@ import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
 import androidx.media3.session.MediaController;
+import androidx.media3.session.SessionCommand;
+import androidx.media3.common.util.Util;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
@@ -106,6 +108,7 @@ public class AudioPlayerFragment extends Fragment implements
     private boolean showTimeLeft;
     private boolean seekedToChapterStart = false;
     private int currentChapterIndex = -1;
+    private long currentMediaId = -1;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -189,7 +192,8 @@ public class AudioPlayerFragment extends Fragment implements
     private void setupControlButtons() {
         butRev.setOnClickListener(v -> {
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekBack);
+                PlaybackController.seekRelativeMedia3(getContext(), currentMedia,
+                        -UserPreferences.getRewindSecs() * 1000);
             } else {
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo(playbackService.getCurrentPosition()
@@ -218,7 +222,8 @@ public class AudioPlayerFragment extends Fragment implements
         });
         butFF.setOnClickListener(v -> {
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekForward);
+                PlaybackController.seekRelativeMedia3(getContext(), currentMedia,
+                        UserPreferences.getFastForwardSecs() * 1000);
             } else {
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo(playbackService.getCurrentPosition()
@@ -248,7 +253,7 @@ public class AudioPlayerFragment extends Fragment implements
         if (FeedItemEvent.indexOfItemWithId(event.items, currentMedia.getItemId()) != -1) {
             AudioPlayerFragment.this.loadMediaInfo(false);
         }
-        if (event.items.isEmpty()) {
+        if (event.items.isEmpty() && !PlaybackService.isRunning) {
             // The unread update event is sometimes abused to trigger UI updates
             updatePosition(new PlaybackPositionEvent(currentMedia.getPosition(),
                     currentMedia.getDuration()));
@@ -300,6 +305,7 @@ public class AudioPlayerFragment extends Fragment implements
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(media -> {
             currentMedia = media;
+            currentMediaId = media.getId();
             updateUi();
             if (media.getChapters() == null && !includingChapters) {
                 loadMediaInfo(true);
@@ -315,6 +321,10 @@ public class AudioPlayerFragment extends Fragment implements
         updatePlaybackSpeedButton(new SpeedChangedEvent(PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia)));
         setChapterDividers();
         setupOptionsMenu();
+        updatePlayButton();
+    }
+
+    private void updatePlayButton() {
         boolean isPlaying = PlaybackService.isRunning
                 && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING;
         butPlay.setIsShowPlay(!isPlaying);
@@ -322,7 +332,12 @@ public class AudioPlayerFragment extends Fragment implements
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusEvent(PlayerStatusEvent event) {
-        loadMediaInfo(false);
+        long playingMediaId = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
+        if (currentMedia == null || currentMediaId != playingMediaId) {
+            loadMediaInfo(false);
+        } else {
+            updatePlayButton();
+        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -433,8 +448,7 @@ public class AudioPlayerFragment extends Fragment implements
                     seekedToChapterStart = true;
                     final int positionFinal = position;
                     if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                        PlaybackController.bindToMedia3Service(getContext(), controller ->
-                                controller.seekTo(positionFinal));
+                        PlaybackController.seekToMedia3(getContext(), currentMedia, positionFinal);
                     } else {
                         PlaybackController.bindToService(getActivity(), playbackService ->
                                 playbackService.seekTo(positionFinal));
@@ -468,8 +482,7 @@ public class AudioPlayerFragment extends Fragment implements
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), controller ->
-                        controller.seekTo((long) (controller.getDuration() * prog)));
+                PlaybackController.seekToProgressMedia3(getContext(), currentMedia, prog);
             } else {
                 PlaybackController.bindToService(getActivity(), playbackService ->
                         playbackService.seekTo((int) (playbackService.getDuration() * prog)));

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -514,17 +514,32 @@ public class AudioPlayerFragment extends Fragment implements
             seekedToChapterStart = false;
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
-            int duration = currentMedia.getDuration();
-            if (duration > 0) {
-                int targetPosition = (int) (duration * prog);
-                applyUiSeekSettle(targetPosition, duration);
-            }
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
                 PlaybackController.bindToMedia3Service(getContext(), controller ->
-                        controller.seekTo((long) (controller.getDuration() * prog)));
+                        {
+                            int duration = (int) controller.getDuration();
+                            if (duration <= 0) {
+                                duration = currentMedia.getDuration();
+                            }
+                            if (duration > 0) {
+                                int targetPosition = (int) (duration * prog);
+                                applyUiSeekSettle(targetPosition, duration);
+                                controller.seekTo(targetPosition);
+                            }
+                        });
             } else {
                 PlaybackController.bindToService(getActivity(), playbackService ->
-                        playbackService.seekTo((int) (playbackService.getDuration() * prog)));
+                        {
+                            int duration = playbackService.getDuration();
+                            if (duration <= 0) {
+                                duration = currentMedia.getDuration();
+                            }
+                            if (duration > 0) {
+                                int targetPosition = (int) (duration * prog);
+                                applyUiSeekSettle(targetPosition, duration);
+                                playbackService.seekTo(targetPosition);
+                            }
+                        });
             }
         }
         cardViewSeek.setScaleX(1f);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -263,11 +263,11 @@ public class AudioPlayerFragment extends Fragment implements
     }
 
     private void applyUiSeekSettle(int targetPosition, int duration) {
-        final float playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia);
+        float playbackSpeed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia);
+        TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         uiSeekGenerationCounter++;
         activeUiSeekGeneration = uiSeekGenerationCounter;
         lastUiSeekTimestampMs = System.currentTimeMillis();
-        TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         lastUiSeekTargetDisplayPosition = converter.convert(targetPosition);
         currentMedia.setPosition(targetPosition);
         updatePosition(new PlaybackPositionEvent(targetPosition, duration));
@@ -414,6 +414,7 @@ public class AudioPlayerFragment extends Fragment implements
         float playbackSpeed = currentMedia != null ? PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentMedia) : 1.0f;
         TimeSpeedConverter converter = new TimeSpeedConverter(playbackSpeed);
         int convertedPosition = converter.convert(event.getPosition());
+        int convertedDuration = converter.convert(event.getDuration());
         if (activeUiSeekGeneration > 0 && lastUiSeekTargetDisplayPosition != Playable.INVALID_TIME) {
             long elapsed = System.currentTimeMillis() - lastUiSeekTimestampMs;
             boolean positionCloseToTarget = Math.abs(convertedPosition - lastUiSeekTargetDisplayPosition)
@@ -425,7 +426,6 @@ public class AudioPlayerFragment extends Fragment implements
                 lastUiSeekTargetDisplayPosition = Playable.INVALID_TIME;
             }
         }
-        int convertedDuration = converter.convert(event.getDuration());
         int remainingTime = converter.convert(Math.max(event.getDuration() - event.getPosition(), 0));
         if (currentMedia != null) {
             currentChapterIndex = Chapter.getAfterPosition(currentMedia.getChapters(), convertedPosition);
@@ -515,29 +515,31 @@ public class AudioPlayerFragment extends Fragment implements
         } else if (currentMedia != null) {
             final float prog = seekBar.getProgress() / ((float) seekBar.getMax());
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), controller -> {
-                    int duration = (int) controller.getDuration();
-                    if (duration <= 0) {
-                        duration = currentMedia.getDuration();
-                    }
-                    if (duration > 0) {
-                        int targetPosition = (int) (duration * prog);
-                        applyUiSeekSettle(targetPosition, duration);
-                        controller.seekTo(targetPosition);
-                    }
-                });
+                PlaybackController.bindToMedia3Service(getContext(), controller ->
+                        {
+                            int duration = (int) controller.getDuration();
+                            if (duration <= 0) {
+                                duration = currentMedia.getDuration();
+                            }
+                            if (duration > 0) {
+                                int targetPosition = (int) (duration * prog);
+                                applyUiSeekSettle(targetPosition, duration);
+                                controller.seekTo(targetPosition);
+                            }
+                        });
             } else {
-                PlaybackController.bindToService(getActivity(), playbackService -> {
-                    int duration = playbackService.getDuration();
-                    if (duration <= 0) {
-                        duration = currentMedia.getDuration();
-                    }
-                    if (duration > 0) {
-                        int targetPosition = (int) (duration * prog);
-                        applyUiSeekSettle(targetPosition, duration);
-                        playbackService.seekTo(targetPosition);
-                    }
-                });
+                PlaybackController.bindToService(getActivity(), playbackService ->
+                        {
+                            int duration = playbackService.getDuration();
+                            if (duration <= 0) {
+                                duration = currentMedia.getDuration();
+                            }
+                            if (duration > 0) {
+                                int targetPosition = (int) (duration * prog);
+                                applyUiSeekSettle(targetPosition, duration);
+                                playbackService.seekTo(targetPosition);
+                            }
+                        });
             }
         }
         cardViewSeek.setScaleX(1f);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -39,6 +39,8 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.Objects;
+
 /**
  * Fragment which is supposed to be displayed outside of the MediaplayerActivity.
  */
@@ -164,11 +166,15 @@ public class ExternalPlayerFragment extends Fragment {
         if (media == null) {
             return;
         }
+        boolean mediaChanged = currentMedia == null
+                || !Objects.equals(currentMedia.getIdentifier(), media.getIdentifier());
         currentMedia = media;
         ((MainActivity) getActivity()).setPlayerVisible(true);
         txtvTitle.setText(media.getEpisodeTitle());
         feedName.setText(media.getFeedTitle());
-        onPositionObserverUpdate(new PlaybackPositionEvent(media.getPosition(), media.getDuration()));
+        if (mediaChanged) {
+            onPositionObserverUpdate(new PlaybackPositionEvent(media.getPosition(), media.getDuration()));
+        }
         boolean isPlaying = PlaybackService.isRunning
                 && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING;
         butPlay.setIsShowPlay(!isPlaying);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -166,7 +166,7 @@ public class ExternalPlayerFragment extends Fragment {
         if (media == null) {
             return;
         }
-        final boolean mediaChanged = currentMedia == null
+        boolean mediaChanged = currentMedia == null
                 || !Objects.equals(currentMedia.getIdentifier(), media.getIdentifier());
         currentMedia = media;
         ((MainActivity) getActivity()).setPlayerVisible(true);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -52,6 +52,9 @@ public class ExternalPlayerFragment extends Fragment {
     private ProgressBar progressBar;
     private Disposable disposable;
     private Playable currentMedia;
+    private int latestLivePosition = Playable.INVALID_TIME;
+    private int latestLiveDuration = Playable.INVALID_TIME;
+    private long latestLiveMediaId = -1;
 
     public ExternalPlayerFragment() {
         super();
@@ -118,11 +121,22 @@ public class ExternalPlayerFragment extends Fragment {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPlayerStatusEvent(PlayerStatusEvent event) {
-        loadMediaInfo();
+        long playingMediaId = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
+        Object currentIdentifier = currentMedia != null ? currentMedia.getIdentifier() : null;
+        boolean sameMedia = currentIdentifier instanceof Long
+                && (playingMediaId <= 0 || ((Long) currentIdentifier) == playingMediaId);
+        if (!sameMedia) {
+            loadMediaInfo();
+        } else {
+            updatePlayButton();
+        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPositionObserverUpdate(PlaybackPositionEvent event) {
+        latestLiveMediaId = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
+        latestLivePosition = event.getPosition();
+        latestLiveDuration = event.getDuration();
         if (event.getPosition() == Playable.INVALID_TIME || event.getDuration() == Playable.INVALID_TIME) {
             return;
         }
@@ -168,10 +182,19 @@ public class ExternalPlayerFragment extends Fragment {
         ((MainActivity) getActivity()).setPlayerVisible(true);
         txtvTitle.setText(media.getEpisodeTitle());
         feedName.setText(media.getFeedTitle());
-        onPositionObserverUpdate(new PlaybackPositionEvent(media.getPosition(), media.getDuration()));
-        boolean isPlaying = PlaybackService.isRunning
-                && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING;
-        butPlay.setIsShowPlay(!isPlaying);
+        int position = media.getPosition();
+        int duration = media.getDuration();
+        Object currentIdentifier = media.getIdentifier();
+        boolean sameMediaAsLive = currentIdentifier instanceof Long
+                && (Long) currentIdentifier == latestLiveMediaId
+                && latestLivePosition != Playable.INVALID_TIME
+                && latestLiveDuration != Playable.INVALID_TIME;
+        if (sameMediaAsLive) {
+            position = latestLivePosition;
+            duration = latestLiveDuration;
+        }
+        onPositionObserverUpdate(new PlaybackPositionEvent(position, duration));
+        updatePlayButton();
 
         RequestOptions options = new RequestOptions()
                 .placeholder(R.color.light_gray)
@@ -195,5 +218,11 @@ public class ExternalPlayerFragment extends Fragment {
             butPlay.setVisibility(View.VISIBLE);
             ((MainActivity) getActivity()).getBottomSheet().setLocked(false);
         }
+    }
+
+    private void updatePlayButton() {
+        boolean isPlaying = PlaybackService.isRunning
+                && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING;
+        butPlay.setIsShowPlay(!isPlaying);
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -39,8 +39,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
-import java.util.Objects;
-
 /**
  * Fragment which is supposed to be displayed outside of the MediaplayerActivity.
  */
@@ -166,15 +164,11 @@ public class ExternalPlayerFragment extends Fragment {
         if (media == null) {
             return;
         }
-        boolean mediaChanged = currentMedia == null
-                || !Objects.equals(currentMedia.getIdentifier(), media.getIdentifier());
         currentMedia = media;
         ((MainActivity) getActivity()).setPlayerVisible(true);
         txtvTitle.setText(media.getEpisodeTitle());
         feedName.setText(media.getFeedTitle());
-        if (mediaChanged) {
-            onPositionObserverUpdate(new PlaybackPositionEvent(media.getPosition(), media.getDuration()));
-        }
+        onPositionObserverUpdate(new PlaybackPositionEvent(media.getPosition(), media.getDuration()));
         boolean isPlaying = PlaybackService.isRunning
                 && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING;
         butPlay.setIsShowPlay(!isPlaying);

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -166,7 +166,7 @@ public class ExternalPlayerFragment extends Fragment {
         if (media == null) {
             return;
         }
-        boolean mediaChanged = currentMedia == null
+        final boolean mediaChanged = currentMedia == null
                 || !Objects.equals(currentMedia.getIdentifier(), media.getIdentifier());
         currentMedia = media;
         ((MainActivity) getActivity()).setPlayerVisible(true);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -78,10 +78,12 @@ public class Media3PlaybackService extends MediaLibraryService {
     private static final String TAG = "M3PlaybackService";
 
     private static final long POSITION_OBSERVER_INTERVAL_MS = 250;
+    private static final long SEEK_SETTLE_TOLERANCE_MS = 500;
     public static final String ACTION_WIDGET_REWIND = "de.danoeh.antennapod.action.WIDGET_REWIND";
     public static final String ACTION_WIDGET_FAST_FORWARD = "de.danoeh.antennapod.action.WIDGET_FAST_FORWARD";
     public static final String ACTION_WIDGET_SKIP = "de.danoeh.antennapod.action.WIDGET_SKIP";
     private static final long POSITION_SAVE_INTERVAL_MS = 5000;
+    private static final int STREAMING_POSITION_MAX_JUMP_MS = 1000;
     private ExoPlayer exoPlayer;
     private Player player;
     private MediaLibrarySession mediaSession;
@@ -92,6 +94,9 @@ public class Media3PlaybackService extends MediaLibraryService {
     private Disposable positionObserverDisposable;
     private Disposable queueLoaderDisposable;
     private long lastPositionSaveTime = 0;
+    private long lastReportedPosition = 0;
+    private long seekTargetPosition = -1;
+    private boolean userRequestedSeek = false;
     private SleepTimer sleepTimer;
     @Nullable
     private LoudnessEnhancer loudnessEnhancer = null;
@@ -137,7 +142,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                     return;
                 }
 
-                if (currentPlayable != null && !getPlayWhenReady()) {
+                if (currentPlayable != null && !getPlayWhenReady() && getPlaybackState() == Player.STATE_READY) {
                     long savedPosition = getCurrentPosition();
                     long startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
                             (int) savedPosition, currentPlayable.getLastPlayedTimeStatistics());
@@ -167,8 +172,20 @@ public class Media3PlaybackService extends MediaLibraryService {
 
             @Override
             public void seekTo(long positionMs) {
-                super.seekTo(positionMs);
-                EventBus.getDefault().post(new PlaybackPositionEvent((int) positionMs, (int) getDuration()));
+                long resolvedTarget = Math.max(0, positionMs);
+                long duration = getDuration();
+                if (duration > 0) {
+                    resolvedTarget = Math.min(resolvedTarget, duration);
+                }
+                userRequestedSeek = true;
+                seekTargetPosition = resolvedTarget;
+                lastReportedPosition = player.getCurrentPosition();
+                super.seekTo(resolvedTarget);
+                if (currentPlayable != null) {
+                    currentPlayable.setPosition((int) resolvedTarget);
+                    PlayableUtils.saveCurrentPosition(currentPlayable, (int) resolvedTarget,
+                            System.currentTimeMillis());
+                }
             }
         };
         player.addListener(playerListener);
@@ -305,6 +322,26 @@ public class Media3PlaybackService extends MediaLibraryService {
         }
 
         @Override
+        public void onPositionDiscontinuity(@NonNull Player.PositionInfo oldPosition,
+                @NonNull Player.PositionInfo newPosition, int reason) {
+            if (player == null) {
+                return;
+            }
+            boolean isSeekDiscontinuity = reason == Player.DISCONTINUITY_REASON_SEEK
+                    || reason == Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT;
+            if (!isSeekDiscontinuity) {
+                return;
+            }
+            long position = getStablePosition();
+            long duration = player.getDuration();
+            if (position < 0 || duration <= 0) {
+                return;
+            }
+            lastReportedPosition = position;
+            EventBus.getDefault().post(new PlaybackPositionEvent((int) position, (int) duration));
+        }
+
+        @Override
         public void onMediaItemTransition(@Nullable MediaItem mediaItem, int reason) {
             ensureCurrentMediaLoaded();
             EventBus.getDefault().post(new PlayerStatusEvent());
@@ -362,6 +399,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             positionObserverDisposable.dispose();
         }
 
+        lastReportedPosition = player != null ? player.getCurrentPosition() : 0;
         positionObserverDisposable = Observable.interval(0, POSITION_OBSERVER_INTERVAL_MS, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
@@ -369,10 +407,11 @@ public class Media3PlaybackService extends MediaLibraryService {
                             if (currentPlayable == null || player == null) {
                                 return;
                             }
-                            long position = player.getCurrentPosition();
+                            long position = getStablePosition();
                             long duration = player.getDuration();
                             float speed = player.getPlaybackParameters().speed;
                             if (duration > 0) {
+                                lastReportedPosition = position;
                                 EventBus.getDefault().post(
                                         new PlaybackPositionEvent((int) position, (int) duration));
                                 if (ignored % (1000 / POSITION_OBSERVER_INTERVAL_MS) == 0) {
@@ -420,6 +459,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(media -> {
                             currentPlayable = media;
+                            lastReportedPosition = player != null ? player.getCurrentPosition() : 0;
                             if (player == null) {
                                 return;
                             }
@@ -429,7 +469,8 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 return;
                             }
                             allowStreamingThisTime = false;
-                            currentPlayable.setPosition((int) player.getCurrentPosition());
+                            int positionToSet = (int) getStablePosition();
+                            currentPlayable.setPosition(positionToSet);
                             currentPlayable.onPlaybackStart();
                             if (currentPlayable.getItem() != null
                                     && !currentPlayable.getItem().isTagged(FeedItem.TAG_QUEUE)) {
@@ -482,9 +523,33 @@ public class Media3PlaybackService extends MediaLibraryService {
         } catch (NumberFormatException e) {
             return;
         }
-        long position = player.getCurrentPosition();
+        long position = getStablePosition();
         long timestamp = System.currentTimeMillis();
         PlayableUtils.saveCurrentPosition(currentPlayable, (int) position, timestamp);
+    }
+
+    private long getStablePosition() {
+        if (player == null) {
+            return 0;
+        }
+        long position = player.getCurrentPosition();
+        long targetPosition = seekTargetPosition;
+        if (userRequestedSeek && targetPosition >= 0) {
+            long duration = player.getDuration();
+            if (duration > 0) {
+                targetPosition = Math.min(targetPosition, duration);
+            }
+            if (position >= 0 && Math.abs(position - targetPosition) <= SEEK_SETTLE_TOLERANCE_MS) {
+                userRequestedSeek = false;
+                seekTargetPosition = -1;
+                return position;
+            }
+            return targetPosition;
+        }
+        if (position >= 0) {
+            return position;
+        }
+        return Math.max(0, lastReportedPosition);
     }
 
     private void onPlaybackEnd(FeedMedia media) {
@@ -641,6 +706,9 @@ public class Media3PlaybackService extends MediaLibraryService {
                             allowStreamingThisTime = false;
 
                             currentPlayable = nextMedia;
+                            lastReportedPosition = 0;
+                            userRequestedSeek = false;
+                            seekTargetPosition = -1;
                             currentPlayable.onPlaybackStart();
                             PlaybackPreferences.writeMediaPlaying(nextMedia);
                             if (nextMedia.getItem() != null && nextMedia.getItem().getFeed() != null) {

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -168,6 +168,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             @Override
             public void seekTo(long positionMs) {
                 super.seekTo(positionMs);
+                EventBus.getDefault().post(new PlaybackPositionEvent((int) positionMs, (int) getDuration()));
             }
         };
         player.addListener(playerListener);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -164,6 +164,11 @@ public class Media3PlaybackService extends MediaLibraryService {
             public void seekForward() {
                 seekTo(Math.min(getDuration(), getCurrentPosition() + UserPreferences.getFastForwardSecs() * 1000L));
             }
+
+            @Override
+            public void seekTo(long positionMs) {
+                super.seekTo(positionMs);
+            }
         };
         player.addListener(playerListener);
         mediaSession = new MediaLibraryService.MediaLibrarySession.Builder(this, player, sessionCallback)
@@ -261,8 +266,8 @@ public class Media3PlaybackService extends MediaLibraryService {
                     }
                 }
                 startNextInQueue(media.getItem());
+                EventBus.getDefault().post(new PlayerStatusEvent());
             }
-            EventBus.getDefault().post(new PlayerStatusEvent());
         }
 
         @Override

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -76,6 +76,11 @@ import java.util.concurrent.TimeUnit;
 
 public class Media3PlaybackService extends MediaLibraryService {
     private static final String TAG = "M3PlaybackService";
+
+    private static final long POSITION_OBSERVER_INTERVAL_MS = 250;
+    public static final String ACTION_WIDGET_REWIND = "de.danoeh.antennapod.action.WIDGET_REWIND";
+    public static final String ACTION_WIDGET_FAST_FORWARD = "de.danoeh.antennapod.action.WIDGET_FAST_FORWARD";
+    public static final String ACTION_WIDGET_SKIP = "de.danoeh.antennapod.action.WIDGET_SKIP";
     private static final long POSITION_SAVE_INTERVAL_MS = 5000;
     private ExoPlayer exoPlayer;
     private Player player;
@@ -351,7 +356,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             positionObserverDisposable.dispose();
         }
 
-        positionObserverDisposable = Observable.interval(1, TimeUnit.SECONDS)
+        positionObserverDisposable = Observable.interval(0, POSITION_OBSERVER_INTERVAL_MS, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         ignored -> {
@@ -364,10 +369,12 @@ public class Media3PlaybackService extends MediaLibraryService {
                             if (duration > 0) {
                                 EventBus.getDefault().post(
                                         new PlaybackPositionEvent((int) position, (int) duration));
-                                WidgetUpdater.WidgetState widgetState = new WidgetUpdater.WidgetState(currentPlayable,
-                                        Util.shouldShowPlayButton(player) ? PlayerStatus.PAUSED : PlayerStatus.PLAYING,
-                                        (int) position, (int) duration, speed);
-                                WidgetUpdater.updateWidget(this, widgetState);
+                                if (ignored % (1000 / POSITION_OBSERVER_INTERVAL_MS) == 0) {
+                                    WidgetUpdater.WidgetState widgetState = new WidgetUpdater.WidgetState(currentPlayable,
+                                            Util.shouldShowPlayButton(player) ? PlayerStatus.PAUSED : PlayerStatus.PLAYING,
+                                            (int) position, (int) duration, speed);
+                                    WidgetUpdater.updateWidget(this, widgetState);
+                                }
                                 long currentTime = System.currentTimeMillis();
                                 if (currentTime - lastPositionSaveTime >= POSITION_SAVE_INTERVAL_MS) {
                                     saveCurrentPosition();

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
@@ -560,17 +560,19 @@ public abstract class PlaybackController {
             return;
         }
         int targetPosition = clampPosition(requestedPosition, media.getDuration());
-        boolean wasRunning = PlaybackService.isRunning;
-        if (!wasRunning) {
+        if (!PlaybackService.isRunning) {
             ContextCompat.startForegroundService(context, new Intent(context, Media3PlaybackService.class));
         }
         bindToMedia3Service(context, controller -> {
-            if (!wasRunning) {
+            boolean mediaAlreadyLoaded = controller.getCurrentMediaItem() != null
+                    && String.valueOf(media.getId()).equals(controller.getCurrentMediaItem().mediaId);
+            if (mediaAlreadyLoaded) {
+                controller.seekTo(targetPosition);
+            } else {
                 controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media), targetPosition);
                 controller.prepare();
-                EventBus.getDefault().post(new PlaybackPositionEvent(targetPosition, media.getDuration()));
-            } else {
                 controller.seekTo(targetPosition);
+                EventBus.getDefault().post(new PlaybackPositionEvent(targetPosition, media.getDuration()));
             }
             persistSeekTarget(media, targetPosition);
         });
@@ -629,5 +631,6 @@ public abstract class PlaybackController {
 
     private static void persistSeekTarget(FeedMedia media, int position) {
         media.setPosition(position);
+        PlayableUtils.saveCurrentPosition(media, position, System.currentTimeMillis());
     }
 }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
@@ -568,6 +568,7 @@ public abstract class PlaybackController {
             if (!wasRunning) {
                 controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media), targetPosition);
                 controller.prepare();
+                EventBus.getDefault().post(new PlaybackPositionEvent(targetPosition, media.getDuration()));
             } else {
                 controller.seekTo(targetPosition);
             }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackController.java
@@ -19,6 +19,7 @@ import androidx.media3.session.SessionToken;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import de.danoeh.antennapod.playback.base.BuildConfig;
+import de.danoeh.antennapod.playback.base.MediaItemAdapter;
 import de.danoeh.antennapod.playback.service.internal.PlayableUtils;
 import de.danoeh.antennapod.model.playback.TimerValue;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -49,6 +50,9 @@ import java.util.concurrent.ExecutionException;
 public abstract class PlaybackController {
 
     private static final String TAG = "PlaybackController";
+    private static final Object MEDIA3_CONTROLLER_LOCK = new Object();
+    private static MediaController sharedMedia3Controller;
+    private static ListenableFuture<MediaController> sharedMedia3ControllerFuture;
 
     private final Activity activity;
     private PlaybackService playbackService;
@@ -516,19 +520,113 @@ public abstract class PlaybackController {
     }
 
     public static void bindToMedia3Service(Context context, Consumer<MediaController> consumer) {
-        SessionToken sessionToken = new SessionToken(context,
-                new ComponentName(context, Media3PlaybackService.class));
-        ListenableFuture<MediaController> controllerFuture =
-                new MediaController.Builder(context, sessionToken).buildAsync();
+        MediaController cachedController;
+        ListenableFuture<MediaController> controllerFuture;
+        synchronized (MEDIA3_CONTROLLER_LOCK) {
+            cachedController = sharedMedia3Controller;
+            if (cachedController != null) {
+                consumer.accept(cachedController);
+                return;
+            }
+            if (sharedMedia3ControllerFuture == null) {
+                Context appContext = context.getApplicationContext();
+                SessionToken sessionToken = new SessionToken(appContext,
+                        new ComponentName(appContext, Media3PlaybackService.class));
+                sharedMedia3ControllerFuture = new MediaController.Builder(appContext, sessionToken).buildAsync();
+            }
+            controllerFuture = sharedMedia3ControllerFuture;
+        }
         controllerFuture.addListener(() -> {
             try {
                 MediaController controller = controllerFuture.get();
+                synchronized (MEDIA3_CONTROLLER_LOCK) {
+                    if (sharedMedia3Controller == null) {
+                        sharedMedia3Controller = controller;
+                    }
+                }
                 consumer.accept(controller);
-                controller.release();
             } catch (ExecutionException | InterruptedException e) {
-                e.printStackTrace();
+                Log.e(TAG, "Unable to obtain Media3 controller", e);
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }, MoreExecutors.directExecutor());
 
+    }
+
+    public static void seekToMedia3(Context context, FeedMedia media, int requestedPosition) {
+        if (media == null) {
+            return;
+        }
+        int targetPosition = clampPosition(requestedPosition, media.getDuration());
+        boolean wasRunning = PlaybackService.isRunning;
+        if (!wasRunning) {
+            ContextCompat.startForegroundService(context, new Intent(context, Media3PlaybackService.class));
+        }
+        bindToMedia3Service(context, controller -> {
+            if (!wasRunning) {
+                controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media), targetPosition);
+                controller.prepare();
+            } else {
+                controller.seekTo(targetPosition);
+            }
+            persistSeekTarget(media, targetPosition);
+        });
+    }
+
+    public static void seekRelativeMedia3(Context context, FeedMedia media, int deltaMs) {
+        if (media == null) {
+            return;
+        }
+        if (!PlaybackService.isRunning) {
+            int targetPosition = clampPosition(media.getPosition() + deltaMs, media.getDuration());
+            seekToMedia3(context, media, targetPosition);
+            return;
+        }
+        bindToMedia3Service(context, controller -> {
+            int duration = (int) controller.getDuration();
+            if (duration <= 0) {
+                duration = media.getDuration();
+            }
+            int targetPosition = clampPosition((int) controller.getCurrentPosition() + deltaMs, duration);
+            controller.seekTo(targetPosition);
+            persistSeekTarget(media, targetPosition);
+        });
+    }
+
+    public static void seekToProgressMedia3(Context context, FeedMedia media, float progress) {
+        if (media == null) {
+            return;
+        }
+        if (!PlaybackService.isRunning) {
+            int targetPosition = clampPosition((int) (media.getDuration() * progress), media.getDuration());
+            seekToMedia3(context, media, targetPosition);
+            return;
+        }
+        bindToMedia3Service(context, controller -> {
+            int duration = (int) controller.getDuration();
+            if (duration <= 0) {
+                duration = media.getDuration();
+            }
+            if (duration <= 0) {
+                return;
+            }
+            int targetPosition = clampPosition((int) (duration * progress), duration);
+            controller.seekTo(targetPosition);
+            persistSeekTarget(media, targetPosition);
+        });
+    }
+
+    private static int clampPosition(int position, int duration) {
+        int clamped = Math.max(0, position);
+        if (duration > 0) {
+            clamped = Math.min(clamped, duration);
+        }
+        return clamped;
+    }
+
+    private static void persistSeekTarget(FeedMedia media, int position) {
+        media.setPosition(position);
     }
 }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackService.java
@@ -128,6 +128,7 @@ public class PlaybackService extends MediaBrowserServiceCompat {
      * Logging tag
      */
     private static final String TAG = "PlaybackService";
+    private static final long POSITION_OBSERVER_INTERVAL_MS = 250;
 
     public static final String ACTION_PLAYER_STATUS_CHANGED = "action.de.danoeh.antennapod.core.service.playerStatusChanged";
     private static final String AVRCP_ACTION_PLAYER_STATUS_CHANGED = "com.android.music.playstatechanged";
@@ -1848,11 +1849,11 @@ public class PlaybackService extends MediaBrowserServiceCompat {
         }
 
         Log.d(TAG, "Setting up position observer");
-        positionEventTimer = Observable.interval(1, TimeUnit.SECONDS)
+        positionEventTimer = Observable.interval(0, POSITION_OBSERVER_INTERVAL_MS, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(number -> {
                     EventBus.getDefault().post(new PlaybackPositionEvent(getCurrentPosition(), getDuration()));
-                    if (Build.VERSION.SDK_INT < 29) {
+                    if (Build.VERSION.SDK_INT < 29 && number % (1000 / POSITION_OBSERVER_INTERVAL_MS) == 0) {
                         notificationBuilder.updatePosition(getCurrentPosition(), getCurrentPlaybackSpeed());
                         NotificationManager notificationManager = (NotificationManager)
                                 getSystemService(NOTIFICATION_SERVICE);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
@@ -53,7 +53,7 @@ public class PlaybackServiceStarter {
                         == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
                     controller.play(); // Casting somehow does not play when not quickly starting the old episode
                 }
-                controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media), Math.max(0, media.getPosition()));
+                controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media));
                 controller.prepare();
                 controller.play();
             });

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
@@ -53,7 +53,7 @@ public class PlaybackServiceStarter {
                         == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
                     controller.play(); // Casting somehow does not play when not quickly starting the old episode
                 }
-                controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media));
+                controller.setMediaItem(MediaItemAdapter.fromPlayableStub(media), Math.max(0, media.getPosition()));
                 controller.prepare();
                 controller.play();
             });

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -239,14 +239,9 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 })
                 .subscribeOn(Schedulers.io())
                 .subscribe(result -> {
-                    long startPosition;
-                    if (startPositionMs != C.TIME_UNSET) {
-                        startPosition = startPositionMs;
-                    } else {
-                        startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
-                        startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
-                                (int) startPosition, result.second.getLastPlayedTimeStatistics());
-                    }
+                    long startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
+                    startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
+                            (int) startPosition, result.second.getLastPlayedTimeStatistics());
                     future.set(new MediaSession.MediaItemsWithStartPosition(result.first, index, startPosition));
                 }, error -> {
                     Log.e(TAG, "Failed to load media", error);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -239,9 +239,14 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 })
                 .subscribeOn(Schedulers.io())
                 .subscribe(result -> {
-                    long startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
-                    startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
-                            (int) startPosition, result.second.getLastPlayedTimeStatistics());
+                    long startPosition;
+                    if (startPositionMs != C.TIME_UNSET) {
+                        startPosition = startPositionMs;
+                    } else {
+                        startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
+                        startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
+                                (int) startPosition, result.second.getLastPlayedTimeStatistics());
+                    }
                     future.set(new MediaSession.MediaItemsWithStartPosition(result.first, index, startPosition));
                 }, error -> {
                     Log.e(TAG, "Failed to load media", error);

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -239,9 +239,12 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 })
                 .subscribeOn(Schedulers.io())
                 .subscribe(result -> {
-                    long startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
-                    startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
-                            (int) startPosition, result.second.getLastPlayedTimeStatistics());
+                    long startPosition = startPositionMs;
+                    if (startPosition == C.TIME_UNSET) {
+                        startPosition = SkipUtils.skipIntroIfNecessary(context, result.second);
+                        startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
+                                (int) startPosition, result.second.getLastPlayedTimeStatistics());
+                    }
                     future.set(new MediaSession.MediaItemsWithStartPosition(result.first, index, startPosition));
                 }, error -> {
                     Log.e(TAG, "Failed to load media", error);


### PR DESCRIPTION
### Description

Fix to the player progress bar and timestamp to remove jitter/lag and provide a smoother experience. Closes #8447.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
