### PR TITLE
Fix crash when leaving while delete dialog is open

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/Feed.java
@@ -2,6 +2,7 @@ package de.danoeh.antennapod.model.feed;
 
 import androidx.annotation.Nullable;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -14,7 +15,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @author daniel
  */
-public class Feed {
+public class Feed implements Serializable {
 
     public static final int FEEDFILETYPE_FEED = 0;
     public static final int STATE_SUBSCRIBED = 0;

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedFunding.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedFunding.java
@@ -2,9 +2,10 @@ package de.danoeh.antennapod.model.feed;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
-public class FeedFunding {
+public class FeedFunding implements Serializable {
     public static final String FUNDING_ENTRIES_SEPARATOR = "\u001e";
     public static final String FUNDING_TITLE_SEPARATOR = "\u001f";
 


### PR DESCRIPTION
### Description

Fix crash when resuming the activity while "delete podcast" dialog is open.

The dialog gets called with a `Feed` as its extra but the `Feed` object is not serializable. When the background activity gets killed, restoring from the instance state is broken and crashes the app. Simply making it serializable fixes the problem. Crash reported through Google Play.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
