### PR TITLE
Fix miniplayer disappearing when switching episode during cast

### DIFF
--- a/playback/cast/README.md
+++ b/playback/cast/README.md
@@ -1,4 +1,18 @@
 # :playback:cast
 
 This module provides Chromecast support for the Google Play version of the app.
-Implements `PlaybackServiceMediaPlayer` using the Cast SDK; compiled only in the `play` build flavor.
+Compiled only in the `play` build flavor (the `free` flavor contains no-op stubs).
+
+## Active path (Media3)
+
+`CastPlayerWrapper.wrap(localPlayer, context)` builds a Media3 `CastPlayer` that automatically
+routes playback to the Cast device when a session is active and falls back to the local player
+otherwise. It uses `ApMediaItemConverter` (inner class) to translate between Media3 `MediaItem`
+and Cast `MediaQueueItem`. The media database ID is round-tripped through Cast metadata under
+the key `"media_id"`, which `Media3PlaybackService.ensureCurrentMediaLoaded()` reads back to
+look up the `FeedMedia` from the local database.
+
+## Legacy path (CastPsmp)
+
+`CastPsmp` implements `PlaybackServiceMediaPlayer` for the old `PlaybackService`. It is still
+compiled but is effectively dead code — `PlaybackService` throws an exception if started.

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -310,8 +310,6 @@ public class Media3PlaybackService extends MediaLibraryService {
         public void onMediaItemTransition(@Nullable MediaItem mediaItem, int reason) {
             if (mediaItem == null) {
                 currentPlayable = null;
-                PlaybackPreferences.writeNoMediaPlaying();
-                EventBus.getDefault().post(new PlayerStatusEvent());
             } else {
                 ensureCurrentMediaLoaded();
             }


### PR DESCRIPTION
### Description

Fix miniplayer disappearing when switching episode during cast. The player comes back after a while (probably because of other service changes since that issue was opened) but it disappearing is the wrong behavior. With this change, the player stays active until actually transitioning to "playing".

Closes #8504

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
