### PR TITLE
Blend fresh New/Inbox episodes into Android Auto's For You feed

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ForYouBlender.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ForYouBlender.java
@@ -1,0 +1,25 @@
+package de.danoeh.antennapod.playback.service.internal;
+
+import de.danoeh.antennapod.model.feed.FeedItem;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class ForYouBlender {
+
+    static List<FeedItem> blend(List<FeedItem> inProgress, List<FeedItem> fresh) {
+        List<FeedItem> episodes = new ArrayList<>(inProgress);
+        Set<Long> seen = new HashSet<>();
+        for (FeedItem item : episodes) {
+            seen.add(item.getId());
+        }
+        for (FeedItem item : fresh) {
+            if (seen.add(item.getId())) {
+                episodes.add(item);
+            }
+        }
+        return episodes;
+    }
+}

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -56,6 +56,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     private static final String MEDIA_ID_SUBSCRIPTIONS = "subscriptions";
     private static final String MEDIA_ID_CONTINUE_LISTENING = "continue_listening";
     private static final int CONTINUE_LISTENING_NUM_EPISODES = 8;
+    private static final int CONTINUE_LISTENING_NUM_NEW = 22;
     private static final ImmutableList<String> BROWSABLE_MEDIA_IDS = ImmutableList.of(
             MEDIA_ID_ROOT, MEDIA_ID_QUEUE, MEDIA_ID_DOWNLOADS, MEDIA_ID_EPISODES,
             MEDIA_ID_SUBSCRIPTIONS, MEDIA_ID_CONTINUE_LISTENING);
@@ -419,8 +420,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                                 future::setException));
                 return future;
             case MEDIA_ID_CONTINUE_LISTENING:
-                disposables.add(Single.fromCallable(
-                                () -> DBReader.getPausedQueue(CONTINUE_LISTENING_NUM_EPISODES))
+                disposables.add(Single.fromCallable(this::loadContinueListeningEpisodes)
                         .subscribeOn(Schedulers.io())
                         .subscribe(
                                 items -> future.set(LibraryResult.ofItemList(
@@ -492,6 +492,14 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
             }
         }
         return builder.build();
+    }
+
+    @WorkerThread
+    private List<FeedItem> loadContinueListeningEpisodes() {
+        List<FeedItem> inProgress = DBReader.getPausedQueue(CONTINUE_LISTENING_NUM_EPISODES);
+        List<FeedItem> fresh = DBReader.getEpisodes(0, CONTINUE_LISTENING_NUM_NEW,
+                new FeedItemFilter(FeedItemFilter.NEW), UserPreferences.getInboxSortedOrder());
+        return ForYouBlender.blend(inProgress, fresh);
     }
 
     @WorkerThread

--- a/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/ForYouBlenderTest.java
+++ b/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/ForYouBlenderTest.java
@@ -1,0 +1,69 @@
+package de.danoeh.antennapod.playback.service.internal;
+
+import de.danoeh.antennapod.model.feed.FeedItem;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ForYouBlenderTest {
+
+    @Test
+    public void inProgressEpisodesComeFirstThenFresh() {
+        List<FeedItem> result = ForYouBlender.blend(items(1, 2), items(3, 4));
+        assertEquals(Arrays.asList(1L, 2L, 3L, 4L), ids(result));
+    }
+
+    @Test
+    public void freshEpisodesAlreadyInProgressAreNotDuplicated() {
+        List<FeedItem> result = ForYouBlender.blend(items(1, 2), items(2, 3));
+        assertEquals(Arrays.asList(1L, 2L, 3L), ids(result));
+    }
+
+    @Test
+    public void duplicatesWithinFreshAreRemoved() {
+        List<FeedItem> result = ForYouBlender.blend(items(1), items(2, 2, 3));
+        assertEquals(Arrays.asList(1L, 2L, 3L), ids(result));
+    }
+
+    @Test
+    public void emptyInProgressReturnsFreshOnly() {
+        List<FeedItem> result = ForYouBlender.blend(Collections.emptyList(), items(5, 6));
+        assertEquals(Arrays.asList(5L, 6L), ids(result));
+    }
+
+    @Test
+    public void emptyFreshReturnsInProgressOnly() {
+        List<FeedItem> result = ForYouBlender.blend(items(5, 6), Collections.emptyList());
+        assertEquals(Arrays.asList(5L, 6L), ids(result));
+    }
+
+    @Test
+    public void bothEmptyReturnsEmpty() {
+        List<FeedItem> result = ForYouBlender.blend(
+                Collections.emptyList(), Collections.emptyList());
+        assertEquals(Collections.emptyList(), ids(result));
+    }
+
+    private static List<FeedItem> items(long... episodeIds) {
+        List<FeedItem> list = new ArrayList<>();
+        for (long id : episodeIds) {
+            FeedItem item = new FeedItem();
+            item.setId(id);
+            list.add(item);
+        }
+        return list;
+    }
+
+    private static List<Long> ids(List<FeedItem> items) {
+        List<Long> result = new ArrayList<>();
+        for (FeedItem item : items) {
+            result.add(item.getId());
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
### Description

Android Auto's "For You" surface is fed by the root AntennaPod returns to the `googlequicksearchbox` browser, which today is the in-progress list (`getPausedQueue`). For anyone who starts more episodes than they finish, that surface becomes a backlog of half-listened episodes with no fresh content.

This blends the feed: up to 8 in-progress (paused) episodes first, followed by up to 22 episodes from the New/Inbox filter, deduplicated by id. The in-progress half is unchanged. The fresh fill uses the deterministic New/Inbox mechanism — the same one the Home screen's Inbox section uses — rather than guessing newest-across-subscriptions, and it adds no new settings. This is a second attempt at #8326, shaped to address the two concerns raised there (predictable source, no new settings) by construction.

This PR is based on #8557 (Fix Android Auto browse lists hanging when streaming) and should be merged after it; without that fix, the larger For You feed can hit the same streaming spinner. Until #8557 merges, this PR's diff includes its commit as well.

Closes: #8556

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description
- [x] If it is a core feature, I have added automated tests
