### PR TITLE
Fix queue deletion potentially removing wrong episode

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/queue/QueueFragment.java
@@ -156,8 +156,10 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
             case REMOVED:
             case IRREVERSIBLE_REMOVED:
                 position = FeedItemEvent.indexOfItemWithId(queue, event.item.getId());
-                queue.remove(position);
-                recyclerAdapter.notifyItemRemoved(position);
+                if (position >= 0) {
+                    queue.remove(position);
+                    recyclerAdapter.notifyItemRemoved(position);
+                }
                 break;
             case CLEARED:
                 queue.clear();
@@ -165,8 +167,10 @@ public class QueueFragment extends Fragment implements MaterialToolbar.OnMenuIte
                 break;
             case MOVED:
                 position = FeedItemEvent.indexOfItemWithId(queue, event.item.getId());
-                queue.add(event.position, queue.remove(position));
-                recyclerAdapter.notifyItemMoved(position, event.position);
+                if (position >= 0) {
+                    queue.add(event.position, queue.remove(position));
+                    recyclerAdapter.notifyItemMoved(position, event.position);
+                }
                 break;
             default:
                 return;


### PR DESCRIPTION
### Description

Fix queue deletion potentially removing wrong episode. FeedItemEvent.indexOfItemWithId returns -1 when an item isn't found in the list; queue.remove(-1) in Java removes the last element. A removed/missing item therefore silently removes the last episode in the queue. This is only a visual glitch, not something related to the database, but still worth guarding against.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
