### PR TITLE
Show "Korean" instead of "Ko" in translators list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,7 @@
 | Italian | Champ0999, Giovanni Donisi, Luca |
 | Japanese | Shuuji TAKAHASHI (shuuji3) |
 | Kannada (India) | Anonymous |
-| Ko | DY |
+| Korean | DY |
 | Lithuanian | Marija Grineviciute, kalchen6666 |
 | Macedonian | AND, Kristijan \Fremen\ Velkovski |
 | Malayalam | Nikhil Krishnakumar |

--- a/scripts/createContributors.py
+++ b/scripts/createContributors.py
@@ -50,6 +50,7 @@ ANDROID_LANG_FIXES = {
     "ji": "Yiddish",
     "sw": "Swahili",
     "el": "Modern Greek",
+    "ko": "Korean",
 }
 def lang_name(code):
     code = code.lower()

--- a/ui/preferences/src/main/assets/translators.csv
+++ b/ui/preferences/src/main/assets/translators.csv
@@ -24,7 +24,7 @@ Indonesian;Adrien N, Arif Budiman, kharrr69
 Italian;Champ0999, Giovanni Donisi, Luca
 Japanese;Shuuji TAKAHASHI (shuuji3)
 Kannada (India);Anonymous
-Ko;DY
+Korean;DY
 Lithuanian;Marija Grineviciute, kalchen6666
 Macedonian;AND, Kristijan \Fremen\ Velkovski
 Malayalam;Nikhil Krishnakumar


### PR DESCRIPTION
### Description

The translators list in `Settings → About` shows `Ko` for the Korean translation, while every other row shows a full language name. `scripts/createContributors.py` derives the name with `pycountry.languages.lookup("ko").name`, and ISO 639-3 contains a language literally named "Ko", which `lookup()` can match ahead of Korean's `alpha_2` code. `ANDROID_LANG_FIXES` already exists for this class of problem, so this adds `"ko": "Korean"` there and applies the resulting value to the two generated files. I could not run the script to confirm the `pycountry` behaviour, so the diagnosis is based on reading the code; the wrong value in the generated files is reproducible regardless.

Closes: #8705

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [ ] I have run the automated code checks using `./gradlew checkstyle lint` — `checkstyle` passes; `lint` could not run in my environment (no Android SDK installed), leaving that to CI
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests
