### PR TITLE
Enforce issue template and reject issue assignment automatically

### DIFF
--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -1,0 +1,29 @@
+name: Issue comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  issue-comment:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.comment.body || '';
+            const assignmentRequest = /\b(please|can|could|would)\b.{0,40}\bassign\b|\bassign (me|this|it)\b|\bbe assigned\b/i;
+            if (!assignmentRequest.test(body)) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: 'Thanks for your interest! It looks like you asked to be assigned to this issue. '
+                + 'We do not assign issues. Anyone is free to open a pull request at any time. '
+                + 'Please have a look at our [contribution guidelines](https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md) before getting started.',
+            });

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -1,0 +1,54 @@
+name: Issue opened
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  issue-opened:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const isBugReport = body.includes('### Steps to reproduce') || body.includes('### App version');
+            const isFeatureRequest = body.includes('### Feature or improvement you want');
+            const existingLabels = context.payload.issue.labels.map(l => l.name);
+
+            const addMissing = async (labels) => {
+              const missing = labels.filter(l => !existingLabels.includes(l));
+              if (missing.length > 0) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  labels: missing,
+                });
+              }
+            };
+
+            if (isBugReport) {
+              await addMissing(['Type: Possible bug']);
+            } else if (isFeatureRequest) {
+              await addMissing(['Needs: Triage', 'Type: Feature request']);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: 'Please use one of the issue templates when opening an issue. '
+                  + 'You can find them at https://github.com/AntennaPod/AntennaPod/issues/new/choose\n\n'
+                  + 'This issue has been closed automatically.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,4 +103,6 @@ Never create commits directly on the `develop` or `master` branch. Always checko
 
 # Issue Conventions
 When creating an issue, always follow one of the issue templates in `.github/ISSUE_TEMPLATE/`.
-Apply the corresponding labels and always mention in the technical info box that the issue was AI generated.
+Apply the corresponding labels that are marked in the issue template yaml file.
+Always mention in the technical info box that the issue was AI generated.
+If you do not follow these, the issue gets closed automatically.


### PR DESCRIPTION
### Description

We are receiving a lot of AI generated issues recently.
- Automatically apply the corresponding labels if they are missing
- Strengthen the AI instructions
- Close issues that do not follow the issue template (leaving a comment)
- While at it, also leave a comment when someone wants to be assigned to an issue

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
