### PR TITLE
Fix queue swipe action crashes

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromQueueSwipeAction.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/swipeactions/RemoveFromQueueSwipeAction.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.ui.swipeactions;
 
+import android.app.Activity;
 import android.content.Context;
+import android.util.Log;
 import androidx.fragment.app.Fragment;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.event.MessageEvent;
@@ -8,9 +10,14 @@ import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.greenrobot.eventbus.EventBus;
 
 public class RemoveFromQueueSwipeAction implements SwipeAction {
+
+    private static final String TAG = "RemoveFromQueueSwipeAction";
 
     @Override
     public String getId() {
@@ -34,14 +41,23 @@ public class RemoveFromQueueSwipeAction implements SwipeAction {
 
     @Override
     public void performAction(FeedItem item, Fragment fragment, FeedItemFilter filter) {
-        int position = DBReader.getQueueIDList().indexOf(item.getId());
-        DBWriter.removeQueueItem(fragment.requireActivity(), true, item);
-        if (willRemove(filter, item)) {
-            EventBus.getDefault().post(new MessageEvent(
-                    fragment.getResources().getQuantityString(R.plurals.removed_from_queue_message, 1, 1),
-                    context -> DBWriter.addQueueItemAt(fragment.requireActivity(), item.getId(), position),
-                    fragment.getString(R.string.undo)));
-        }
+        Single.fromCallable(() -> DBReader.getQueueIDList().indexOf(item.getId()))
+                .subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(position -> {
+                    Activity activity = fragment.getActivity();
+                    if (activity == null) {
+                        return;
+                    }
+
+                    DBWriter.removeQueueItem(activity, true, item);
+                    if (willRemove(filter, item)) {
+                        EventBus.getDefault().post(new MessageEvent(
+                                fragment.getResources().getQuantityString(R.plurals.removed_from_queue_message, 1, 1),
+                                context -> DBWriter.addQueueItemAt(activity, item.getId(), position),
+                                fragment.getString(R.string.undo)));
+                    }
+                }, throwable -> Log.e(TAG, "Failed to get queue position", throwable));
     }
 
     @Override


### PR DESCRIPTION
### Description

This fixes two queue-related crashes in `RemoveFromQueueSwipeAction`.

The first crash occurs because queue-position lookup is performed synchronously on the main thread:

```java
DBReader.getQueueIDList().indexOf(item.getId())
```

When queue-related swipe actions remove an already queued item, this database access can trigger:

```text
RuntimeException: I/O on main thread
```

The second crash occurs when the Undo snackbar action is triggered after the originating `QueueFragment` has been detached.

The existing implementation later executes:

```java
fragment.requireActivity()
```

during queue removal and Undo restoration. If the user removes an item, navigates away from Queue, and then taps Undo, AntennaPod can crash with:

```text
IllegalStateException:
Fragment QueueFragment not attached to an activity
```

The detached-fragment crash reproduces in the Play Store production build.

This change performs the queue-position lookup asynchronously before continuing the existing removal and Undo flow.

The implementation preserves:

* Existing `SwipeAction` contract
* Existing `AddToQueueSwipeAction` delegation behavior
* Existing queue removal behavior
* Existing Undo behavior
* Existing queue restoration position behavior

The implementation also captures a validated activity reference before queue operations begin and reuses that reference throughout the removal and restoration flow, preventing detached-fragment crashes after navigation.

Closes: #8512

Closes: #8513

## Verification

### Before

* Reproduced the main-thread database crash described in #8512 on:

  * `upstream/master` 3.12.0-beta3f (1d8f35402)
  * `upstream/develop` 3.12.0-beta1f (95f94ca78)

* Reproduced the detached-fragment Undo crash described in #8513 on:

  * Play Store production build 3.11.4 (9286bfb5f)

### After

* Verified queue removal succeeds without crashing.
* Verified queued-item removal through `AddToQueueSwipeAction` succeeds without crashing.
* Verified Undo appears after queue removal.
* Verified Undo restores the item successfully.
* Verified queue restoration position remains correct.
* Verified tapping Undo after navigating away from Queue no longer crashes.

## Before Video — Main-thread Database Crash

Please review #8512.

## Before Video — Detached Fragment Undo Crash

Please review #8513.

## After Video

* The video begins on the About screen of the current develop build under test.
* Returning from the About screen lands on Queue, which contains a single queued episode.
* The queued episode is swiped to the right.
* The Swipe Actions Queue settings dialog appears.
* **Remove from queue** is already configured.
* `Confirm` is tapped to close the dialog.
* The queued episode is swiped to the right again.
* The episode is removed from the queue without crashing.
* Undo is tapped on the snackbar.
* The episode is restored to the queue.
* The Subscriptions fragment is opened.
* An episode is swiped to the right.
* The Swipe Actions settings dialog appears.
* The swipe action is changed to **Add to queue** and confirmed.
* Three episodes are swiped to the right.
* The episodes are added to the queue without crashing.
* Queue is opened and now contains four queued episodes.
* A queued episode is swiped to the right and removed from the queue.
* While the Undo snackbar is still visible, navigation leaves Queue and returns to Subscriptions.
* Undo is tapped on the snackbar.
* No crash occurs.
* Queue is opened again.
* The removed episode has been restored and the queue again contains four episodes.
* The video ends after demonstrating:
  * successful queue removal,
  * successful Undo restoration,
  * successful Add to Queue behavior,
  * correct queue restoration position behavior, and
  * elimination of the detached-fragment Undo crash.

https://github.com/user-attachments/assets/01b9f0b4-4d2c-4c77-9c26-65aedbeb3df7

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
