### PR TITLE
Make it possible to scale widget vertically

### DIFF
--- a/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/PlayerWidget.java
+++ b/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/PlayerWidget.java
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.util.Log;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
@@ -47,6 +48,13 @@ public class PlayerWidget extends AppWidgetProvider {
             scheduleWorkaround(context);
             prefs.edit().putBoolean(KEY_WORKAROUND_ENABLED, true).apply();
         }
+    }
+
+    @Override
+    public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager,
+                                          int appWidgetId, Bundle newOptions) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions);
+        WidgetUpdaterWorker.enqueueWork(context);
     }
 
     @Override

--- a/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
+++ b/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
@@ -164,6 +164,7 @@ public abstract class WidgetUpdater {
 
             if (showCoverAsBcg) {
                 views.setViewVisibility(R.id.imgvCover, View.GONE);
+                views.setViewVisibility(R.id.imgvCoverLarge, View.GONE);
                 views.setViewVisibility(R.id.imgvBackground, View.VISIBLE);
                 int iconSize = 4 * context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
                 Bitmap icon = null;
@@ -176,7 +177,10 @@ public abstract class WidgetUpdater {
                     views.setViewVisibility(R.id.imgvBackground, View.GONE);
                 }
             } else {
-                views.setViewVisibility(R.id.imgvCover, View.VISIBLE);
+                int minHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT);
+                boolean largeCover = minHeight >= 100;
+                views.setViewVisibility(R.id.imgvCover, largeCover ? View.GONE : View.VISIBLE);
+                views.setViewVisibility(R.id.imgvCoverLarge, largeCover ? View.VISIBLE : View.GONE);
                 views.setViewVisibility(R.id.imgvBackground, View.GONE);
                 int iconSize = context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
                 int radius = context.getResources().getDimensionPixelSize(R.dimen.widget_inner_radius);
@@ -185,9 +189,9 @@ public abstract class WidgetUpdater {
                     icon = loadCover(context, iconSize, widgetState.media, new RoundedCorners(radius));
                 }
                 if (icon != null) {
-                    views.setImageViewBitmap(R.id.imgvCover, icon);
+                    views.setImageViewBitmap(largeCover ? R.id.imgvCoverLarge : R.id.imgvCover, icon);
                 } else {
-                    views.setImageViewResource(R.id.imgvCover, R.mipmap.ic_launcher);
+                    views.setImageViewResource(largeCover ? R.id.imgvCoverLarge : R.id.imgvCover, R.mipmap.ic_launcher);
                 }
             }
             int backgroundColor = prefs.getInt(PlayerWidget.KEY_WIDGET_COLOR + id, PlayerWidget.DEFAULT_COLOR);

--- a/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
+++ b/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
@@ -82,6 +82,7 @@ public abstract class WidgetUpdater {
         if (widgetState.media != null) {
             views.setOnClickPendingIntent(R.id.layout_left, startMediaPlayer);
             views.setOnClickPendingIntent(R.id.imgvCover, startMediaPlayer);
+            views.setOnClickPendingIntent(R.id.imgvCoverLarge, startMediaPlayer);
             views.setOnClickPendingIntent(R.id.butPlaybackSpeed, startPlaybackSpeedDialog);
 
             views.setTextViewText(R.id.txtvTitle, widgetState.media.getEpisodeTitle());
@@ -178,11 +179,13 @@ public abstract class WidgetUpdater {
                 }
             } else {
                 int minHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT);
-                boolean largeCover = minHeight >= 100;
+                boolean largeCover = minHeight >= 100 && columns >= 2;
                 views.setViewVisibility(R.id.imgvCover, largeCover ? View.GONE : View.VISIBLE);
                 views.setViewVisibility(R.id.imgvCoverLarge, largeCover ? View.VISIBLE : View.GONE);
                 views.setViewVisibility(R.id.imgvBackground, View.GONE);
-                int iconSize = context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
+                int iconSize = largeCover
+                        ? context.getResources().getDimensionPixelSize(R.dimen.widget_cover_large)
+                        : context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
                 int radius = context.getResources().getDimensionPixelSize(R.dimen.widget_inner_radius);
                 Bitmap icon = null;
                 if (widgetState.media != null) {

--- a/ui/widget/src/main/res/layout/player_widget.xml
+++ b/ui/widget/src/main/res/layout/player_widget.xml
@@ -62,6 +62,16 @@
                 android:layout_marginStart="12dp"
                 android:orientation="vertical">
 
+                <ImageView
+                    android:id="@+id/imgvCoverLarge"
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="4dp"
+                    android:src="@mipmap/ic_launcher"
+                    android:importantForAccessibility="no"
+                    android:visibility="gone" />
+
                 <TextView
                     android:id="@+id/txtNoPlaying"
                     android:layout_width="wrap_content"
@@ -69,6 +79,7 @@
                     android:maxLines="3"
                     android:text="@string/no_media_playing_label"
                     android:textColor="@color/white"
+                    android:layout_marginTop="8dp"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 
@@ -79,6 +90,7 @@
                     android:maxLines="1"
                     android:ellipsize="end"
                     android:textColor="@color/white"
+                    android:layout_marginTop="8dp"
                     android:textSize="16sp"
                     android:textStyle="bold"
                     android:visibility="gone" />
@@ -95,14 +107,17 @@
                 <LinearLayout
                     android:id="@+id/extendedButtonsContainer"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:maxHeight="56dp"
                     android:orientation="horizontal"
-                    android:visibility="gone">
+                    android:visibility="gone"
+                    tools:ignore="NestedWeights">
 
                     <ImageButton
                         android:id="@+id/butPlaybackSpeed"
                         android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:background="?android:attr/selectableItemBackground"
                         android:contentDescription="@string/playback_speed"
@@ -113,7 +128,7 @@
                     <ImageButton
                         android:id="@+id/butRew"
                         android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:background="?android:attr/selectableItemBackground"
                         android:contentDescription="@string/rewind_label"
@@ -124,7 +139,7 @@
                     <ImageButton
                         android:id="@+id/butPlayExtended"
                         android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:background="?android:attr/selectableItemBackground"
                         android:contentDescription="@string/play_label"
@@ -135,7 +150,7 @@
                     <ImageButton
                         android:id="@+id/butFastForward"
                         android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:background="?android:attr/selectableItemBackground"
                         android:contentDescription="@string/fast_forward_label"
@@ -146,7 +161,7 @@
                     <ImageButton
                         android:id="@+id/butSkip"
                         android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_height="match_parent"
                         android:layout_weight="1"
                         android:background="?android:attr/selectableItemBackground"
                         android:contentDescription="@string/skip_episode_label"

--- a/ui/widget/src/main/res/layout/player_widget.xml
+++ b/ui/widget/src/main/res/layout/player_widget.xml
@@ -64,8 +64,8 @@
 
                 <ImageView
                     android:id="@+id/imgvCoverLarge"
-                    android:layout_width="72dp"
-                    android:layout_height="72dp"
+                    android:layout_width="@dimen/widget_cover_large"
+                    android:layout_height="@dimen/widget_cover_large"
                     android:layout_marginTop="12dp"
                     android:layout_marginBottom="4dp"
                     android:src="@mipmap/ic_launcher"

--- a/ui/widget/src/main/res/values/dimens.xml
+++ b/ui/widget/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="widget_margin">0dp</dimen>
     <dimen name="widget_inner_radius">4dp</dimen>
+    <dimen name="widget_cover_large">72dp</dimen>
 </resources>

--- a/ui/widget/src/main/res/xml/player_widget_info.xml
+++ b/ui/widget/src/main/res/xml/player_widget_info.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:resizeMode="horizontal"
+    android:resizeMode="horizontal|vertical"
     android:initialLayout="@layout/player_widget"
     android:updatePeriodMillis="86400000"
     android:previewImage="@drawable/ic_widget_preview"


### PR DESCRIPTION
### Description

The Android lock screen ignores whether a widget supports resizing or not, it does it anyway. This makes the layout more acceptable and enables support officially.

Closes #8459

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
