### PR TITLE
Fix playback speed not set when playing next from queue

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -439,6 +439,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         }
     }
 
+    @OptIn(markerClass = UnstableApi.class)
     private boolean confirmStreamingIfNeeded(FeedMedia media) {
         if (needsStreaming(media) && !NetworkUtils.isStreamingAllowed() && !allowStreamingThisTime) {
             showStreamingConfirmation(media);
@@ -448,6 +449,7 @@ public class Media3PlaybackService extends MediaLibraryService {
         return false;
     }
 
+    @OptIn(markerClass = UnstableApi.class)
     private void switchToPlayable(FeedMedia media) {
         currentPlayable = media;
         currentPlayable.onPlaybackStart();

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -420,35 +420,14 @@ public class Media3PlaybackService extends MediaLibraryService {
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(media -> {
-                            currentPlayable = media;
-                            if (player == null) {
+                            if (player == null || confirmStreamingIfNeeded(media)) {
                                 return;
                             }
-                            if (needsStreaming(media) && !NetworkUtils.isStreamingAllowed()
-                                    && !allowStreamingThisTime) {
-                                showStreamingConfirmation(media);
-                                return;
+                            media.setPosition((int) player.getCurrentPosition());
+                            if (media.getItem() != null && !media.getItem().isTagged(FeedItem.TAG_QUEUE)) {
+                                DBWriter.addQueueItem(this, media.getItem());
                             }
-                            allowStreamingThisTime = false;
-                            currentPlayable.setPosition((int) player.getCurrentPosition());
-                            currentPlayable.onPlaybackStart();
-                            if (currentPlayable.getItem() != null
-                                    && !currentPlayable.getItem().isTagged(FeedItem.TAG_QUEUE)) {
-                                DBWriter.addQueueItem(this, currentPlayable.getItem());
-                            }
-                            float speed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentPlayable);
-                            player.setPlaybackSpeed(speed);
-                            boolean enabled = PlaybackSpeedUtils.getCurrentSkipSilencePreference(
-                                    currentPlayable) == FeedPreferences.SkipSilence.AGGRESSIVE;
-                            PlaybackPreferences.setCurrentlyPlayingTemporarySkipSilence(enabled);
-                            exoPlayer.setSkipSilenceEnabled(enabled);
-                            if (currentPlayable.getItem() != null
-                                    && currentPlayable.getItem().getFeed() != null) {
-                                volumeAdaptionFactor = currentPlayable.getItem().getFeed()
-                                        .getPreferences().getVolumeAdaptionSetting().getAdaptionFactor();
-                                applyVolumeAdaption(1.0f);
-                            }
-                            updatePlaybackPreferences();
+                            switchToPlayable(media);
                         },
                                 error -> Log.e(TAG, "Failed to load current media", error));
 
@@ -458,6 +437,33 @@ public class Media3PlaybackService extends MediaLibraryService {
                     ? player.getCurrentMediaItem().mediaId
                     : "null"), e);
         }
+    }
+
+    private boolean confirmStreamingIfNeeded(FeedMedia media) {
+        if (needsStreaming(media) && !NetworkUtils.isStreamingAllowed() && !allowStreamingThisTime) {
+            showStreamingConfirmation(media);
+            return true;
+        }
+        allowStreamingThisTime = false;
+        return false;
+    }
+
+    private void switchToPlayable(FeedMedia media) {
+        currentPlayable = media;
+        currentPlayable.onPlaybackStart();
+
+        float speed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentPlayable);
+        player.setPlaybackSpeed(speed);
+        boolean enabled = PlaybackSpeedUtils.getCurrentSkipSilencePreference(currentPlayable)
+                == FeedPreferences.SkipSilence.AGGRESSIVE;
+        PlaybackPreferences.setCurrentlyPlayingTemporarySkipSilence(enabled);
+        exoPlayer.setSkipSilenceEnabled(enabled);
+        if (currentPlayable.getItem() != null && currentPlayable.getItem().getFeed() != null) {
+            volumeAdaptionFactor = currentPlayable.getItem().getFeed()
+                    .getPreferences().getVolumeAdaptionSetting().getAdaptionFactor();
+            applyVolumeAdaption(1.0f);
+        }
+        updatePlaybackPreferences();
     }
 
     private void updatePlaybackPreferences() {
@@ -670,24 +676,12 @@ public class Media3PlaybackService extends MediaLibraryService {
                         pair -> {
                             final FeedMedia nextMedia = pair.first;
                             final MediaItem nextMediaItem = pair.second;
-                            if (needsStreaming(nextMedia) && !NetworkUtils.isStreamingAllowed()
-                                    && !allowStreamingThisTime) {
-                                showStreamingConfirmation(nextMedia);
+                            if (player == null || confirmStreamingIfNeeded(nextMedia)) {
                                 return;
                             }
-                            allowStreamingThisTime = false;
-
-                            currentPlayable = nextMedia;
-                            currentPlayable.onPlaybackStart();
-                            updatePlaybackPreferences();
-                            if (nextMedia.getItem() != null && nextMedia.getItem().getFeed() != null) {
-                                volumeAdaptionFactor = nextMedia.getItem().getFeed()
-                                        .getPreferences().getVolumeAdaptionSetting().getAdaptionFactor();
-                                applyVolumeAdaption(1.0f);
-                            }
+                            switchToPlayable(nextMedia);
                             player.setPlayWhenReady(UserPreferences.isFollowQueue());
-                            player.setMediaItem(nextMediaItem,
-                                    SkipUtils.skipIntroIfNecessary(this, nextMedia));
+                            player.setMediaItem(nextMediaItem, SkipUtils.skipIntroIfNecessary(this, nextMedia));
                             player.prepare();
                         },
                         error -> Log.e(TAG, "Failed to load next queue item", error),


### PR DESCRIPTION
### Description

Fix playback speed not set when playing next from queue. We had two different places that set the current playable. Extract this to a single place and do speed setup there.

Closes #8520

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
