### PR TITLE
Improve synchronisation set-up UX

### DIFF
--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -744,6 +744,8 @@
     <string name="synchronization_choose_title">Choose synchronization provider</string>
     <string name="synchronization_summary_unchoosen">You can choose from multiple providers to synchronize your subscriptions and episode play state with</string>
     <string name="dialog_choose_sync_service_title">Choose synchronization provider</string>
+    <string name="synchronization_provider_chooser_explanation">Devices need a central server to synchronize. AntennaPod does not offer such central synchronization server, but allows you to connect with the different types of servers listed below.</string>
+    <string name="more_information_label">More information</string>
     <string name="gpodnet_description">Gpodder.net is an open-source podcast synchronization service that you can install on your own server. Gpodder.net is independent of the AntennaPod project.</string>
     <string name="synchronization_summary_nextcloud">Gpodder Sync is an open-source Nextcloud app that you can easily install on your own server. Gpodder Sync is independent of the AntennaPod project.</string>
     <string name="synchronization_host_explanation">You can pick your own server to synchronize with. When you have identified your preferred synchronization server, please enter its address here.</string>

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/GpodderAuthenticationFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/GpodderAuthenticationFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import android.widget.ViewFlipper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.fragment.app.DialogFragment;
 import com.google.android.material.button.MaterialButton;
@@ -42,6 +43,7 @@ public class GpodderAuthenticationFragment extends DialogFragment {
     public static final String TAG = "GpodnetAuthActivity";
 
     private ViewFlipper viewFlipper;
+    private Button backButton;
 
     private static final int STEP_DEFAULT = -1;
     private static final int STEP_HOSTNAME = 0;
@@ -63,6 +65,7 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         MaterialAlertDialogBuilder dialog = new MaterialAlertDialogBuilder(getContext());
         dialog.setTitle(R.string.gpodnetauth_login_butLabel);
         dialog.setNegativeButton(R.string.cancel_label, null);
+        dialog.setNeutralButton(R.string.enqueue_location_back, null);
         dialog.setCancelable(false);
         this.setCancelable(false);
 
@@ -71,7 +74,13 @@ public class GpodderAuthenticationFragment extends DialogFragment {
         advance();
         dialog.setView(root);
 
-        return dialog.create();
+        AlertDialog alertDialog = dialog.create();
+        alertDialog.setOnShowListener(dialogInterface -> {
+            backButton = alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL);
+            backButton.setOnClickListener(view -> showPreviousStep());
+            updateBackButtonVisibility();
+        });
+        return alertDialog;
     }
 
     private void setupHostView(View view) {
@@ -264,8 +273,25 @@ public class GpodderAuthenticationFragment extends DialogFragment {
                 viewFlipper.showNext();
             }
             currentStep++;
+            updateBackButtonVisibility();
         } else {
             dismiss();
+        }
+    }
+
+    private void showPreviousStep() {
+        if (currentStep <= STEP_HOSTNAME || currentStep >= STEP_FINISH) {
+            return;
+        }
+        currentStep--;
+        viewFlipper.showPrevious();
+        updateBackButtonVisibility();
+    }
+
+    private void updateBackButtonVisibility() {
+        if (backButton != null) {
+            backButton.setVisibility(currentStep > STEP_HOSTNAME && currentStep < STEP_FINISH
+                    ? View.VISIBLE : View.GONE);
         }
     }
 

--- a/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
+++ b/ui/preferences/src/main/java/de/danoeh/antennapod/ui/preferences/screen/synchronization/SynchronizationPreferencesFragment.java
@@ -23,17 +23,26 @@ import com.google.android.material.snackbar.Snackbar;
 
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationProvider;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
+import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.ui.preferences.R;
 import de.danoeh.antennapod.ui.preferences.screen.AnimatedPreferenceFragment;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.Locale;
+import java.util.Set;
+
 import de.danoeh.antennapod.event.SyncServiceEvent;
 import de.danoeh.antennapod.storage.preferences.SynchronizationCredentials;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
 
 public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragment {
+    private static final String ANTENNAPOD_WEBSITE = "https://antennapod.org";
+    private static final String SYNC_HELP_PATH = "/s/sync-help";
+    private static final Set<String> WEBSITE_LANGUAGES = Set.of(
+            "ca", "da", "de", "es", "fa", "fr", "gl", "it", "ja", "nb_NO", "nl", "tr");
+
     private static final String PREFERENCE_SYNCHRONIZATION_DESCRIPTION = "preference_synchronization_description";
     private static final String PREFERENCE_GPODNET_SETLOGIN_INFORMATION = "pref_gpodnet_setlogin_information";
     private static final String PREFERENCE_SYNC = "pref_synchronization_sync";
@@ -161,6 +170,10 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
     private void chooseProviderAndLogin() {
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(getContext());
         builder.setTitle(R.string.dialog_choose_sync_service_title);
+        View header = View.inflate(getContext(), R.layout.dialog_sync_provider_chooser_header, null);
+        header.findViewById(R.id.syncHelpLink).setOnClickListener(v ->
+                IntentUtils.openInBrowser(getContext(), getLocalizedWebsiteLink(SYNC_HELP_PATH)));
+        builder.setView(header);
 
         SynchronizationProvider[] providers = SynchronizationProvider.values();
         ListAdapter adapter = new ArrayAdapter<>(getContext(), R.layout.alertdialog_sync_provider_chooser, providers) {
@@ -207,6 +220,17 @@ public class SynchronizationPreferencesFragment extends AnimatedPreferenceFragme
         });
 
         builder.show();
+    }
+
+    private String getLocalizedWebsiteLink(String path) {
+        String deviceLanguage = Locale.getDefault().getLanguage();
+        if ("nb".equals(deviceLanguage)) {
+            deviceLanguage = "nb_NO";
+        }
+        if (WEBSITE_LANGUAGES.contains(deviceLanguage)) {
+            return ANTENNAPOD_WEBSITE + "/" + deviceLanguage + path;
+        }
+        return ANTENNAPOD_WEBSITE + path;
     }
 
     private boolean isProviderSelected(@NonNull SynchronizationProvider provider) {

--- a/ui/preferences/src/main/res/drawable/ic_open_in_new.xml
+++ b/ui/preferences/src/main/res/drawable/ic_open_in_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M14,3h7v7h-2V6.41l-9.83,9.83 -1.41,-1.41L17.59,5H14V3zM5,5h5v2H7v10h10v-3h2v5H5V5z" />
+</vector>

--- a/ui/preferences/src/main/res/layout/dialog_sync_provider_chooser_header.xml
+++ b/ui/preferences/src/main/res/layout/dialog_sync_provider_chooser_header.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/synchronization_provider_chooser_explanation" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/syncHelpLink"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:insetLeft="0dp"
+        android:insetRight="0dp"
+        android:minWidth="0dp"
+        android:text="@string/more_information_label"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        app:icon="@drawable/ic_open_in_new"
+        app:iconGravity="textEnd" />
+
+</LinearLayout>


### PR DESCRIPTION
### Description

Improves the synchronisation set-up UX so users can more clearly complete account setup and understand the next steps.

Closes: #6096

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
