### PR TITLE
Update media duration with player duration

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -550,6 +550,9 @@ public class Media3PlaybackService extends MediaLibraryService {
         } catch (NumberFormatException e) {
             return;
         }
+        if (player.isCurrentMediaItemSeekable() && player.getDuration() > 0) {
+            currentPlayable.setDuration((int) player.getDuration());
+        }
         long position = player.getCurrentPosition();
         long timestamp = System.currentTimeMillis();
         PlayableUtils.saveCurrentPosition(currentPlayable, (int) position, timestamp);


### PR DESCRIPTION
### Description

Update media duration with player duration. This helps when the feed does not specify a duration (or specifies a wrong one). The old service stored only when the feed had no duration. With more and more podcasts doing dynamic ad insertion changing the durations of episodes, we should just always store the duration (like it is done when downloading).

Closes #8617

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
