### PR TITLE
Restore Media3 Next behavior

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -167,7 +167,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             @Override
             public void seekToNextMediaItem() {
                 if (currentPlayable != null) {
-                    startNextInQueue(currentPlayable, true);
+                    startNextInQueue(currentPlayable, true, false);
                 }
             }
 
@@ -194,9 +194,6 @@ public class Media3PlaybackService extends MediaLibraryService {
                 @NonNull Bundle args) {
             if (customCommand.customAction.equals(SESSION_COMMAND_PLAYBACK_SPEED.customAction)) {
                 setNextPlaybackSpeed();
-                return Futures.immediateFuture(new SessionResult(SessionResult.RESULT_SUCCESS));
-            } else if (customCommand.customAction.equals(SESSION_COMMAND_SKIP_TO_NEXT.customAction)) {
-                session.getPlayer().seekToNextMediaItem();
                 return Futures.immediateFuture(new SessionResult(SessionResult.RESULT_SUCCESS));
             } else if (customCommand.customAction.equals(SESSION_COMMAND_NEXT_CHAPTER.customAction)) {
                 seekToNextChapter();
@@ -259,10 +256,10 @@ public class Media3PlaybackService extends MediaLibraryService {
             if (playbackState == Player.STATE_ENDED && currentPlayable != null) {
                 FeedMedia media = currentPlayable;
                 currentPlayable = null; // To avoid position updater saving position after we already reset it
-                onPlaybackEnd(media);
                 if (sleepTimer != null && sleepTimer.isActive()) {
                     sleepTimer.episodeFinishedPlayback();
                     if (!sleepTimer.shouldContinueToNextEpisode()) {
+                        finalizePlayback(media, true, false, false);
                         player.stop();
                         player.clearMediaItems();
                         PlaybackPreferences.writeNoMediaPlaying();
@@ -272,7 +269,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                         return;
                     }
                 }
-                startNextInQueue(media, false);
+                startNextInQueue(media, false, true);
             }
         }
 
@@ -505,10 +502,6 @@ public class Media3PlaybackService extends MediaLibraryService {
         PlayableUtils.saveCurrentPosition(currentPlayable, (int) position, timestamp);
     }
 
-    private void onPlaybackEnd(FeedMedia media) {
-        finalizePlayback(media, true, false, false);
-    }
-
     private void finalizePlayback(FeedMedia media, boolean ended, boolean skipped, boolean playingNext) {
         if (media == null) {
             return;
@@ -521,8 +514,10 @@ public class Media3PlaybackService extends MediaLibraryService {
 
         SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, ended || almostEnded);
         if (item != null) {
+            if (almostEnded) {
+                DBWriter.markItemsPlayed(FeedItem.PLAYED, true, Collections.singletonList(item));
+            }
             if (ended || almostEnded || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
-                DBWriter.markItemsPlayed(FeedItem.PLAYED, ended || (skipped && almostEnded), Collections.singletonList(item));
                 DBWriter.removeQueueItem(this, ended, item);
                 FeedPreferences.AutoDeleteAction action = item.getFeed().getPreferences().getCurrentAutoDelete();
                 boolean autoDeleteEnabledGlobally = UserPreferences.isAutoDelete()
@@ -570,7 +565,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         List<Chapter> chapters = currentPlayable.getChapters();
         if (chapters == null) {
             if (currentPlayable.getItem() != null) {
-                startNextInQueue(currentPlayable, true);
+                startNextInQueue(currentPlayable, true, false);
             }
             return;
         }
@@ -579,7 +574,7 @@ public class Media3PlaybackService extends MediaLibraryService {
 
         if (chapters.size() < nextChapter + 1) {
             if (currentPlayable.getItem() != null) {
-                startNextInQueue(currentPlayable, true);
+                startNextInQueue(currentPlayable, true, false);
             }
             return;
         }
@@ -637,7 +632,7 @@ public class Media3PlaybackService extends MediaLibraryService {
      * Loads the next item, and starts it if continuous playback is enabled.
      */
     @UnstableApi
-    private void startNextInQueue(FeedMedia media, boolean wasSkipped) {
+    private void startNextInQueue(FeedMedia media, boolean wasSkipped, boolean ended) {
         if (queueLoaderDisposable != null) {
             queueLoaderDisposable.dispose();
         }
@@ -667,7 +662,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 return;
                             }
                             allowStreamingThisTime = false;
-                            finalizePlayback(media, false, wasSkipped, true);
+                            finalizePlayback(media, ended, wasSkipped, true);
 
                             currentPlayable = nextMedia;
                             currentPlayable.onPlaybackStart();
@@ -684,7 +679,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                         },
                         error -> Log.e(TAG, "Failed to load next queue item", error),
                         () -> {
-                            finalizePlayback(media, false, wasSkipped, false);
+                            finalizePlayback(media, ended, wasSkipped, false);
                             currentPlayable = null;
                             player.stop();
                             player.clearMediaItems();

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -513,7 +513,7 @@ public class Media3PlaybackService extends MediaLibraryService {
 
         SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, ended || almostEnded);
         if (item != null) {
-            if (almostEnded) {
+            if (ended || almostEnded) {
                 DBWriter.markItemsPlayed(FeedItem.PLAYED, true, Collections.singletonList(item));
             }
             if (ended || almostEnded || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
@@ -644,8 +644,11 @@ public class Media3PlaybackService extends MediaLibraryService {
         }
         queueLoaderDisposable = Maybe.fromCallable(() -> {
             FeedItem nextItem = DBReader.getNextInQueue(item);
-            if (nextItem != null && nextItem.getMedia() != null) {
-                return new Pair<>(nextItem.getMedia(), MediaItemAdapter.fromPlayable(Media3PlaybackService.this, nextItem.getMedia(), false));
+            boolean hasNext = nextItem != null && nextItem.getMedia() != null;
+            finalizePlayback(media, ended, wasSkipped, hasNext);
+            if (hasNext) {
+                return new Pair<>(nextItem.getMedia(),
+                        MediaItemAdapter.fromPlayable(Media3PlaybackService.this, nextItem.getMedia(), false));
             }
             return null;
         })
@@ -661,7 +664,6 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 return;
                             }
                             allowStreamingThisTime = false;
-                            finalizePlayback(media, ended, wasSkipped, true);
 
                             currentPlayable = nextMedia;
                             currentPlayable.onPlaybackStart();
@@ -678,7 +680,6 @@ public class Media3PlaybackService extends MediaLibraryService {
                         },
                         error -> Log.e(TAG, "Failed to load next queue item", error),
                         () -> {
-                            finalizePlayback(media, ended, wasSkipped, false);
                             currentPlayable = null;
                             player.stop();
                             player.clearMediaItems();

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -22,6 +22,8 @@ import androidx.media3.session.SessionCommand;
 import androidx.media3.session.SessionResult;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+
+import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.PlayerErrorEvent;
 import de.danoeh.antennapod.event.StreamingConfirmationEvent;
 import de.danoeh.antennapod.event.settings.VolumeAdaptionChangedEvent;
@@ -119,6 +121,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             public Player.Commands getAvailableCommands() {
                 return super.getAvailableCommands()
                         .buildUpon()
+                        .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
                         .remove(Player.COMMAND_SEEK_TO_PREVIOUS)
                         .remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
                         .build();
@@ -164,7 +167,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             @Override
             public void seekToNextMediaItem() {
                 if (currentPlayable != null) {
-                    startNextInQueue(currentPlayable.getItem());
+                    startNextInQueue(currentPlayable, true);
                 }
             }
 
@@ -269,7 +272,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                         return;
                     }
                 }
-                startNextInQueue(media.getItem());
+                startNextInQueue(media, false);
             }
         }
 
@@ -503,6 +506,10 @@ public class Media3PlaybackService extends MediaLibraryService {
     }
 
     private void onPlaybackEnd(FeedMedia media) {
+        finalizePlayback(media, true, false, false);
+    }
+
+    private void finalizePlayback(FeedMedia media, boolean ended, boolean skipped, boolean playingNext) {
         if (media == null) {
             return;
         }
@@ -512,11 +519,11 @@ public class Media3PlaybackService extends MediaLibraryService {
         boolean almostEnded = media.getDuration() > 0
                 && media.getPosition() >= media.getDuration() - smartMarkAsPlayedSecs * 1000;
 
-        SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, almostEnded);
-        if (almostEnded) {
-            if (item != null) {
-                DBWriter.markItemsPlayed(FeedItem.PLAYED, true, Collections.singletonList(item));
-                DBWriter.removeQueueItem(this, true, item);
+        SynchronizationQueue.getInstance().enqueueEpisodePlayed(media, ended || almostEnded);
+        if (item != null) {
+            if (ended || almostEnded || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
+                DBWriter.markItemsPlayed(FeedItem.PLAYED, ended || (skipped && almostEnded), Collections.singletonList(item));
+                DBWriter.removeQueueItem(this, ended, item);
                 FeedPreferences.AutoDeleteAction action = item.getFeed().getPreferences().getCurrentAutoDelete();
                 boolean autoDeleteEnabledGlobally = UserPreferences.isAutoDelete()
                         && (!item.getFeed().isLocalFeed() || UserPreferences.isAutoDeleteLocal());
@@ -527,6 +534,8 @@ public class Media3PlaybackService extends MediaLibraryService {
                     DBWriter.deleteFeedMediaOfItem(this, media);
                 }
             }
+        }
+        if (ended || skipped || playingNext) {
             DBWriter.addItemToPlaybackHistory(media);
         }
     }
@@ -561,7 +570,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         List<Chapter> chapters = currentPlayable.getChapters();
         if (chapters == null) {
             if (currentPlayable.getItem() != null) {
-                startNextInQueue(currentPlayable.getItem());
+                startNextInQueue(currentPlayable, true);
             }
             return;
         }
@@ -570,7 +579,7 @@ public class Media3PlaybackService extends MediaLibraryService {
 
         if (chapters.size() < nextChapter + 1) {
             if (currentPlayable.getItem() != null) {
-                startNextInQueue(currentPlayable.getItem());
+                startNextInQueue(currentPlayable, true);
             }
             return;
         }
@@ -628,10 +637,14 @@ public class Media3PlaybackService extends MediaLibraryService {
      * Loads the next item, and starts it if continuous playback is enabled.
      */
     @UnstableApi
-    private void startNextInQueue(FeedItem item) {
+    private void startNextInQueue(FeedMedia media, boolean wasSkipped) {
         if (queueLoaderDisposable != null) {
             queueLoaderDisposable.dispose();
         }
+        if (media == null) {
+            return;
+        }
+        FeedItem item = media.getItem();
         if (item == null) {
             return;
         }
@@ -654,10 +667,11 @@ public class Media3PlaybackService extends MediaLibraryService {
                                 return;
                             }
                             allowStreamingThisTime = false;
+                            finalizePlayback(media, false, wasSkipped, true);
 
                             currentPlayable = nextMedia;
                             currentPlayable.onPlaybackStart();
-                            PlaybackPreferences.writeMediaPlaying(nextMedia);
+                            updatePlaybackPreferences();
                             if (nextMedia.getItem() != null && nextMedia.getItem().getFeed() != null) {
                                 volumeAdaptionFactor = nextMedia.getItem().getFeed()
                                         .getPreferences().getVolumeAdaptionSetting().getAdaptionFactor();
@@ -670,12 +684,17 @@ public class Media3PlaybackService extends MediaLibraryService {
                         },
                         error -> Log.e(TAG, "Failed to load next queue item", error),
                         () -> {
+                            finalizePlayback(media, false, wasSkipped, false);
+                            currentPlayable = null;
                             player.stop();
                             player.clearMediaItems();
                             PlaybackPreferences.writeNoMediaPlaying();
                             EventBus.getDefault().post(new PlayerStatusEvent());
                             EventBus.getDefault().post(
                                     new PlaybackServiceEvent(PlaybackServiceEvent.Action.SERVICE_SHUT_DOWN));
+                            if (wasSkipped) {
+                                EventBus.getDefault().post(new MessageEvent(getString(R.string.no_following_in_queue)));
+                            }
                         });
     }
 

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -132,7 +132,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 .build();
         return new MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(sessionCommands)
-                .setCustomLayout(buildCustomLayout())
+                .setMediaButtonPreferences(buildCustomLayout())
                 .setAvailablePlayerCommands(playerCommands)
                 .build();
     }
@@ -140,12 +140,12 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     @Override
     @UnstableApi
     public void onPostConnect(@NonNull MediaSession session, @NonNull MediaSession.ControllerInfo controller) {
-        session.setCustomLayout(buildCustomLayout());
+        session.setMediaButtonPreferences(buildCustomLayout());
     }
 
     @UnstableApi
     public void refreshNotification(MediaLibraryService.MediaLibrarySession session) {
-        session.setCustomLayout(buildCustomLayout());
+        session.setMediaButtonPreferences(buildCustomLayout());
     }
 
     @UnstableApi
@@ -180,6 +180,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
 
         if (UserPreferences.showSkipOnFullNotification()) {
             buttons.add(new CommandButton.Builder(CommandButton.ICON_NEXT)
+                    .setSlots(CommandButton.SLOT_OVERFLOW)
                     .setSessionCommand(SESSION_COMMAND_SKIP_TO_NEXT)
                     .setDisplayName(context.getString(R.string.skip_episode_label))
                     .build());

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -66,8 +66,6 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
             = new SessionCommand("fast_forward", Bundle.EMPTY);
     protected static final SessionCommand SESSION_COMMAND_PLAYBACK_SPEED
             = new SessionCommand("playback_speed", Bundle.EMPTY);
-    protected static final SessionCommand SESSION_COMMAND_SKIP_TO_NEXT
-            = new SessionCommand("skip_to_next", Bundle.EMPTY);
     protected static final SessionCommand SESSION_COMMAND_NEXT_CHAPTER
             = new SessionCommand("next_chapter", Bundle.EMPTY);
     public static final SessionCommand SESSION_COMMAND_SKIP_SILENCE
@@ -118,7 +116,6 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 .add(SESSION_COMMAND_REWIND)
                 .add(SESSION_COMMAND_FAST_FORWARD)
                 .add(SESSION_COMMAND_PLAYBACK_SPEED)
-                .add(SESSION_COMMAND_SKIP_TO_NEXT)
                 .add(SESSION_COMMAND_NEXT_CHAPTER)
                 .add(SESSION_COMMAND_SKIP_SILENCE)
                 .add(SESSION_COMMAND_SET_SLEEP_TIMER)
@@ -181,7 +178,7 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
         if (UserPreferences.showSkipOnFullNotification()) {
             buttons.add(new CommandButton.Builder(CommandButton.ICON_NEXT)
                     .setSlots(CommandButton.SLOT_OVERFLOW)
-                    .setSessionCommand(SESSION_COMMAND_SKIP_TO_NEXT)
+                    .setPlayerCommand(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
                     .setDisplayName(context.getString(R.string.skip_episode_label))
                     .build());
         }


### PR DESCRIPTION
### Description

Restore the legacy Media3 Next behavior while centralizing playback finalization across playback transitions.

This PR replaces the custom Media3 NEXT session command with the standard `Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM` command and routes manual Next, natural playback completion, and chapter-based queue advancement through a shared playback finalization path.

Centralizing playback finalization restores the legacy behavior for:

* played-state updates
* playback synchronization
* playback history
* queue removal
* auto-delete evaluation
* end-of-queue handling

The PR also improves playback state synchronization by:

* routing playback preference updates through the existing centralized helper after switching episodes
* clearing stale playback state when the final queue item is skipped or playback ends
* restoring the end-of-queue message when manually skipping the final queued episode
* replacing the legacy custom notification layout API with Media3 media button preferences while exposing the standard Media3 NEXT command

Closes #8528

### Demo

https://github.com/user-attachments/assets/f3bda20c-4348-4a83-adce-789779f16dd1

The video demonstrates:

- Manual Next advancing to the next queued episode with immediate playback UI updates.
- Manual Next on the final queue item restoring the legacy end-of-queue behavior with the existing message.


### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests