### PR TITLE
Fix stale position broadcast in new playback service

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -172,7 +172,7 @@ public class Media3PlaybackService extends MediaLibraryService {
             public void seekTo(long positionMs) {
                 super.seekTo(positionMs);
                 EventBus.getDefault().post(
-                        new PlaybackPositionEvent((int) player.getCurrentPosition(), (int) player.getDuration()));
+                        new PlaybackPositionEvent((int) positionMs, (int) player.getDuration()));
             }
         };
         player.addListener(playerListener);


### PR DESCRIPTION
### Description

Fix stale position broadcast in new playback service. super.seekTo() is asynchronous. player.getCurrentPosition() called immediately after still returns the old position.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
