### PR TITLE
Fix full black theme toolbar turning grey when scrolled

### DIFF
--- a/ui/common/src/main/res/values/styles.xml
+++ b/ui/common/src/main/res/values/styles.xml
@@ -128,6 +128,11 @@
         <item name="android:color">@color/white</item>
         <item name="android:colorBackground">@color/black</item>
         <item name="colorSurface">@color/black</item>
+        <item name="colorSurfaceContainer">@color/black</item>
+        <item name="colorSurfaceContainerHigh">@color/black</item>
+        <item name="colorSurfaceContainerHighest">@color/black</item>
+        <item name="colorSurfaceContainerLow">@color/black</item>
+        <item name="colorSurfaceContainerLowest">@color/black</item>
         <item name="background_color">@color/black</item>
         <item name="background_elevated">@color/black</item>
     </style>
@@ -137,6 +142,11 @@
         <item name="android:color">@color/white</item>
         <item name="android:colorBackground">@color/black</item>
         <item name="colorSurface">@color/black</item>
+        <item name="colorSurfaceContainer">@color/black</item>
+        <item name="colorSurfaceContainerHigh">@color/black</item>
+        <item name="colorSurfaceContainerHighest">@color/black</item>
+        <item name="colorSurfaceContainerLow">@color/black</item>
+        <item name="colorSurfaceContainerLowest">@color/black</item>
         <item name="background_color">@color/black</item>
         <item name="background_elevated">@color/black</item>
         <item name="colorPrimaryContainer">#0D182B</item>


### PR DESCRIPTION
### Description

Closes: #8565

The `TrueBlack` ("Full black") theme overrides `colorSurface` to pure black, but doesn't override the Material 3 `colorSurfaceContainer`, `colorSurfaceContainerHigh/Highest/Low/Lowest` color roles. These are what `MaterialToolbar`/`AppBarLayout` switch to when the toolbar becomes tonally elevated (e.g. when the collapsing header on a podcast's episode list scrolls away and the toolbar lifts). Since those roles weren't overridden, they fell back to the base `Dark` theme's grey (`#1C2024`), making the toolbar visibly grey instead of black once scrolled.

This adds the same black override to those five color roles, in both `Theme.AntennaPod.TrueBlack` and `Theme.AntennaPod.Dynamic.TrueBlack`.

**Tested:** Verified on-device — enabled Full black theme, opened a podcast's episode list, scrolled until the header collapsed and the toolbar lifted. Before the fix the toolbar turned grey; after the fix it stays black.

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests