### PR TITLE
Fix crash when speed dialog gets closed while handler is running

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/VariableSpeedDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/VariableSpeedDialog.java
@@ -191,15 +191,13 @@ public class VariableSpeedDialog extends BottomSheetDialogFragment {
             });
             holder.chip.setOnClickListener(v -> {
                 UserPreferences.setPlaybackSpeed(speed);
-                new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                    if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                        PlaybackController.bindToMedia3Service(getContext(),
-                                controller -> controller.setPlaybackSpeed(speed));
-                    } else if (controller != null) {
-                        controller.setPlaybackSpeed(speed);
-                    }
-                    dismiss();
-                }, 200);
+                if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
+                    PlaybackController.bindToMedia3Service(getContext(),
+                            controller -> controller.setPlaybackSpeed(speed));
+                } else if (controller != null) {
+                    controller.setPlaybackSpeed(speed);
+                }
+                new Handler(Looper.getMainLooper()).postDelayed(() -> dismiss(), 200);
             });
         }
 


### PR DESCRIPTION
### Description

Fix crash when speed dialog gets closed while handler is running. This seems super hard to trigger, but apparently some of our beta testers managed to do it.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
