### PR TITLE
Restore Media3 Next playback synchronization

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/AudioPlayerFragment.java
@@ -28,6 +28,7 @@ import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.playback.service.PlaybackService;
 import de.danoeh.antennapod.playback.service.PlaybackServiceStarter;
+import de.danoeh.antennapod.playback.service.internal.MediaLibrarySessionCallback;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
@@ -232,7 +233,9 @@ public class AudioPlayerFragment extends Fragment implements
         });
         butSkip.setOnClickListener(v -> {
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getContext(), MediaController::seekToNextMediaItem);
+                PlaybackController.bindToMedia3Service(getContext(), controller ->
+                        controller.sendCustomCommand(MediaLibrarySessionCallback.SESSION_COMMAND_SKIP_TO_NEXT,
+                                Bundle.EMPTY));
             } else {
                 getActivity().sendBroadcast(
                         MediaButtonStarter.createIntent(getContext(), KeyEvent.KEYCODE_MEDIA_NEXT));

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -22,6 +22,8 @@ import androidx.media3.session.SessionCommand;
 import androidx.media3.session.SessionResult;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.PlayerErrorEvent;
 import de.danoeh.antennapod.event.StreamingConfirmationEvent;
 import de.danoeh.antennapod.event.settings.VolumeAdaptionChangedEvent;
@@ -164,7 +166,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             @Override
             public void seekToNextMediaItem() {
                 if (currentPlayable != null) {
-                    startNextInQueue(currentPlayable.getItem());
+                    startNextInQueue(currentPlayable.getItem(), true);
                 }
             }
 
@@ -269,7 +271,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                         return;
                     }
                 }
-                startNextInQueue(media.getItem());
+                startNextInQueue(media.getItem(), false);
             }
         }
 
@@ -456,6 +458,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 applyVolumeAdaption(1.0f);
                             }
                             updatePlaybackPreferences();
+                            EventBus.getDefault().post(new PlayerStatusEvent());
                         },
                                 error -> Log.e(TAG, "Failed to load current media", error));
 
@@ -556,7 +559,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         List<Chapter> chapters = currentPlayable.getChapters();
         if (chapters == null) {
             if (currentPlayable.getItem() != null) {
-                startNextInQueue(currentPlayable.getItem());
+                startNextInQueue(currentPlayable.getItem(), true);
             }
             return;
         }
@@ -565,7 +568,7 @@ public class Media3PlaybackService extends MediaLibraryService {
 
         if (chapters.size() < nextChapter + 1) {
             if (currentPlayable.getItem() != null) {
-                startNextInQueue(currentPlayable.getItem());
+                startNextInQueue(currentPlayable.getItem(), true);
             }
             return;
         }
@@ -623,7 +626,7 @@ public class Media3PlaybackService extends MediaLibraryService {
      * Loads the next item, and starts it if continuous playback is enabled.
      */
     @UnstableApi
-    private void startNextInQueue(FeedItem item) {
+    private void startNextInQueue(FeedItem item, boolean wasSkipped) {
         if (queueLoaderDisposable != null) {
             queueLoaderDisposable.dispose();
         }
@@ -665,11 +668,18 @@ public class Media3PlaybackService extends MediaLibraryService {
                         },
                         error -> Log.e(TAG, "Failed to load next queue item", error),
                         () -> {
+                            if (wasSkipped && !UserPreferences.shouldSkipKeepEpisode()) {
+                                DBWriter.markItemsPlayed(FeedItem.PLAYED, false, Collections.singletonList(item));
+                                DBWriter.removeQueueItem(this, false, item);
+                            }
                             player.stop();
                             player.clearMediaItems();
                             PlaybackPreferences.writeNoMediaPlaying();
                             EventBus.getDefault().post(
                                     new PlaybackServiceEvent(PlaybackServiceEvent.Action.SERVICE_SHUT_DOWN));
+                            if (wasSkipped) {
+                                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_following_in_queue)));
+                            }
                         });
     }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/PlaybackServiceStarter.java
@@ -9,6 +9,7 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.playback.Playable;
 import de.danoeh.antennapod.playback.base.BuildConfig;
 import de.danoeh.antennapod.playback.base.MediaItemAdapter;
+import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 
 public class PlaybackServiceStarter {
     private final Context context;
@@ -46,6 +47,7 @@ public class PlaybackServiceStarter {
             PlaybackController.bindToMedia3Service(context, controller -> {
                 if (controller.getCurrentMediaItem() != null && media instanceof FeedMedia
                         && ("" + ((FeedMedia) media).getId()).equals(controller.getCurrentMediaItem().mediaId)) {
+                    PlaybackPreferences.writeMediaPlaying((FeedMedia) media);
                     controller.play();
                     return;
                 }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -66,7 +66,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
             = new SessionCommand("fast_forward", Bundle.EMPTY);
     protected static final SessionCommand SESSION_COMMAND_PLAYBACK_SPEED
             = new SessionCommand("playback_speed", Bundle.EMPTY);
-    protected static final SessionCommand SESSION_COMMAND_SKIP_TO_NEXT
+    public static final SessionCommand SESSION_COMMAND_SKIP_TO_NEXT
             = new SessionCommand("skip_to_next", Bundle.EMPTY);
     protected static final SessionCommand SESSION_COMMAND_NEXT_CHAPTER
             = new SessionCommand("next_chapter", Bundle.EMPTY);


### PR DESCRIPTION
### Description

While investigating the Media3 **Next** button, I found that Media3 playback state could become out of sync after playback had been cleared. Starting playback again could reuse stale playback state, preventing the miniplayer from reappearing until a later playback state change.

This PR addresses the related Media3 synchronization issues together.

* Restore the Media3 **Next** button by routing it through AntennaPod's existing Media3 skip-to-next session command instead of calling `seekToNextMediaItem()` directly.
* Restore the end-of-queue message for user-initiated skips of the final queue item, matching the legacy playback service behavior.
* Prevent `PlaybackServiceStarter` from treating a stale `MediaItem` as resumable after playback has been cleared.
* Notify the UI after Media3 loads the current media so the miniplayer and playback state remain synchronized when playback starts again.

Closes: #8516

Closes: #8528

Closes: #8530

## Verification

The attached videos demonstrate the corrected behavior:

* Media3 Next button and end-of-queue behavior (#8528)

https://github.com/user-attachments/assets/1cf50f97-45ef-4f77-baa2-7b6f7eed4c8a

---

* Media3 playback synchronization (#8516 and #8530)

https://github.com/user-attachments/assets/25ebb017-ee1c-4646-9a4f-f5b5ec11a051

During this investigation, I also found a broader Media3 skipped-item queue cleanup parity gap. That behavior is outside the scope of this PR and will be tracked separately.

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests