### PR TITLE
We just need one copy of the "empty inbox" text

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/InboxFragment.java
@@ -49,7 +49,7 @@ public class InboxFragment extends EpisodesListFragment {
         updateToolbar();
         emptyView.setIcon(R.drawable.ic_inbox);
         emptyView.setTitle(R.string.no_inbox_head_label);
-        emptyView.setMessage(R.string.no_inbox_label);
+        emptyView.setMessage(R.string.home_new_empty_text);
         return root;
     }
 

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -439,7 +439,6 @@
     <string name="no_all_episodes_label">When you add a podcast, the episodes will be shown here.</string>
     <string name="no_all_episodes_filtered_label">Try clearing the filter to see more episodes.</string>
     <string name="no_inbox_head_label">No episodes in the inbox</string>
-    <string name="no_inbox_label">When new episodes arrive, they will be shown here. You can then decide if you are interested in them or not.</string>
     <string name="no_subscriptions_head_label">No subscriptions</string>
     <string name="no_subscriptions_label">To subscribe to a podcast, press the plus icon below.</string>
     <string name="no_archive_head_label">Nothing archived</string>


### PR DESCRIPTION
### Description

We just need one copy of the "empty inbox" text
Closes #8456

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
