### PR TITLE
Fix crash in sync preferences fragment

### DIFF
--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
@@ -52,6 +52,7 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
         super.onStart();
         ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(R.string.synchronization_pref);
         updateScreen();
+        updateActionBar();
         EventBus.getDefault().register(this);
     }
 
@@ -106,6 +107,7 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
             Snackbar.make(getView(), R.string.pref_synchronization_logout_toast, Snackbar.LENGTH_LONG).show();
             SynchronizationSettings.setSelectedSyncProvider(null);
             updateScreen();
+            updateActionBar();
             return true;
         });
     }
@@ -141,10 +143,17 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
                     SynchronizationCredentials.getUsername(), SynchronizationCredentials.getHosturl());
             Spanned formattedSummary = HtmlCompat.fromHtml(summary, HtmlCompat.FROM_HTML_MODE_LEGACY);
             findPreference(PREFERENCE_LOGOUT).setSummary(formattedSummary);
+        } else {
+            findPreference(PREFERENCE_LOGOUT).setSummary(null);
+        }
+    }
+
+    private void updateActionBar() {
+        // Do not call from onCreate; ActionBar is not yet available at that point
+        if (SynchronizationSettings.isProviderConnected()) {
             updateLastSyncReport(SynchronizationSettings.isLastSyncSuccessful(),
                     SynchronizationSettings.getLastSyncAttempt());
         } else {
-            findPreference(PREFERENCE_LOGOUT).setSummary(null);
             ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(null);
         }
     }


### PR DESCRIPTION
### Description

Fix crash in sync preferences fragment. When changing the theme while on the sync preferences page, we went through onCreate with restoring the instance state. In this case, the action bar is not available, so we crash. Move action bar handling to a new function that is not called from onCreate.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
