### PR TITLE
Fix widget play button

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ project.ext {
     coreVersion = "1.16.0"
     fragmentVersion = "1.8.9"
     mediaVersion = "1.6.0"
-    media3Version = "1.9.0"
+    media3Version = "1.10.0"
     paletteVersion = "1.0.0"
     preferenceVersion = "1.2.1"
     recyclerViewVersion = "1.4.0"

--- a/ui/app-start-intent/build.gradle
+++ b/ui/app-start-intent/build.gradle
@@ -9,4 +9,6 @@ android {
 
 dependencies {
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    implementation "androidx.media3:media3-common:$media3Version"
+    implementation "androidx.media3:media3-session:$media3Version"
 }

--- a/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MediaButtonStarter.java
+++ b/ui/app-start-intent/src/main/java/de/danoeh/antennapod/ui/appstartintent/MediaButtonStarter.java
@@ -1,10 +1,16 @@
 package de.danoeh.antennapod.ui.appstartintent;
 
 import android.app.PendingIntent;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.view.KeyEvent;
+
+import androidx.annotation.OptIn;
+import androidx.media3.common.Player;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.session.MediaSessionService;
+import androidx.media3.session.PlaybackPendingIntentBuilder;
 
 public abstract class MediaButtonStarter {
     private static final String INTENT = "de.danoeh.antennapod.NOTIFY_BUTTON_RECEIVER";
@@ -22,14 +28,22 @@ public abstract class MediaButtonStarter {
         return startingIntent;
     }
 
-    public static PendingIntent createPendingIntent(Context context, int eventCode) {
-        if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-            Intent intent = createIntent(context, eventCode)
-                    .setComponent(new ComponentName(context, MEDIA3_PLAYBACK_SERVICE))
-                    .putExtra(EXTRA_MEDIA_BUTTON_SOURCE, MEDIA_BUTTON_SOURCE_WIDGET);
-            return PendingIntent.getService(context, eventCode, intent, PendingIntent.FLAG_IMMUTABLE);
+    @OptIn(markerClass = UnstableApi.class)
+    public static PendingIntent createPendingIntent(Context context, @Player.Command int command) {
+        Bundle extras = new Bundle();
+        extras.putString(EXTRA_MEDIA_BUTTON_SOURCE, MEDIA_BUTTON_SOURCE_WIDGET);
+        return new PlaybackPendingIntentBuilder(context, command, getMedia3ServiceClass())
+                .setStartAsForegroundService(command == Player.COMMAND_PLAY_PAUSE)
+                .setExtras(extras)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends MediaSessionService> getMedia3ServiceClass() {
+        try {
+            return (Class<? extends MediaSessionService>) Class.forName(MEDIA3_PLAYBACK_SERVICE);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
         }
-        return PendingIntent.getBroadcast(context, eventCode, createIntent(context, eventCode),
-                PendingIntent.FLAG_IMMUTABLE);
     }
 }

--- a/ui/widget/build.gradle
+++ b/ui/widget/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':ui:glide')
 
     annotationProcessor "androidx.annotation:annotation:$annotationVersion"
+    implementation "androidx.media3:media3-common:$media3Version"
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "androidx.work:work-runtime:$workManagerVersion"
     implementation "com.github.bumptech.glide:glide:$glideVersion"

--- a/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
+++ b/ui/widget/src/main/java/de/danoeh/antennapod/ui/widget/WidgetUpdater.java
@@ -8,9 +8,10 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.widget.RemoteViews;
+
+import androidx.media3.common.Player;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.Transformation;
@@ -107,21 +108,21 @@ public abstract class WidgetUpdater {
                 views.setContentDescription(R.id.butPlayExtended, context.getString(R.string.play_label));
             }
             views.setOnClickPendingIntent(R.id.butPlay,
-                    MediaButtonStarter.createPendingIntent(context, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE));
+                    MediaButtonStarter.createPendingIntent(context, Player.COMMAND_PLAY_PAUSE));
             views.setOnClickPendingIntent(R.id.butPlayExtended,
-                    MediaButtonStarter.createPendingIntent(context, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE));
+                    MediaButtonStarter.createPendingIntent(context, Player.COMMAND_PLAY_PAUSE));
             views.setOnClickPendingIntent(R.id.butRew,
-                    MediaButtonStarter.createPendingIntent(context, KeyEvent.KEYCODE_MEDIA_REWIND));
+                    MediaButtonStarter.createPendingIntent(context, Player.COMMAND_SEEK_BACK));
             views.setOnClickPendingIntent(R.id.butFastForward,
-                    MediaButtonStarter.createPendingIntent(context, KeyEvent.KEYCODE_MEDIA_FAST_FORWARD));
+                    MediaButtonStarter.createPendingIntent(context, Player.COMMAND_SEEK_FORWARD));
             views.setOnClickPendingIntent(R.id.butSkip,
-                    MediaButtonStarter.createPendingIntent(context, KeyEvent.KEYCODE_MEDIA_NEXT));
+                    MediaButtonStarter.createPendingIntent(context, Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM));
         } else {
             // start the app if they click anything
             views.setOnClickPendingIntent(R.id.layout_left, startMediaPlayer);
             views.setOnClickPendingIntent(R.id.butPlay, startMediaPlayer);
             views.setOnClickPendingIntent(R.id.butPlayExtended,
-                    MediaButtonStarter.createPendingIntent(context, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE));
+                    MediaButtonStarter.createPendingIntent(context, Player.COMMAND_PLAY_PAUSE));
             views.setViewVisibility(R.id.txtvProgress, View.GONE);
             views.setViewVisibility(R.id.txtvTitle, View.GONE);
             views.setViewVisibility(R.id.txtNoPlaying, View.VISIBLE);


### PR DESCRIPTION
### Description

Fix widget play button. Media3 1.10 ships a new utility function `PlaybackPendingIntentBuilder` that can start playback from widgets. It is somewhat risky to bump the media3 version in a patch release, so we should likely start with a 3.12.1-beta1 version first.

Closes #8664

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
