### PR TITLE
Query auto-download candidates in database instead of loading all epi…

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
@@ -7,10 +7,8 @@ import android.os.BatteryManager;
 import android.util.Log;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
@@ -52,27 +50,18 @@ public class AutomaticDownloadAlgorithm {
                 Log.d(TAG, "Performing auto-dl of undownloaded episodes");
 
                 boolean globalAutoDownloadEnabled = UserPreferences.isEnableAutodownloadGlobal();
-                final List<FeedItem> newItems = DBReader.getAutoDownloadCandidates(globalAutoDownloadEnabled);
+                boolean autoDownloadQueueEnabled = UserPreferences.isEnableAutodownloadQueue();
+                final List<FeedItem> newItems = DBReader.getAutoDownloadCandidates(
+                        globalAutoDownloadEnabled, autoDownloadQueueEnabled);
                 final List<FeedItem> candidates = new ArrayList<>();
-                final Set<Long> candidateIds = new HashSet<>();
 
                 for (FeedItem newItem : newItems) {
                     FeedPreferences feedPrefs = newItem.getFeed().getPreferences();
-                    boolean shouldAdd = feedPrefs.isAutoDownload(globalAutoDownloadEnabled)
-                            && feedPrefs.getFilter().shouldAutoDownload(newItem)
-                            && candidateIds.add(newItem.getId());
+                    boolean shouldAdd = (autoDownloadQueueEnabled && newItem.isTagged(FeedItem.TAG_QUEUE))
+                            || (feedPrefs.isAutoDownload(globalAutoDownloadEnabled)
+                            && feedPrefs.getFilter().shouldAutoDownload(newItem));
                     if (shouldAdd) {
                         candidates.add(newItem);
-                    }
-                }
-
-                if (UserPreferences.isEnableAutodownloadQueue()) {
-                    final List<FeedItem> queue = DBReader.getQueue();
-                    for (FeedItem item : queue) {
-                        boolean notYetAdded = candidateIds.add(item.getId());
-                        if (notYetAdded) {
-                            candidates.add(item);
-                        }
                     }
                 }
 

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/autodownload/AutomaticDownloadAlgorithm.java
@@ -7,12 +7,13 @@ import android.os.BatteryManager;
 import android.util.Log;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
-import de.danoeh.antennapod.model.feed.FeedItemFilter;
-import de.danoeh.antennapod.model.feed.SortOrder;
 import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.storage.database.DBReader;
@@ -50,14 +51,17 @@ public class AutomaticDownloadAlgorithm {
 
                 Log.d(TAG, "Performing auto-dl of undownloaded episodes");
 
-                final List<FeedItem> newItems = DBReader.getEpisodes(0, Integer.MAX_VALUE,
-                        new FeedItemFilter(FeedItemFilter.NEW), SortOrder.DATE_NEW_OLD);
+                boolean globalAutoDownloadEnabled = UserPreferences.isEnableAutodownloadGlobal();
+                final List<FeedItem> newItems = DBReader.getAutoDownloadCandidates(globalAutoDownloadEnabled);
                 final List<FeedItem> candidates = new ArrayList<>();
+                final Set<Long> candidateIds = new HashSet<>();
+
                 for (FeedItem newItem : newItems) {
                     FeedPreferences feedPrefs = newItem.getFeed().getPreferences();
-                    if (feedPrefs.isAutoDownload(UserPreferences.isEnableAutodownloadGlobal())
-                            && !candidates.contains(newItem)
-                            && feedPrefs.getFilter().shouldAutoDownload(newItem)) {
+                    boolean shouldAdd = feedPrefs.isAutoDownload(globalAutoDownloadEnabled)
+                            && feedPrefs.getFilter().shouldAutoDownload(newItem)
+                            && candidateIds.add(newItem.getId());
+                    if (shouldAdd) {
                         candidates.add(newItem);
                     }
                 }
@@ -65,7 +69,8 @@ public class AutomaticDownloadAlgorithm {
                 if (UserPreferences.isEnableAutodownloadQueue()) {
                     final List<FeedItem> queue = DBReader.getQueue();
                     for (FeedItem item : queue) {
-                        if (!candidates.contains(item)) {
+                        boolean notYetAdded = candidateIds.add(item.getId());
+                        if (notYetAdded) {
                             candidates.add(item);
                         }
                     }

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -345,7 +345,9 @@ public class DbReaderTest {
                 feed.getItems().get(0).setNew();
                 adapter.setCompleteFeed(feed);
             }
-            adapter.setQueue(Arrays.asList(feeds.get(0).getItems().get(0), feeds.get(2).getItems().get(0)));
+            adapter.setQueue(Arrays.asList(feeds.get(0).getItems().get(0), feeds.get(2).getItems().get(0),
+                    feeds.get(3).getItems().get(0), feeds.get(4).getItems().get(0),
+                    feeds.get(5).getItems().get(0), noMediaFeed.getItems().get(0)));
             adapter.close();
 
             List<FeedItem> candidates = DBReader.getAutoDownloadCandidates(false, false);

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -18,7 +18,9 @@ import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedItemFilter;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.feed.FeedOrder;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
 import de.danoeh.antennapod.model.feed.SortOrder;
+import de.danoeh.antennapod.model.feed.VolumeAdaptionSetting;
 import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.storage.database.NavDrawerData;
@@ -311,6 +313,52 @@ public class DbReaderTest {
                 }
                 assertTrue(found);
             }
+        }
+
+        @Test
+        public void testGetAutoDownloadCandidates() {
+            List<Feed> feeds = saveFeedlist(7, 1, true);
+            Feed noMediaFeed = saveFeedlist(1, 1, false).get(0);
+            feeds.add(noMediaFeed);
+            for (Feed feed : feeds) {
+                feed.setPreferences(new FeedPreferences(feed.getId(), FeedPreferences.AutoDownloadSetting.GLOBAL,
+                        FeedPreferences.AutoDeleteAction.GLOBAL, VolumeAdaptionSetting.OFF,
+                        FeedPreferences.NewEpisodesAction.GLOBAL, null, null));
+            }
+
+            feeds.get(0).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.ENABLED);
+            feeds.get(1).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.GLOBAL);
+            feeds.get(2).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.DISABLED);
+            feeds.get(3).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.ENABLED);
+            feeds.get(3).getItems().get(0).getMedia().setDownloaded(true, System.currentTimeMillis());
+            feeds.get(4).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.ENABLED);
+            feeds.get(4).getItems().get(0).disableAutoDownload();
+            feeds.get(5).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.ENABLED);
+            feeds.get(5).setDownloadUrl(Feed.PREFIX_LOCAL_FOLDER + "test");
+            feeds.get(6).getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.ENABLED);
+            feeds.get(6).setState(Feed.STATE_ARCHIVED);
+            noMediaFeed.getPreferences().setAutoDownload(FeedPreferences.AutoDownloadSetting.ENABLED);
+
+            PodDBAdapter adapter = PodDBAdapter.getInstance();
+            adapter.open();
+            for (Feed feed : feeds) {
+                feed.getItems().get(0).setNew();
+                adapter.setCompleteFeed(feed);
+            }
+            adapter.close();
+
+            List<FeedItem> candidates = DBReader.getAutoDownloadCandidates(false);
+            assertEquals(1, candidates.size());
+            assertEquals(feeds.get(0).getItems().get(0).getId(), candidates.get(0).getId());
+
+            candidates = DBReader.getAutoDownloadCandidates(true);
+            assertEquals(2, candidates.size());
+            List<Long> candidateIds = new ArrayList<>();
+            for (FeedItem candidate : candidates) {
+                candidateIds.add(candidate.getId());
+            }
+            assertTrue(candidateIds.contains(feeds.get(0).getItems().get(0).getId()));
+            assertTrue(candidateIds.contains(feeds.get(1).getItems().get(0).getId()));
         }
 
         @Test

--- a/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
+++ b/net/download/service/src/test/java/de/danoeh/antennapod/net/download/service/episode/autodownload/DbReaderTest.java
@@ -345,13 +345,14 @@ public class DbReaderTest {
                 feed.getItems().get(0).setNew();
                 adapter.setCompleteFeed(feed);
             }
+            adapter.setQueue(Arrays.asList(feeds.get(0).getItems().get(0), feeds.get(2).getItems().get(0)));
             adapter.close();
 
-            List<FeedItem> candidates = DBReader.getAutoDownloadCandidates(false);
+            List<FeedItem> candidates = DBReader.getAutoDownloadCandidates(false, false);
             assertEquals(1, candidates.size());
             assertEquals(feeds.get(0).getItems().get(0).getId(), candidates.get(0).getId());
 
-            candidates = DBReader.getAutoDownloadCandidates(true);
+            candidates = DBReader.getAutoDownloadCandidates(true, false);
             assertEquals(2, candidates.size());
             List<Long> candidateIds = new ArrayList<>();
             for (FeedItem candidate : candidates) {
@@ -359,6 +360,15 @@ public class DbReaderTest {
             }
             assertTrue(candidateIds.contains(feeds.get(0).getItems().get(0).getId()));
             assertTrue(candidateIds.contains(feeds.get(1).getItems().get(0).getId()));
+
+            candidates = DBReader.getAutoDownloadCandidates(false, true);
+            assertEquals(2, candidates.size());
+            candidateIds.clear();
+            for (FeedItem candidate : candidates) {
+                candidateIds.add(candidate.getId());
+            }
+            assertTrue(candidateIds.contains(feeds.get(0).getItems().get(0).getId()));
+            assertTrue(candidateIds.contains(feeds.get(2).getItems().get(0).getId()));
         }
 
         @Test

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -235,19 +235,21 @@ public final class DBReader {
     }
 
     /**
-     * Loads new, undownloaded episodes that are eligible for automatic download, newest first.
+     * Loads episodes that are eligible for automatic download, newest first.
      * This should be preferred over loading all new episodes and filtering them in Java.
      *
      * @param globalAutoDownloadEnabled Whether automatic download is enabled in the global settings.
+     * @param includeQueue Whether episodes in the queue should be included.
      * @return A list of FeedItems that are candidates for automatic download.
      *         The Feed-attribute of the FeedItems will already be set correctly.
      */
     @NonNull
-    public static synchronized List<FeedItem> getAutoDownloadCandidates(boolean globalAutoDownloadEnabled) {
+    public static synchronized List<FeedItem> getAutoDownloadCandidates(boolean globalAutoDownloadEnabled,
+                                                                         boolean includeQueue) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();
         try (FeedItemCursor cursor = new FeedItemCursor(
-                adapter.getAutoDownloadCandidatesCursor(globalAutoDownloadEnabled))) {
+                adapter.getAutoDownloadCandidatesCursor(globalAutoDownloadEnabled, includeQueue))) {
             List<FeedItem> items = extractItemlistFromCursor(cursor);
             if (!items.isEmpty()) {
                 loadFeedDataOfFeedItemList(items);

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBReader.java
@@ -234,6 +234,30 @@ public final class DBReader {
         }
     }
 
+    /**
+     * Loads new, undownloaded episodes that are eligible for automatic download, newest first.
+     * This should be preferred over loading all new episodes and filtering them in Java.
+     *
+     * @param globalAutoDownloadEnabled Whether automatic download is enabled in the global settings.
+     * @return A list of FeedItems that are candidates for automatic download.
+     *         The Feed-attribute of the FeedItems will already be set correctly.
+     */
+    @NonNull
+    public static synchronized List<FeedItem> getAutoDownloadCandidates(boolean globalAutoDownloadEnabled) {
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        try (FeedItemCursor cursor = new FeedItemCursor(
+                adapter.getAutoDownloadCandidatesCursor(globalAutoDownloadEnabled))) {
+            List<FeedItem> items = extractItemlistFromCursor(cursor);
+            if (!items.isEmpty()) {
+                loadFeedDataOfFeedItemList(items);
+            }
+            return items;
+        } finally {
+            adapter.close();
+        }
+    }
+
     public static synchronized int getTotalEpisodeCount(FeedItemFilter filter) {
         PodDBAdapter adapter = PodDBAdapter.getInstance();
         adapter.open();

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1132,16 +1132,19 @@ public class PodDBAdapter {
         String feedHasAutoDownload = TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
                 + " IN (SELECT " + KEY_ID + " FROM " + TABLE_NAME_FEEDS
                 + " WHERE " + KEY_STATE + "=" + Feed.STATE_SUBSCRIBED
-                + " AND (" + KEY_DOWNLOAD_URL + " IS NULL OR " + KEY_DOWNLOAD_URL
-                + " NOT LIKE '" + Feed.PREFIX_LOCAL_FOLDER + "%')"
                 + " AND " + KEY_AUTO_DOWNLOAD_ENABLED + feedAutoDownloadCondition + ")";
+        String feedIsNotLocal = TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
+                + " IN (SELECT " + KEY_ID + " FROM " + TABLE_NAME_FEEDS
+                + " WHERE " + KEY_DOWNLOAD_URL + " IS NULL OR " + KEY_DOWNLOAD_URL
+                + " NOT LIKE '" + Feed.PREFIX_LOCAL_FOLDER + "%')";
         String queueCondition = includeQueue ? " OR " + SELECT_KEY_IS_IN_QUEUE : "";
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
-                + " WHERE (" + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW
-                + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD_ENABLED + "!=0"
+                + " WHERE " + TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD_ENABLED + "!=0"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_ID + " IS NOT NULL"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + "=0"
-                + " AND " + feedHasAutoDownload + queueCondition + ")"
+                + " AND " + feedIsNotLocal
+                + " AND ((" + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW
+                + " AND " + feedHasAutoDownload + ")" + queueCondition + ")"
                 + " ORDER BY " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " DESC";
         return db.rawQuery(query, null);
     }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1125,6 +1125,25 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
+    public final Cursor getAutoDownloadCandidatesCursor(boolean globalAutoDownloadEnabled) {
+        String feedAutoDownloadCondition = globalAutoDownloadEnabled
+                ? "!=" + FeedPreferences.AutoDownloadSetting.DISABLED.code
+                : "=" + FeedPreferences.AutoDownloadSetting.ENABLED.code;
+        final String query = SELECT_FEED_ITEMS_AND_MEDIA
+                + " WHERE " + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW
+                + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD_ENABLED + "!=0"
+                + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_ID + " IS NOT NULL"
+                + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + "=0"
+                + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
+                + " IN (SELECT " + KEY_ID + " FROM " + TABLE_NAME_FEEDS
+                + " WHERE " + KEY_STATE + "=" + Feed.STATE_SUBSCRIBED
+                + " AND (" + KEY_DOWNLOAD_URL + " IS NULL OR " + KEY_DOWNLOAD_URL
+                + " NOT LIKE '" + Feed.PREFIX_LOCAL_FOLDER + "%')"
+                + " AND " + KEY_AUTO_DOWNLOAD_ENABLED + feedAutoDownloadCondition + ")"
+                + " ORDER BY " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " DESC";
+        return db.rawQuery(query, null);
+    }
+
     public final Cursor getEpisodeCountCursor(FeedItemFilter filter) {
         String filterQuery = FeedItemFilterQuery.generateFrom(filter);
         String whereClause = "".equals(filterQuery) ? "" : " WHERE " + filterQuery;

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1129,17 +1129,18 @@ public class PodDBAdapter {
         String feedAutoDownloadCondition = globalAutoDownloadEnabled
                 ? "!=" + FeedPreferences.AutoDownloadSetting.DISABLED.code
                 : "=" + FeedPreferences.AutoDownloadSetting.ENABLED.code;
+        String feedHasAutoDownload = TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
+                + " IN (SELECT " + KEY_ID + " FROM " + TABLE_NAME_FEEDS
+                + " WHERE " + KEY_STATE + "=" + Feed.STATE_SUBSCRIBED
+                + " AND (" + KEY_DOWNLOAD_URL + " IS NULL OR " + KEY_DOWNLOAD_URL
+                + " NOT LIKE '" + Feed.PREFIX_LOCAL_FOLDER + "%')"
+                + " AND " + KEY_AUTO_DOWNLOAD_ENABLED + feedAutoDownloadCondition + ")";
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
                 + " WHERE " + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW
                 + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD_ENABLED + "!=0"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_ID + " IS NOT NULL"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + "=0"
-                + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_FEED
-                + " IN (SELECT " + KEY_ID + " FROM " + TABLE_NAME_FEEDS
-                + " WHERE " + KEY_STATE + "=" + Feed.STATE_SUBSCRIBED
-                + " AND (" + KEY_DOWNLOAD_URL + " IS NULL OR " + KEY_DOWNLOAD_URL
-                + " NOT LIKE '" + Feed.PREFIX_LOCAL_FOLDER + "%')"
-                + " AND " + KEY_AUTO_DOWNLOAD_ENABLED + feedAutoDownloadCondition + ")"
+                + " AND " + feedHasAutoDownload
                 + " ORDER BY " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " DESC";
         return db.rawQuery(query, null);
     }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -1125,7 +1125,7 @@ public class PodDBAdapter {
         return db.rawQuery(query, null);
     }
 
-    public final Cursor getAutoDownloadCandidatesCursor(boolean globalAutoDownloadEnabled) {
+    public final Cursor getAutoDownloadCandidatesCursor(boolean globalAutoDownloadEnabled, boolean includeQueue) {
         String feedAutoDownloadCondition = globalAutoDownloadEnabled
                 ? "!=" + FeedPreferences.AutoDownloadSetting.DISABLED.code
                 : "=" + FeedPreferences.AutoDownloadSetting.ENABLED.code;
@@ -1135,12 +1135,13 @@ public class PodDBAdapter {
                 + " AND (" + KEY_DOWNLOAD_URL + " IS NULL OR " + KEY_DOWNLOAD_URL
                 + " NOT LIKE '" + Feed.PREFIX_LOCAL_FOLDER + "%')"
                 + " AND " + KEY_AUTO_DOWNLOAD_ENABLED + feedAutoDownloadCondition + ")";
+        String queueCondition = includeQueue ? " OR " + SELECT_KEY_IS_IN_QUEUE : "";
         final String query = SELECT_FEED_ITEMS_AND_MEDIA
-                + " WHERE " + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW
+                + " WHERE (" + TABLE_NAME_FEED_ITEMS + "." + KEY_READ + "=" + FeedItem.NEW
                 + " AND " + TABLE_NAME_FEED_ITEMS + "." + KEY_AUTO_DOWNLOAD_ENABLED + "!=0"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_ID + " IS NOT NULL"
                 + " AND " + TABLE_NAME_FEED_MEDIA + "." + KEY_DOWNLOAD_DATE + "=0"
-                + " AND " + feedHasAutoDownload
+                + " AND " + feedHasAutoDownload + queueCondition + ")"
                 + " ORDER BY " + TABLE_NAME_FEED_ITEMS + "." + KEY_PUBDATE + " DESC";
         return db.rawQuery(query, null);
     }


### PR DESCRIPTION
Hallo everybody, 

thanks a lot for the great app, big fan for years!

### Description

The automatic download check loaded all new episodes into memory before filtering them by feed and episode settings, blocking all database access (e.g. queue loading) for seconds on large libraries, even when automatic download was globally disabled.

This moves the eligibility filtering (feed auto-download setting, read state, download state, media presence, feed state, local feeds) into a dedicated database query that only returns actual candidates, and replaces the quadratic list deduplication with an ID-based set lookup. 
The remaining Java-side filters (per-feed episode filter and the existing safety checks) are kept unchanged, so the set of downloaded episodes is identical to before.

Measured on a `~33,000` episode library: queue load during the check drops from `~2.28 s` to `~31 ms` when automatic download is disabled (zero-row result).

Closes #8655

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] ~If it is a core feature, I have added automated tests~
