### PR TITLE
Clarify sync is waiting for Wi-Fi on mobile data

### DIFF
--- a/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SynchronizationQueueImpl.java
+++ b/net/sync/service/src/main/java/de/danoeh/antennapod/net/sync/service/SynchronizationQueueImpl.java
@@ -10,6 +10,7 @@ import androidx.work.WorkManager;
 import de.danoeh.antennapod.event.SyncServiceEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.net.common.NetworkUtils;
 import de.danoeh.antennapod.net.sync.serviceinterface.EpisodeAction;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
@@ -53,7 +54,8 @@ public class SynchronizationQueueImpl extends SynchronizationQueue {
 
     private static OneTimeWorkRequest.Builder getWorkRequest() {
         Constraints.Builder constraints = new Constraints.Builder();
-        if (UserPreferences.isAllowMobileSync()) {
+        boolean allowMobileSync = UserPreferences.isAllowMobileSync();
+        if (allowMobileSync) {
             constraints.setRequiredNetworkType(NetworkType.CONNECTED);
         } else {
             constraints.setRequiredNetworkType(NetworkType.UNMETERED);
@@ -69,7 +71,10 @@ public class SynchronizationQueueImpl extends SynchronizationQueue {
         } else {
             // Give it some time, so other possible actions can be queued.
             builder.setInitialDelay(20L, TimeUnit.SECONDS);
-            EventBus.getDefault().postSticky(new SyncServiceEvent(R.string.sync_status_started));
+            int status = !allowMobileSync && NetworkUtils.isNetworkRestricted()
+                    ? R.string.sync_status_wait_for_wifi
+                    : R.string.sync_status_started;
+            EventBus.getDefault().postSticky(new SyncServiceEvent(status));
         }
         return builder;
     }

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -655,6 +655,7 @@
     <string name="sync_status_upload_played">Uploading played status…</string>
     <string name="sync_status_subscriptions">Synchronizing subscriptions…</string>
     <string name="sync_status_wait_for_downloads">Waiting for subscriptions refresh…</string>
+    <string name="sync_status_wait_for_wifi">Waiting for Wi-Fi to sync subscriptions…</string>
     <string name="sync_status_success">Synchronization successful</string>
     <string name="sync_status_error">Synchronization failed</string>
 


### PR DESCRIPTION
### Description

When allow-mobile-sync is off and the device is on a restricted/mobile network, show a "Waiting for Wi-Fi to sync subscriptions…" status instead of implying sync already started while WorkManager is waiting for unmetered connectivity.

Closes: #6458

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
