### PR TITLE
Re-implement 'skip' button remapping

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -219,17 +219,34 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                 return true;
             } else if (!fromWidget && keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
                 // Media3 translates HEADSETHOOK double-tap to MEDIA_NEXT.
-                // Instead of skipping to the next episode, do a fast-forward.
-                session.getPlayer().seekForward();
+                performHardwareButtonAction(session.getPlayer(), UserPreferences.getHardwareForwardButton());
                 return true;
             } else if (!fromWidget && keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS) {
                 // Media3 translates HEADSETHOOK triple-tap to MEDIA_PREVIOUS.
-                // Instead of going to the previous episode, do a rewind.
-                session.getPlayer().seekBack();
+                performHardwareButtonAction(session.getPlayer(), UserPreferences.getHardwarePreviousButton());
                 return true;
             }
         }
         return false;
+    }
+
+    @UnstableApi
+    private void performHardwareButtonAction(Player player, int action) {
+        switch (action) {
+            case KeyEvent.KEYCODE_MEDIA_NEXT:
+                player.seekToNextMediaItem();
+                break;
+            case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+                player.seekTo(0);
+                break;
+            case KeyEvent.KEYCODE_MEDIA_REWIND:
+                player.seekBack();
+                break;
+            case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+            default:
+                player.seekForward();
+                break;
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description

The new playback service never called getHardwareForwardButton. Re-implement 'skip' button remapping.
Closes #8607

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
