### PR TITLE
Fix media resumption and service lifecycle in Media3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.1"
 kotlin = "2.3.20"
-media3 = "1.9.0"
+media3 = "1.11.0"
 wear-compose = "1.6.0"
 compose = "1.7.5"
 lifecycle-runtime-compose = "2.8.7"

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/MediaLibrarySessionCallback.java
@@ -342,8 +342,9 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
     public ListenableFuture<MediaSession.MediaItemsWithStartPosition> onPlaybackResumption(
             @NonNull MediaSession mediaSession, @NonNull MediaSession.ControllerInfo controller) {
         SettableFuture<MediaSession.MediaItemsWithStartPosition> future = SettableFuture.create();
-        Single.fromCallable(() -> {
-            FeedMedia media = DBReader.getFeedMedia(PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+        Maybe.fromCallable(() -> {
+            long mediaId = PlaybackPreferences.getCurrentlyPlayingFeedMediaId();
+            FeedMedia media = (mediaId != PlaybackPreferences.NO_MEDIA_PLAYING) ? DBReader.getFeedMedia(mediaId) : null;
             // If there is no media to resume, media3 crashes. So instead of crashing, just play something random.
             if (media == null) {
                 List<FeedItem> recentQueue = DBReader.getPausedQueue(1);
@@ -372,7 +373,8 @@ public class MediaLibrarySessionCallback implements MediaLibraryService.MediaLib
                                             0, startPosition);
                             future.set(result);
                         },
-                        future::setException
+                        future::setException,
+                        () -> future.setException(new Exception("No media found"))
                 );
         return future;
     }


### PR DESCRIPTION
### Description

Closes: #8666

Fixes media playback resumption when triggered from Bluetooth earbud buttons after the app has been paused or backgrounded. Upgrades Media3 to 1.11.0 to include `BluetoothValidationActivity` required by Android 16's Bluetooth stack for AVRCP media button intent routing, along with upstream background foreground service crash fixes. Additionally, handles missing or unplayed media cleanly with RxJava `Maybe` during playback resumption to avoid throwing `NullPointerException` when no media is available.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
