### PR TITLE
Fix auto-skip ending not triggering when silence skip jumps past threshold

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/SkipUtils.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/SkipUtils.java
@@ -52,10 +52,11 @@ public final class SkipUtils {
         FeedPreferences preferences = media.getItem().getFeed().getPreferences();
         int skipEnd = preferences.getFeedSkipEnding();
         long remainingTime = duration - position;
+        long skipEndMs = skipEnd * 1000L;
         if (skipEnd > 0
-                && skipEnd * 1000L < duration
-                && (remainingTime - (skipEnd * 1000L) > 0)
-                && ((remainingTime - skipEnd * 1000L) < (speed * 1000))) {
+                && skipEndMs < duration
+                && remainingTime > 0
+                && remainingTime <= skipEndMs + (long) (speed * 1000)) {
             Log.d(TAG, "skipEndingIfNecessary: Skipping remaining " + (duration - position));
             EventBus.getDefault().post(
                     new MessageEvent(

--- a/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/SkipUtilsTest.java
+++ b/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/SkipUtilsTest.java
@@ -1,0 +1,123 @@
+package de.danoeh.antennapod.playback.service.internal;
+
+import android.content.Context;
+import de.danoeh.antennapod.model.feed.Feed;
+import de.danoeh.antennapod.model.feed.FeedItem;
+import de.danoeh.antennapod.model.feed.FeedMedia;
+import de.danoeh.antennapod.model.feed.FeedPreferences;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class SkipUtilsTest {
+
+    private static final long DURATION_MS = 30 * 60 * 1000L;
+    private static final int SKIP_ENDING_SECONDS = 30;
+    private static final float SPEED_NORMAL = 1.0f;
+
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+    }
+
+    private FeedMedia createFeedMediaWithSkipEnding(int skipEndingSeconds) {
+        FeedPreferences prefs = mock(FeedPreferences.class);
+        when(prefs.getFeedSkipEnding()).thenReturn(skipEndingSeconds);
+
+        Feed feed = mock(Feed.class);
+        when(feed.getPreferences()).thenReturn(prefs);
+
+        FeedItem item = mock(FeedItem.class);
+        when(item.getFeed()).thenReturn(feed);
+
+        FeedMedia media = mock(FeedMedia.class);
+        when(media.getItem()).thenReturn(item);
+
+        return media;
+    }
+
+    @Test
+    public void testNormalPlayback_triggersSkipInWindow() {
+        FeedMedia media = createFeedMediaWithSkipEnding(SKIP_ENDING_SECONDS);
+        long skipPointMs = DURATION_MS - SKIP_ENDING_SECONDS * 1000L;
+        long position = skipPointMs - 500;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, position, DURATION_MS, SPEED_NORMAL);
+        assertTrue("Should skip when position is within the normal trigger window", result);
+    }
+
+    @Test
+    public void testNormalPlayback_triggersSkipJustPastThreshold() {
+        FeedMedia media = createFeedMediaWithSkipEnding(SKIP_ENDING_SECONDS);
+        long skipPointMs = DURATION_MS - SKIP_ENDING_SECONDS * 1000L;
+        long position = skipPointMs + 100;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, position, DURATION_MS, SPEED_NORMAL);
+        assertTrue("Should skip when position just crosses past skip threshold", result);
+    }
+
+    @Test
+    public void testNormalPlayback_doesNotTriggerBeforeWindow() {
+        FeedMedia media = createFeedMediaWithSkipEnding(SKIP_ENDING_SECONDS);
+        long skipPointMs = DURATION_MS - SKIP_ENDING_SECONDS * 1000L;
+        long position = skipPointMs - 2000;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, position, DURATION_MS, SPEED_NORMAL);
+        assertFalse("Should not skip when well before skip threshold", result);
+    }
+
+    @Test
+    public void testSilenceSkip_jumpsIntoSkipZone() {
+        FeedMedia media = createFeedMediaWithSkipEnding(SKIP_ENDING_SECONDS);
+        long position = DURATION_MS - 15_000L;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, position, DURATION_MS, SPEED_NORMAL);
+        assertTrue("Should skip when silence-skip jumps position into the skip zone", result);
+    }
+
+    @Test
+    public void testNoSkipWhenDisabled() {
+        FeedMedia media = createFeedMediaWithSkipEnding(0);
+        long position = DURATION_MS - 15_000L;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, position, DURATION_MS, SPEED_NORMAL);
+        assertFalse("Should not skip when skip ending is disabled", result);
+    }
+
+    @Test
+    public void testNoSkipWhenSkipEndExceedsDuration() {
+        FeedMedia media = createFeedMediaWithSkipEnding(60);
+        long shortDuration = 30_000L;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, 20_000L, shortDuration, SPEED_NORMAL);
+        assertFalse("Should not skip when skip ending exceeds episode duration", result);
+    }
+
+    @Test
+    public void testNoSkipWhenAtExactEnd() {
+        FeedMedia media = createFeedMediaWithSkipEnding(SKIP_ENDING_SECONDS);
+        long position = DURATION_MS;
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, position, DURATION_MS, SPEED_NORMAL);
+        assertFalse("Should not skip when already at the exact end", result);
+    }
+
+    @Test
+    public void testNoSkipWhenNullFeedInfo() {
+        FeedMedia media = mock(FeedMedia.class);
+        when(media.getItem()).thenReturn(null);
+
+        boolean result = SkipUtils.skipEndingIfNecessary(context, media, DURATION_MS - 15_000L, DURATION_MS, SPEED_NORMAL);
+        assertFalse("Should not skip when feed info is null", result);
+    }
+}


### PR DESCRIPTION
Closes: #6805

### Description

When both "Skip Silence" and "Auto Skip End" are enabled, silence-skipping can jump the playback position past the narrow trigger window for auto-skip-end, causing it to never fire.

The old condition required remaining time to fall within `(skipEnd*1000, skipEnd*1000 + speed*1000)` — a ~1-second window *above* the skip threshold. When silence-skip jumped the position directly into the skip zone (remaining < skipEnd), the condition `(remainingTime - skipEnd*1000) > 0` was false and auto-skip never triggered.

The fix widens the trigger range to `(0, skipEndMs + speed*1000]`, covering both the normal approach window and positions that have already entered the skip zone.

**Testing with audio files:**
Two test MP3 files are attached (2 minutes each, auto-skip-end = 15 seconds):
- `test_failure_case.mp3` — Silence from 1:40–1:52 spans the skip threshold (1:45). Skip-silence jumps into the skip zone; with the fix, auto-skip fires immediately.
- `test_success_case.mp3` — Silence at 0:50–0:55, far from the skip zone. Normal playback hits the threshold at 1:45 as expected. Control case.

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests