### PR TITLE
Keep completed episodes during sleep timer

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/service/playback/SleepTimerPreferencesTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/service/playback/SleepTimerPreferencesTest.java
@@ -19,4 +19,12 @@ public class SleepTimerPreferencesTest {
         assertFalse(SleepTimerPreferences.isInTimeRange(1, 6, 6));
         assertFalse(SleepTimerPreferences.isInTimeRange(20, 6, 8));
     }
+
+    @Test
+    public void testKeepCompletedEpisodes() {
+        SleepTimerPreferences.setKeepCompletedEpisodes(true);
+        assertTrue(SleepTimerPreferences.keepCompletedEpisodes());
+        SleepTimerPreferences.setKeepCompletedEpisodes(false);
+        assertFalse(SleepTimerPreferences.keepCompletedEpisodes());
+    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/playback/SleepTimerDialog.java
@@ -211,12 +211,15 @@ public class SleepTimerDialog extends BottomSheetDialogFragment {
         viewBinding.autoEnableCheckbox.setChecked(SleepTimerPreferences.autoEnable());
         viewBinding.shakeToResetCheckbox.setChecked(SleepTimerPreferences.shakeToReset());
         viewBinding.vibrateCheckbox.setChecked(SleepTimerPreferences.vibrate());
+        viewBinding.keepCompletedEpisodesCheckbox.setChecked(SleepTimerPreferences.keepCompletedEpisodes());
         refreshAutoEnableControls(SleepTimerPreferences.autoEnable());
 
         viewBinding.shakeToResetCheckbox.setOnCheckedChangeListener((buttonView, isChecked)
                 -> SleepTimerPreferences.setShakeToReset(isChecked));
         viewBinding.vibrateCheckbox.setOnCheckedChangeListener((buttonView, isChecked)
                 -> SleepTimerPreferences.setVibrate(isChecked));
+        viewBinding.keepCompletedEpisodesCheckbox.setOnCheckedChangeListener((buttonView, isChecked)
+                -> SleepTimerPreferences.setKeepCompletedEpisodes(isChecked));
         viewBinding.autoEnableCheckbox.setOnCheckedChangeListener((compoundButton, isChecked)
                 -> {
             boolean mostOfDay = isSleepTimerConfiguredForMostOfTheDay();

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -151,6 +151,12 @@
                 android:layout_height="wrap_content"
                 android:text="@string/timer_vibration_label" />
 
+            <CheckBox
+                android:id="@+id/keepCompletedEpisodesCheckbox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/keep_completed_episodes" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -556,6 +556,11 @@ public class Media3PlaybackService extends MediaLibraryService {
     }
 
     private void updateDatabaseAfterPlayback(FeedMedia media, boolean ended, boolean skipped, boolean playingNext) {
+        updateDatabaseAfterPlayback(media, ended, skipped, playingNext, false);
+    }
+
+    private void updateDatabaseAfterPlayback(FeedMedia media, boolean ended, boolean skipped, boolean playingNext,
+                                             boolean keepCompletedEpisodes) {
         if (media == null) {
             return;
         }
@@ -570,8 +575,14 @@ public class Media3PlaybackService extends MediaLibraryService {
             if (ended || almostEnded) {
                 DBWriter.markItemsPlayed(FeedItem.PLAYED, true, Collections.singletonList(item));
             }
-            if (ended || almostEnded || (skipped && !UserPreferences.shouldSkipKeepEpisode())) {
+            boolean finished = ended || almostEnded;
+            boolean keepCompleted = keepCompletedEpisodes || (finished && sleepTimer != null && sleepTimer.isActive()
+                    && SleepTimerPreferences.keepCompletedEpisodes());
+            if (!keepCompleted
+                    && (finished || (skipped && !UserPreferences.shouldSkipKeepEpisode()))) {
                 DBWriter.removeQueueItem(this, ended, item);
+            }
+            if (!keepCompleted && (finished || (skipped && !UserPreferences.shouldSkipKeepEpisode()))) {
                 FeedPreferences.AutoDeleteAction action = item.getFeed().getPreferences().getCurrentAutoDelete();
                 boolean autoDeleteEnabledGlobally = UserPreferences.isAutoDelete()
                         && (!item.getFeed().isLocalFeed() || UserPreferences.isAutoDeleteLocal());
@@ -689,9 +700,10 @@ public class Media3PlaybackService extends MediaLibraryService {
         FeedMedia media = currentPlayable;
         currentPlayable = null; // To avoid position updater saving position after we already reset it
         if (sleepTimer != null && sleepTimer.isActive()) {
+            boolean keepCompletedEpisodes = SleepTimerPreferences.keepCompletedEpisodes();
             sleepTimer.episodeFinishedPlayback();
             if (!sleepTimer.shouldContinueToNextEpisode()) {
-                updateDatabaseAfterPlayback(media, true, false, false);
+                updateDatabaseAfterPlayback(media, true, false, false, keepCompletedEpisodes);
                 player.stop();
                 player.clearMediaItems();
                 PlaybackPreferences.writeNoMediaPlaying();

--- a/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/SleepTimerPreferences.java
+++ b/storage/preferences/src/main/java/de/danoeh/antennapod/storage/preferences/SleepTimerPreferences.java
@@ -22,6 +22,7 @@ public class SleepTimerPreferences {
     private static final String PREF_AUTO_ENABLE = "AutoEnable";
     private static final String PREF_AUTO_ENABLE_FROM = "AutoEnableFrom";
     private static final String PREF_AUTO_ENABLE_TO = "AutoEnableTo";
+    private static final String PREF_KEEP_COMPLETED_EPISODES = "KeepCompletedEpisodes";
 
     private static final int DEFAULT_TIMER_TYPE = 0;
     private static final int DEFAULT_AUTO_ENABLE_FROM = 22;
@@ -73,6 +74,14 @@ public class SleepTimerPreferences {
 
     public static boolean vibrate() {
         return prefs.getBoolean(PREF_VIBRATE, false);
+    }
+
+    public static void setKeepCompletedEpisodes(boolean keepCompletedEpisodes) {
+        prefs.edit().putBoolean(PREF_KEEP_COMPLETED_EPISODES, keepCompletedEpisodes).apply();
+    }
+
+    public static boolean keepCompletedEpisodes() {
+        return prefs.getBoolean(PREF_KEEP_COMPLETED_EPISODES, false);
     }
 
     public static void setShakeToReset(boolean shakeToReset) {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -716,6 +716,7 @@
     </plurals>
     <string name="shake_to_reset_label">Shake to reset</string>
     <string name="timer_vibration_label">Vibrate shortly before end</string>
+    <string name="keep_completed_episodes">Keep completed episodes</string>
     <string name="time_seconds">seconds</string>
     <string name="time_minutes">minutes</string>
     <string name="time_hours">hours</string>


### PR DESCRIPTION
### Description

Adds an opt-in “Keep completed episodes” checkbox to the sleep timer dialog.

When enabled, episodes that complete while the sleep timer is active stay in the queue and are not automatically deleted. Playback outside an active sleep timer, and the existing manual deletion settings, are unchanged.

This implements the sleep-timer-scoped variant discussed in the forum: https://forum.antennapod.org/t/an-option-to-choose-whether-to-automatically-remove-episodes-from-the-queue-when-finished/4250/7

### Checklist

- [x] I have read the contribution guidelines.
- [x] I have performed a self-review of the changes.
- [x] I have run `./gradlew checkstyle`.
- [ ] `./gradlew lint` is blocked locally by Windows' command-line limit in the existing `:app:spotbugsPlayDebug` task.
- [x] The changes follow the AntennaPod code style.
- [x] The relevant existing feature request is linked above; no duplicate GitHub issue was created.
- [x] I added an automated test for the new sleep timer preference.