### PR TITLE
Fix seek played duration

### DIFF
--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -412,7 +412,10 @@ public class FeedMedia implements Playable {
         startPosition = Math.max(position, 0);
         playedDurationWhenStarted = playedDuration;
     }
-
+    public void resetPlayedDurationBaseline() {
+        startPosition = Math.max(position, 0);
+        playedDurationWhenStarted = playedDuration;
+    }
     @Override
     public int getPlayableType() {
         return PLAYABLE_TYPE_FEEDMEDIA;

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedMedia.java
@@ -412,10 +412,12 @@ public class FeedMedia implements Playable {
         startPosition = Math.max(position, 0);
         playedDurationWhenStarted = playedDuration;
     }
+
     public void resetPlayedDurationBaseline() {
         startPosition = Math.max(position, 0);
         playedDurationWhenStarted = playedDuration;
     }
+
     @Override
     public int getPlayableType() {
         return PLAYABLE_TYPE_FEEDMEDIA;

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -185,6 +185,12 @@ public class Media3PlaybackService extends MediaLibraryService {
             @Override
             public void seekTo(long positionMs) {
                 super.seekTo(positionMs);
+
+                if (currentPlayable != null) {
+                    currentPlayable.setPosition((int) positionMs);
+                    currentPlayable.resetPlayedDurationBaseline();
+                }
+
                 EventBus.getDefault().post(
                         new PlaybackPositionEvent((int) positionMs, (int) player.getDuration()));
             }


### PR DESCRIPTION
### Description

Fixes an issue where seeking forward incorrectly increases the recorded played duration.

When playback starts, the current playback position and played duration are stored as the baseline. When the user seeks to a different position, this baseline is reset so that the skipped portion is not incorrectly counted as played time.

### Testing

- Verified that seeking forward does not increase played duration by the skipped interval.
- Verified that normal playback time continues to be added to played duration.
- Ran `./gradlew checkstyle lint` successfully.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
