### PR TITLE
Add playback speed control to WearOS episode screen

### DIFF
--- a/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailActivity.kt
+++ b/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -68,6 +69,8 @@ class EpisodeDetailActivity : ComponentActivity() {
                     onPause = { viewModel.pause() },
                     onSkipForward = { viewModel.skipForward() },
                     onSkipBackward = { viewModel.skipBackward() },
+                    onSpeedPickerOpen = { viewModel.openSpeedPicker() },
+                    onSpeedSelected = { speed -> viewModel.setSpeed(speed) },
                     onOpenOnPhone = { viewModel.openOnPhone() }
                 )
             }
@@ -86,11 +89,18 @@ fun EpisodeDetailScreen(
     onPause: () -> Unit,
     onSkipForward: () -> Unit,
     onSkipBackward: () -> Unit,
+    onSpeedPickerOpen: () -> Unit,
+    onSpeedSelected: (Float) -> Unit,
     onOpenOnPhone: () -> Unit
 ) {
     val item = uiState.item
     val scrollState = rememberScalingLazyListState()
     var titleExpanded by remember { mutableStateOf(false) }
+
+    if (uiState.isSpeedPickerOpen) {
+        SpeedPickerScreen(onSpeedSelected = onSpeedSelected)
+        return
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         ScalingLazyColumn(
@@ -170,6 +180,19 @@ fun EpisodeDetailScreen(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
                     ) {
+                        FilledTonalIconButton(onClick = onSpeedPickerOpen, modifier = Modifier.size(48.dp)) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Icon(
+                                    painter = painterResource(NotificationsR.drawable.ic_notification_playback_speed),
+                                    contentDescription = stringResource(CommonR.string.playback_speed),
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Text(
+                                    text = "%.2f".format(uiState.playbackSpeed),
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+                            }
+                        }
                         FilledTonalIconButton(onClick = onSkipBackward, modifier = Modifier.size(48.dp)) {
                             Icon(
                                 painter = painterResource(NotificationsR.drawable.ic_notification_fast_rewind),
@@ -224,6 +247,30 @@ fun EpisodeDetailScreen(
 
             item {
                 Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+        ScrollIndicator(state = scrollState, modifier = Modifier.align(Alignment.CenterEnd))
+    }
+}
+
+@Composable
+private fun SpeedPickerScreen(onSpeedSelected: (Float) -> Unit) {
+    val speeds = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+    val scrollState = rememberScalingLazyListState()
+    Box(modifier = Modifier.fillMaxSize()) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            state = scrollState,
+            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 32.dp),
+            autoCentering = null
+        ) {
+            speeds.forEach { speed ->
+                item {
+                    ListItem(
+                        text = "%.2f×".format(speed),
+                        onClick = { onSpeedSelected(speed) }
+                    )
+                }
             }
         }
         ScrollIndicator(state = scrollState, modifier = Modifier.align(Alignment.CenterEnd))

--- a/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailViewModel.kt
+++ b/app-wearos/src/main/java/de/danoeh/antennapod/wearos/EpisodeDetailViewModel.kt
@@ -23,7 +23,9 @@ data class EpisodeDetailUiState(
     val position: Int = 0,
     val duration: Int = 0,
     val isCurrentlyPlaying: Boolean = false,
-    val hasStartedPlaying: Boolean = false
+    val hasStartedPlaying: Boolean = false,
+    val playbackSpeed: Float = 1.0f,
+    val isSpeedPickerOpen: Boolean = false
 )
 
 class EpisodeDetailViewModel(application: Application, private val episode: FeedItem) : AndroidViewModel(application) {
@@ -57,7 +59,8 @@ class EpisodeDetailViewModel(application: Application, private val episode: Feed
                         position = position,
                         duration = duration,
                         isCurrentlyPlaying = isCurrentlyPlaying,
-                        hasStartedPlaying = it.hasStartedPlaying || isCurrentlyPlaying
+                        hasStartedPlaying = it.hasStartedPlaying || isCurrentlyPlaying,
+                        playbackSpeed = liveData?.playbackSpeed ?: it.playbackSpeed
                     )
                 }
             }
@@ -80,6 +83,17 @@ class EpisodeDetailViewModel(application: Application, private val episode: Feed
 
     fun skipBackward() {
         viewModelScope.launch(Dispatchers.IO) { WearMessageSender.send(getApplication(), WearDataPaths.SKIP_BACKWARD) }
+    }
+
+    fun openSpeedPicker() {
+        _uiState.update { it.copy(isSpeedPickerOpen = true) }
+    }
+
+    fun setSpeed(speed: Float) {
+        _uiState.update { it.copy(isSpeedPickerOpen = false, playbackSpeed = speed) }
+        viewModelScope.launch(Dispatchers.IO) {
+            WearMessageSender.send(getApplication(), WearDataPaths.setSpeedPath(speed))
+        }
     }
 
     fun openOnPhone() {

--- a/app/src/play/java/de/danoeh/antennapod/WearListenerService.java
+++ b/app/src/play/java/de/danoeh/antennapod/WearListenerService.java
@@ -47,8 +47,10 @@ public class WearListenerService extends WearableListenerService {
                     return;
                 }
                 if (!PlaybackService.isRunning) {
+                    float tempSpeed = PlaybackPreferences.getCurrentlyPlayingTemporaryPlaybackSpeed();
+                    float stoppedSpeed = tempSpeed < 0 ? 1.0f : tempSpeed;
                     reply(sourceNodeId, WearDataPaths.NOW_PLAYING,
-                            WearSerializer.nowPlayingToBytes(media.getItem(), false));
+                            WearSerializer.nowPlayingToBytes(media.getItem(), false, stoppedSpeed));
                     return;
                 }
                 PlaybackController.bindToMedia3Service(this, controller -> {
@@ -56,8 +58,9 @@ public class WearListenerService extends WearableListenerService {
                     if (controller.getDuration() > 0) {
                         media.setDuration((int) controller.getDuration());
                     }
+                    float speed = controller.getPlaybackParameters().speed;
                     reply(sourceNodeId, WearDataPaths.NOW_PLAYING,
-                            WearSerializer.nowPlayingToBytes(media.getItem(), true));
+                            WearSerializer.nowPlayingToBytes(media.getItem(), true, speed));
                 });
                 break;
             case WearDataPaths.PAUSE:
@@ -99,6 +102,13 @@ public class WearListenerService extends WearableListenerService {
                         reply(sourceNodeId, path, WearSerializer.episodesToBytes(feedItems));
                     } catch (NumberFormatException e) {
                         Log.w(TAG, "Ignoring malformed feed episodes path: " + path, e);
+                    }
+                } else if (path.startsWith(WearDataPaths.SET_SPEED_PREFIX)) {
+                    try {
+                        float speed = Float.parseFloat(path.substring(WearDataPaths.SET_SPEED_PREFIX.length()));
+                        PlaybackController.bindToMedia3Service(this, controller -> controller.setPlaybackSpeed(speed));
+                    } catch (NumberFormatException e) {
+                        Log.w(TAG, "Ignoring malformed set_speed path: " + path, e);
                     }
                 } else if (path.startsWith(WearDataPaths.OPEN_ON_PHONE_PREFIX)) {
                     try {

--- a/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearDataPaths.java
+++ b/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearDataPaths.java
@@ -11,10 +11,15 @@ public final class WearDataPaths {
     public static final String PAUSE = "/pause";
     public static final String SKIP_FORWARD = "/skip_forward";
     public static final String SKIP_BACKWARD = "/skip_backward";
+    public static final String SET_SPEED_PREFIX = "/set_speed/";
     public static final String OPEN_ON_PHONE_PREFIX = "/open_on_phone/";
 
     public static String playPath(long itemId) {
         return PLAY_PREFIX + itemId;
+    }
+
+    public static String setSpeedPath(float speed) {
+        return SET_SPEED_PREFIX + speed;
     }
 
     public static String openOnPhonePath(long itemId) {

--- a/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearNowPlaying.java
+++ b/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearNowPlaying.java
@@ -5,9 +5,11 @@ import de.danoeh.antennapod.model.feed.FeedItem;
 public class WearNowPlaying {
     public final FeedItem item;
     public final boolean isPlaying;
+    public final float playbackSpeed;
 
-    public WearNowPlaying(FeedItem item, boolean isPlaying) {
+    public WearNowPlaying(FeedItem item, boolean isPlaying, float playbackSpeed) {
         this.item = item;
         this.isPlaying = isPlaying;
+        this.playbackSpeed = playbackSpeed;
     }
 }

--- a/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializer.java
+++ b/net/sync/wear-interface/src/main/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializer.java
@@ -22,6 +22,7 @@ public final class WearSerializer {
     private static final String KEY_DURATION = "duration";
     private static final String KEY_POSITION = "position";
     private static final String KEY_IS_PLAYING = "is_playing";
+    private static final String KEY_PLAYBACK_SPEED = "playback_speed";
 
     private WearSerializer() {
     }
@@ -115,10 +116,11 @@ public final class WearSerializer {
     }
 
     @NonNull
-    public static byte[] nowPlayingToBytes(@NonNull FeedItem item, boolean isPlaying) {
+    public static byte[] nowPlayingToBytes(@NonNull FeedItem item, boolean isPlaying, float playbackSpeed) {
         try {
             JSONObject obj = episodeToJson(item);
             obj.put(KEY_IS_PLAYING, isPlaying);
+            obj.put(KEY_PLAYBACK_SPEED, playbackSpeed);
             return obj.toString().getBytes(StandardCharsets.UTF_8);
         } catch (JSONException e) {
             return new byte[0];
@@ -134,7 +136,8 @@ public final class WearSerializer {
             JSONObject obj = new JSONObject(new String(data, StandardCharsets.UTF_8));
             FeedItem item = episodeFromJson(obj);
             boolean isPlaying = obj.optBoolean(KEY_IS_PLAYING, false);
-            return new WearNowPlaying(item, isPlaying);
+            float playbackSpeed = (float) obj.optDouble(KEY_PLAYBACK_SPEED, 1.0);
+            return new WearNowPlaying(item, isPlaying, playbackSpeed);
         } catch (JSONException e) {
             return null;
         }

--- a/net/sync/wear-interface/src/test/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializerTest.java
+++ b/net/sync/wear-interface/src/test/java/de/danoeh/antennapod/net/sync/wearinterface/WearSerializerTest.java
@@ -106,7 +106,7 @@ public class WearSerializerTest {
         FeedMedia media = new FeedMedia(0, item, 7200000, 120000, 0, null, null, null, 0, null, 0, 0L);
         item.setMedia(media);
 
-        byte[] bytes = WearSerializer.nowPlayingToBytes(item, true);
+        byte[] bytes = WearSerializer.nowPlayingToBytes(item, true, 1.25f);
         WearNowPlaying result = WearSerializer.nowPlayingFromBytes(bytes);
 
         assertTrue(result != null);
@@ -115,6 +115,7 @@ public class WearSerializerTest {
         assertEquals(7200000, result.item.getMedia().getDuration());
         assertEquals(120000, result.item.getMedia().getPosition());
         assertTrue(result.isPlaying);
+        assertEquals(1.25f, result.playbackSpeed, 0.001f);
     }
 
     @Test


### PR DESCRIPTION
### Description

Add a playback-speed control to the WearOS episode screen's control row, next to the existing rewind/play-pause/fast-forward buttons from #8564. Tapping it opens a picker with speed presets (0.5x-2.0x); selecting one calls `MediaController.setPlaybackSpeed()` on the phone. The current speed round-trips through the existing `/now_playing` sync payload so the watch reflects speed changes made elsewhere.

Closes: #8567

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description
- [x] If it is a core feature, I have added automated tests
