### PR TITLE
Fix playing next on chromecast

### DIFF
--- a/playback/cast/src/free/java/de/danoeh/antennapod/playback/cast/CastPlayerWrapper.java
+++ b/playback/cast/src/free/java/de/danoeh/antennapod/playback/cast/CastPlayerWrapper.java
@@ -7,4 +7,8 @@ public class CastPlayerWrapper {
     public static Player wrap(Player player, Context context) {
         return player;
     }
+
+    public static boolean hasPlaybackJustFinished(Context context) {
+        return false;
+    }
 }

--- a/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastPlayerWrapper.java
+++ b/playback/cast/src/play/java/de/danoeh/antennapod/playback/cast/CastPlayerWrapper.java
@@ -13,6 +13,12 @@ import androidx.media3.common.Player;
 import androidx.media3.common.util.UnstableApi;
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaQueueItem;
+import com.google.android.gms.cast.MediaStatus;
+import com.google.android.gms.cast.framework.CastContext;
+import com.google.android.gms.cast.framework.CastSession;
+import com.google.android.gms.cast.framework.media.RemoteMediaClient;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.images.WebImage;
 import de.danoeh.antennapod.playback.base.MediaItemAdapter;
 
@@ -29,6 +35,31 @@ public class CastPlayerWrapper {
                 .setLocalPlayer(player)
                 .setRemotePlayer(remotePlayer)
                 .build();
+    }
+
+    public static boolean hasPlaybackJustFinished(Context context) {
+        // When Cast finishes, it unloads the media session, so the Media3 CastPlayer reports IDLE, not ENDED.
+        // Media3 never reads the Cast SDK's idle reason, so "finished naturally" and "stopped by user" look identical.
+        // This method reads the idle reason directly from the Cast SDK to make that distinction.
+        // It only gives a meaningful result while the idle status is still current, i.e. when called synchronously
+        // from a Player listener callback reacting to the unload.
+        if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) != ConnectionResult.SUCCESS) {
+            return false;
+        }
+        try {
+            CastSession castSession = CastContext.getSharedInstance(context)
+                    .getSessionManager().getCurrentCastSession();
+            if (castSession == null) {
+                return false;
+            }
+            RemoteMediaClient remoteMediaClient = castSession.getRemoteMediaClient();
+            return remoteMediaClient != null
+                    && remoteMediaClient.getPlayerState() == MediaStatus.PLAYER_STATE_IDLE
+                    && remoteMediaClient.getIdleReason() == MediaStatus.IDLE_REASON_FINISHED;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     /**

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -255,22 +255,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                 saveCurrentPosition();
             }
             if (playbackState == Player.STATE_ENDED && currentPlayable != null) {
-                FeedMedia media = currentPlayable;
-                currentPlayable = null; // To avoid position updater saving position after we already reset it
-                if (sleepTimer != null && sleepTimer.isActive()) {
-                    sleepTimer.episodeFinishedPlayback();
-                    if (!sleepTimer.shouldContinueToNextEpisode()) {
-                        finalizePlayback(media, true, false, false);
-                        player.stop();
-                        player.clearMediaItems();
-                        PlaybackPreferences.writeNoMediaPlaying();
-                        EventBus.getDefault().post(
-                                new PlaybackServiceEvent(PlaybackServiceEvent.Action.SERVICE_SHUT_DOWN));
-                        EventBus.getDefault().post(new PlayerStatusEvent());
-                        return;
-                    }
-                }
-                startNextInQueue(media, false, true);
+                handlePlaybackEnded();
             }
         }
 
@@ -310,7 +295,12 @@ public class Media3PlaybackService extends MediaLibraryService {
         @Override
         public void onMediaItemTransition(@Nullable MediaItem mediaItem, int reason) {
             if (mediaItem == null) {
-                currentPlayable = null;
+                if (currentPlayable != null
+                        && CastPlayerWrapper.hasPlaybackJustFinished(Media3PlaybackService.this)) {
+                    handlePlaybackEnded();
+                } else {
+                    currentPlayable = null;
+                }
             } else {
                 ensureCurrentMediaLoaded();
             }
@@ -501,7 +491,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         PlayableUtils.saveCurrentPosition(currentPlayable, (int) position, timestamp);
     }
 
-    private void finalizePlayback(FeedMedia media, boolean ended, boolean skipped, boolean playingNext) {
+    private void updateDatabaseAfterPlayback(FeedMedia media, boolean ended, boolean skipped, boolean playingNext) {
         if (media == null) {
             return;
         }
@@ -629,6 +619,26 @@ public class Media3PlaybackService extends MediaLibraryService {
         return !media.localFileAvailable() && !URLUtil.isContentUrl(media.getStreamUrl());
     }
 
+    @UnstableApi
+    private void handlePlaybackEnded() {
+        FeedMedia media = currentPlayable;
+        currentPlayable = null; // To avoid position updater saving position after we already reset it
+        if (sleepTimer != null && sleepTimer.isActive()) {
+            sleepTimer.episodeFinishedPlayback();
+            if (!sleepTimer.shouldContinueToNextEpisode()) {
+                updateDatabaseAfterPlayback(media, true, false, false);
+                player.stop();
+                player.clearMediaItems();
+                PlaybackPreferences.writeNoMediaPlaying();
+                EventBus.getDefault().post(
+                        new PlaybackServiceEvent(PlaybackServiceEvent.Action.SERVICE_SHUT_DOWN));
+                EventBus.getDefault().post(new PlayerStatusEvent());
+                return;
+            }
+        }
+        startNextInQueue(media, false, true);
+    }
+
     /**
      * Loads the next item, and starts it if continuous playback is enabled.
      */
@@ -647,7 +657,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         queueLoaderDisposable = Maybe.fromCallable(() -> {
             FeedItem nextItem = DBReader.getNextInQueue(item);
             boolean hasNext = nextItem != null && nextItem.getMedia() != null;
-            finalizePlayback(media, ended, wasSkipped, hasNext);
+            updateDatabaseAfterPlayback(media, ended, wasSkipped, hasNext);
             if (hasNext) {
                 return new Pair<>(nextItem.getMedia(),
                         MediaItemAdapter.fromPlayable(Media3PlaybackService.this, nextItem.getMedia(), false));


### PR DESCRIPTION
### Description

That was a tricky one. When Cast finishes, it unloads the media session, so the Media3 CastPlayer reports IDLE, not ENDED like the local player. Media3 never reads the Cast SDK's idle reason, so "finished naturally" and "stopped by user" look identical. We now manually read the idle reason directly from the Cast SDK to make that distinction.

Closes #8508

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
