### PR TITLE
Fix back button in settings not working

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     implementation libs.androidx.palette
     implementation libs.androidx.preference
     implementation libs.androidx.recyclerview
+    implementation libs.androidx.transition
     implementation libs.androidx.viewpager2
     implementation libs.androidx.work.runtime
     implementation libs.google.material

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ androidx-test-espresso-contrib = { module = "androidx.test.espresso:espresso-con
 androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version = "1.1.1" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
+androidx-transition = { module = "androidx.transition:transition", version = "1.7.0" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.1.0" }
 androidx-wear = { module = "androidx.wear:wear", version = "1.3.0" }


### PR DESCRIPTION
### Description

Fix back button in settings not working. Looks like Google fixed it in a more recent dependency. Simply upgrading is enough to make the settings back stack work for physical navigation buttons.

Closes #7934

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
