### PR TITLE
Remove almost unused animations

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -55,7 +55,6 @@ import de.danoeh.antennapod.storage.databasemaintenanceservice.DatabaseMaintenan
 import de.danoeh.antennapod.storage.importexport.AutomaticDatabaseExportWorker;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
-import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
 import de.danoeh.antennapod.ui.common.NavigationToolbarActivity;
@@ -513,24 +512,12 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
         updateMainBackCallbackEnabledState();
     }
 
-    public void loadChildFragment(Fragment fragment, TransitionEffect transition, String navigationTag) {
+    public void loadChildFragment(Fragment fragment, String navigationTag) {
         Objects.requireNonNull(fragment);
         if (navigationTag != null && bottomNavigation != null) {
             bottomNavigation.updateSelectedItem(navigationTag);
         }
-        FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-
-        if (transition == TransitionEffect.FADE) {
-            transaction.setCustomAnimations(R.anim.fade_in, R.anim.fade_out);
-        } else if (transition == TransitionEffect.SLIDE) {
-            transaction.setCustomAnimations(
-                    R.anim.slide_right_in,
-                    R.anim.slide_left_out,
-                    R.anim.slide_left_in,
-                    R.anim.slide_right_out);
-        }
-
-        transaction
+        getSupportFragmentManager().beginTransaction()
                 .hide(getSupportFragmentManager().findFragmentByTag(MAIN_FRAGMENT_TAG))
                 .add(R.id.main_content_view, fragment, MAIN_FRAGMENT_TAG)
                 .addToBackStack(null)
@@ -538,12 +525,8 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
         updateMainBackCallbackEnabledState();
     }
 
-    public void loadChildFragment(Fragment fragment, TransitionEffect transition) {
-        loadChildFragment(fragment, transition, null);
-    }
-
     public void loadChildFragment(Fragment fragment) {
-        loadChildFragment(fragment, TransitionEffect.NONE);
+        loadChildFragment(fragment, null);
     }
 
     @Override
@@ -760,7 +743,7 @@ public class MainActivity extends CastEnabledActivity implements NavigationToolb
                 if (intent.getBooleanExtra(MainActivityStarter.EXTRA_CLEAR_BACK_STACK, true)) {
                     loadFragment(tag, null);
                 } else {
-                    loadChildFragment(createFragmentInstance(tag, args), TransitionEffect.NONE, tag);
+                    loadChildFragment(createFragmentInstance(tag, args), tag);
                 }
             }
             sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);

--- a/app/src/main/java/de/danoeh/antennapod/ui/TransitionEffect.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/TransitionEffect.java
@@ -1,5 +1,0 @@
-package de.danoeh.antennapod.ui;
-
-public enum TransitionEffect {
-    NONE, FADE, SLIDE
-}

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedInfoFragment.java
@@ -23,7 +23,6 @@ import de.danoeh.antennapod.activity.MainActivity;
 import de.danoeh.antennapod.databinding.FeedinfoBinding;
 import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.storage.database.DBWriter;
-import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.common.ClipboardUtils;
@@ -107,8 +106,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                         .show(getChildFragmentManager().beginTransaction(), "FeedStatistics"));
 
         viewBinding.statisticsButton.setOnClickListener(view -> {
-            StatisticsFragment fragment = new StatisticsFragment();
-            ((MainActivity) getActivity()).loadChildFragment(fragment, TransitionEffect.SLIDE);
+            ((MainActivity) getActivity()).loadChildFragment(new StatisticsFragment());
         });
         viewBinding.header.txtvTitle.setOnLongClickListener(v -> {
             ClipboardUtils.copyText(viewBinding.header.txtvTitle);
@@ -241,8 +239,7 @@ public class FeedInfoFragment extends Fragment implements MaterialToolbar.OnMenu
                     .commitAllowingStateLoss();
 
             viewBinding.statisticsButton.setOnClickListener(view -> {
-                StatisticsFragment fragment = new StatisticsFragment();
-                ((MainActivity) getActivity()).loadChildFragment(fragment, TransitionEffect.SLIDE);
+                ((MainActivity) getActivity()).loadChildFragment(new StatisticsFragment());
             });
         }
 

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/FeedItemlistFragment.java
@@ -43,7 +43,6 @@ import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.CoverLoader;
 import de.danoeh.antennapod.ui.FeedItemFilterDialog;
 import de.danoeh.antennapod.ui.MenuItemUtils;
-import de.danoeh.antennapod.ui.TransitionEffect;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
 import de.danoeh.antennapod.ui.cleaner.HtmlToPlainText;
 import de.danoeh.antennapod.ui.common.ClipboardUtils;
@@ -567,8 +566,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
             if (feed == null) {
                 return;
             }
-            FeedSettingsFragment fragment = FeedSettingsFragment.newInstance(feed);
-            ((MainActivity) getActivity()).loadChildFragment(fragment, TransitionEffect.SLIDE);
+            ((MainActivity) getActivity()).loadChildFragment(FeedSettingsFragment.newInstance(feed));
         });
         viewBinding.header.butFilter.setOnClickListener(v -> {
             if (feed == null) {
@@ -611,7 +609,7 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
         }
         FeedInfoFragment fragment = FeedInfoFragment.newInstance(feed);
         if (getActivity() instanceof MainActivity) {
-            ((MainActivity) getActivity()).loadChildFragment(fragment, TransitionEffect.SLIDE);
+            ((MainActivity) getActivity()).loadChildFragment(fragment);
         } else {
             getActivity().getSupportFragmentManager()
                     .beginTransaction()

--- a/ui/common/src/main/res/anim/slide_left_in.xml
+++ b/ui/common/src/main/res/anim/slide_left_in.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
-    <translate
-        android:fromXDelta="-100%" android:toXDelta="0%"
-        android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="@integer/fragment_transition_duration"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator" />
-</set>

--- a/ui/common/src/main/res/anim/slide_left_out.xml
+++ b/ui/common/src/main/res/anim/slide_left_out.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
-    <translate
-        android:fromXDelta="0%" android:toXDelta="-100%"
-        android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="@integer/fragment_transition_duration"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator"  />
-</set>

--- a/ui/common/src/main/res/anim/slide_right_in.xml
+++ b/ui/common/src/main/res/anim/slide_right_in.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
-    <translate
-        android:fromXDelta="100%" android:toXDelta="0%"
-        android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="@integer/fragment_transition_duration"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator" />
-</set>

--- a/ui/common/src/main/res/anim/slide_right_out.xml
+++ b/ui/common/src/main/res/anim/slide_right_out.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shareInterpolator="false">
-    <translate
-        android:fromXDelta="0%" android:toXDelta="100%"
-        android:fromYDelta="0%" android:toYDelta="0%"
-        android:duration="@integer/fragment_transition_duration"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator" />
-</set>

--- a/ui/preferences/src/main/res/layout/gpodnetauth_dialog.xml
+++ b/ui/preferences/src/main/res/layout/gpodnetauth_dialog.xml
@@ -10,9 +10,7 @@
         android:id="@+id/viewflipper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:measureAllChildren="false"
-        android:inAnimation="@anim/slide_right_in"
-        android:outAnimation="@anim/slide_left_out">
+        android:measureAllChildren="false">
 
         <include
             layout="@layout/gpodnetauth_host" />


### PR DESCRIPTION
### Description

Remove animation framework for showing subpages. Only the feed info and feed settings used them, it's not really worth the complexity. Also, it makes it harder to add more native material3 animations later.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
