### PR TITLE
Disable repeat requests through media session

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -127,7 +127,19 @@ public class Media3PlaybackService extends MediaLibraryService {
                         .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
                         .remove(Player.COMMAND_SEEK_TO_PREVIOUS)
                         .remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                        .remove(Player.COMMAND_SET_REPEAT_MODE)
+                        .remove(Player.COMMAND_SET_SHUFFLE_MODE)
                         .build();
+            }
+
+            @Override
+            public void setRepeatMode(int repeatMode) {
+                // Ignored, some car stereos set this via Bluetooth, which would make episodes loop forever
+            }
+
+            @Override
+            public void setShuffleModeEnabled(boolean shuffleModeEnabled) {
+                // Ignored, some car stereos set this via Bluetooth
             }
 
             @Override


### PR DESCRIPTION
### Description

Apparently some car Bluetooth systems can configure AntennaPod to repeat mode. We do not want that, we handle playback ourselves.

https://forum.antennapod.org/t/episodes-loops-instead-of-playing-next-in-queue/8953
Closes #8650

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
