### PR TITLE
Stop playback when Media3 task is removed

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -188,6 +188,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                 EventBus.getDefault().post(
                         new PlaybackPositionEvent((int) positionMs, (int) player.getDuration()));
             }
+
         };
         player.addListener(playerListener);
         mediaSession = new MediaLibraryService.MediaLibrarySession.Builder(this, player, sessionCallback)
@@ -197,6 +198,15 @@ public class Media3PlaybackService extends MediaLibraryService {
             keepServiceRunningWhileCasting();
             loadCurrentMediaWhileCasting();
         }
+    }
+
+    @Override
+    public void onTaskRemoved(Intent rootIntent) {
+        if (!isCasting() && player != null) {
+            player.pause();
+            player.stop();
+        }
+        super.onTaskRemoved(rootIntent);
     }
 
     private void loadCurrentMediaWhileCasting() {


### PR DESCRIPTION
### Description

When AntennaPod is swiped away from Recents while playing, `Media3PlaybackService` continues playback indefinitely because it does not handle task removal.

This adds an `onTaskRemoved()` override to `Media3PlaybackService` that stops playback when the app task is removed, unless a Cast session is active. It then delegates to the default `MediaSessionService` handling.

This matches the expected behavior of apps such as Spotify and allows AntennaPod to be fully closed from Recents without requiring playback to be paused first.

Closes: #8680

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why each line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (`Closes: #8680`) in the description
- [ ] If it is a core feature, I have added automated tests