### PR TITLE
Fix clicking timestamp in non-playing item description

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/episode/ItemFragment.java
@@ -127,8 +127,15 @@ public class ItemFragment extends Fragment {
                 return;
             }
             if (BuildConfig.USE_MEDIA3_PLAYBACK_SERVICE) {
-                PlaybackController.bindToMedia3Service(getActivity(), controller ->
-                        controller.seekTo(time));
+                PlaybackController.bindToMedia3Service(getActivity(), controller -> {
+                    if (item.getMedia() != null && controller.getCurrentMediaItem() != null
+                            && ("" + item.getMedia().getId()).equals(controller.getCurrentMediaItem().mediaId)) {
+                        controller.seekTo(time);
+                    } else {
+                        EventBus.getDefault().post(
+                                new MessageEvent(getString(R.string.play_this_to_seek_position_message)));
+                    }
+                });
                 return;
             }
             PlaybackController.bindToService(getActivity(), playbackService -> {


### PR DESCRIPTION
### Description

Fix clicking timestamp in non-playing item description
Closes #8709

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
