### PR TITLE
Fix export success snackbar Share crash

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
@@ -219,9 +220,14 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
     }
 
     void showExportSuccessSnackbar(Uri uri, String mimeType) {
-        Snackbar.make(getView(), R.string.export_success_title, Snackbar.LENGTH_LONG)
+        View view = getView();
+        if (view == null) {
+            return;
+        }
+
+        Snackbar.make(view, R.string.export_success_title, Snackbar.LENGTH_LONG)
                 .setAction(R.string.share_label, v ->
-                        new ShareCompat.IntentBuilder(getContext())
+                        new ShareCompat.IntentBuilder(v.getContext())
                                 .setType(mimeType)
                                 .addStream(uri)
                                 .setChooserTitle(R.string.share_label)


### PR DESCRIPTION
### Description

This fixes a crash that can occur when the Share action in the export success snackbar is tapped after leaving Backup & restore.

The existing implementation retrieves context from the fragment when the snackbar action is clicked:

```java
new ShareCompat.IntentBuilder(getContext())
```

If the user performs an export, navigates away from Backup & restore, and taps Share while the snackbar is still visible, the fragment may no longer have a valid context, resulting in:

```text
java.lang.NullPointerException
    at androidx.core.util.Preconditions.checkNotNull(Preconditions.java:137)
    at androidx.core.app.ShareCompat$IntentBuilder.<init>(ShareCompat.java:306)
    at de.danoeh.antennapod.ui.screen.preferences.ImportExportPreferencesFragment.lambda$showExportSuccessSnackbar$13(ImportExportPreferencesFragment.java:224)
    at com.google.android.material.snackbar.Snackbar.lambda$setAction$0$com-google-android-material-snackbar-Snackbar(Snackbar.java:357)
```

This change adds a null guard on the fragment view before creating the snackbar. The Share action now resolves context from the clicked view rather than from the fragment. All existing export, snackbar, and share behavior is preserved.

Closes: #8517

## Verification

### Before

* Reproduced the crash described in #8517 on:

  * 3.12.0-beta3f (1d8f354)
  * 3.12.0-beta1f (95f94ca)
  * 3.11.4 (9286bfb)

* Verified that tapping **Share** in the export success snackbar after leaving **Backup & restore** crashes the application.

### After

* Verified Database export succeeds.
* Verified OPML export succeeds.
* Verified HTML export succeeds.
* Verified Favorites export succeeds.
* Verified the export success snackbar still appears.
* Verified navigation away from **Backup & restore** while the snackbar is visible.
* Verified tapping **Share** opens the Android share chooser.
* Verified no crash occurs.
* Verified behavior for multiple export types.

## Before Video — Export Share Snackbar Crash

Please review #8517.

### Video - Export Share Snackbar Fix Verification

* The video begins on the About screen showing AntennaPod version **3.12.0-beta1f (95f94ca78)**.
* The Back arrow is tapped to return to Settings.
* Backup & restore is opened.
* Database export is selected.
* Save is tapped to export the database.
* The export completes successfully and the export success snackbar appears.
* The Back arrow is tapped to return to Settings.
* Share is tapped on the export success snackbar.
* The Android share chooser opens successfully.
* Backup & restore is reopened.
* OPML export is selected.
* Save is tapped to export the file.
* The export completes successfully and the export success snackbar appears.
* The Back arrow is tapped to return to Settings.
* Share is tapped on the export success snackbar.
* The Android share sheet opens successfully.
* The video ends after demonstrating that the Share action works correctly after leaving Backup & restore.

https://github.com/user-attachments/assets/02516524-6cad-4795-aa84-87d912171bc7

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests

