### PR TITLE
Improve sync set-up UX, add chapter-skip hardware buttons, clarify Wi-Fi-only sync

### DIFF
--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SynchronizationQueueImpl.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SynchronizationQueueImpl.java
@@ -69,7 +69,11 @@ public class SynchronizationQueueImpl extends SynchronizationQueue {
         } else {
             // Give it some time, so other possible actions can be queued.
             builder.setInitialDelay(20L, TimeUnit.SECONDS);
-            EventBus.getDefault().postSticky(new SyncServiceEvent(R.string.sync_status_started));
+            if (UserPreferences.isAllowMobileSync()) {
+                EventBus.getDefault().postSticky(new SyncServiceEvent(R.string.sync_status_started));
+            } else {
+                EventBus.getDefault().postSticky(new SyncServiceEvent(R.string.sync_status_waiting_for_wifi));
+            }
         }
         return builder;
     }

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -259,6 +259,18 @@ public class Media3PlaybackService extends MediaLibraryService {
             }
             return super.onCustomCommand(session, controller, customCommand, args);
         }
+
+        @Override
+        @UnstableApi
+        protected void skipChapterForward(MediaSession session) {
+            seekToNextChapterOrForward();
+        }
+
+        @Override
+        @UnstableApi
+        protected void skipChapterBack(MediaSession session) {
+            seekToPreviousChapterOrRewind();
+        }
     };
 
     @UnstableApi
@@ -633,6 +645,50 @@ public class Media3PlaybackService extends MediaLibraryService {
         }
 
         player.seekTo(chapters.get(nextChapter).getStart());
+    }
+
+    @UnstableApi
+    private void seekToNextChapterOrForward() {
+        if (currentPlayable == null || player == null) {
+            return;
+        }
+        List<Chapter> chapters = currentPlayable.getChapters();
+        if (chapters == null || chapters.isEmpty()) {
+            player.seekForward();
+            return;
+        }
+
+        int nextChapter = Chapter.getAfterPosition(chapters, (int) player.getCurrentPosition()) + 1;
+
+        if (chapters.size() < nextChapter + 1) {
+            player.seekForward();
+            return;
+        }
+
+        player.seekTo(chapters.get(nextChapter).getStart());
+    }
+
+    @UnstableApi
+    private void seekToPreviousChapterOrRewind() {
+        if (currentPlayable == null || player == null) {
+            return;
+        }
+        List<Chapter> chapters = currentPlayable.getChapters();
+        if (chapters == null || chapters.isEmpty()) {
+            player.seekBack();
+            return;
+        }
+
+        int chapterIndex = Chapter.getAfterPosition(chapters, (int) player.getCurrentPosition());
+        if (chapterIndex < 0) {
+            player.seekBack();
+            return;
+        }
+        if (chapters.get(chapterIndex).getStart() == player.getCurrentPosition() && chapterIndex > 0) {
+            chapterIndex--;
+        }
+
+        player.seekTo(chapters.get(chapterIndex).getStart());
     }
 
     private boolean shouldBlockForStreamingConfirmation() {

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -77,6 +77,9 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     public static final SessionCommand SESSION_COMMAND_EXTEND_SLEEP_TIMER
             = new SessionCommand("extend_sleep_timer", Bundle.EMPTY);
 
+    private static final int KEYCODE_SKIP_CHAPTER_FORWARD = 91;
+    private static final int KEYCODE_SKIP_CHAPTER_BACK = 92;
+
     private static final String EXTRA_VALUE = "value";
 
     public static Bundle createBundle(boolean value) {
@@ -219,17 +222,48 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 return true;
             } else if (!fromWidget && keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
                 // Media3 translates HEADSETHOOK double-tap to MEDIA_NEXT.
-                // Instead of skipping to the next episode, do a fast-forward.
-                session.getPlayer().seekForward();
-                return true;
+                // Handle remapped button as notification button which is not remapped again.
+                return handleKeycode(session, UserPreferences.getHardwareForwardButton());
             } else if (!fromWidget && keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS) {
                 // Media3 translates HEADSETHOOK triple-tap to MEDIA_PREVIOUS.
-                // Instead of going to the previous episode, do a rewind.
-                session.getPlayer().seekBack();
-                return true;
+                // Handle remapped button as notification button which is not remapped again.
+                return handleKeycode(session, UserPreferences.getHardwarePreviousButton());
             }
         }
         return false;
+    }
+
+    private boolean handleKeycode(MediaSession session, int keyCode) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+                session.getPlayer().seekForward();
+                return true;
+            case KeyEvent.KEYCODE_MEDIA_REWIND:
+                session.getPlayer().seekBack();
+                return true;
+            case KeyEvent.KEYCODE_MEDIA_NEXT:
+                session.getPlayer().seekToNextMediaItem();
+                return true;
+            case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                session.getPlayer().seekTo(0);
+                return true;
+            case KEYCODE_SKIP_CHAPTER_FORWARD:
+                skipChapterForward(session);
+                return true;
+            case KEYCODE_SKIP_CHAPTER_BACK:
+                skipChapterBack(session);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    protected void skipChapterForward(MediaSession session) {
+        session.getPlayer().seekForward();
+    }
+
+    protected void skipChapterBack(MediaSession session) {
+        session.getPlayer().seekBack();
     }
 
     @Override

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <!-- Other -->
     <string name="confirm_label">Confirm</string>
     <string name="cancel_label">Cancel</string>
+    <string name="back_label">Back</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="enabled">Enabled</string>
@@ -475,6 +476,8 @@
     <string name="button_action_rewind">Rewind</string>
     <string name="button_action_skip_episode">Skip episode</string>
     <string name="button_action_restart_episode">Restart episode</string>
+    <string name="button_action_skip_chapter_forward">Skip chapter forward (fallback: fast-forward)</string>
+    <string name="button_action_skip_chapter_back">Skip chapter back (fallback: rewind)</string>
     <string name="pref_followQueue_sum">Jump to next queue item when playback completes</string>
     <string name="pref_auto_delete_playback_sum">Delete episode when playback completes</string>
     <string name="pref_auto_delete_playback_title">Delete after playing</string>
@@ -650,6 +653,7 @@
 
     <!-- Synchronization -->
     <string name="sync_status_started">Sync started</string>
+    <string name="sync_status_waiting_for_wifi">Waiting for Wi-Fi (mobile data sync is disabled)</string>
     <string name="sync_status_episodes_upload">Uploading episode changes…</string>
     <string name="sync_status_episodes_download">Downloading episode changes…</string>
     <string name="sync_status_upload_played">Uploading played status…</string>
@@ -742,6 +746,8 @@
 
     <!-- Synchronisation -->
     <string name="synchronization_choose_title">Choose synchronization provider</string>
+    <string name="synchronization_choose_provider_intro">Devices need a central server to synchronize. AntennaPod does not offer such central synchronization server, but allows you to connect with the different types of servers listed below.</string>
+    <string name="synchronization_more_information">More information</string>
     <string name="synchronization_summary_unchoosen">You can choose from multiple providers to synchronize your subscriptions and episode play state with</string>
     <string name="dialog_choose_sync_service_title">Choose synchronization provider</string>
     <string name="gpodnet_description">Gpodder.net is an open-source podcast synchronization service that you can install on your own server. Gpodder.net is independent of the AntennaPod project.</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/GpodderAuthenticationFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/GpodderAuthenticationFragment.java
@@ -68,6 +68,7 @@ public class GpodderAuthenticationFragment extends DialogFragment {
 
         View root = View.inflate(getContext(), R.layout.gpodnetauth_dialog, null);
         viewFlipper = root.findViewById(R.id.viewflipper);
+        root.findViewById(R.id.backButton).setOnClickListener(v -> previous());
         advance();
         dialog.setView(root);
 
@@ -152,15 +153,17 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         MaterialButton createDeviceButton = view.findViewById(R.id.createDeviceButton);
         createDeviceButton.setOnClickListener(v -> createDevice(view));
 
-        for (GpodnetDevice device : devices) {
-            View row = View.inflate(getContext(), R.layout.gpodnetauth_device_row, null);
-            Button selectDeviceButton = row.findViewById(R.id.selectDeviceButton);
-            selectDeviceButton.setOnClickListener(v -> {
-                selectedDevice = device;
-                advance();
-            });
-            selectDeviceButton.setText(device.getCaption());
-            devicesContainer.addView(row);
+        if (devicesContainer.getChildCount() == 0) {
+            for (GpodnetDevice device : devices) {
+                View row = View.inflate(getContext(), R.layout.gpodnetauth_device_row, null);
+                Button selectDeviceButton = row.findViewById(R.id.selectDeviceButton);
+                selectDeviceButton.setOnClickListener(v -> {
+                    selectedDevice = device;
+                    advance();
+                });
+                selectDeviceButton.setText(device.getCaption());
+                devicesContainer.addView(row);
+            }
         }
     }
 
@@ -266,6 +269,13 @@ public class GpodderAuthenticationFragment extends DialogFragment {
             currentStep++;
         } else {
             dismiss();
+        }
+    }
+
+    private void previous() {
+        if (currentStep > STEP_HOSTNAME) {
+            viewFlipper.showPrevious();
+            currentStep--;
         }
     }
 

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
@@ -2,8 +2,11 @@ package de.danoeh.antennapod.ui.preferences.screen.synchronization;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.format.DateUtils;
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -14,6 +17,7 @@ import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.core.text.HtmlCompat;
@@ -32,6 +36,9 @@ import org.greenrobot.eventbus.ThreadMode;
 import de.danoeh.antennapod.event.SyncServiceEvent;
 import de.danoeh.antennapod.storage.preferences.SynchronizationCredentials;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
+
+import java.util.Arrays;
+import java.util.Locale;
 
 public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragment {
     private static final String PREFERENCE_SYNCHRONIZATION_DESCRIPTION = "preference_synchronization_description";
@@ -161,6 +168,12 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
     private void chooseProviderAndLogin() {
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(getContext());
         builder.setTitle(R.string.dialog_choose_sync_service_title);
+        String intro = getString(R.string.synchronization_choose_provider_intro);
+        String moreInformation = getString(R.string.synchronization_more_information);
+        SpannableString message = new SpannableString(intro + "\n\n" + moreInformation);
+        message.setSpan(new URLSpan(getLocalizedWebsiteLink()), intro.length() + 2, message.length(),
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        builder.setMessage(message);
 
         SynchronizationProvider[] providers = SynchronizationProvider.values();
         ListAdapter adapter = new ArrayAdapter<>(getContext(), R.layout.alertdialog_sync_provider_chooser, providers) {
@@ -206,7 +219,20 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
             updateScreen();
         });
 
-        builder.show();
+        AlertDialog dialog = builder.show();
+        TextView messageView = dialog.findViewById(android.R.id.message);
+        if (messageView != null) {
+            messageView.setMovementMethod(LinkMovementMethod.getInstance());
+        }
+    }
+
+    private String getLocalizedWebsiteLink() {
+        String language = Locale.getDefault().getLanguage();
+        if (!"en".equals(language)
+                && Arrays.asList("da", "de", "es", "fr", "it", "nl", "fa", "ja").contains(language)) {
+            return "https://antennapod.org/" + language + "/s/sync-help";
+        }
+        return "https://antennapod.org/s/sync-help";
     }
 
     private boolean isProviderSelected(@NonNull SynchronizationProvider provider) {

--- a/ui/preferences/src/main/res/layout/gpodnetauth_credentials.xml
+++ b/ui/preferences/src/main/res/layout/gpodnetauth_credentials.xml
@@ -80,4 +80,10 @@
         android:layout_height="wrap_content"
         android:text="@string/synchronization_login_butLabel" />
 
+    <Button
+        android:id="@+id/backButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/back_label" />
+
 </LinearLayout>

--- a/ui/preferences/src/main/res/layout/gpodnetauth_device.xml
+++ b/ui/preferences/src/main/res/layout/gpodnetauth_device.xml
@@ -64,4 +64,10 @@
         android:textColor="?attr/icon_red"
         android:visibility="gone" />
 
+    <Button
+        android:id="@id/backButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/back_label" />
+
 </LinearLayout>

--- a/ui/preferences/src/main/res/layout/gpodnetauth_finish.xml
+++ b/ui/preferences/src/main/res/layout/gpodnetauth_finish.xml
@@ -27,4 +27,11 @@
         android:layout_marginTop="8dp"
         android:text="@string/synchronization_sync_changes_title" />
 
+    <Button
+        android:id="@id/backButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/back_label" />
+
 </LinearLayout>

--- a/ui/preferences/src/main/res/values/arrays.xml
+++ b/ui/preferences/src/main/res/values/arrays.xml
@@ -174,6 +174,8 @@
         <item>@string/button_action_rewind</item>
         <item>@string/button_action_skip_episode</item>
         <item>@string/button_action_restart_episode</item>
+        <item>@string/button_action_skip_chapter_forward</item>
+        <item>@string/button_action_skip_chapter_back</item>
     </string-array>
 
     <string-array name="button_action_values">
@@ -181,6 +183,8 @@
         <item>@string/keycode_media_rewind</item>
         <item>@string/keycode_media_next</item>
         <item>@string/keycode_media_previous</item>
+        <item>@string/keycode_skip_chapter_forward</item>
+        <item>@string/keycode_skip_chapter_back</item>
     </string-array>
 
     <string-array name="enqueue_location_options">

--- a/ui/preferences/src/main/res/values/keycodes.xml
+++ b/ui/preferences/src/main/res/values/keycodes.xml
@@ -6,4 +6,6 @@
     <string name="keycode_media_previous">88</string>
     <string name="keycode_media_rewind">89</string>
     <string name="keycode_media_fast_forward">90</string>
+    <string name="keycode_skip_chapter_forward">91</string>
+    <string name="keycode_skip_chapter_back">92</string>
 </resources>


### PR DESCRIPTION
### Description

Synchronisation set-up: the provider chooser dialog now explains that AntennaPod does not host a synchronization server and links to the sync help page, and the gPodder authentication wizard supports navigating back to fix previously entered values.

Hardware buttons: two new actions "Skip chapter forward (fallback: fast-forward)" and "Skip chapter back (fallback: rewind)" can be assigned to the hardware forward/back buttons. They jump between chapters and fall back to fast-forward/rewind when no chapters are available.

Mobile data: when syncing on mobile data is disabled, the sync status now shows "Waiting for Wi-Fi (mobile data sync is disabled)" instead of "Sync started", making it clear that nothing will be synced until a Wi-Fi connection is available.

Closes: #6096
Closes: #5770
Closes: #6458

### Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
