### PR TITLE
Don't swallow PlayerStatusEvent if media changed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ExternalPlayerFragment.java
@@ -10,7 +10,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
@@ -79,12 +78,6 @@ public class ExternalPlayerFragment extends Fragment {
                 }
             }
         });
-        return root;
-    }
-
-    @Override
-    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
         butPlay.setOnClickListener(v -> {
             if (PlaybackService.isRunning
                     && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING) {
@@ -100,7 +93,7 @@ public class ExternalPlayerFragment extends Fragment {
                         .start();
             }
         });
-        loadMediaInfo();
+        return root;
     }
 
     @Override

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -311,10 +311,10 @@ public class Media3PlaybackService extends MediaLibraryService {
             if (mediaItem == null) {
                 currentPlayable = null;
                 PlaybackPreferences.writeNoMediaPlaying();
+                EventBus.getDefault().post(new PlayerStatusEvent());
             } else {
                 ensureCurrentMediaLoaded();
             }
-            EventBus.getDefault().post(new PlayerStatusEvent());
         }
 
         @Override
@@ -322,6 +322,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             PlaybackService.isRunning = false;
             EventBus.getDefault().post(new PlayerErrorEvent(
                     ExoPlayerUtils.translateErrorReason(error, Media3PlaybackService.this)));
+            EventBus.getDefault().post(new PlayerStatusEvent());
         }
     };
 
@@ -471,14 +472,15 @@ public class Media3PlaybackService extends MediaLibraryService {
     }
 
     private void updatePlaybackPreferences() {
+        int statusBefore = PlaybackPreferences.getCurrentPlayerStatus();
+        long mediaBefore = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
         if (currentPlayable != null) {
             PlaybackPreferences.writeMediaPlaying(currentPlayable);
         }
         int status = PlaybackService.isRunning ? PlaybackPreferences.PLAYER_STATUS_PLAYING
                 : PlaybackPreferences.PLAYER_STATUS_PAUSED;
-        int statusBefore = PlaybackPreferences.getCurrentPlayerStatus();
         PlaybackPreferences.setCurrentPlayerStatus(status);
-        if (status != statusBefore) {
+        if (status != statusBefore || (currentPlayable != null && currentPlayable.getId() != mediaBefore)) {
             EventBus.getDefault().post(new PlayerStatusEvent());
         }
     }
@@ -671,6 +673,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                             player.stop();
                             player.clearMediaItems();
                             PlaybackPreferences.writeNoMediaPlaying();
+                            EventBus.getDefault().post(new PlayerStatusEvent());
                             EventBus.getDefault().post(
                                     new PlaybackServiceEvent(PlaybackServiceEvent.Action.SERVICE_SHUT_DOWN));
                         });


### PR DESCRIPTION
### Description

Don't swallow PlayerStatusEvent if media changed. We only checked the status, but if we directly started a new episode without going through pause/play, we skipped sending the PlayerStatusEvent incorrectly.

Closes #8548
Closes #8516
Closes #8530

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
