### PR TITLE
Add if-range header when downloading

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/remote/HttpDownloader.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/remote/HttpDownloader.java
@@ -92,6 +92,11 @@ public class HttpDownloader extends Downloader {
                 request.setSoFar(destination.length());
                 httpReq.addHeader("Range", "bytes=" + request.getSoFar() + "-");
                 Log.d(TAG, "Adding range header: " + request.getSoFar());
+                // Only continue if the etag matches, otherwise the file might have changed
+                if (!TextUtils.isEmpty(request.getLastModified())) {
+                    httpReq.addHeader("If-Range", request.getLastModified());
+                    Log.d(TAG, "Adding If-Range header: " + request.getLastModified());
+                }
             }
 
             Response response = newCall(httpReq);


### PR DESCRIPTION
### Description

Add if-range header when downloading. Only resume download if the server tells us that the file didn't change in the meantime. This can happen especially in the presence of dynamic ad insertion.

Original idea by @bushnelb in #8441

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
