### PR TITLE
Catch 'out of space' errors that only surface when closing file

### DIFF
--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/remote/HttpDownloader.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/remote/HttpDownloader.java
@@ -1,6 +1,8 @@
 package de.danoeh.antennapod.net.download.service.feed.remote;
 
 import android.os.StatFs;
+import android.system.ErrnoException;
+import android.system.OsConstants;
 import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
@@ -173,7 +175,13 @@ public class HttpDownloader extends Downloader {
                 }
             } catch (IOException e) {
                 Log.e(TAG, Log.getStackTraceString(e));
+                if (isOutOfSpace(e)) {
+                    throw e;
+                }
             }
+            out.close(); // Catch ENOSPC, which may only surface on close
+            out = null;
+
             if (cancelled) {
                 onCancelled();
             } else {
@@ -215,6 +223,13 @@ public class HttpDownloader extends Downloader {
             String message = e.getMessage();
             if (message != null && message.contains("Trust anchor for certification path not found")) {
                 onFail(DownloadError.ERROR_CERTIFICATE, e.getMessage());
+                return;
+            }
+            if (isOutOfSpace(e)) {
+                if (!destination.delete()) {
+                    Log.d(TAG, "Could not delete partially downloaded file " + destination.getName());
+                }
+                onFail(DownloadError.ERROR_NOT_ENOUGH_SPACE, e.getMessage());
                 return;
             }
             onFail(DownloadError.ERROR_IO_ERROR, e.getMessage());
@@ -281,6 +296,16 @@ public class HttpDownloader extends Downloader {
             details = String.valueOf(response.code());
         }
         onFail(error, details);
+    }
+
+    private static boolean isOutOfSpace(IOException e) {
+        if (e.getCause() instanceof ErrnoException
+                && ((ErrnoException) e.getCause()).errno == OsConstants.ENOSPC) {
+            return true;
+        }
+        String message = e.getMessage();
+        return message != null
+                && (message.contains("ENOSPC") || message.contains("No space left on device"));
     }
 
     private static long getFreeSpaceAvailable() {


### PR DESCRIPTION
### Description

Some download errors might only surface when actually closing the file. AntennaPod didn't catch those, and simply marked the file as downloaded. Only when playing, it then noticed the problem.

Based on #8125 by @schwarzspecht but without double close, not attributing a wrong issue, no deletion of pre-existing file, and no inverted condition in the log.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
