### PR TITLE
Fix resetting playback of currently playing episode

### DIFF
--- a/app/src/androidTest/java/de/test/antennapod/playback/PlaybackTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/playback/PlaybackTest.java
@@ -21,7 +21,6 @@ import de.danoeh.antennapod.storage.database.LongList;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
-import de.danoeh.antennapod.ui.episodeslist.FeedItemMenuHandler;
 import de.test.antennapod.EspressoTestUtils;
 import de.test.antennapod.IgnoreOnCi;
 import de.test.antennapod.ui.UITestUtils;
@@ -144,30 +143,6 @@ public class PlaybackTest {
         activityTestRule.launchActivity(new Intent());
         DBWriter.clearQueue().get();
         startLocalPlayback();
-    }
-
-    @Test
-    public void testResetPlaybackOnCurrentlyPlayingItem() throws Exception {
-        uiTestUtils.addLocalFeedData(true);
-        activityTestRule.launchActivity(new Intent());
-        DBWriter.clearQueue().get();
-        final List<FeedItem> episodes = DBReader.getEpisodes(0, 10,
-                FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD);
-        startLocalPlayback();
-        FeedMedia media = episodes.get(0).getMedia();
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
-                () -> media.getId() == PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
-
-        FeedItem item = DBReader.getFeedItem(episodes.get(0).getId());
-        item.getMedia().setPosition(5000);
-        FeedItemMenuHandler.onMenuItemClicked(
-                activityTestRule.getActivity().getSupportFragmentManager().getFragments().get(0),
-                R.id.reset_position, item);
-
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
-                () -> PlaybackPreferences.NO_MEDIA_PLAYING == PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
-        assertEquals(0, DBReader.getFeedItem(item.getId()).getMedia().getPosition());
-        assertEquals(FeedItem.UNPLAYED, DBReader.getFeedItem(item.getId()).getPlayState());
     }
 
     protected void setContinuousPlaybackPreference(boolean value) {

--- a/app/src/androidTest/java/de/test/antennapod/playback/PlaybackTest.java
+++ b/app/src/androidTest/java/de/test/antennapod/playback/PlaybackTest.java
@@ -21,6 +21,7 @@ import de.danoeh.antennapod.storage.database.LongList;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MediaButtonStarter;
+import de.danoeh.antennapod.ui.episodeslist.FeedItemMenuHandler;
 import de.test.antennapod.EspressoTestUtils;
 import de.test.antennapod.IgnoreOnCi;
 import de.test.antennapod.ui.UITestUtils;
@@ -143,6 +144,30 @@ public class PlaybackTest {
         activityTestRule.launchActivity(new Intent());
         DBWriter.clearQueue().get();
         startLocalPlayback();
+    }
+
+    @Test
+    public void testResetPlaybackOnCurrentlyPlayingItem() throws Exception {
+        uiTestUtils.addLocalFeedData(true);
+        activityTestRule.launchActivity(new Intent());
+        DBWriter.clearQueue().get();
+        final List<FeedItem> episodes = DBReader.getEpisodes(0, 10,
+                FeedItemFilter.unfiltered(), SortOrder.DATE_NEW_OLD);
+        startLocalPlayback();
+        FeedMedia media = episodes.get(0).getMedia();
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
+                () -> media.getId() == PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+
+        FeedItem item = DBReader.getFeedItem(episodes.get(0).getId());
+        item.getMedia().setPosition(5000);
+        FeedItemMenuHandler.onMenuItemClicked(
+                activityTestRule.getActivity().getSupportFragmentManager().getFragments().get(0),
+                R.id.reset_position, item);
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
+                () -> PlaybackPreferences.NO_MEDIA_PLAYING == PlaybackPreferences.getCurrentlyPlayingFeedMediaId());
+        assertEquals(0, DBReader.getFeedItem(item.getId()).getMedia().getPosition());
+        assertEquals(FeedItem.UNPLAYED, DBReader.getFeedItem(item.getId()).getPlayState());
     }
 
     protected void setContinuousPlaybackPreference(boolean value) {

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/EpisodeMultiSelectActionHandler.java
@@ -17,12 +17,11 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.net.sync.serviceinterface.EpisodeAction;
 import de.danoeh.antennapod.net.sync.serviceinterface.SynchronizationQueue;
-import de.danoeh.antennapod.playback.service.PlaybackServiceInterface;
+import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
 import de.danoeh.antennapod.storage.preferences.SynchronizationSettings;
-import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.ui.share.ShareDialog;
 import de.danoeh.antennapod.ui.view.LocalDeleteModal;
 
@@ -197,7 +196,10 @@ public class EpisodeMultiSelectActionHandler {
             episode.getMedia().setPosition(0);
             if (PlaybackPreferences.getCurrentlyPlayingFeedMediaId() == episode.getMedia().getId()) {
                 PlaybackPreferences.writeNoMediaPlaying();
-                IntentUtils.sendLocalBroadcast(activity, PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
+                PlaybackController.bindToMedia3Service(activity, controller -> {
+                    controller.clearMediaItems();
+                    controller.stop();
+                });
             }
             toReset.add(episode);
         }

--- a/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/episodeslist/FeedItemMenuHandler.java
@@ -21,7 +21,7 @@ import de.danoeh.antennapod.event.MessageEvent;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterface;
 import de.danoeh.antennapod.storage.preferences.PlaybackPreferences;
-import de.danoeh.antennapod.playback.service.PlaybackServiceInterface;
+import de.danoeh.antennapod.playback.service.PlaybackController;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.ui.common.IntentUtils;
 import de.danoeh.antennapod.playback.service.PlaybackStatus;
@@ -208,7 +208,10 @@ public class FeedItemMenuHandler {
             selectedItem.getMedia().setPosition(0);
             if (PlaybackPreferences.getCurrentlyPlayingFeedMediaId() == selectedItem.getMedia().getId()) {
                 PlaybackPreferences.writeNoMediaPlaying();
-                IntentUtils.sendLocalBroadcast(context, PlaybackServiceInterface.ACTION_SHUTDOWN_PLAYBACK_SERVICE);
+                PlaybackController.bindToMedia3Service(context, controller -> {
+                    controller.clearMediaItems();
+                    controller.stop();
+                });
             }
             DBWriter.markItemsPlayed(FeedItem.UNPLAYED, true, Collections.singletonList(selectedItem));
         } else if (menuItemId == R.id.visit_website_item) {


### PR DESCRIPTION
### Description
Resetting playback on the currently playing episode previously broadcasted a legacy shutdown action that was unhandled by `Media3PlaybackService`, leaving the player running in the background and desynchronizing the UI and stored playback position. This updates `FeedItemMenuHandler` and `EpisodeMultiSelectActionHandler` to bind to the Media3 playback controller to clear media items and stop playback.

Closes: #8703

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests