### PR TITLE
Update CI checks to use node 24 actions

### DIFF
--- a/.github/workflows/assign-milestone.yml
+++ b/.github/workflows/assign-milestone.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [develop]
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get or create milestone
         id: get-milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = '${{ steps.milestone.outputs.name }}';
@@ -56,7 +56,7 @@ jobs:
             return milestone.number;
 
       - name: Assign milestone to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.update({

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -79,7 +79,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -126,7 +126,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Cache Gradle
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR Conventions
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issueRegex = /#\d+/i;


### PR DESCRIPTION
### Description

Update CI checks to use node 24 actions. Node 20 actions will be deprecated next week. Also update the action to run in the target repo, not the source repo. Maybe that helps to avoid a 403 error when trying to assign the milestone.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
