### PR TITLE
Show chapter image in Android Auto and notification

### DIFF
--- a/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
+++ b/playback/base/src/main/java/de/danoeh/antennapod/playback/base/MediaItemAdapter.java
@@ -15,6 +15,8 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
 import com.bumptech.glide.Glide;
 import com.google.common.collect.ImmutableList;
+import de.danoeh.antennapod.model.feed.Chapter;
+import de.danoeh.antennapod.model.feed.EmbeddedChapterImage;
 import de.danoeh.antennapod.model.feed.Feed;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
@@ -28,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 public class MediaItemAdapter {
     private static final String TAG = "MediaItemAdapter";
+    private static final long CHAPTER_ARTWORK_TIMEOUT_MS = 2000;
     public static final String MEDIA_ID_FEED_PREFIX = "FeedId:";
     public static final String MEDIA_ID_CONFIRM_STREAMING = "confirm_streaming";
     public static final String KEY_STREAM_URL = "stream_url";
@@ -108,6 +111,52 @@ public class MediaItemAdapter {
                         .setExtras(requestExtras)
                         .build())
                 .build();
+    }
+
+    /**
+     * Create a copy of a media item that carries the artwork of the given chapter.
+     * Falls back to the episode cover if the chapter has no image or it cannot be loaded.
+     * Do NOT use this method on the main thread.
+     */
+    public static MediaItem withChapterArtwork(Context context, MediaItem item,
+                                               Playable playable, int chapterIndex) {
+        ThreadUtils.assertNotMainThread();
+        int iconSize = (int) (128 * context.getResources().getDisplayMetrics().density);
+        Bitmap bitmap = loadChapterArtworkBitmap(context, playable, chapterIndex, iconSize);
+        if (bitmap == null) {
+            bitmap = loadArtworkBitmap(context, playable, iconSize);
+        }
+        if (bitmap == null) {
+            return item;
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 80, bos);
+        // The episode artworkUri would otherwise still point at the episode cover,
+        // which external processes may prefer over the chapter image bytes.
+        MediaMetadata metadata = item.mediaMetadata.buildUpon()
+                .setArtworkData(bos.toByteArray(), MediaMetadata.PICTURE_TYPE_FRONT_COVER)
+                .setArtworkUri(null)
+                .build();
+        return item.buildUpon().setMediaMetadata(metadata).build();
+    }
+
+    private static Bitmap loadChapterArtworkBitmap(Context context, Playable playable,
+                                                   int chapterIndex, int iconSize) {
+        List<Chapter> chapters = playable.getChapters();
+        if (chapters == null || chapterIndex < 0 || chapterIndex >= chapters.size()
+                || TextUtils.isEmpty(chapters.get(chapterIndex).getImageUrl())) {
+            return null;
+        }
+        try {
+            return Glide.with(context)
+                    .asBitmap()
+                    .load(EmbeddedChapterImage.getModelFor(playable, chapterIndex))
+                    .submit(iconSize, iconSize)
+                    .get(CHAPTER_ARTWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (Exception exception) {
+            Log.e(TAG, "Skipping to load chapter artwork bitmap: " + exception.getMessage());
+            return null;
+        }
     }
 
     private static Bitmap loadArtworkBitmap(Context context, Playable playable, int iconSize) {

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -92,6 +92,8 @@ public class Media3PlaybackService extends MediaLibraryService {
     private Disposable mediaLoaderDisposable;
     private Disposable positionObserverDisposable;
     private Disposable queueLoaderDisposable;
+    private Disposable chapterArtworkDisposable;
+    private int lastChapterArtworkIndex = -1;
     private long lastPositionSaveTime = 0;
     private SleepTimer sleepTimer;
     @Nullable
@@ -187,6 +189,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                 super.seekTo(positionMs);
                 EventBus.getDefault().post(
                         new PlaybackPositionEvent((int) positionMs, (int) player.getDuration()));
+                updateChapterArtwork();
             }
         };
         player.addListener(playerListener);
@@ -390,6 +393,10 @@ public class Media3PlaybackService extends MediaLibraryService {
             queueLoaderDisposable.dispose();
             queueLoaderDisposable = null;
         }
+        if (chapterArtworkDisposable != null) {
+            chapterArtworkDisposable.dispose();
+            chapterArtworkDisposable = null;
+        }
         saveCurrentPosition();
         if (loudnessEnhancer != null) {
             loudnessEnhancer.release();
@@ -438,6 +445,7 @@ public class Media3PlaybackService extends MediaLibraryService {
                                     player.seekTo(player.getDuration());
                                 }
                             }
+                            updateChapterArtwork();
                         }, error -> Log.e(TAG, "Position observer error", error));
     }
 
@@ -494,6 +502,42 @@ public class Media3PlaybackService extends MediaLibraryService {
         }
     }
 
+    private void updateChapterArtwork() {
+        if (player == null || currentPlayable == null || isCasting()
+                || !player.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
+            return;
+        }
+        List<Chapter> chapters = currentPlayable.getChapters();
+        if (chapters == null || chapters.isEmpty()) {
+            return;
+        }
+        MediaItem currentItem = player.getCurrentMediaItem();
+        if (currentItem == null) {
+            return;
+        }
+        int chapterIndex = Chapter.getAfterPosition(chapters, (int) player.getCurrentPosition());
+        if (chapterIndex < 0 || chapterIndex == lastChapterArtworkIndex) {
+            return;
+        }
+        lastChapterArtworkIndex = chapterIndex;
+        FeedMedia playable = currentPlayable;
+        String mediaId = currentItem.mediaId;
+        if (chapterArtworkDisposable != null) {
+            chapterArtworkDisposable.dispose();
+        }
+        chapterArtworkDisposable = Single
+                .fromCallable(() -> MediaItemAdapter.withChapterArtwork(this, currentItem, playable, chapterIndex))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(updatedItem -> {
+                    if (player == null || player.getCurrentMediaItem() == null
+                            || !mediaId.equals(player.getCurrentMediaItem().mediaId)) {
+                        return;
+                    }
+                    player.replaceMediaItem(player.getCurrentMediaItemIndex(), updatedItem);
+                }, error -> Log.e(TAG, "Failed to update chapter artwork", error));
+    }
+
     @OptIn(markerClass = UnstableApi.class)
     private boolean confirmStreamingIfNeeded(FeedMedia media) {
         if (needsStreaming(media) && !NetworkUtils.isStreamingAllowed()
@@ -508,6 +552,7 @@ public class Media3PlaybackService extends MediaLibraryService {
     @OptIn(markerClass = UnstableApi.class)
     private void switchToPlayable(FeedMedia media) {
         currentPlayable = media;
+        lastChapterArtworkIndex = -1;
         currentPlayable.onPlaybackStart();
 
         float speed = PlaybackSpeedUtils.getCurrentPlaybackSpeed(currentPlayable);

--- a/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/ChapterArtworkMediaItemUpdateTest.java
+++ b/playback/service/src/test/java/de/danoeh/antennapod/playback/service/internal/ChapterArtworkMediaItemUpdateTest.java
@@ -1,0 +1,67 @@
+package de.danoeh.antennapod.playback.service.internal;
+
+import android.content.Context;
+import androidx.annotation.OptIn;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.MediaMetadata;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.database.StandaloneDatabaseProvider;
+import androidx.media3.datasource.cache.NoOpCacheEvictor;
+import androidx.media3.datasource.cache.SimpleCache;
+import androidx.media3.exoplayer.source.MediaSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@OptIn(markerClass = UnstableApi.class)
+@RunWith(RobolectricTestRunner.class)
+public class ChapterArtworkMediaItemUpdateTest {
+    private SimpleCache simpleCache;
+    private ExoPlayerUtils.ApMediaSourceFactory factory;
+
+    @Before
+    public void setUp() {
+        Context context = RuntimeEnvironment.getApplication();
+        simpleCache = new SimpleCache(new File(context.getCacheDir(), "test-streaming"),
+                new NoOpCacheEvictor(), new StandaloneDatabaseProvider(context));
+        factory = new ExoPlayerUtils.ApMediaSourceFactory(context, simpleCache);
+    }
+
+    @After
+    public void tearDown() {
+        simpleCache.release();
+    }
+
+    private static MediaItem itemWithArtwork(byte[] artwork) {
+        return new MediaItem.Builder()
+                .setUri("file:///storage/episode.mp3")
+                .setMediaId("42")
+                .setMediaMetadata(new MediaMetadata.Builder()
+                        .setTitle("Episode")
+                        .setArtworkData(artwork, MediaMetadata.PICTURE_TYPE_FRONT_COVER)
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void artworkOnlyChangeUpdatesMediaItemInPlace() {
+        MediaSource source = factory.createMediaSource(itemWithArtwork(new byte[] {1, 2, 3}));
+        assertTrue(source.canUpdateMediaItem(itemWithArtwork(new byte[] {4, 5, 6})));
+    }
+
+    @Test
+    public void differentUriRebuildsMediaSource() {
+        MediaItem original = itemWithArtwork(new byte[] {1, 2, 3});
+        MediaSource source = factory.createMediaSource(original);
+        assertFalse(source.canUpdateMediaItem(
+                original.buildUpon().setUri("file:///storage/other.mp3").build()));
+    }
+}


### PR DESCRIPTION
### Description

The media session artwork was only set when playback started, so Android Auto, the media notification and the lock screen kept showing the episode cover for the whole episode, even when its chapters carry their own images.

This updates the current `MediaItem`'s artwork whenever playback crosses a chapter boundary, using `Player.replaceMediaItem()`. When only the metadata changes, media3 updates the existing media source in place instead of rebuilding it, so there is no re-prepare, no rebuffering and no position discontinuity. The chapter image is loaded off the main thread and falls back to the episode cover when a chapter has no image or it cannot be loaded in time. Updating is skipped while casting, because `CastPlayer` recreates the item rather than updating it in place.

Verified on a Pixel 8a and with the Desktop Head Unit: the artwork changes at chapter boundaries both in the notification and in Android Auto, without interrupting playback.

Closes: #7695

#### Notification:

<img width="326" height="164" alt="image" src="https://github.com/user-attachments/assets/8c88bf42-8940-4564-a6fe-c96398d36f2c" />

<img width="326" height="164" alt="image" src="https://github.com/user-attachments/assets/4ec2eb16-3fc0-47da-8f0b-d2b871ffd409" />

#### Desktop Head Unit:

<img width="326" height="208" alt="android-auto-chapter-1" src="https://github.com/user-attachments/assets/2a7c067f-3ccf-41e1-96a8-48a9792c1017" />

<img width="326" height="208" alt="android-auto-chapter-2" src="https://github.com/user-attachments/assets/21fbf171-edbe-4ff4-b641-0a838b9020d8" />


### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
