### PR TITLE
Make progress indicator more visible in dark theme

### DIFF
--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -319,7 +319,7 @@
     </style>
 
     <style name="Widget.AntennaPod.LinearProgressIndicator" parent="Widget.Material3.LinearProgressIndicator">
-        <item name="trackColor">#18000000</item>
+        <item name="trackColor">#55888888</item>
     </style>
 
     <style name="Widget.AntennaPod.ActionBar" parent="Widget.Material3.Light.ActionBar.Solid">


### PR DESCRIPTION
### Description

Make progress indicator more visible in dark theme

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
