### PR TITLE
Show episode cover art on WearOS

### DIFF
--- a/app-wearos/build.gradle
+++ b/app-wearos/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation libs.kotlinx.coroutines.play.services
     implementation libs.androidx.activity.compose
     implementation libs.androidx.appcompat
+    implementation libs.coil.compose
 
     testImplementation libs.junit
 }

--- a/app-wearos/src/main/AndroidManifest.xml
+++ b/app-wearos/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <uses-feature android:name="android.hardware.type.watch" android:required="true" />
 
     <application

--- a/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailActivity.kt
+++ b/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailActivity.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import coil.compose.AsyncImage
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -43,6 +42,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.dynamicColorScheme
+import coil.compose.AsyncImage
 import de.danoeh.antennapod.model.feed.FeedItem
 import de.danoeh.antennapod.ui.common.Converter
 import de.danoeh.antennapod.ui.common.DateFormatter

--- a/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailActivity.kt
+++ b/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import coil.compose.AsyncImage
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -100,6 +101,16 @@ fun EpisodeDetailScreen(
             contentPadding = PaddingValues(horizontal = 8.dp, vertical = 32.dp),
             autoCentering = null
         ) {
+            if (uiState.coverUrl != null) {
+                item {
+                    AsyncImage(
+                        model = uiState.coverUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(80.dp)
+                    )
+                }
+            }
+
             item {
                 val dateStr = DateFormatter.formatAbbrev(LocalContext.current, item.getPubDate())
                 Text(

--- a/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailViewModel.kt
+++ b/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailViewModel.kt
@@ -23,7 +23,8 @@ data class EpisodeDetailUiState(
     val position: Int = 0,
     val duration: Int = 0,
     val isCurrentlyPlaying: Boolean = false,
-    val hasStartedPlaying: Boolean = false
+    val hasStartedPlaying: Boolean = false,
+    val coverUrl: String? = null
 )
 
 class EpisodeDetailViewModel(application: Application, private val episode: FeedItem) : AndroidViewModel(application) {
@@ -52,12 +53,14 @@ class EpisodeDetailViewModel(application: Application, private val episode: Feed
                 val position = liveData?.item?.media?.position ?: episode.media?.position ?: 0
                 val duration = liveData?.item?.media?.duration?.takeIf { it > 0 } ?: episode.media?.duration ?: 0
                 val isCurrentlyPlaying = liveData?.isPlaying == true
+                val coverUrl = liveData?.coverUrl
                 _uiState.update {
                     it.copy(
                         position = position,
                         duration = duration,
                         isCurrentlyPlaying = isCurrentlyPlaying,
-                        hasStartedPlaying = it.hasStartedPlaying || isCurrentlyPlaying
+                        hasStartedPlaying = it.hasStartedPlaying || isCurrentlyPlaying,
+                        coverUrl = coverUrl ?: it.coverUrl
                     )
                 }
             }

--- a/app/src/play/java/de/danoeh/antennapod/WearListenerService.java
+++ b/app/src/play/java/de/danoeh/antennapod/WearListenerService.java
@@ -46,9 +46,14 @@ public class WearListenerService extends WearableListenerService {
                 if (media == null) {
                     return;
                 }
+                FeedItem nowPlayingItem = media.getItem();
+                String itemImageUrl = nowPlayingItem != null ? nowPlayingItem.getImageUrl() : null;
+                String feedImageUrl = nowPlayingItem != null && nowPlayingItem.getFeed() != null
+                        ? nowPlayingItem.getFeed().getImageUrl() : null;
+                String coverUrl = itemImageUrl != null ? itemImageUrl : feedImageUrl;
                 if (!PlaybackService.isRunning) {
                     reply(sourceNodeId, WearDataPaths.NOW_PLAYING,
-                            WearSerializer.nowPlayingToBytes(media.getItem(), false));
+                            WearSerializer.nowPlayingToBytes(nowPlayingItem, false, coverUrl));
                     return;
                 }
                 PlaybackController.bindToMedia3Service(this, controller -> {
@@ -57,7 +62,7 @@ public class WearListenerService extends WearableListenerService {
                         media.setDuration((int) controller.getDuration());
                     }
                     reply(sourceNodeId, WearDataPaths.NOW_PLAYING,
-                            WearSerializer.nowPlayingToBytes(media.getItem(), true));
+                            WearSerializer.nowPlayingToBytes(nowPlayingItem, true, coverUrl));
                 });
                 break;
             case WearDataPaths.PAUSE:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ wear-compose = "1.6.0"
 compose = "1.7.5"
 lifecycle-runtime-compose = "2.8.7"
 glide = "4.16.0"
+coil = "2.7.0"
 okhttp = "4.12.0"
 espresso = "3.5.0"
 androidx-test = "1.5.0"
@@ -59,6 +60,7 @@ commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.18.0
 commons-io = { module = "commons-io:commons-io", version = "2.5" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.15.1" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 glide-okhttp3-integration = { module = "com.github.bumptech.glide:okhttp3-integration", version.ref = "glide" }
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearNowPlaying.java
+++ b/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearNowPlaying.java
@@ -5,9 +5,11 @@ import de.danoeh.antennapod.model.feed.FeedItem;
 public class WearNowPlaying {
     public final FeedItem item;
     public final boolean isPlaying;
+    public final String coverUrl;
 
-    public WearNowPlaying(FeedItem item, boolean isPlaying) {
+    public WearNowPlaying(FeedItem item, boolean isPlaying, String coverUrl) {
         this.item = item;
         this.isPlaying = isPlaying;
+        this.coverUrl = coverUrl;
     }
 }

--- a/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializer.java
+++ b/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializer.java
@@ -22,6 +22,7 @@ public final class WearSerializer {
     private static final String KEY_DURATION = "duration";
     private static final String KEY_POSITION = "position";
     private static final String KEY_IS_PLAYING = "is_playing";
+    private static final String KEY_COVER_URL = "cover_url";
 
     private WearSerializer() {
     }
@@ -115,10 +116,13 @@ public final class WearSerializer {
     }
 
     @NonNull
-    public static byte[] nowPlayingToBytes(@NonNull FeedItem item, boolean isPlaying) {
+    public static byte[] nowPlayingToBytes(@NonNull FeedItem item, boolean isPlaying, @Nullable String coverUrl) {
         try {
             JSONObject obj = episodeToJson(item);
             obj.put(KEY_IS_PLAYING, isPlaying);
+            if (coverUrl != null) {
+                obj.put(KEY_COVER_URL, coverUrl);
+            }
             return obj.toString().getBytes(StandardCharsets.UTF_8);
         } catch (JSONException e) {
             return new byte[0];
@@ -134,7 +138,8 @@ public final class WearSerializer {
             JSONObject obj = new JSONObject(new String(data, StandardCharsets.UTF_8));
             FeedItem item = episodeFromJson(obj);
             boolean isPlaying = obj.optBoolean(KEY_IS_PLAYING, false);
-            return new WearNowPlaying(item, isPlaying);
+            String coverUrl = obj.optString(KEY_COVER_URL, null);
+            return new WearNowPlaying(item, isPlaying, coverUrl);
         } catch (JSONException e) {
             return null;
         }

--- a/net/sync/wear-interface/src/test/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializerTest.java
+++ b/net/sync/wear-interface/src/test/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializerTest.java
@@ -106,7 +106,7 @@ public class WearSerializerTest {
         FeedMedia media = new FeedMedia(0, item, 7200000, 120000, 0, null, null, null, 0, null, 0, 0L);
         item.setMedia(media);
 
-        byte[] bytes = WearSerializer.nowPlayingToBytes(item, true);
+        byte[] bytes = WearSerializer.nowPlayingToBytes(item, true, "https://example.com/cover.jpg");
         WearNowPlaying result = WearSerializer.nowPlayingFromBytes(bytes);
 
         assertTrue(result != null);
@@ -115,6 +115,7 @@ public class WearSerializerTest {
         assertEquals(7200000, result.item.getMedia().getDuration());
         assertEquals(120000, result.item.getMedia().getPosition());
         assertTrue(result.isPlaying);
+        assertEquals("https://example.com/cover.jpg", result.coverUrl);
     }
 
     @Test


### PR DESCRIPTION
### Description

Show the episode/podcast cover art on the WearOS episode detail screen, above the title. The phone populates a `cover_url` field in the existing `/now_playing` sync payload from the episode's own image with a fallback to the podcast feed's image (avoiding `getImageLocation()`, which can return local paths the watch can't reach), and the watch renders it with Coil's `AsyncImage`.

Closes: #8566

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description
- [x] If it is a core feature, I have added automated tests
