### PR TITLE
Open cover/chapter image fullscreen on tap in the audio player

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
@@ -13,7 +13,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -24,23 +23,18 @@ import androidx.core.content.ContextCompat;
 import androidx.core.graphics.BlendModeColorFilterCompat;
 import androidx.core.graphics.BlendModeCompat;
 import androidx.fragment.app.Fragment;
-import androidx.media3.session.MediaController;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
-import de.danoeh.antennapod.BuildConfig;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.event.PlayerStatusEvent;
 import de.danoeh.antennapod.model.feed.Feed;
-import de.danoeh.antennapod.playback.service.PlaybackService;
-import de.danoeh.antennapod.playback.service.PlaybackServiceStarter;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
-import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
 import de.danoeh.antennapod.ui.appstartintent.OnlineFeedviewActivityStarter;
 import de.danoeh.antennapod.ui.chapters.ChapterUtils;
 import de.danoeh.antennapod.ui.screen.chapter.ChaptersFragment;
@@ -78,26 +72,8 @@ public class CoverFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         viewBinding = CoverFragmentBinding.inflate(inflater);
-        viewBinding.imgvCover.setOnClickListener(v -> {
-            if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                if (PlaybackService.isRunning) {
-                    PlaybackController.bindToMedia3Service(getActivity(), MediaController::pause);
-                } else if (media != null) {
-                    new PlaybackServiceStarter(getContext(), media)
-                            .callEvenIfRunning(true)
-                            .start();
-                }
-                return;
-            }
-            if (PlaybackService.isRunning
-                    && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING) {
-                getContext().sendBroadcast(MediaButtonStarter.createIntent(getContext(), KeyEvent.KEYCODE_MEDIA_PAUSE));
-            } else if (media != null) {
-                new PlaybackServiceStarter(getContext(), media)
-                        .callEvenIfRunning(true)
-                        .start();
-            }
-        });
+        viewBinding.imgvCover.setOnClickListener(v ->
+                new FullscreenCoverDialog().show(getChildFragmentManager(), FullscreenCoverDialog.TAG));
         viewBinding.openDescription.setOnClickListener(view -> ((AudioPlayerFragment) requireParentFragment())
                 .scrollToPage(AudioPlayerFragment.POS_DESCRIPTION, true));
         ColorFilter colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/FullscreenCoverDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/FullscreenCoverDialog.java
@@ -1,0 +1,194 @@
+package de.danoeh.antennapod.ui.screen.playback.audio;
+
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.graphics.drawable.Drawable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.fragment.app.DialogFragment;
+import androidx.media3.session.MediaController;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestBuilder;
+import com.bumptech.glide.load.resource.bitmap.FitCenter;
+import com.bumptech.glide.request.RequestOptions;
+import de.danoeh.antennapod.BuildConfig;
+import de.danoeh.antennapod.databinding.FullscreenCoverDialogBinding;
+import de.danoeh.antennapod.event.PlayerStatusEvent;
+import de.danoeh.antennapod.event.playback.PlaybackPositionEvent;
+import de.danoeh.antennapod.model.feed.Chapter;
+import de.danoeh.antennapod.model.feed.EmbeddedChapterImage;
+import de.danoeh.antennapod.model.playback.Playable;
+import de.danoeh.antennapod.playback.service.PlaybackController;
+import de.danoeh.antennapod.playback.service.PlaybackService;
+import de.danoeh.antennapod.playback.service.PlaybackServiceStarter;
+import de.danoeh.antennapod.storage.database.DBReader;
+import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
+import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
+import de.danoeh.antennapod.ui.chapters.ChapterUtils;
+import de.danoeh.antennapod.ui.episodes.ImageResourceUtils;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
+/**
+ * Shows the cover (or the current chapter image) of the playing episode in an immersive
+ * fullscreen view. Tapping toggles play/pause, the system back button/gesture closes the dialog
+ * and the image is kept in sync with chapter changes while it is open.
+ */
+public class FullscreenCoverDialog extends DialogFragment {
+    public static final String TAG = "FullscreenCoverDialog";
+    private FullscreenCoverDialogBinding viewBinding;
+    private Disposable disposable;
+    private int displayedChapterIndex = -1;
+    private Playable media;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setStyle(DialogFragment.STYLE_NO_FRAME, android.R.style.Theme_Black_NoTitleBar_Fullscreen);
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        viewBinding = FullscreenCoverDialogBinding.inflate(inflater, container, false);
+        viewBinding.imgvCover.setOnClickListener(v -> togglePlayback());
+        return viewBinding.getRoot();
+    }
+
+    private void togglePlayback() {
+        if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
+            if (PlaybackService.isRunning) {
+                PlaybackController.bindToMedia3Service(getActivity(), MediaController::pause);
+            } else if (media != null) {
+                new PlaybackServiceStarter(getContext(), media)
+                        .callEvenIfRunning(true)
+                        .start();
+            }
+            return;
+        }
+        if (PlaybackService.isRunning
+                && PlaybackPreferences.getCurrentPlayerStatus() == PlaybackPreferences.PLAYER_STATUS_PLAYING) {
+            getContext().sendBroadcast(MediaButtonStarter.createIntent(getContext(), KeyEvent.KEYCODE_MEDIA_PAUSE));
+        } else if (media != null) {
+            new PlaybackServiceStarter(getContext(), media)
+                    .callEvenIfRunning(true)
+                    .start();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        applyImmersiveFullscreen();
+        loadMediaInfo();
+        EventBus.getDefault().register(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        EventBus.getDefault().unregister(this);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (disposable != null) {
+            disposable.dispose();
+        }
+        viewBinding = null;
+    }
+
+    private void applyImmersiveFullscreen() {
+        Window window = getDialog() != null ? getDialog().getWindow() : null;
+        if (window == null) {
+            return;
+        }
+        window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        WindowCompat.setDecorFitsSystemWindows(window, false);
+        WindowInsetsControllerCompat controller =
+                new WindowInsetsControllerCompat(window, window.getDecorView());
+        controller.hide(WindowInsetsCompat.Type.systemBars());
+        controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+    }
+
+    private void loadMediaInfo() {
+        if (disposable != null) {
+            disposable.dispose();
+        }
+        disposable = Maybe.<Playable>create(emitter -> {
+            Playable media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+            if (media != null) {
+                ChapterUtils.loadChapters(media, getContext(), false);
+                emitter.onSuccess(media);
+            } else {
+                emitter.onComplete();
+            }
+        }).subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(media -> {
+                    this.media = media;
+                    displayedChapterIndex = Chapter.getAfterPosition(media.getChapters(), media.getPosition());
+                    displayCoverImage();
+                }, error -> Log.e(TAG, Log.getStackTraceString(error)));
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPlayerStatusEvent(PlayerStatusEvent event) {
+        loadMediaInfo();
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onEventMainThread(PlaybackPositionEvent event) {
+        if (media == null) {
+            return;
+        }
+        int newChapterIndex = Chapter.getAfterPosition(media.getChapters(), event.getPosition());
+        if (newChapterIndex > -1 && newChapterIndex != displayedChapterIndex) {
+            displayedChapterIndex = newChapterIndex;
+            displayCoverImage();
+        }
+    }
+
+    private void displayCoverImage() {
+        if (viewBinding == null || media == null) {
+            return;
+        }
+        RequestOptions options = new RequestOptions()
+                .dontAnimate()
+                .transform(new FitCenter());
+
+        RequestBuilder<Drawable> cover = Glide.with(this)
+                .load(media.getImageLocation())
+                .error(Glide.with(this)
+                        .load(ImageResourceUtils.getFallbackImageLocation(media))
+                        .apply(options))
+                .apply(options);
+
+        if (displayedChapterIndex == -1 || media.getChapters() == null
+                || TextUtils.isEmpty(media.getChapters().get(displayedChapterIndex).getImageUrl())) {
+            cover.into(viewBinding.imgvCover);
+        } else {
+            Glide.with(this)
+                    .load(EmbeddedChapterImage.getModelFor(media, displayedChapterIndex))
+                    .apply(options)
+                    .thumbnail(cover)
+                    .error(cover)
+                    .into(viewBinding.imgvCover);
+        }
+    }
+}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ZoomableImageView.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/ZoomableImageView.java
@@ -1,0 +1,181 @@
+package de.danoeh.antennapod.ui.screen.playback.audio;
+
+import android.content.Context;
+import android.graphics.Matrix;
+import android.graphics.RectF;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatImageView;
+
+/**
+ * An ImageView that supports pinch-to-zoom and panning on top of a fit-center base scale.
+ *
+ * <p>The user zoom and pan are stored in a supplementary matrix that is kept separate from the
+ * fit-center base matrix. This way the zoom survives drawable changes (e.g. when the chapter image
+ * changes while the fullscreen view stays open) and only resets to the default fit when the view is
+ * recreated.</p>
+ */
+public class ZoomableImageView extends AppCompatImageView {
+    private static final float MIN_SCALE = 1f;
+    private static final float MAX_SCALE = 5f;
+
+    private final Matrix baseMatrix = new Matrix();
+    private final Matrix suppMatrix = new Matrix();
+    private final Matrix drawMatrix = new Matrix();
+    private final RectF displayRect = new RectF();
+    private final float[] matrixValues = new float[9];
+    private ScaleGestureDetector scaleDetector;
+    private GestureDetector gestureDetector;
+
+    public ZoomableImageView(@NonNull Context context) {
+        super(context);
+        init(context);
+    }
+
+    public ZoomableImageView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    public ZoomableImageView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    private void init(Context context) {
+        super.setScaleType(ScaleType.MATRIX);
+        scaleDetector = new ScaleGestureDetector(context, new ScaleListener());
+        gestureDetector = new GestureDetector(context, new GestureListener());
+    }
+
+    @Override
+    public void setImageDrawable(@Nullable Drawable drawable) {
+        super.setImageDrawable(drawable);
+        updateBaseMatrix();
+        applyMatrix();
+    }
+
+    @Override
+    protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
+        super.onSizeChanged(width, height, oldWidth, oldHeight);
+        updateBaseMatrix();
+        applyMatrix();
+    }
+
+    @Override
+    public boolean onTouchEvent(@NonNull MotionEvent event) {
+        scaleDetector.onTouchEvent(event);
+        gestureDetector.onTouchEvent(event);
+        return true;
+    }
+
+    @Override
+    public boolean performClick() {
+        return super.performClick();
+    }
+
+    private void updateBaseMatrix() {
+        Drawable drawable = getDrawable();
+        if (drawable == null || getWidth() == 0 || getHeight() == 0) {
+            return;
+        }
+        int drawableWidth = drawable.getIntrinsicWidth();
+        int drawableHeight = drawable.getIntrinsicHeight();
+        if (drawableWidth <= 0 || drawableHeight <= 0) {
+            return;
+        }
+        float scale = Math.min((float) getWidth() / drawableWidth, (float) getHeight() / drawableHeight);
+        float translateX = (getWidth() - drawableWidth * scale) / 2f;
+        float translateY = (getHeight() - drawableHeight * scale) / 2f;
+        baseMatrix.reset();
+        baseMatrix.postScale(scale, scale);
+        baseMatrix.postTranslate(translateX, translateY);
+    }
+
+    private float getSuppScale() {
+        suppMatrix.getValues(matrixValues);
+        return matrixValues[Matrix.MSCALE_X];
+    }
+
+    private void applyMatrix() {
+        checkBounds();
+        drawMatrix.set(baseMatrix);
+        drawMatrix.postConcat(suppMatrix);
+        setImageMatrix(drawMatrix);
+    }
+
+    private void checkBounds() {
+        Drawable drawable = getDrawable();
+        if (drawable == null || getWidth() == 0 || getHeight() == 0) {
+            return;
+        }
+        drawMatrix.set(baseMatrix);
+        drawMatrix.postConcat(suppMatrix);
+        displayRect.set(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+        drawMatrix.mapRect(displayRect);
+
+        float viewWidth = getWidth();
+        float viewHeight = getHeight();
+        float deltaX = 0;
+        float deltaY = 0;
+
+        if (displayRect.width() <= viewWidth) {
+            deltaX = (viewWidth - displayRect.width()) / 2f - displayRect.left;
+        } else if (displayRect.left > 0) {
+            deltaX = -displayRect.left;
+        } else if (displayRect.right < viewWidth) {
+            deltaX = viewWidth - displayRect.right;
+        }
+
+        if (displayRect.height() <= viewHeight) {
+            deltaY = (viewHeight - displayRect.height()) / 2f - displayRect.top;
+        } else if (displayRect.top > 0) {
+            deltaY = -displayRect.top;
+        } else if (displayRect.bottom < viewHeight) {
+            deltaY = viewHeight - displayRect.bottom;
+        }
+
+        suppMatrix.postTranslate(deltaX, deltaY);
+    }
+
+    private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
+        @Override
+        public boolean onScale(@NonNull ScaleGestureDetector detector) {
+            float scaleFactor = detector.getScaleFactor();
+            float currentScale = getSuppScale();
+            float targetScale = currentScale * scaleFactor;
+            if (targetScale < MIN_SCALE) {
+                scaleFactor = MIN_SCALE / currentScale;
+            } else if (targetScale > MAX_SCALE) {
+                scaleFactor = MAX_SCALE / currentScale;
+            }
+            suppMatrix.postScale(scaleFactor, scaleFactor, detector.getFocusX(), detector.getFocusY());
+            applyMatrix();
+            return true;
+        }
+    }
+
+    private class GestureListener extends GestureDetector.SimpleOnGestureListener {
+        @Override
+        public boolean onSingleTapConfirmed(@NonNull MotionEvent event) {
+            performClick();
+            return true;
+        }
+
+        @Override
+        public boolean onScroll(@Nullable MotionEvent firstEvent, @NonNull MotionEvent secondEvent,
+                                float distanceX, float distanceY) {
+            if (scaleDetector.isInProgress() || getSuppScale() <= MIN_SCALE) {
+                return false;
+            }
+            suppMatrix.postTranslate(-distanceX, -distanceY);
+            applyMatrix();
+            return true;
+        }
+    }
+}

--- a/app/src/main/res/layout/fullscreen_cover_dialog.xml
+++ b/app/src/main/res/layout/fullscreen_cover_dialog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageView
+<de.danoeh.antennapod.ui.screen.playback.audio.ZoomableImageView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/imgvCover"
@@ -9,5 +9,4 @@
     android:clickable="true"
     android:focusable="true"
     android:importantForAccessibility="no"
-    android:scaleType="fitCenter"
     tools:src="@android:drawable/sym_def_app_icon" />

--- a/app/src/main/res/layout/fullscreen_cover_dialog.xml
+++ b/app/src/main/res/layout/fullscreen_cover_dialog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/imgvCover"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    android:clickable="true"
+    android:focusable="true"
+    android:importantForAccessibility="no"
+    android:scaleType="fitCenter"
+    tools:src="@android:drawable/sym_def_app_icon" />


### PR DESCRIPTION
### Description

Tapping the cover in the audio player currently toggles play/pause. This PR changes
that tap to open the currently shown image — the episode cover or, when the current
chapter has its own image, the chapter image — in an immersive fullscreen view.

Behavior:
- The image is scaled as large as possible while preserving its aspect ratio
  (`fitCenter`). In portrait it touches the left/right screen edges; rotating to
  landscape re-fits it so it touches the top/bottom edges.
- **Pinch-to-zoom and panning** are supported, so the image can be zoomed in further
  (e.g. when a square graphic is embedded in a differently shaped image). The zoom is
  preserved across automatic chapter-image changes while the view stays open and resets
  to the default fit only when the fullscreen view is reopened.
- Tapping the fullscreen image toggles play/pause, just like the player page did before.
- The system back button/gesture closes the fullscreen view and returns to the player.
- While the fullscreen view stays open, the shown image automatically follows chapter
  changes (same logic as the regular cover view).

Implementation:
- New `FullscreenCoverDialog` (a `DialogFragment`) shows the image on a black background,
  configured for immersive fullscreen (system bars hidden). It reuses the existing Glide
  loading and chapter-tracking logic from `CoverFragment` (`EmbeddedChapterImage` +
  `PlaybackPositionEvent`).
- New `ZoomableImageView` (a custom `AppCompatImageView`) implements pinch-to-zoom and
  panning with no additional dependency. The user zoom/pan is kept in a supplementary
  matrix separate from the fit-center base matrix, which is why it survives drawable
  changes and only resets when the view is recreated.
- `CoverFragment` now opens this dialog on cover tap instead of toggling playback.

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description — no tracking issue yet; opened as a draft for discussion.
- [x] If it is a core feature, I have added automated tests — not yet; the change is UI-only. Happy to add instrumentation tests if desired.

---

Opened as a **draft** to gather maintainer feedback before finalizing. Manually tested on a physical device: portrait/landscape fit, pinch-to-zoom + pan, zoom retained across chapter changes and reset on reopen, tap-to-toggle, back navigation, and live chapter-image switching.
