### PR TITLE
Treat fast-forward beyond episode end as playback completion

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -164,7 +164,15 @@ public class Media3PlaybackService extends MediaLibraryService {
 
             @Override
             public void seekForward() {
-                seekTo(Math.min(getDuration(), getCurrentPosition() + UserPreferences.getFastForwardSecs() * 1000L));
+                long duration = getDuration();
+                long target = getCurrentPosition() + UserPreferences.getFastForwardSecs() * 1000L;
+
+                if (duration > 0 && target >= duration) {
+                    handlePlaybackEnded();
+                    return;
+                }
+
+                seekTo(target);
             }
 
             @Override


### PR DESCRIPTION
### Description

When fast-forwarding reaches or crosses the known end of an episode, treat it as logical playback completion rather than seeking past the known end and relying on Media3 to report playback completion.

This routes the boundary through the existing `handlePlaybackEnded()` flow, preserving the established end-of-playback behavior for continuous playback, queue progression, playback history, database updates, and episode-based sleep timers.

Closes #8591

### After Video

https://github.com/user-attachments/assets/ed4f590f-e45f-4ae2-a6c7-7b553c26edde

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
