### PR TITLE
Fix video/audio playback freeze from buffer size/duration mismatch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.1"
 kotlin = "2.3.20"
-media3 = "1.9.0"
+media3 = "1.11.0"
 wear-compose = "1.6.0"
 compose = "1.7.5"
 lifecycle-runtime-compose = "2.8.7"

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerUtils.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerUtils.java
@@ -53,8 +53,8 @@ public class ExoPlayerUtils {
         return new ExoPlayer.Builder(context)
                 .setLoadControl(new DefaultLoadControl.Builder()
                         .setBufferDurationsMs(
-                                (int) TimeUnit.MINUTES.toMillis(2),
-                                (int) TimeUnit.MINUTES.toMillis(10),
+                                (int) TimeUnit.HOURS.toMillis(1),
+                                (int) TimeUnit.HOURS.toMillis(3),
                                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
                                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS)
                         .setBackBuffer((int) TimeUnit.MINUTES.toMillis(5), true)

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerUtils.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ExoPlayerUtils.java
@@ -53,11 +53,12 @@ public class ExoPlayerUtils {
         return new ExoPlayer.Builder(context)
                 .setLoadControl(new DefaultLoadControl.Builder()
                         .setBufferDurationsMs(
-                                (int) TimeUnit.HOURS.toMillis(1),
-                                (int) TimeUnit.HOURS.toMillis(3),
+                                (int) TimeUnit.MINUTES.toMillis(2),
+                                (int) TimeUnit.MINUTES.toMillis(10),
                                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
                                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS)
                         .setBackBuffer((int) TimeUnit.MINUTES.toMillis(5), true)
+                        .setPrioritizeTimeOverSizeThresholds(true)
                         .build())
                 .setAudioAttributes(new AudioAttributes.Builder()
                         .setUsage(C.USAGE_MEDIA)


### PR DESCRIPTION
### Description

`DefaultLoadControl` was set with a 1-3h buffer duration target but no matching byte budget, so Media3's default byte-priority behavior caps loading almost immediately on higher-bitrate content, causing an infinite `PLAYING`/`BUFFERING` loop. `setPrioritizeTimeOverSizeThresholds(true)` makes the duration target authoritative; the target is also reduced from 1-3h to 2-10min so the now-honored target doesn't balloon memory usage.

Closes: #8673

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description
- [ ] If it is a core feature, I have added automated tests
