### PR TITLE
Avoid gradle newDsl warning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-android.newDsl=false
 android.onlyEnableUnitTestForTheTestedBuildType=false
 android.nonTransitiveRClass=false
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,6 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-spotbugs = { id = "com.github.spotbugs", version = "6.4.8" }
+spotbugs = { id = "com.github.spotbugs", version = "6.5.11" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.3.0" }
 triplet-play = { id = "com.github.triplet.play", version = "4.0.0" }


### PR DESCRIPTION
### Description

Compiling showed that the newDsl property is deprecated. Remove it and upgrade the dependency that would otherwise break.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
