### PR TITLE
Apply milestone to closed issues as well

### DIFF
--- a/.github/workflows/assign-milestone.yml
+++ b/.github/workflows/assign-milestone.yml
@@ -65,3 +65,31 @@ jobs:
               issue_number: context.payload.pull_request.number,
               milestone: ${{ steps.get-milestone.outputs.result }},
             });
+
+      - name: Assign milestone to linked issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const query = `query ($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  closingIssuesReferences(first: 100) {
+                    nodes { number }
+                  }
+                }
+              }
+            }`;
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: context.payload.pull_request.number,
+            });
+            const issues = result.repository.pullRequest.closingIssuesReferences.nodes;
+            for (const issue of issues) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                milestone: ${{ steps.get-milestone.outputs.result }},
+              });
+            }


### PR DESCRIPTION
### Description

When closing a PR, we add a milestone with the next release to avoid people asking in every PR why the feature is not available yet. This works quite nicely. Now people started asking in the linked issues. Adapting the workflow to also apply the milestone to the closed issues.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
