### PR TITLE
Fix (invisible) crash when episode does not have chapters

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/audio/CoverFragment.java
@@ -62,6 +62,8 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.List;
+
 import static android.widget.LinearLayout.LayoutParams.MATCH_PARENT;
 import static android.widget.LinearLayout.LayoutParams.WRAP_CONTENT;
 
@@ -222,9 +224,10 @@ public class CoverFragment extends Fragment {
     }
 
     private void refreshChapterData(int chapterIndex) {
-        if (chapterIndex > -1) {
-            if (media.getPosition() > media.getDuration() || chapterIndex >= media.getChapters().size() - 1) {
-                displayedChapterIndex = media.getChapters().size() - 1;
+        List<Chapter> chapters = media.getChapters();
+        if (chapterIndex > -1 && chapters != null) {
+            if (media.getPosition() > media.getDuration() || chapterIndex >= chapters.size() - 1) {
+                displayedChapterIndex = chapters.size() - 1;
                 viewBinding.butNextChapter.setVisibility(View.INVISIBLE);
             } else {
                 displayedChapterIndex = chapterIndex;


### PR DESCRIPTION
### Description

Fix (invisible) crash when episode does not have chapters. Add proper null check.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
