### PR TITLE
Enable code obfuscation for internal library and R classes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,9 +146,9 @@ jobs:
       - name: Create keystore for the release build
         if: matrix.version.build-type == 'release'
         run: keytool -genkeypair -dname "cn=AntennaPod CI, o=AntennaPod, c=DE" -alias alias -keystore app/keystore -storepass password -keypass password -keyalg RSA -keysize 2048 -validity 10000
-      - name: Build with Gradle
+      - name: Build with Gradle (debug)
         if: matrix.version.build-type == 'debug'
-        run: ./gradlew assemblePlayDebugAndroidTest
+        run: ./gradlew assemblePlayDebugAndroidTest -PtestBuildType=debug
       - name: Build with Gradle (release)
         if: matrix.version.build-type == 'release'
         run: ./gradlew assemblePlayReleaseAndroidTest -PtestBuildType=release

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -103,7 +103,7 @@ jobs:
           path: app/build/outputs/apk/play/debug/app-play-debug.apk
 
   emulator-test:
-    name: "Emulator Test API ${{ matrix.version.api-level }}"
+    name: "Emulator Test API ${{ matrix.version.api-level }} ${{ matrix.version.build-type }}"
     needs: static-analysis
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -112,10 +112,19 @@ jobs:
         version:
           - api-level: 23
             target: default
+            build-type: debug
           - api-level: 30
             target: aosp_atd
+            build-type: debug
           - api-level: 36
             target: aosp_atd
+            build-type: debug
+          - api-level: 23
+            target: default
+            build-type: release
+          - api-level: 36
+            target: aosp_atd
+            build-type: release
     steps:
       - name: Remove unused packages to save space
         run: sudo apt-get remove firefox google-chrome-stable microsoft-edge-stable snapd powershell azure-cli llvm-16 llvm-17 llvm-18 llvm-16-dev llvm-17-dev llvm-18-dev
@@ -134,8 +143,15 @@ jobs:
           key: gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
       - name: Configure parallel build
         run: echo "org.gradle.parallel=true" >> local.properties
+      - name: Create keystore for the release build
+        if: matrix.version.build-type == 'release'
+        run: keytool -genkeypair -dname "cn=AntennaPod CI, o=AntennaPod, c=DE" -alias alias -keystore app/keystore -storepass password -keypass password -keyalg RSA -keysize 2048 -validity 10000
       - name: Build with Gradle
+        if: matrix.version.build-type == 'debug'
         run: ./gradlew assemblePlayDebugAndroidTest
+      - name: Build with Gradle (release)
+        if: matrix.version.build-type == 'release'
+        run: ./gradlew assemblePlayReleaseAndroidTest -PtestBuildType=release
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -151,7 +167,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: bash .github/workflows/runEmulatorTests.sh
+          script: bash .github/workflows/runEmulatorTests.sh ${{ matrix.version.build-type }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:

--- a/.github/workflows/runEmulatorTests.sh
+++ b/.github/workflows/runEmulatorTests.sh
@@ -3,9 +3,16 @@
 set -o pipefail
 adb logcat -c
 
+buildType="${1:-debug}"
+
 runTests() {
-    ./gradlew connectedPlayDebugAndroidTest connectedDebugAndroidTest \
-        -Pandroid.testInstrumentationRunnerArguments.notAnnotation=de.test.antennapod.IgnoreOnCi
+    if [ "$buildType" = "release" ]; then
+        ./gradlew connectedPlayReleaseAndroidTest -PtestBuildType=release \
+            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=de.test.antennapod.IgnoreOnCi
+    else
+        ./gradlew connectedPlayDebugAndroidTest connectedDebugAndroidTest \
+            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=de.test.antennapod.IgnoreOnCi
+    fi
 }
 
 # Retry tests to make them less flaky

--- a/.github/workflows/runEmulatorTests.sh
+++ b/.github/workflows/runEmulatorTests.sh
@@ -10,7 +10,7 @@ runTests() {
         ./gradlew connectedPlayReleaseAndroidTest -PtestBuildType=release \
             -Pandroid.testInstrumentationRunnerArguments.notAnnotation=de.test.antennapod.IgnoreOnCi
     else
-        ./gradlew connectedPlayDebugAndroidTest connectedDebugAndroidTest \
+        ./gradlew connectedPlayDebugAndroidTest connectedDebugAndroidTest -PtestBuildType=debug \
             -Pandroid.testInstrumentationRunnerArguments.notAnnotation=de.test.antennapod.IgnoreOnCi
     fi
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,11 @@ android {
             minifyEnabled true
             shrinkResources true
             signingConfig signingConfigs.releaseConfig
+            testProguardFiles "proguard-test.cfg"
         }
     }
+
+    testBuildType = project.findProperty("testBuildType") ?: "debug"
 
     lint {
         disable 'CheckResult', 'MissingMediaBrowserServiceIntentFilter', 'UnusedAttribute', 'InflateParams',

--- a/app/proguard-test.cfg
+++ b/app/proguard-test.cfg
@@ -1,0 +1,8 @@
+# awaitility
+-dontwarn java.beans.BeanInfo
+-dontwarn java.beans.Introspector
+-dontwarn java.beans.IntrospectionException
+-dontwarn java.beans.PropertyDescriptor
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.ThreadInfo
+-dontwarn java.lang.management.ThreadMXBean

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -1,4 +1,3 @@
--dontobfuscate
 -renamesourcefileattribute SourceFile
 -keepattributes SourceFile,LineNumberTable
 -optimizations !code/allocation/variable
@@ -9,8 +8,8 @@
 
 # Keep our own classes and members. They are all used.
 # Without this, methods only used in tests are removed and break tests.
--keep class de.danoeh.antennapod**
--keepclassmembers class de.danoeh.antennapod** {*;}
+-keep class !de.danoeh.antennapod.**R$**,!de.danoeh.antennapod.**R,de.danoeh.antennapod**
+-keepclassmembers class !de.danoeh.antennapod.**R$**,!de.danoeh.antennapod.**R,de.danoeh.antennapod** {*;}
 -keep class de.test.antennapod**
 -keepclassmembers class de.test.antennapod** {*;}
 
@@ -28,26 +27,14 @@
     public *;
 }
 
-# android-iconify
--keep class com.joanzapata.** { *; }
-
-# RxJava
--keep class io.reactivex.Single
-
-# Retrofit 2.0
--dontwarn retrofit2.**
--keep class retrofit2.** { *; }
--keepattributes Signature
--keepattributes Exceptions
-
--keepclasseswithmembers class * {
-    @retrofit2.http.* <methods>;
+# Keep stack traces of libraries readable
+-keep,allowshrinking,allowoptimization class * {
+    public *;
+    protected *;
 }
 
-# Moshi
--keep class com.squareup.moshi.** { *; }
--keep interface com.squareup.moshi.** { *; }
-####
+-keepattributes Signature
+-keepattributes Exceptions
 
 # awaitility
 -dontwarn java.beans.BeanInfo

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -27,6 +27,12 @@
     public *;
 }
 
+# Room instantiates the generated implementation reflectively.
+# The rule that Room ships keeps the class but not its constructor.
+-keep class * extends androidx.room.RoomDatabase {
+    <init>();
+}
+
 # Keep stack traces of libraries readable
 -keep,allowshrinking,allowoptimization class * {
     public *;
@@ -35,12 +41,3 @@
 
 -keepattributes Signature
 -keepattributes Exceptions
-
-# awaitility
--dontwarn java.beans.BeanInfo
--dontwarn java.beans.Introspector
--dontwarn java.beans.IntrospectionException
--dontwarn java.beans.PropertyDescriptor
--dontwarn java.lang.management.ManagementFactory
--dontwarn java.lang.management.ThreadInfo
--dontwarn java.lang.management.ThreadMXBean

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -10,21 +10,28 @@
 # Without this, methods only used in tests are removed and break tests.
 -keep class !de.danoeh.antennapod.**R$**,!de.danoeh.antennapod.**R,de.danoeh.antennapod**
 -keepclassmembers class !de.danoeh.antennapod.**R$**,!de.danoeh.antennapod.**R,de.danoeh.antennapod** {*;}
--keep class de.test.antennapod**
--keepclassmembers class de.test.antennapod** {*;}
+
+# Instrumented tests reference the app's own R class, which is not inlined
+# because resource IDs are not final. The R classes of the library modules
+# are just copies of it and are not referenced at runtime.
+-keep class de.danoeh.antennapod.R$* {*;}
 
 # Keep methods used in tests.
 # This is only needed when running tests with proguard enabled.
--keepclassmembers class org.apache.commons.lang3.StringUtils {*;}
+-keepclassmembers class org.apache.commons.lang3.** {
+    public static *;
+}
+-keepclassmembers class org.apache.commons.io.** {
+    public static *;
+}
 -keepclassmembers class androidx.appcompat.app.ActionBar {
     public ** getTitle();
 }
--keepclassmembers class org.apache.commons.io.IOUtils {
-    public static void write(...);
+-keepclassmembers class androidx.preference.PreferenceManager {
+    public static *;
 }
-
--keep public class org.jsoup.** {
-    public *;
+-keepclassmembers class androidx.tracing.Trace {
+    public static *;
 }
 
 # Room instantiates the generated implementation reflectively.

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -16,8 +16,8 @@
 # are just copies of it and are not referenced at runtime.
 -keep class de.danoeh.antennapod.R$* {*;}
 
-# Keep methods used in tests.
-# This is only needed when running tests with proguard enabled.
+# Instrumented tests call library methods that the app itself never calls.
+# R8 only sees the app, so it would remove or inline them.
 -keepclassmembers class org.apache.commons.lang3.** {
     public static *;
 }
@@ -29,6 +29,9 @@
 }
 -keepclassmembers class androidx.preference.PreferenceManager {
     public static *;
+}
+-keepclassmembers class androidx.drawerlayout.widget.** {
+    *;
 }
 -keepclassmembers class androidx.tracing.Trace {
     public static *;


### PR DESCRIPTION
### Description

Google now forces developers to enable code obfuscation:
https://android-developers.googleblog.com/2026/08/app-quality-memory-optimization-secure-onboarding.html

This PR enables it for all library internal classes and the generated AntennaPod `R` classes, but not actual AntennaPod code. It brings us below Googles threshold while hopefully not impacting the readability of stack traces much. Because the obfuscation makes the class/field names shorter, this also reduces the DEX size of AntennaPod from ~10MB to ~7MB.

Also, add a new CI lane that checks the release build.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
