### PR TITLE
Add a simple test for the media3 library session callback

### DIFF
--- a/mockitoAgent.gradle
+++ b/mockitoAgent.gradle
@@ -1,0 +1,13 @@
+configurations {
+    mockitoAgent
+}
+
+dependencies {
+    mockitoAgent("org.mockito:mockito-core:$mockitoVersion") {
+        transitive = false
+    }
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs "-javaagent:${configurations.mockitoAgent.asPath}"
+}

--- a/mockitoAgent.gradle
+++ b/mockitoAgent.gradle
@@ -9,5 +9,5 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    jvmArgs "-javaagent:${configurations.mockitoAgent.asPath}"
+    jvmArgs "-javaagent:${configurations.mockitoAgent.singleFile}"
 }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
 }
 apply from: "../common.gradle"
+apply from: "../mockitoAgent.gradle"
 
 android {
     namespace "de.danoeh.antennapod.model"

--- a/net/download/service/build.gradle
+++ b/net/download/service/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 apply from: "../../../common.gradle"
 apply from: "../../../playFlavor.gradle"
+apply from: "../../../mockitoAgent.gradle"
 
 android {
     namespace "de.danoeh.antennapod.net.download.service"

--- a/playback/service/build.gradle
+++ b/playback/service/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 apply from: "../../common.gradle"
 apply from: "../../playFlavor.gradle"
+apply from: "../../mockitoAgent.gradle"
 
 android {
     namespace "de.danoeh.antennapod.playback.service"
@@ -48,4 +49,6 @@ dependencies {
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "androidx.test:core:$testCoreVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallbackTest.java
+++ b/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallbackTest.java
@@ -14,6 +14,7 @@ import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
 import de.danoeh.antennapod.storage.database.PodDBAdapter;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +23,7 @@ import org.robolectric.RuntimeEnvironment;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -45,12 +47,18 @@ public class MediaLibrarySessionCallbackTest {
         callback = new MediaLibrarySessionCallback(context);
     }
 
+    @After
+    public void tearDown() {
+        PodDBAdapter.tearDownTests();
+    }
+
     @Test
     public void onSetMediaItemsStub() throws Exception {
         long mediaId = seedEpisode().getId();
         MediaItem browseItem = MediaItemAdapter.fromMediaIdStub(mediaId);
         MediaSession.MediaItemsWithStartPosition result = callback.onSetMediaItems(
-                session, controllerInfo, Collections.singletonList(browseItem), C.INDEX_UNSET, C.TIME_UNSET).get();
+                session, controllerInfo, Collections.singletonList(browseItem), C.INDEX_UNSET, C.TIME_UNSET)
+                .get(5, TimeUnit.SECONDS);
         assertEquals(1, result.mediaItems.size());
         assertEquals(String.valueOf(mediaId), result.mediaItems.get(0).mediaId);
         assertEquals(EPISODE_TITLE, result.mediaItems.get(0).mediaMetadata.title);
@@ -60,7 +68,8 @@ public class MediaLibrarySessionCallbackTest {
     public void onPlaybackResumption() throws Exception {
         FeedMedia media = seedEpisode();
         PlaybackPreferences.writeMediaPlaying(media);
-        MediaSession.MediaItemsWithStartPosition result = callback.onPlaybackResumption(session, controllerInfo).get();
+        MediaSession.MediaItemsWithStartPosition result = callback.onPlaybackResumption(session, controllerInfo)
+                .get(5, TimeUnit.SECONDS);
         assertEquals(1, result.mediaItems.size());
         assertEquals(String.valueOf(media.getId()), result.mediaItems.get(0).mediaId);
     }

--- a/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallbackTest.java
+++ b/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallbackTest.java
@@ -1,0 +1,79 @@
+package de.danoeh.antennapod.playback.service.internal;
+
+import android.content.Context;
+import androidx.media3.common.C;
+import androidx.media3.common.MediaItem;
+import androidx.media3.session.MediaSession;
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
+import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueueStub;
+import de.danoeh.antennapod.playback.base.MediaItemAdapter;
+import de.danoeh.antennapod.storage.database.FeedDatabaseWriter;
+import de.danoeh.antennapod.storage.database.PodDBAdapter;
+import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
+import de.danoeh.antennapod.storage.preferences.UserPreferences;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricTestRunner.class)
+public class MediaLibrarySessionCallbackTest {
+    private static final String EPISODE_TITLE = "Episode Title";
+    private Context context;
+    private MediaLibrarySessionCallback callback;
+    private final MediaSession session = mock(MediaSession.class);
+    private final MediaSession.ControllerInfo controllerInfo = mock(MediaSession.ControllerInfo.class);
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        UserPreferences.init(context);
+        PlaybackPreferences.init(context);
+        PodDBAdapter.init(context);
+        PodDBAdapter.deleteDatabase();
+        SynchronizationQueue.setInstance(new SynchronizationQueueStub());
+        callback = new MediaLibrarySessionCallback(context);
+    }
+
+    @Test
+    public void onSetMediaItemsStub() throws Exception {
+        long mediaId = seedEpisode().getId();
+        MediaItem browseItem = MediaItemAdapter.fromMediaIdStub(mediaId);
+        MediaSession.MediaItemsWithStartPosition result = callback.onSetMediaItems(
+                session, controllerInfo, Collections.singletonList(browseItem), C.INDEX_UNSET, C.TIME_UNSET).get();
+        assertEquals(1, result.mediaItems.size());
+        assertEquals(String.valueOf(mediaId), result.mediaItems.get(0).mediaId);
+        assertEquals(EPISODE_TITLE, result.mediaItems.get(0).mediaMetadata.title);
+    }
+
+    @Test
+    public void onPlaybackResumption() throws Exception {
+        FeedMedia media = seedEpisode();
+        PlaybackPreferences.writeMediaPlaying(media);
+        MediaSession.MediaItemsWithStartPosition result = callback.onPlaybackResumption(session, controllerInfo).get();
+        assertEquals(1, result.mediaItems.size());
+        assertEquals(String.valueOf(media.getId()), result.mediaItems.get(0).mediaId);
+    }
+
+    private FeedMedia seedEpisode() {
+        Feed feed = new Feed("url", null, null);
+        feed.setItems(new ArrayList<>());
+        FeedItem item = new FeedItem();
+        item.setItemIdentifier("id");
+        item.setTitle(EPISODE_TITLE);
+        item.setMedia(new FeedMedia(item, "http://example.com", 2, "mime"));
+        item.setFeed(feed);
+        feed.getItems().add(item);
+        return FeedDatabaseWriter.updateFeed(context, feed, false).getItems().get(0).getMedia();
+    }
+}


### PR DESCRIPTION
### Description

Add a simple test for the media3 library session callback. This prepares adding more tests later.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
