### PR TITLE
PR bot: handle full URL, handle closed issue

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -35,7 +35,8 @@ jobs:
           github-token: ${{ secrets.ANTENNAPOD_BOT_PAT }}
           script: |
             const body = context.payload.pull_request.body || "";
-            const closingRegex = /\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|contributes to):?\s+#(\d+)/ig;
+            const issueUrl = `https?:\\/\\/github\\.com\\/${context.repo.owner}\\/${context.repo.repo}\\/issues\\/`;
+            const closingRegex = new RegExp(`\\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|contributes to):?\\s+(?:#|${issueUrl})(\\d+)`, "ig");
 
             const issueNumbers = [];
             let match;
@@ -83,6 +84,10 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issueNumber,
               });
+              if (issue.state === "closed") {
+                await convertToDraft("Issue #" + issueNumber + " is already closed. Please link to an open issue or explain why this PR is still needed. The PR has been converted to draft.");
+                return;
+              }
               const labels = issue.labels.map(l => l.name);
               const hasNeedsLabel = needsLabels.some(nl => labels.includes(nl));
               if (hasNeedsLabel) {


### PR DESCRIPTION
### Description

The comment didn't work for full URLs like `Closes https://github.com/AntennaPod/AntennaPod/issue/xy`.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
