### PR TITLE
Fix Android Auto browse lists hanging when streaming

### DIFF
--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
@@ -221,11 +221,40 @@ public class MediaItemAdapter {
                 .build();
     }
 
-    public static ImmutableList<MediaItem> fromItemList(Context context, List<FeedItem> feedItems) {
+    /**
+     * Create a lightweight media item for display in a browsable list. Unlike {@link #fromPlayable},
+     * this performs no blocking work (no redirect resolution, no artwork download). The playback URI
+     * and full metadata are resolved later from the media id when the item is actually selected
+     * (see enrichMediaItems). This keeps browsing large lists responsive, which especially matters
+     * when streaming, where every item would otherwise trigger a network request just to be listed.
+     */
+    public static MediaItem fromPlayableForBrowsing(Playable playable) {
+        MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder();
+        metadataBuilder.setTitle(playable.getEpisodeTitle());
+        metadataBuilder.setIsPlayable(true);
+        metadataBuilder.setIsBrowsable(false);
+        metadataBuilder.setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE);
+        String mediaId = "0";
+        if (playable instanceof FeedMedia) {
+            FeedMedia feedMedia = (FeedMedia) playable;
+            mediaId = String.valueOf(feedMedia.getId());
+            metadataBuilder.setSubtitle(feedMedia.getFeedTitle());
+        }
+        String imageLocation = playable.getImageLocation();
+        if (imageLocation != null && imageLocation.startsWith("http")) {
+            metadataBuilder.setArtworkUri(Uri.parse(imageLocation));
+        }
+        return new MediaItem.Builder()
+                .setMediaId(mediaId)
+                .setMediaMetadata(metadataBuilder.build())
+                .build();
+    }
+
+    public static ImmutableList<MediaItem> fromItemList(List<FeedItem> feedItems) {
         ImmutableList.Builder<MediaItem> itemsBuilder = ImmutableList.builder();
         for (FeedItem item : feedItems) {
             if (item.getMedia() != null) {
-                itemsBuilder.add(MediaItemAdapter.fromPlayable(context, item.getMedia()));
+                itemsBuilder.add(fromPlayableForBrowsing(item.getMedia()));
             }
         }
         return itemsBuilder.build();

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -374,7 +374,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                         .subscribeOn(Schedulers.io())
                         .subscribe(
                                 items -> future.set(LibraryResult.ofItemList(
-                                        MediaItemAdapter.fromItemList(context, items), params)),
+                                        MediaItemAdapter.fromItemList(items), params)),
                                 error -> {
                                     Log.e(TAG, "Failed to load continue listening", error);
                                     future.set(LibraryResult.ofItemList(ImmutableList.of(), params));
@@ -400,7 +400,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 })
                         .subscribeOn(Schedulers.io())
                         .subscribe(items -> future.set(LibraryResult.ofItemList(
-                                        MediaItemAdapter.fromItemList(context, items), params)),
+                                        MediaItemAdapter.fromItemList(items), params)),
                                 future::setException));
                 return future;
         }
@@ -416,7 +416,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                         DBReader.searchFeedItems(0, query, FeedItemFilter.unfiltered()))
                 .subscribeOn(Schedulers.io())
                 .subscribe(items -> future.set(LibraryResult.ofItemList(
-                                MediaItemAdapter.fromItemList(context, items), params)),
+                                MediaItemAdapter.fromItemList(items), params)),
                         future::setException));
         return future;
     }


### PR DESCRIPTION
### Description

When streaming (rather than downloading), opening an Android Auto browse list with many episodes could hang on a loading spinner forever. Building a browsable list resolved every item's playback URL up front via a blocking network request (`RedirectChecker.getFinalUrl`), plus a blocking artwork load. For a streaming user every item is non-local, so listing N episodes meant N sequential network requests on one thread, which can exceed Android Auto's browse timeout.

This renders browse list items from cached data only (title, subtitle and artwork URI) using a new lightweight `MediaItemAdapter.fromPlayableForBrowsing`. The full playback URL is still resolved when an item is actually selected (via `enrichMediaItems`), so playback is unaffected and the per-item network work during browsing — which was discarded anyway — is removed.

Closes: #8555

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description
- [ ] If it is a core feature, I have added automated tests
