### PR TITLE
Fix crash when choosing data folder

### DIFF
--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/downloads/DataFolderAdapter.java
@@ -17,6 +17,7 @@ import de.danoeh.antennapod.ui.preferences.R;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.ViewHolder> {
@@ -74,8 +75,8 @@ public class DataFolderAdapter extends RecyclerView.Adapter<DataFolderAdapter.Vi
 
     private List<StoragePath> getStorageEntries(Context context) {
         final List<File> mediaDirs = new ArrayList<>();
-        mediaDirs.addAll(List.of(context.getExternalFilesDirs(null)));
-        mediaDirs.addAll(List.of(context.getExternalMediaDirs()));
+        mediaDirs.addAll(Arrays.asList(context.getExternalFilesDirs(null)));
+        mediaDirs.addAll(Arrays.asList(context.getExternalMediaDirs()));
         final List<StoragePath> entries = new ArrayList<>(mediaDirs.size());
         for (File dir : mediaDirs) {
             if (!isWritable(dir)) {


### PR DESCRIPTION
### Description

This fixes a crash when opening **Settings → Downloads → Choose data folder** while Android reports an external/public storage volume that is registered but currently unavailable.

`DataFolderAdapter` was using `List.of(...)` with the arrays returned by Android storage directory APIs. In the unavailable-volume case, those arrays can contain `null` entries. `List.of(...)` rejects null elements and throws before the existing `isWritable(dir)` filtering logic can run.

This change uses `Arrays.asList(...)` instead, preserving the existing flow where non-writable or null storage entries are filtered by `isWritable(dir)`.

Validation performed:

- Reproduced the crash locally with a mounted/unmounted public storage volume scenario.
- Verified the crash no longer occurs after the fix.
- Verified the chooser updates from 4 entries → 2 entries when the public volume is unavailable.
- Verified the chooser returns to 4 entries when the public volume is available again.

Closes: #7919

## Before Video

- The video begins on the Downloads settings screen.

- The data-folder chooser initially opens successfully and displays 4 storage entries.

- The external/public storage volume is then unmounted using the reproduction ADB command.

- After unmounting the volume, opening **Settings → Downloads → Choose data folder** causes AntennaPod to crash immediately.

- Returning to the Downloads screen and attempting to open the data-folder chooser again reproduces the crash consistently.

https://github.com/user-attachments/assets/71600000-e28e-4ebf-abb1-652a088758b0

## After Video

- The video begins on the Downloads settings screen.

- Opening **Choose data folder** initially displays 4 storage entries while the external/public storage volume is available.

- The reproduction ADB command is then used to unmount the external/public storage volume.

- After dismissing the dialog and reopening **Choose data folder**, the application remains stable and displays only the 2 remaining available storage locations. No crash occurs.

- The reproduction ADB command is then used again to restore the external/public storage volume.

- After dismissing and reopening the chooser once more, all 4 storage entries return as expected.

- The video ends back on the Downloads settings screen, demonstrating that the chooser now updates dynamically as storage volumes become unavailable or available again without crashing.

https://github.com/user-attachments/assets/a60e099a-d5f4-4b5c-83d6-c89369bc24ff

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests