### PR TITLE
Add PortCast import and export

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -166,6 +166,12 @@
         </activity>
 
         <activity
+            android:name=".activity.PortcastImportActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:label="@string/portcast_import_label"
+            android:exported="false"/>
+
+        <activity
             android:name=".ui.screen.playback.video.VideoplayerActivity"
             android:configChanges="keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize"
             android:supportsPictureInPicture="true"

--- a/app/src/main/java/de/danoeh/antennapod/activity/PortcastImportActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/PortcastImportActivity.java
@@ -1,0 +1,350 @@
+package de.danoeh.antennapod.activity;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.util.SparseBooleanArray;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import de.danoeh.antennapod.R;
+import de.danoeh.antennapod.net.download.serviceinterface.FeedUpdateManager;
+import de.danoeh.antennapod.storage.database.DBReader;
+import de.danoeh.antennapod.storage.database.DBWriter;
+import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
+import de.danoeh.antennapod.databinding.OpmlSelectionBinding;
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
+import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
+import de.danoeh.antennapod.storage.importexport.PortcastDocument;
+import de.danoeh.antennapod.storage.importexport.PortcastEpisode;
+import de.danoeh.antennapod.storage.importexport.PortcastQueueEntry;
+import de.danoeh.antennapod.storage.importexport.PortcastReader;
+import de.danoeh.antennapod.storage.importexport.PortcastSubscription;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import de.danoeh.antennapod.ui.common.ToolbarActivity;
+import de.danoeh.antennapod.ui.screen.preferences.ParentalControlDialog;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Activity for importing PortCast files (subscriptions, play state and queue).
+ */
+public class PortcastImportActivity extends ToolbarActivity {
+    private static final String TAG = "PortcastImportActivity";
+    @Nullable private Uri uri;
+    private OpmlSelectionBinding viewBinding;
+    private ArrayAdapter<String> listAdapter;
+    private MenuItem selectAll;
+    private MenuItem deselectAll;
+    private PortcastDocument document;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        viewBinding = OpmlSelectionBinding.inflate(getLayoutInflater());
+        setContentView(viewBinding.getRoot());
+
+        viewBinding.feedlist.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+        viewBinding.feedlist.setOnItemClickListener((parent, view, position, id) -> {
+            SparseBooleanArray checked = viewBinding.feedlist.getCheckedItemPositions();
+            int checkedCount = 0;
+            for (int i = 0; i < checked.size(); i++) {
+                if (checked.valueAt(i)) {
+                    checkedCount++;
+                }
+            }
+            if (checkedCount == listAdapter.getCount()) {
+                selectAll.setVisible(false);
+                deselectAll.setVisible(true);
+            } else {
+                deselectAll.setVisible(false);
+                selectAll.setVisible(true);
+            }
+        });
+        viewBinding.butCancel.setOnClickListener(v -> {
+            setResult(RESULT_CANCELED);
+            finish();
+        });
+        viewBinding.butConfirm.setOnClickListener(v -> {
+            if (UserPreferences.isParentalControlPasswordSet()
+                    && UserPreferences.isParentalControlRequireSubscribeSet()) {
+                ParentalControlDialog.show(this, this::doImport);
+                return;
+            }
+            doImport();
+        });
+
+        Uri uri = getIntent().getData();
+        if (uri != null && uri.toString().startsWith("/")) {
+            uri = Uri.parse("file://" + uri.toString());
+        } else {
+            String extraText = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+            if (extraText != null) {
+                uri = Uri.parse(extraText);
+            }
+        }
+        importUri(uri);
+    }
+
+    private void doImport() {
+        viewBinding.progressBar.setVisibility(View.VISIBLE);
+        Completable.fromAction(() -> {
+            SparseBooleanArray checked = viewBinding.feedlist.getCheckedItemPositions();
+            for (int i = 0; i < checked.size(); i++) {
+                if (!checked.valueAt(i)) {
+                    continue;
+                }
+                importSubscription(document.getSubscriptions().get(checked.keyAt(i)));
+            }
+            importQueue();
+            FeedUpdateManager.getInstance().runOnce(this);
+        })
+                .subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        () -> {
+                            viewBinding.progressBar.setVisibility(View.GONE);
+                            Intent intent = new Intent(PortcastImportActivity.this, MainActivity.class);
+                            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+                            startActivity(intent);
+                            finish();
+                        }, e -> {
+                            e.printStackTrace();
+                            viewBinding.progressBar.setVisibility(View.GONE);
+                            Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                        });
+    }
+
+    private void importSubscription(PortcastSubscription subscription) {
+        if (TextUtils.isEmpty(subscription.getFeedUrl())) {
+            return;
+        }
+        String title = !TextUtils.isEmpty(subscription.getTitle())
+                ? subscription.getTitle() : "Unknown podcast";
+        Feed feed = new Feed(subscription.getFeedUrl(), null, title);
+        if (!TextUtils.isEmpty(subscription.getPodcastGuid())) {
+            feed.setFeedIdentifier(subscription.getPodcastGuid());
+        }
+        feed.setItems(new ArrayList<>());
+        Feed savedFeed = FeedDatabaseWriter.updateFeed(this, feed, false);
+        if (savedFeed == null) {
+            return;
+        }
+        applyPreferences(savedFeed, subscription);
+        applyEpisodes(savedFeed, subscription);
+    }
+
+    private void applyPreferences(Feed savedFeed, PortcastSubscription subscription) {
+        FeedPreferences preferences = new FeedPreferences(savedFeed.getId(),
+                FeedPreferences.AutoDownloadSetting.GLOBAL, FeedPreferences.AutoDeleteAction.GLOBAL,
+                VolumeAdaptionSetting.OFF, FeedPreferences.NewEpisodesAction.GLOBAL, null, null);
+        preferences.getTags().addAll(subscription.getTags());
+        if (subscription.getPlaybackSpeed() != null) {
+            preferences.setFeedPlaybackSpeed(subscription.getPlaybackSpeed());
+        }
+        if (subscription.getSkipIntroSeconds() != null) {
+            preferences.setFeedSkipIntro(subscription.getSkipIntroSeconds());
+        }
+        if (subscription.getSkipEndingSeconds() != null) {
+            preferences.setFeedSkipEnding(subscription.getSkipEndingSeconds());
+        }
+        if (subscription.getAutoUpdate() != null) {
+            preferences.setKeepUpdated(subscription.getAutoUpdate());
+        }
+        try {
+            DBWriter.setFeedPreferences(preferences).get();
+        } catch (Exception e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+        }
+    }
+
+    private void applyEpisodes(Feed savedFeed, PortcastSubscription subscription) {
+        List<FeedItem> toPersist = new ArrayList<>();
+        for (PortcastEpisode episode : subscription.getEpisodes()) {
+            if (TextUtils.isEmpty(episode.getGuid()) && TextUtils.isEmpty(episode.getEnclosureUrl())) {
+                continue;
+            }
+            FeedItem item = findExisting(savedFeed, episode);
+            if (item == null) {
+                item = new FeedItem();
+                item.setItemIdentifier(episode.getGuid());
+                item.setTitle(!TextUtils.isEmpty(episode.getGuid()) ? episode.getGuid() : episode.getEnclosureUrl());
+                item.setPubDate(episode.getLastPlayedAt() != null ? episode.getLastPlayedAt() : new Date());
+                item.setMedia(new FeedMedia(item, episode.getEnclosureUrl(), 0, null));
+            }
+            item.setFeed(savedFeed);
+            boolean completed = PortcastDocument.STATUS_COMPLETED.equals(episode.getStatus());
+            item.setPlayState(completed ? FeedItem.PLAYED : FeedItem.UNPLAYED);
+            if (item.getMedia() != null) {
+                item.getMedia().setPosition(completed ? 0 : episode.getPositionSeconds() * 1000);
+                if (episode.getLastPlayedAt() != null) {
+                    item.getMedia().setLastPlayedTimeHistory(episode.getLastPlayedAt());
+                }
+            }
+            toPersist.add(item);
+        }
+        if (!toPersist.isEmpty()) {
+            try {
+                DBWriter.setItemList(toPersist).get();
+            } catch (Exception e) {
+                Log.e(TAG, Log.getStackTraceString(e));
+            }
+        }
+    }
+
+    private FeedItem findExisting(Feed savedFeed, PortcastEpisode episode) {
+        for (FeedItem item : savedFeed.getItems()) {
+            if (!TextUtils.isEmpty(episode.getGuid()) && episode.getGuid().equals(item.getItemIdentifier())) {
+                return item;
+            }
+            if (!TextUtils.isEmpty(episode.getEnclosureUrl()) && item.getMedia() != null
+                    && episode.getEnclosureUrl().equals(item.getMedia().getDownloadUrl())) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    private void importQueue() {
+        List<FeedItem> queueItems = new ArrayList<>();
+        for (PortcastQueueEntry entry : document.getQueue()) {
+            String guid = TextUtils.isEmpty(entry.getGuid()) ? null : entry.getGuid();
+            String enclosureUrl = TextUtils.isEmpty(entry.getEnclosureUrl()) ? "" : entry.getEnclosureUrl();
+            if (guid == null && enclosureUrl.isEmpty()) {
+                continue;
+            }
+            FeedItem item = DBReader.getFeedItemByGuidOrEpisodeUrl(guid, enclosureUrl);
+            if (item != null) {
+                queueItems.add(item);
+            }
+        }
+        if (!queueItems.isEmpty()) {
+            try {
+                DBReader.loadFeedDataOfFeedItemList(queueItems);
+                DBWriter.addQueueItem(this, queueItems.toArray(new FeedItem[0])).get();
+            } catch (Exception e) {
+                Log.e(TAG, Log.getStackTraceString(e));
+            }
+        }
+    }
+
+    void importUri(@Nullable Uri uri) {
+        if (uri == null) {
+            new MaterialAlertDialogBuilder(this)
+                    .setMessage(R.string.opml_import_error_no_file)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show();
+            return;
+        }
+        this.uri = uri;
+        startImport();
+    }
+
+    private List<String> getTitleList() {
+        List<String> result = new ArrayList<>();
+        if (document != null) {
+            for (PortcastSubscription subscription : document.getSubscriptions()) {
+                result.add(!TextUtils.isEmpty(subscription.getTitle())
+                        ? subscription.getTitle() : subscription.getFeedUrl());
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.opml_selection_options, menu);
+        selectAll = menu.findItem(R.id.select_all_item);
+        deselectAll = menu.findItem(R.id.deselect_all_item);
+        deselectAll.setVisible(false);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        final int itemId = item.getItemId();
+        if (itemId == R.id.select_all_item) {
+            selectAll.setVisible(false);
+            selectAllItems(true);
+            deselectAll.setVisible(true);
+            return true;
+        } else if (itemId == R.id.deselect_all_item) {
+            deselectAll.setVisible(false);
+            selectAllItems(false);
+            selectAll.setVisible(true);
+            return true;
+        } else if (itemId == android.R.id.home) {
+            finish();
+        }
+        return false;
+    }
+
+    private void selectAllItems(boolean b) {
+        for (int i = 0; i < viewBinding.feedlist.getCount(); i++) {
+            viewBinding.feedlist.setItemChecked(i, b);
+        }
+    }
+
+    /** Starts the import process. */
+    private void startImport() {
+        viewBinding.progressBar.setVisibility(View.VISIBLE);
+
+        Observable.fromCallable(() -> {
+            InputStream fileStream = getContentResolver().openInputStream(uri);
+            BOMInputStream bomInputStream = new BOMInputStream(fileStream);
+            ByteOrderMark bom = bomInputStream.getBOM();
+            String charsetName = (bom == null) ? "UTF-8" : bom.getCharsetName();
+            Reader reader = new InputStreamReader(bomInputStream, charsetName);
+            PortcastReader portcastReader = new PortcastReader();
+            PortcastDocument result = portcastReader.readDocument(reader);
+            reader.close();
+            return result;
+        })
+                .subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        result -> {
+                            viewBinding.progressBar.setVisibility(View.GONE);
+                            Log.d(TAG, "Parsing was successful");
+                            document = result;
+                            listAdapter = new ArrayAdapter<>(PortcastImportActivity.this,
+                                    android.R.layout.simple_list_item_multiple_choice,
+                                    getTitleList());
+                            viewBinding.feedlist.setAdapter(listAdapter);
+                        }, e -> {
+                            Log.d(TAG, Log.getStackTraceString(e));
+                            viewBinding.progressBar.setVisibility(View.GONE);
+                            MaterialAlertDialogBuilder alert = new MaterialAlertDialogBuilder(this);
+                            alert.setTitle(R.string.error_label);
+                            alert.setMessage(getString(R.string.portcast_reader_error));
+                            alert.setPositiveButton(android.R.string.ok, (dialog, which) -> finish());
+                            alert.show();
+                        });
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/preferences/ImportExportPreferencesFragment.java
@@ -26,7 +26,9 @@ import androidx.core.content.FileProvider;
 import com.google.android.material.snackbar.Snackbar;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.activity.OpmlImportActivity;
+import de.danoeh.antennapod.activity.PortcastImportActivity;
 import de.danoeh.antennapod.storage.database.DBReader;
+import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.SortOrder;
@@ -35,6 +37,7 @@ import de.danoeh.antennapod.storage.importexport.DatabaseExporter;
 import de.danoeh.antennapod.storage.importexport.FavoritesWriter;
 import de.danoeh.antennapod.storage.importexport.HtmlWriter;
 import de.danoeh.antennapod.storage.importexport.OpmlWriter;
+import de.danoeh.antennapod.storage.importexport.PortcastWriter;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import io.reactivex.rxjava3.core.Completable;
@@ -51,13 +54,17 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String TAG = "ImportExPrefFragment";
     private static final String PREF_OPML_EXPORT = "prefOpmlExport";
     private static final String PREF_OPML_IMPORT = "prefOpmlImport";
+    private static final String PREF_PORTCAST_EXPORT = "prefPortcastExport";
+    private static final String PREF_PORTCAST_IMPORT = "prefPortcastImport";
     private static final String PREF_HTML_EXPORT = "prefHtmlExport";
     private static final String PREF_DATABASE_IMPORT = "prefDatabaseImport";
     private static final String PREF_DATABASE_EXPORT = "prefDatabaseExport";
@@ -65,6 +72,8 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
     private static final String PREF_FAVORITE_EXPORT = "prefFavoritesExport";
     private static final String DEFAULT_OPML_OUTPUT_NAME = "antennapod-feeds-%s.opml";
     private static final String CONTENT_TYPE_OPML = "text/x-opml";
+    private static final String DEFAULT_PORTCAST_OUTPUT_NAME = "antennapod-%s.portcast.json";
+    private static final String CONTENT_TYPE_PORTCAST = "application/json";
     private static final String DEFAULT_HTML_OUTPUT_NAME = "antennapod-feeds-%s.html";
     private static final String CONTENT_TYPE_HTML = "text/html";
     private static final String DEFAULT_FAVORITES_OUTPUT_NAME = "antennapod-favorites-%s.html";
@@ -79,6 +88,17 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
     private final ActivityResultLauncher<Intent> chooseFavoritesExportPathLauncher =
             registerForActivityResult(new StartActivityForResult(),
                     result -> exportToDocument(result, Export.FAVORITES));
+    private final ActivityResultLauncher<Intent> choosePortcastExportPathLauncher =
+            registerForActivityResult(new StartActivityForResult(),
+                    result -> exportToDocument(result, Export.PORTCAST));
+    private final ActivityResultLauncher<String> choosePortcastImportPathLauncher =
+            registerForActivityResult(new GetContent(), uri -> {
+                if (uri != null) {
+                    final Intent intent = new Intent(getContext(), PortcastImportActivity.class);
+                    intent.setData(uri);
+                    startActivity(intent);
+                }
+            });
     private final ActivityResultLauncher<Intent> restoreDatabaseLauncher =
             registerForActivityResult(new StartActivityForResult(), this::restoreDatabaseResult);
     private final ActivityResultLauncher<String> backupDatabaseLauncher =
@@ -136,6 +156,21 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
                 preference -> {
                     try {
                         chooseOpmlImportPathLauncher.launch("*/*");
+                    } catch (ActivityNotFoundException e) {
+                        Snackbar.make(getView(), R.string.unable_to_start_system_file_manager, Snackbar.LENGTH_LONG)
+                                .show();
+                    }
+                    return true;
+                });
+        findPreference(PREF_PORTCAST_EXPORT).setOnPreferenceClickListener(
+                preference -> {
+                    openExportPathPicker(Export.PORTCAST, choosePortcastExportPathLauncher);
+                    return true;
+                });
+        findPreference(PREF_PORTCAST_IMPORT).setOnPreferenceClickListener(
+                preference -> {
+                    try {
+                        choosePortcastImportPathLauncher.launch("*/*");
                     } catch (ActivityNotFoundException e) {
                         Snackbar.make(getView(), R.string.unable_to_start_system_file_manager, Snackbar.LENGTH_LONG)
                                 .show();
@@ -358,6 +393,19 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
                 case OPML:
                     OpmlWriter.writeDocument(DBReader.getFeedList(), writer);
                     break;
+                case PORTCAST:
+                    List<Feed> feeds = DBReader.getFeedList();
+                    for (Feed feed : feeds) {
+                        feed.setItems(DBReader.getFeedItemList(feed, FeedItemFilter.unfiltered(),
+                                SortOrder.DATE_NEW_OLD, 0, Integer.MAX_VALUE));
+                    }
+                    Set<Long> favoriteIds = new HashSet<>();
+                    for (FeedItem favorite : DBReader.getEpisodes(0, Integer.MAX_VALUE,
+                            new FeedItemFilter(FeedItemFilter.IS_FAVORITE), SortOrder.DATE_NEW_OLD)) {
+                        favoriteIds.add(favorite.getId());
+                    }
+                    PortcastWriter.writeDocument(feeds, DBReader.getQueue(), favoriteIds, writer, getContext());
+                    break;
                 case FAVORITES:
                     List<FeedItem> allFavorites = DBReader.getEpisodes(0, Integer.MAX_VALUE,
                             new FeedItemFilter(FeedItemFilter.IS_FAVORITE), SortOrder.DATE_NEW_OLD);
@@ -416,6 +464,7 @@ public class ImportExportPreferencesFragment extends AnimatedPreferenceFragment 
 
     private enum Export {
         OPML(CONTENT_TYPE_OPML, DEFAULT_OPML_OUTPUT_NAME, R.string.opml_export_label),
+        PORTCAST(CONTENT_TYPE_PORTCAST, DEFAULT_PORTCAST_OUTPUT_NAME, R.string.portcast_export_label),
         HTML(CONTENT_TYPE_HTML, DEFAULT_HTML_OUTPUT_NAME, R.string.html_export_label),
         FAVORITES(CONTENT_TYPE_HTML, DEFAULT_FAVORITES_OUTPUT_NAME, R.string.favorites_export_label);
 

--- a/storage/importexport/README.md
+++ b/storage/importexport/README.md
@@ -1,4 +1,6 @@
 # :storage:importexport
 
 Import/Export of the AntennaPod database.
-Supports OPML files for feed lists and an AntennaPod-specific backup format for full data export.
+Supports OPML files for feed lists, the cross-app [PortCast](https://portcast.org/) JSON format
+(subscriptions, episode play state, queue and per-feed preferences), and an AntennaPod-specific
+backup format for full data export.

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastDocument.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastDocument.java
@@ -1,0 +1,24 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a parsed PortCast file.
+ */
+public class PortcastDocument {
+    public static final String STATUS_UNPLAYED = PortcastSymbols.STATUS_UNPLAYED;
+    public static final String STATUS_IN_PROGRESS = PortcastSymbols.STATUS_IN_PROGRESS;
+    public static final String STATUS_COMPLETED = PortcastSymbols.STATUS_COMPLETED;
+
+    private final List<PortcastSubscription> subscriptions = new ArrayList<>();
+    private final List<PortcastQueueEntry> queue = new ArrayList<>();
+
+    public List<PortcastSubscription> getSubscriptions() {
+        return subscriptions;
+    }
+
+    public List<PortcastQueueEntry> getQueue() {
+        return queue;
+    }
+}

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastEpisode.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastEpisode.java
@@ -1,0 +1,90 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import java.util.Date;
+
+/**
+ * Represents the stored state of a single episode in a PortCast file.
+ */
+public class PortcastEpisode {
+    private String guid;
+    private String enclosureUrl;
+    private String status;
+    private int positionSeconds;
+    private Date lastPlayedAt;
+    private String title;
+    private Date publishedAt;
+    private int durationSeconds;
+    private boolean starred;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Date getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(Date publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public int getDurationSeconds() {
+        return durationSeconds;
+    }
+
+    public void setDurationSeconds(int durationSeconds) {
+        this.durationSeconds = durationSeconds;
+    }
+
+    public boolean isStarred() {
+        return starred;
+    }
+
+    public void setStarred(boolean starred) {
+        this.starred = starred;
+    }
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    public String getEnclosureUrl() {
+        return enclosureUrl;
+    }
+
+    public void setEnclosureUrl(String enclosureUrl) {
+        this.enclosureUrl = enclosureUrl;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public int getPositionSeconds() {
+        return positionSeconds;
+    }
+
+    public void setPositionSeconds(int positionSeconds) {
+        this.positionSeconds = positionSeconds;
+    }
+
+    public Date getLastPlayedAt() {
+        return lastPlayedAt;
+    }
+
+    public void setLastPlayedAt(Date lastPlayedAt) {
+        this.lastPlayedAt = lastPlayedAt;
+    }
+}

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastQueueEntry.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastQueueEntry.java
@@ -1,0 +1,25 @@
+package de.danoeh.antennapod.storage.importexport;
+
+/**
+ * Represents a single queue entry in a PortCast file, in queue order.
+ */
+public class PortcastQueueEntry {
+    private String guid;
+    private String enclosureUrl;
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    public String getEnclosureUrl() {
+        return enclosureUrl;
+    }
+
+    public void setEnclosureUrl(String enclosureUrl) {
+        this.enclosureUrl = enclosureUrl;
+    }
+}

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastReader.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastReader.java
@@ -1,0 +1,195 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.apache.commons.io.IOUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * Reads PortCast documents. See https://portcast.org/.
+ * Unknown or unsupported sections (such as bookmarks or playback events) are ignored.
+ */
+public class PortcastReader {
+    private static final String TAG = "PortcastReader";
+
+    public PortcastDocument readDocument(Reader reader) throws IOException, JSONException {
+        JSONObject root = new JSONObject(IOUtils.toString(reader));
+        if (!root.has(PortcastSymbols.PORTCAST)) {
+            throw new IOException("Not a PortCast file");
+        }
+
+        PortcastDocument document = new PortcastDocument();
+        Map<String, PortcastSubscription> byRef = new HashMap<>();
+
+        JSONArray subscriptions = root.optJSONArray(PortcastSymbols.SUBSCRIPTIONS);
+        if (subscriptions != null) {
+            for (int i = 0; i < subscriptions.length(); i++) {
+                JSONObject json = subscriptions.optJSONObject(i);
+                if (json == null) {
+                    continue;
+                }
+                PortcastSubscription subscription = readSubscription(json);
+                if (TextUtils.isEmpty(subscription.getFeedUrl())
+                        && TextUtils.isEmpty(subscription.getPodcastGuid())) {
+                    continue;
+                }
+                document.getSubscriptions().add(subscription);
+                registerRefs(byRef, subscription, json.optString(PortcastSymbols.SUBSCRIPTION_ID, null));
+            }
+        }
+
+        JSONArray episodes = root.optJSONArray(PortcastSymbols.EPISODES);
+        if (episodes != null) {
+            for (int i = 0; i < episodes.length(); i++) {
+                JSONObject json = episodes.optJSONObject(i);
+                if (json == null) {
+                    continue;
+                }
+                PortcastSubscription subscription = findSubscription(byRef,
+                        json.optJSONObject(PortcastSymbols.SUBSCRIPTION_REF));
+                if (subscription != null) {
+                    subscription.getEpisodes().add(readEpisode(json));
+                }
+            }
+        }
+
+        readPreferences(root, byRef);
+        readQueue(root, document);
+        return document;
+    }
+
+    private PortcastSubscription readSubscription(JSONObject json) {
+        PortcastSubscription subscription = new PortcastSubscription();
+        subscription.setFeedUrl(json.optString(PortcastSymbols.FEED_URL, null));
+        subscription.setPodcastGuid(json.optString(PortcastSymbols.PODCAST_GUID, null));
+        subscription.setTitle(json.optString(PortcastSymbols.TITLE, null));
+        if (json.has(PortcastSymbols.NOTIFICATIONS_ENABLED)) {
+            subscription.setNotificationsEnabled(json.optBoolean(PortcastSymbols.NOTIFICATIONS_ENABLED, true));
+        }
+        JSONArray tags = json.optJSONArray(PortcastSymbols.TAGS);
+        if (tags != null) {
+            for (int i = 0; i < tags.length(); i++) {
+                String tag = tags.optString(i, null);
+                if (!TextUtils.isEmpty(tag)) {
+                    subscription.getTags().add(tag);
+                }
+            }
+        }
+        return subscription;
+    }
+
+    private PortcastEpisode readEpisode(JSONObject json) {
+        PortcastEpisode episode = new PortcastEpisode();
+        episode.setGuid(json.optString(PortcastSymbols.GUID, null));
+        episode.setEnclosureUrl(json.optString(PortcastSymbols.ENCLOSURE_URL, null));
+        episode.setStatus(json.optString(PortcastSymbols.STATUS, PortcastSymbols.STATUS_UNPLAYED));
+        episode.setPositionSeconds(json.optInt(PortcastSymbols.POSITION_SECONDS, 0));
+        episode.setDurationSeconds(json.optInt(PortcastSymbols.DURATION_SECONDS, 0));
+        episode.setTitle(json.optString(PortcastSymbols.TITLE, null));
+        episode.setLastPlayedAt(parseRfc3339(json.optString(PortcastSymbols.LAST_PLAYED_AT, null)));
+        episode.setPublishedAt(parseRfc3339(json.optString(PortcastSymbols.PUBLISHED_AT, null)));
+        episode.setStarred(json.optBoolean(PortcastSymbols.STARRED, false));
+        return episode;
+    }
+
+    private void readPreferences(JSONObject root, Map<String, PortcastSubscription> byRef) {
+        JSONObject preferences = root.optJSONObject(PortcastSymbols.PREFERENCES);
+        if (preferences == null) {
+            return;
+        }
+        JSONObject perFeed = preferences.optJSONObject(PortcastSymbols.PER_FEED);
+        if (perFeed == null) {
+            return;
+        }
+        Iterator<String> keys = perFeed.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            PortcastSubscription subscription = byRef.get(key);
+            JSONObject json = perFeed.optJSONObject(key);
+            if (subscription == null || json == null) {
+                continue;
+            }
+            if (json.has(PortcastSymbols.PLAYBACK_RATE)) {
+                subscription.setPlaybackSpeed((float) json.optDouble(PortcastSymbols.PLAYBACK_RATE));
+            }
+            if (json.has(PortcastSymbols.SKIP_INTRO_SECONDS)) {
+                subscription.setSkipIntroSeconds(json.optInt(PortcastSymbols.SKIP_INTRO_SECONDS));
+            }
+            if (json.has(PortcastSymbols.SKIP_OUTRO_SECONDS)) {
+                subscription.setSkipEndingSeconds(json.optInt(PortcastSymbols.SKIP_OUTRO_SECONDS));
+            }
+        }
+    }
+
+    private void readQueue(JSONObject root, PortcastDocument document) {
+        JSONArray queue = root.optJSONArray(PortcastSymbols.QUEUE);
+        if (queue == null) {
+            return;
+        }
+        for (int i = 0; i < queue.length(); i++) {
+            JSONObject json = queue.optJSONObject(i);
+            JSONObject ref = (json != null) ? json.optJSONObject(PortcastSymbols.EPISODE_REF) : null;
+            if (ref == null) {
+                continue;
+            }
+            PortcastQueueEntry entry = new PortcastQueueEntry();
+            entry.setGuid(ref.optString(PortcastSymbols.GUID, null));
+            entry.setEnclosureUrl(ref.optString(PortcastSymbols.ENCLOSURE_URL, null));
+            if (!TextUtils.isEmpty(entry.getGuid()) || !TextUtils.isEmpty(entry.getEnclosureUrl())) {
+                document.getQueue().add(entry);
+            }
+        }
+    }
+
+    private PortcastSubscription findSubscription(Map<String, PortcastSubscription> byRef, JSONObject ref) {
+        if (ref == null) {
+            return null;
+        }
+        String guid = ref.optString(PortcastSymbols.PODCAST_GUID, null);
+        if (!TextUtils.isEmpty(guid) && byRef.containsKey(guid)) {
+            return byRef.get(guid);
+        }
+        return byRef.get(ref.optString(PortcastSymbols.FEED_URL, ""));
+    }
+
+    private void registerRefs(Map<String, PortcastSubscription> byRef,
+                              PortcastSubscription subscription, String subscriptionId) {
+        if (!TextUtils.isEmpty(subscriptionId)) {
+            byRef.put(subscriptionId, subscription);
+        }
+        if (!TextUtils.isEmpty(subscription.getFeedUrl())) {
+            byRef.put(subscription.getFeedUrl(), subscription);
+        }
+        if (!TextUtils.isEmpty(subscription.getPodcastGuid())) {
+            byRef.put(subscription.getPodcastGuid(), subscription);
+        }
+    }
+
+    private Date parseRfc3339(String value) {
+        if (TextUtils.isEmpty(value)) {
+            return null;
+        }
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        try {
+            return format.parse(value);
+        } catch (ParseException e) {
+            Log.d(TAG, "Unable to parse date: " + value);
+            return null;
+        }
+    }
+}

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastSubscription.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastSubscription.java
@@ -1,0 +1,95 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents a single subscription in a PortCast file, together with the episode
+ * states and per-feed preferences that belong to it.
+ */
+public class PortcastSubscription {
+    private String feedUrl;
+    private String podcastGuid;
+    private String title;
+    private final Set<String> tags = new HashSet<>();
+    private final List<PortcastEpisode> episodes = new ArrayList<>();
+    private Float playbackSpeed;
+    private Integer skipIntroSeconds;
+    private Integer skipEndingSeconds;
+    private Boolean autoUpdate;
+    private Boolean notificationsEnabled;
+
+    public String getFeedUrl() {
+        return feedUrl;
+    }
+
+    public void setFeedUrl(String feedUrl) {
+        this.feedUrl = feedUrl;
+    }
+
+    public String getPodcastGuid() {
+        return podcastGuid;
+    }
+
+    public void setPodcastGuid(String podcastGuid) {
+        this.podcastGuid = podcastGuid;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    public List<PortcastEpisode> getEpisodes() {
+        return episodes;
+    }
+
+    public Float getPlaybackSpeed() {
+        return playbackSpeed;
+    }
+
+    public void setPlaybackSpeed(Float playbackSpeed) {
+        this.playbackSpeed = playbackSpeed;
+    }
+
+    public Integer getSkipIntroSeconds() {
+        return skipIntroSeconds;
+    }
+
+    public void setSkipIntroSeconds(Integer skipIntroSeconds) {
+        this.skipIntroSeconds = skipIntroSeconds;
+    }
+
+    public Integer getSkipEndingSeconds() {
+        return skipEndingSeconds;
+    }
+
+    public void setSkipEndingSeconds(Integer skipEndingSeconds) {
+        this.skipEndingSeconds = skipEndingSeconds;
+    }
+
+    public Boolean getAutoUpdate() {
+        return autoUpdate;
+    }
+
+    public void setAutoUpdate(Boolean autoUpdate) {
+        this.autoUpdate = autoUpdate;
+    }
+
+    public Boolean getNotificationsEnabled() {
+        return notificationsEnabled;
+    }
+
+    public void setNotificationsEnabled(Boolean notificationsEnabled) {
+        this.notificationsEnabled = notificationsEnabled;
+    }
+}

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastSymbols.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastSymbols.java
@@ -1,0 +1,71 @@
+package de.danoeh.antennapod.storage.importexport;
+
+/**
+ * Contains symbols for reading and writing PortCast documents.
+ * See https://portcast.org/ for the protocol definition.
+ */
+final class PortcastSymbols {
+    static final String PROTOCOL_VERSION = "0.2.0";
+
+    static final String PORTCAST = "portcast";
+    static final String GENERATED_AT = "generatedAt";
+    static final String GENERATOR = "generator";
+    static final String NAME = "name";
+    static final String VERSION = "version";
+    static final String URL = "url";
+    static final String GENERATOR_NAME = "AntennaPod";
+    static final String GENERATOR_URL = "https://antennapod.org";
+
+    static final String SUBSCRIPTIONS = "subscriptions";
+    static final String SUBSCRIPTION_ID = "subscriptionId";
+    static final String FEED_URL = "feedUrl";
+    static final String PODCAST_GUID = "podcastGuid";
+    static final String TITLE = "title";
+    static final String AUTHOR = "author";
+    static final String IMAGE_URL = "imageUrl";
+    static final String TAGS = "tags";
+    static final String UPDATED_AT = "updatedAt";
+    static final String NOTIFICATIONS_ENABLED = "notificationsEnabled";
+
+    static final String EPISODES = "episodes";
+    static final String EPISODE_STATE_ID = "episodeStateId";
+    static final String SUBSCRIPTION_REF = "subscriptionRef";
+    static final String EPISODE_REF = "episodeRef";
+    static final String GUID = "guid";
+    static final String ENCLOSURE_URL = "enclosureUrl";
+    static final String STATUS = "status";
+    static final String POSITION_SECONDS = "positionSeconds";
+    static final String DURATION_SECONDS = "durationSeconds";
+    static final String PUBLISHED_AT = "publishedAt";
+    static final String LAST_PLAYED_AT = "lastPlayedAt";
+    static final String STARRED = "starred";
+
+    static final String STATUS_UNPLAYED = "unplayed";
+    static final String STATUS_IN_PROGRESS = "in_progress";
+    static final String STATUS_COMPLETED = "completed";
+
+    static final String QUEUE = "queue";
+    static final String POSITION = "position";
+
+    static final String PREFERENCES = "preferences";
+    static final String GLOBAL = "global";
+    static final String PER_FEED = "perFeed";
+    static final String PLAYBACK_RATE = "playbackRate";
+    static final String SKIP_FORWARD_SECONDS = "skipForwardSeconds";
+    static final String SKIP_BACKWARD_SECONDS = "skipBackwardSeconds";
+    static final String SKIP_INTRO_SECONDS = "skipIntroSeconds";
+    static final String SKIP_OUTRO_SECONDS = "skipOutroSeconds";
+    static final String TRIM_SILENCE = "trimSilence";
+    static final String BOOST_VOICE = "boostVoice";
+
+    static final String COMPLETENESS = "completeness";
+    static final String SECTION = "section";
+    static final String SOURCE = "source";
+    static final String LEVEL = "level";
+    static final String LEVEL_FULL = "full";
+    static final String LEVEL_CURRENT_STATE_ONLY = "current-state-only";
+
+    private PortcastSymbols() {
+
+    }
+}

--- a/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastWriter.java
+++ b/storage/importexport/src/main/java/de/danoeh/antennapod/storage/importexport/PortcastWriter.java
@@ -1,0 +1,283 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
+import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TimeZone;
+
+/** Writes PortCast documents. See https://portcast.org/. */
+public class PortcastWriter {
+    private static final String TAG = "PortcastWriter";
+
+    /**
+     * Writes the given feeds and queue into a PortCast document.
+     *
+     * @param feeds       The complete list of feeds, with their items loaded. Only subscribed feeds are exported.
+     * @param queue       The current playback queue, in order.
+     * @param favoriteIds The ids of all favorite (starred) feed items.
+     * @param writer      Target writer.
+     * @param context     Used to read the app version for the generator field.
+     */
+    public static void writeDocument(List<Feed> feeds, List<FeedItem> queue, Set<Long> favoriteIds,
+                                     Writer writer, Context context) throws IOException {
+        Log.d(TAG, "Starting to write document");
+        try {
+            Set<Long> queuedIds = new HashSet<>();
+            for (FeedItem item : queue) {
+                queuedIds.add(item.getId());
+            }
+            String now = formatRfc3339(new Date());
+            JSONObject root = new JSONObject();
+            root.put(PortcastSymbols.PORTCAST, PortcastSymbols.PROTOCOL_VERSION);
+            root.put(PortcastSymbols.GENERATED_AT, now);
+            root.put(PortcastSymbols.GENERATOR, buildGenerator(context));
+
+            JSONArray subscriptions = new JSONArray();
+            JSONArray episodes = new JSONArray();
+            JSONObject perFeed = new JSONObject();
+            for (Feed feed : feeds) {
+                if (feed.getState() != Feed.STATE_SUBSCRIBED || feed.getDownloadUrl() == null) {
+                    continue;
+                }
+                subscriptions.put(buildSubscription(feed, now));
+                for (FeedItem item : feed.getItems()) {
+                    JSONObject episode = buildEpisode(feed, item, favoriteIds, queuedIds, now);
+                    if (episode != null) {
+                        episodes.put(episode);
+                    }
+                }
+                JSONObject feedPrefs = buildFeedPreferences(feed.getPreferences());
+                if (feedPrefs.length() > 0) {
+                    perFeed.put(feed.getDownloadUrl(), feedPrefs);
+                }
+            }
+            root.put(PortcastSymbols.SUBSCRIPTIONS, subscriptions);
+            root.put(PortcastSymbols.EPISODES, episodes);
+            root.put(PortcastSymbols.QUEUE, buildQueue(queue));
+            root.put(PortcastSymbols.PREFERENCES, buildPreferences(perFeed));
+            root.put(PortcastSymbols.COMPLETENESS, buildCompleteness());
+
+            writer.write(root.toString(2));
+        } catch (JSONException e) {
+            throw new IOException(e);
+        }
+        Log.d(TAG, "Finished writing document");
+    }
+
+    private static JSONObject buildGenerator(Context context) throws JSONException {
+        JSONObject generator = new JSONObject();
+        generator.put(PortcastSymbols.NAME, PortcastSymbols.GENERATOR_NAME);
+        generator.put(PortcastSymbols.URL, PortcastSymbols.GENERATOR_URL);
+        try {
+            String version = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), 0).versionName;
+            if (version != null) {
+                generator.put(PortcastSymbols.VERSION, version);
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, Log.getStackTraceString(e));
+        }
+        return generator;
+    }
+
+    private static JSONObject buildSubscription(Feed feed, String now) throws JSONException {
+        JSONObject subscription = new JSONObject();
+        subscription.put(PortcastSymbols.SUBSCRIPTION_ID, feed.getDownloadUrl());
+        subscription.put(PortcastSymbols.FEED_URL, feed.getDownloadUrl());
+        subscription.put(PortcastSymbols.TITLE, feed.getTitle() != null ? feed.getTitle() : feed.getDownloadUrl());
+        subscription.put(PortcastSymbols.UPDATED_AT, feed.getLastRefreshAttempt() > 0
+                ? formatRfc3339(new Date(feed.getLastRefreshAttempt())) : now);
+        String guid = feed.getFeedIdentifier();
+        if (guid != null && !guid.isEmpty() && !guid.equals(feed.getDownloadUrl())) {
+            subscription.put(PortcastSymbols.PODCAST_GUID, guid);
+        }
+        if (feed.getAuthor() != null) {
+            subscription.put(PortcastSymbols.AUTHOR, feed.getAuthor());
+        }
+        if (feed.getImageUrl() != null) {
+            subscription.put(PortcastSymbols.IMAGE_URL, feed.getImageUrl());
+        }
+        if (feed.getPreferences() != null) {
+            subscription.put(PortcastSymbols.NOTIFICATIONS_ENABLED,
+                    feed.getPreferences().getShowEpisodeNotification());
+            JSONArray tags = new JSONArray();
+            for (String tag : feed.getPreferences().getTags()) {
+                if (!tag.startsWith("#")) {
+                    tags.put(tag);
+                }
+            }
+            if (tags.length() > 0) {
+                subscription.put(PortcastSymbols.TAGS, tags);
+            }
+        }
+        return subscription;
+    }
+
+    private static JSONObject buildEpisode(Feed feed, FeedItem item, Set<Long> favoriteIds,
+                                           Set<Long> queuedIds, String now) throws JSONException {
+        FeedMedia media = item.getMedia();
+        int positionSeconds = (media != null) ? media.getPosition() / 1000 : 0;
+        boolean played = item.getPlayState() == FeedItem.PLAYED;
+        boolean starred = favoriteIds.contains(item.getId());
+        boolean queued = queuedIds.contains(item.getId());
+        if (!played && positionSeconds <= 0 && !starred && !queued) {
+            return null;
+        }
+        JSONObject episode = new JSONObject();
+        episode.put(PortcastSymbols.EPISODE_STATE_ID, episodeStateId(feed, item));
+        episode.put(PortcastSymbols.SUBSCRIPTION_REF, buildSubscriptionRef(feed));
+        if (played) {
+            episode.put(PortcastSymbols.STATUS, PortcastSymbols.STATUS_COMPLETED);
+        } else if (positionSeconds > 0) {
+            episode.put(PortcastSymbols.STATUS, PortcastSymbols.STATUS_IN_PROGRESS);
+            episode.put(PortcastSymbols.POSITION_SECONDS, positionSeconds);
+        } else {
+            episode.put(PortcastSymbols.STATUS, PortcastSymbols.STATUS_UNPLAYED);
+        }
+        Date lastPlayed = (media != null) ? media.getLastPlayedTimeHistory() : null;
+        episode.put(PortcastSymbols.UPDATED_AT, lastPlayed != null ? formatRfc3339(lastPlayed) : now);
+        if (item.getItemIdentifier() != null) {
+            episode.put(PortcastSymbols.GUID, item.getItemIdentifier());
+        }
+        if (media != null && media.getDownloadUrl() != null) {
+            episode.put(PortcastSymbols.ENCLOSURE_URL, media.getDownloadUrl());
+        }
+        if (item.getTitle() != null) {
+            episode.put(PortcastSymbols.TITLE, item.getTitle());
+        }
+        if (item.getPubDate() != null) {
+            episode.put(PortcastSymbols.PUBLISHED_AT, formatRfc3339(item.getPubDate()));
+        }
+        if (media != null && media.getDuration() > 0) {
+            episode.put(PortcastSymbols.DURATION_SECONDS, media.getDuration() / 1000);
+        }
+        if (lastPlayed != null) {
+            episode.put(PortcastSymbols.LAST_PLAYED_AT, formatRfc3339(lastPlayed));
+        }
+        if (starred) {
+            episode.put(PortcastSymbols.STARRED, true);
+        }
+        return episode;
+    }
+
+    private static String episodeStateId(Feed feed, FeedItem item) {
+        String suffix = item.getItemIdentifier() != null ? item.getItemIdentifier()
+                : (item.getMedia() != null ? item.getMedia().getDownloadUrl() : String.valueOf(item.getId()));
+        return feed.getDownloadUrl() + "#" + suffix;
+    }
+
+    private static JSONObject buildSubscriptionRef(Feed feed) throws JSONException {
+        JSONObject ref = new JSONObject();
+        ref.put(PortcastSymbols.FEED_URL, feed.getDownloadUrl());
+        String guid = feed.getFeedIdentifier();
+        if (guid != null && !guid.isEmpty() && !guid.equals(feed.getDownloadUrl())) {
+            ref.put(PortcastSymbols.PODCAST_GUID, guid);
+        }
+        return ref;
+    }
+
+    private static JSONArray buildQueue(List<FeedItem> queue) throws JSONException {
+        JSONArray result = new JSONArray();
+        int position = 1;
+        for (FeedItem item : queue) {
+            JSONObject ref = new JSONObject();
+            if (item.getItemIdentifier() != null) {
+                ref.put(PortcastSymbols.GUID, item.getItemIdentifier());
+            }
+            if (item.getMedia() != null && item.getMedia().getDownloadUrl() != null) {
+                ref.put(PortcastSymbols.ENCLOSURE_URL, item.getMedia().getDownloadUrl());
+            }
+            if (ref.length() == 0) {
+                continue;
+            }
+            JSONObject entry = new JSONObject();
+            entry.put(PortcastSymbols.POSITION, position);
+            entry.put(PortcastSymbols.EPISODE_REF, ref);
+            result.put(entry);
+            position++;
+        }
+        return result;
+    }
+
+    private static JSONObject buildFeedPreferences(FeedPreferences preferences) throws JSONException {
+        JSONObject feedPrefs = new JSONObject();
+        if (preferences == null) {
+            return feedPrefs;
+        }
+        if (preferences.getFeedPlaybackSpeed() != FeedPreferences.SPEED_USE_GLOBAL) {
+            feedPrefs.put(PortcastSymbols.PLAYBACK_RATE, preferences.getFeedPlaybackSpeed());
+        }
+        if (preferences.getFeedSkipIntro() > 0) {
+            feedPrefs.put(PortcastSymbols.SKIP_INTRO_SECONDS, preferences.getFeedSkipIntro());
+        }
+        if (preferences.getFeedSkipEnding() > 0) {
+            feedPrefs.put(PortcastSymbols.SKIP_OUTRO_SECONDS, preferences.getFeedSkipEnding());
+        }
+        if (preferences.getFeedSkipSilence() == FeedPreferences.SkipSilence.AGGRESSIVE) {
+            feedPrefs.put(PortcastSymbols.TRIM_SILENCE, true);
+        }
+        if (isBoost(preferences.getVolumeAdaptionSetting())) {
+            feedPrefs.put(PortcastSymbols.BOOST_VOICE, true);
+        }
+        return feedPrefs;
+    }
+
+    private static boolean isBoost(VolumeAdaptionSetting setting) {
+        return setting == VolumeAdaptionSetting.LIGHT_BOOST
+                || setting == VolumeAdaptionSetting.MEDIUM_BOOST
+                || setting == VolumeAdaptionSetting.HEAVY_BOOST;
+    }
+
+    private static JSONObject buildPreferences(JSONObject perFeed) throws JSONException {
+        JSONObject global = new JSONObject();
+        global.put(PortcastSymbols.PLAYBACK_RATE, UserPreferences.getPlaybackSpeed());
+        global.put(PortcastSymbols.SKIP_FORWARD_SECONDS, UserPreferences.getFastForwardSecs());
+        global.put(PortcastSymbols.SKIP_BACKWARD_SECONDS, UserPreferences.getRewindSecs());
+        JSONObject preferences = new JSONObject();
+        preferences.put(PortcastSymbols.GLOBAL, global);
+        preferences.put(PortcastSymbols.PER_FEED, perFeed);
+        return preferences;
+    }
+
+    private static JSONArray buildCompleteness() throws JSONException {
+        JSONArray completeness = new JSONArray();
+        completeness.put(completenessEntry(PortcastSymbols.SUBSCRIPTIONS, PortcastSymbols.LEVEL_FULL));
+        completeness.put(completenessEntry(PortcastSymbols.EPISODES, PortcastSymbols.LEVEL_CURRENT_STATE_ONLY));
+        completeness.put(completenessEntry(PortcastSymbols.QUEUE, PortcastSymbols.LEVEL_FULL));
+        completeness.put(completenessEntry(PortcastSymbols.PREFERENCES, PortcastSymbols.LEVEL_FULL));
+        return completeness;
+    }
+
+    private static JSONObject completenessEntry(String section, String level) throws JSONException {
+        JSONObject entry = new JSONObject();
+        entry.put(PortcastSymbols.SECTION, section);
+        entry.put(PortcastSymbols.SOURCE, PortcastSymbols.GENERATOR_NAME);
+        entry.put(PortcastSymbols.LEVEL, level);
+        return entry;
+    }
+
+    private static String formatRfc3339(Date date) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format.format(date);
+    }
+}

--- a/storage/importexport/src/test/java/de/danoeh/antennapod/storage/importexport/PortcastReaderTest.java
+++ b/storage/importexport/src/test/java/de/danoeh/antennapod/storage/importexport/PortcastReaderTest.java
@@ -1,0 +1,115 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(RobolectricTestRunner.class)
+public class PortcastReaderTest {
+
+    private static final String SAMPLE = "{"
+            + "\"portcast\":\"0.2.0\","
+            + "\"generatedAt\":\"2026-01-01T00:00:00Z\","
+            + "\"generator\":{\"name\":\"Other App\",\"version\":\"1.0\"},"
+            + "\"subscriptions\":["
+            + "  {\"subscriptionId\":\"https://example.com/feed.xml\",\"feedUrl\":\"https://example.com/feed.xml\","
+            + "   \"podcastGuid\":\"guid-1\",\"title\":\"Test Podcast\",\"updatedAt\":\"2026-01-01T00:00:00Z\","
+            + "   \"tags\":[\"News\",\"Tech\"],\"notificationsEnabled\":true}"
+            + "],"
+            + "\"episodes\":["
+            + "  {\"episodeStateId\":\"e1\",\"subscriptionRef\":{\"podcastGuid\":\"guid-1\"},\"guid\":\"ep-1\","
+            + "   \"enclosureUrl\":\"https://example.com/1.mp3\",\"status\":\"completed\","
+            + "   \"updatedAt\":\"2026-01-02T03:04:05Z\",\"lastPlayedAt\":\"2026-01-02T03:04:05Z\","
+            + "   \"title\":\"Episode 1\",\"durationSeconds\":1800,\"starred\":true},"
+            + "  {\"episodeStateId\":\"e2\",\"subscriptionRef\":{\"feedUrl\":\"https://example.com/feed.xml\"},"
+            + "   \"guid\":\"ep-2\",\"status\":\"in_progress\",\"positionSeconds\":42,"
+            + "   \"updatedAt\":\"2026-01-02T03:04:05Z\"}"
+            + "],"
+            + "\"queue\":["
+            + "  {\"position\":1,\"episodeRef\":{\"guid\":\"ep-2\",\"enclosureUrl\":\"https://example.com/2.mp3\"}}"
+            + "],"
+            + "\"preferences\":{"
+            + "  \"global\":{\"playbackRate\":1.0,\"skipForwardSeconds\":30,\"skipBackwardSeconds\":10},"
+            + "  \"perFeed\":{\"https://example.com/feed.xml\":{\"playbackRate\":1.5,"
+            + "     \"skipIntroSeconds\":30,\"skipOutroSeconds\":20,\"trimSilence\":true}}"
+            + "},"
+            + "\"bookmarks\":[{\"bookmarkId\":\"b1\",\"episodeRef\":{\"guid\":\"ep-1\"},\"atSeconds\":10,"
+            + "   \"createdAt\":\"2026-01-01T00:00:00Z\"}],"
+            + "\"completeness\":[{\"section\":\"episodes\",\"source\":\"Other App\",\"level\":\"full\"}]"
+            + "}";
+
+    @Test
+    public void testReadsSubscriptionAndTags() throws Exception {
+        PortcastDocument document = new PortcastReader().readDocument(new StringReader(SAMPLE));
+        assertEquals(1, document.getSubscriptions().size());
+        PortcastSubscription subscription = document.getSubscriptions().get(0);
+        assertEquals("Test Podcast", subscription.getTitle());
+        assertEquals("https://example.com/feed.xml", subscription.getFeedUrl());
+        assertEquals("guid-1", subscription.getPodcastGuid());
+        assertEquals(2, subscription.getTags().size());
+        assertTrue(subscription.getTags().contains("News"));
+        assertEquals(Boolean.TRUE, subscription.getNotificationsEnabled());
+    }
+
+    @Test
+    public void testEpisodesGroupedByObjectRef() throws Exception {
+        PortcastDocument document = new PortcastReader().readDocument(new StringReader(SAMPLE));
+        PortcastSubscription subscription = document.getSubscriptions().get(0);
+        assertEquals(2, subscription.getEpisodes().size());
+
+        PortcastEpisode completed = findByGuid(subscription, "ep-1");
+        assertEquals(PortcastDocument.STATUS_COMPLETED, completed.getStatus());
+        assertNotNull(completed.getLastPlayedAt());
+        assertEquals("Episode 1", completed.getTitle());
+        assertEquals(1800, completed.getDurationSeconds());
+        assertTrue(completed.isStarred());
+
+        PortcastEpisode inProgress = findByGuid(subscription, "ep-2");
+        assertEquals(PortcastDocument.STATUS_IN_PROGRESS, inProgress.getStatus());
+        assertEquals(42, inProgress.getPositionSeconds());
+    }
+
+    @Test
+    public void testReadsQueueFromEpisodeRef() throws Exception {
+        PortcastDocument document = new PortcastReader().readDocument(new StringReader(SAMPLE));
+        assertEquals(1, document.getQueue().size());
+        assertEquals("ep-2", document.getQueue().get(0).getGuid());
+        assertEquals("https://example.com/2.mp3", document.getQueue().get(0).getEnclosureUrl());
+    }
+
+    @Test
+    public void testReadsPerFeedPreferences() throws Exception {
+        PortcastDocument document = new PortcastReader().readDocument(new StringReader(SAMPLE));
+        PortcastSubscription subscription = document.getSubscriptions().get(0);
+        assertEquals(1.5f, subscription.getPlaybackSpeed(), 0.001f);
+        assertEquals(Integer.valueOf(30), subscription.getSkipIntroSeconds());
+        assertEquals(Integer.valueOf(20), subscription.getSkipEndingSeconds());
+    }
+
+    @Test
+    public void testNonPortcastFileThrows() {
+        try {
+            new PortcastReader().readDocument(new StringReader("{\"foo\":\"bar\"}"));
+            fail("Expected IOException");
+        } catch (Exception e) {
+            assertTrue(e instanceof IOException);
+        }
+    }
+
+    private PortcastEpisode findByGuid(PortcastSubscription subscription, String guid) {
+        for (PortcastEpisode episode : subscription.getEpisodes()) {
+            if (guid.equals(episode.getGuid())) {
+                return episode;
+            }
+        }
+        return null;
+    }
+}

--- a/storage/importexport/src/test/java/de/danoeh/antennapod/storage/importexport/PortcastWriterTest.java
+++ b/storage/importexport/src/test/java/de/danoeh/antennapod/storage/importexport/PortcastWriterTest.java
@@ -1,0 +1,193 @@
+package de.danoeh.antennapod.storage.importexport;
+
+import androidx.test.core.app.ApplicationProvider;
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
+import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class PortcastWriterTest {
+    private long nextId = 1;
+
+    @Before
+    public void setUp() {
+        UserPreferences.init(ApplicationProvider.getApplicationContext());
+    }
+
+    private Feed createFeed(String title, String downloadUrl, String guid) {
+        Feed feed = new Feed(0, null, title, null, null, null, null, null, "rss", guid, null, null, downloadUrl, 0);
+        feed.setPreferences(new FeedPreferences(0, FeedPreferences.AutoDownloadSetting.GLOBAL,
+                FeedPreferences.AutoDeleteAction.GLOBAL, VolumeAdaptionSetting.OFF,
+                FeedPreferences.NewEpisodesAction.GLOBAL, null, null));
+        feed.setItems(new ArrayList<>());
+        return feed;
+    }
+
+    private FeedItem addItem(Feed feed, String guid, String enclosureUrl, int state, int positionMs) {
+        FeedItem item = new FeedItem(nextId++, guid, guid, null, null, state, feed);
+        FeedMedia media = new FeedMedia(item, enclosureUrl, 0, "audio/mpeg");
+        media.setPosition(positionMs);
+        item.setMedia(media);
+        feed.getItems().add(item);
+        return item;
+    }
+
+    private PortcastDocument writeAndRead(List<Feed> feeds, List<FeedItem> queue, Set<Long> favoriteIds)
+            throws Exception {
+        StringWriter writer = new StringWriter();
+        PortcastWriter.writeDocument(feeds, queue, favoriteIds, writer, ApplicationProvider.getApplicationContext());
+        return new PortcastReader().readDocument(new StringReader(writer.toString()));
+    }
+
+    @Test
+    public void testWritesSubscriptionWithGuid() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.emptyList(), Collections.emptySet());
+
+        assertEquals(1, document.getSubscriptions().size());
+        PortcastSubscription subscription = document.getSubscriptions().get(0);
+        assertEquals("My Podcast", subscription.getTitle());
+        assertEquals("https://example.com/feed.xml", subscription.getFeedUrl());
+        assertEquals("guid-123", subscription.getPodcastGuid());
+    }
+
+    @Test
+    public void testGuidNotWrittenWhenEqualToUrl() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "https://example.com/feed.xml");
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.emptyList(), Collections.emptySet());
+
+        assertNull(document.getSubscriptions().get(0).getPodcastGuid());
+    }
+
+    @Test
+    public void testOnlyEpisodesWithStateAreWritten() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        addItem(feed, "played", "https://example.com/1.mp3", FeedItem.PLAYED, 0);
+        addItem(feed, "in-progress", "https://example.com/2.mp3", FeedItem.UNPLAYED, 65000);
+        addItem(feed, "untouched", "https://example.com/3.mp3", FeedItem.UNPLAYED, 0);
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.emptyList(), Collections.emptySet());
+
+        List<PortcastEpisode> episodes = document.getSubscriptions().get(0).getEpisodes();
+        assertEquals(2, episodes.size());
+
+        PortcastEpisode played = findByGuid(episodes, "played");
+        assertEquals(PortcastDocument.STATUS_COMPLETED, played.getStatus());
+
+        PortcastEpisode inProgress = findByGuid(episodes, "in-progress");
+        assertEquals(PortcastDocument.STATUS_IN_PROGRESS, inProgress.getStatus());
+        assertEquals(65, inProgress.getPositionSeconds());
+    }
+
+    @Test
+    public void testStarredUntouchedEpisodeIsWritten() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        FeedItem favorite = addItem(feed, "fav", "https://example.com/fav.mp3", FeedItem.UNPLAYED, 0);
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.emptyList(), new HashSet<>(Collections.singletonList(favorite.getId())));
+
+        List<PortcastEpisode> episodes = document.getSubscriptions().get(0).getEpisodes();
+        assertEquals(1, episodes.size());
+        assertEquals(PortcastDocument.STATUS_UNPLAYED, episodes.get(0).getStatus());
+        assertTrue(episodes.get(0).isStarred());
+    }
+
+    @Test
+    public void testQueueIsWrittenInOrder() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        FeedItem first = addItem(feed, "first", "https://example.com/1.mp3", FeedItem.UNPLAYED, 0);
+        FeedItem second = addItem(feed, "second", "https://example.com/2.mp3", FeedItem.UNPLAYED, 0);
+        List<FeedItem> queue = new ArrayList<>();
+        queue.add(first);
+        queue.add(second);
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed), queue, Collections.emptySet());
+
+        assertEquals(2, document.getQueue().size());
+        assertEquals("first", document.getQueue().get(0).getGuid());
+        assertEquals("second", document.getQueue().get(1).getGuid());
+    }
+
+    @Test
+    public void testQueuedUnplayedEpisodeIsExportedAsEpisode() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        FeedItem queued = addItem(feed, "queued", "https://example.com/q.mp3", FeedItem.UNPLAYED, 0);
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.singletonList(queued), Collections.emptySet());
+
+        List<PortcastEpisode> episodes = document.getSubscriptions().get(0).getEpisodes();
+        assertEquals(1, episodes.size());
+        assertEquals("queued", episodes.get(0).getGuid());
+        assertEquals(1, document.getQueue().size());
+        assertEquals("queued", document.getQueue().get(0).getGuid());
+    }
+
+    @Test
+    public void testOnlySubscribedFeedsExported() throws Exception {
+        Feed subscribed = createFeed("Subscribed", "https://example.com/sub.xml", null);
+        Feed archived = createFeed("Archived", "https://example.com/archived.xml", null);
+        archived.setState(Feed.STATE_ARCHIVED);
+        PortcastDocument document = writeAndRead(Arrays.asList(subscribed, archived),
+                Collections.emptyList(), Collections.emptySet());
+
+        assertEquals(1, document.getSubscriptions().size());
+        assertEquals("Subscribed", document.getSubscriptions().get(0).getTitle());
+    }
+
+    @Test
+    public void testTagsAreWritten() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        feed.getPreferences().getTags().add("News");
+        feed.getPreferences().getTags().add("#root");
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.emptyList(), Collections.emptySet());
+
+        assertTrue(document.getSubscriptions().get(0).getTags().contains("News"));
+        assertEquals(1, document.getSubscriptions().get(0).getTags().size());
+    }
+
+    @Test
+    public void testPerFeedPreferencesRoundTrip() throws Exception {
+        Feed feed = createFeed("My Podcast", "https://example.com/feed.xml", "guid-123");
+        feed.getPreferences().setFeedPlaybackSpeed(1.5f);
+        feed.getPreferences().setFeedSkipIntro(15);
+        feed.getPreferences().setFeedSkipEnding(40);
+        PortcastDocument document = writeAndRead(Collections.singletonList(feed),
+                Collections.emptyList(), Collections.emptySet());
+
+        PortcastSubscription subscription = document.getSubscriptions().get(0);
+        assertEquals(1.5f, subscription.getPlaybackSpeed(), 0.001f);
+        assertEquals(Integer.valueOf(15), subscription.getSkipIntroSeconds());
+        assertEquals(Integer.valueOf(40), subscription.getSkipEndingSeconds());
+    }
+
+    private PortcastEpisode findByGuid(List<PortcastEpisode> episodes, String guid) {
+        for (PortcastEpisode episode : episodes) {
+            if (guid.equals(episode.getGuid())) {
+                return episode;
+            }
+        }
+        return null;
+    }
+}

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -657,6 +657,12 @@
     <string name="database">Database</string>
     <string name="opml">OPML</string>
     <string name="html">HTML</string>
+    <string name="portcast">PortCast</string>
+    <string name="portcast_export_label">PortCast export</string>
+    <string name="portcast_export_summary">Transfer subscriptions, play state and queue to another podcast app</string>
+    <string name="portcast_import_label">PortCast import</string>
+    <string name="portcast_import_summary">Import subscriptions, play state and queue from another podcast app</string>
+    <string name="portcast_reader_error">An error has occurred while reading the file. Make sure that you have actually selected a PortCast file and that the file is valid.</string>
     <string name="html_export_summary">Show your subscriptions to a friend</string>
     <string name="opml_export_summary">Transfer your subscriptions to another podcast app</string>
     <string name="opml_import_summary">Import your subscriptions from another podcast app</string>

--- a/ui/preferences/src/main/res/xml/preferences_import_export.xml
+++ b/ui/preferences/src/main/res/xml/preferences_import_export.xml
@@ -32,6 +32,17 @@
                 android:summary="@string/opml_import_summary"/>
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/portcast">
+        <Preference
+                android:key="prefPortcastExport"
+                android:title="@string/portcast_export_label"
+                android:summary="@string/portcast_export_summary"/>
+        <Preference
+                android:key="prefPortcastImport"
+                android:title="@string/portcast_import_label"
+                android:summary="@string/portcast_import_summary"/>
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/html">
         <Preference
                 android:key="prefHtmlExport"


### PR DESCRIPTION
### Description

Adds support for the [PortCast](https://portcast.org/) format for importing and exporting podcast data, alongside the existing OPML export. PortCast is an open, vendor-neutral JSON format for moving a listener's data between apps. Export writes subscriptions, episode play state, resume positions, favorites, queue order, and per-feed and global preferences; import restores them into the library. It was discussed on the forum: https://forum.antennapod.org/t/data-portability-of-podcast-listening-history-and-the-portcast-protocol/8648

Closes: #8571

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

