### PR TITLE
 fix square corner in play/pause animation in cover Art

### DIFF
--- a/app/src/main/res/drawable/cover_fragment_ripple_border.xml
+++ b/app/src/main/res/drawable/cover_fragment_ripple_border.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="?attr/colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFF" />
+            <corners android:radius="16dp"/>
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -22,7 +22,7 @@
             android:layout_height="0dp"
             android:layout_gravity="center"
             android:layout_marginHorizontal="32dp"
-            android:foreground="?attr/selectableItemBackgroundBorderless"
+            android:foreground="@drawable/cover_fragment_ripple_border"
             android:importantForAccessibility="no"
             android:scaleType="fitCenter"
             squareImageView:direction="minimum"


### PR DESCRIPTION
### Description
#### Problem
Fixes a visual bug where the touch feedback (ripple animation) on the cover art during play/pause actions extends beyond the image's rounded corners, resulting in sharp, square edges bleeding over the layout.

#### Solution
* Created a new XML ripple drawable (`cover_ripple.xml`) with a masking shape that defines a `16dp` corner radius to fit the rounded image perfectly.
* Updated the `ImageView` in the layout file to use this new custom drawable as the `android:foreground`, replacing the previous `?attr/selectableItemBackgroundBorderless` which was causing the bounds overflow.
* Ensured the ripple uses the native `?android:attr/colorControlHighlight` to keep the original system theme coloring.

closes #8538

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
