### PR TITLE
Reduce number of PlayerStatusEvent messages

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -159,6 +159,13 @@ public class Media3PlaybackService extends MediaLibraryService {
             public void seekForward() {
                 seekTo(Math.min(getDuration(), getCurrentPosition() + UserPreferences.getFastForwardSecs() * 1000L));
             }
+
+            @Override
+            public void seekTo(long positionMs) {
+                super.seekTo(positionMs);
+                EventBus.getDefault().post(
+                        new PlaybackPositionEvent((int) player.getCurrentPosition(), (int) player.getDuration()));
+            }
         };
         player.addListener(playerListener);
         mediaSession = new MediaLibraryService.MediaLibrarySession.Builder(this, player, sessionCallback)
@@ -231,7 +238,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         public void onPlaybackStateChanged(int playbackState) {
             if (playbackState == Player.STATE_BUFFERING) {
                 EventBus.getDefault().post(BufferUpdateEvent.started());
-                PlaybackService.isRunning = true; // Immediately show as playing
+                PlaybackService.isRunning = player.getPlayWhenReady(); // Immediately show as playing
                 updatePlaybackPreferences();
             } else {
                 EventBus.getDefault().post(BufferUpdateEvent.ended());
@@ -258,7 +265,6 @@ public class Media3PlaybackService extends MediaLibraryService {
                 }
                 startNextInQueue(media.getItem());
             }
-            EventBus.getDefault().post(new PlayerStatusEvent());
         }
 
         @Override
@@ -280,7 +286,6 @@ public class Media3PlaybackService extends MediaLibraryService {
                     player.getPlaybackParameters().speed);
             WidgetUpdater.updateWidget(Media3PlaybackService.this, widgetState);
             updatePlaybackPreferences();
-            EventBus.getDefault().post(new PlayerStatusEvent());
 
             // Auto-enable sleep timer when playback starts
             if (PlaybackService.isRunning && sleepTimer == null && SleepTimerPreferences.autoEnable()) {
@@ -441,7 +446,6 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 applyVolumeAdaption(1.0f);
                             }
                             updatePlaybackPreferences();
-                            EventBus.getDefault().post(new PlayerStatusEvent());
                         },
                                 error -> Log.e(TAG, "Failed to load current media", error));
 
@@ -454,13 +458,16 @@ public class Media3PlaybackService extends MediaLibraryService {
     }
 
     private void updatePlaybackPreferences() {
-        if (currentPlayable == null || player == null) {
-            return;
+        if (currentPlayable != null) {
+            PlaybackPreferences.writeMediaPlaying(currentPlayable);
         }
-        PlaybackPreferences.writeMediaPlaying(currentPlayable);
-        int status = Util.shouldShowPlayButton(player) ? PlaybackPreferences.PLAYER_STATUS_PAUSED
-                : PlaybackPreferences.PLAYER_STATUS_PLAYING;
+        int status = PlaybackService.isRunning ? PlaybackPreferences.PLAYER_STATUS_PLAYING
+                : PlaybackPreferences.PLAYER_STATUS_PAUSED;
+        int statusBefore = PlaybackPreferences.getCurrentPlayerStatus();
         PlaybackPreferences.setCurrentPlayerStatus(status);
+        if (status != statusBefore) {
+            EventBus.getDefault().post(new PlayerStatusEvent());
+        }
     }
 
     private void saveCurrentPosition() {


### PR DESCRIPTION
### Description

We send lots of duplicate PlayerStatusEvent messages, especially around seeking and when pressing play for the first time. Each of those events starts a re-load of the current fragments. This means we parse chapters again, update the position again, etc.

Closes #8447

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests