### PR TITLE
Improve database indexes for large libraries

### DIFF
--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -355,6 +355,14 @@ class DBUpgrader {
             db.execSQL("DELETE FROM " + PodDBAdapter.TABLE_NAME_FAVORITES + " WHERE " + PodDBAdapter.KEY_FEEDITEM
                     + " NOT IN (SELECT " + PodDBAdapter.KEY_ID + " FROM " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + ")");
         }
+        if (oldVersion < 3130000) {
+            db.execSQL("DROP INDEX IF EXISTS " + PodDBAdapter.INDEX_NAME_FEEDITEMS_READ);
+            db.execSQL(PodDBAdapter.CREATE_INDEX_FEEDITEMS_READ);
+            db.execSQL("DROP INDEX IF EXISTS " + PodDBAdapter.INDEX_NAME_FEEDITEMS_FEED);
+            db.execSQL(PodDBAdapter.CREATE_INDEX_FEEDITEMS_FEED);
+            db.execSQL("DROP INDEX IF EXISTS " + PodDBAdapter.INDEX_NAME_FEEDMEDIA_FEEDITEM);
+            db.execSQL(PodDBAdapter.CREATE_INDEX_FEEDMEDIA_FEEDITEM);
+        }
     }
 
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -55,7 +55,7 @@ public class PodDBAdapter {
 
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
-    public static final int VERSION = 3110000;
+    public static final int VERSION = 3130000;
 
     /**
      * Maximum number of arguments for IN-operator.
@@ -223,25 +223,28 @@ public class PodDBAdapter {
             + KEY_LINK + " TEXT," + KEY_IMAGE_URL + " TEXT)";
 
     // SQL Statements for creating indexes
+    static final String INDEX_NAME_FEEDITEMS_FEED = TABLE_NAME_FEED_ITEMS + "_" + KEY_FEED;
     static final String CREATE_INDEX_FEEDITEMS_FEED = "CREATE INDEX "
-            + TABLE_NAME_FEED_ITEMS + "_" + KEY_FEED + " ON " + TABLE_NAME_FEED_ITEMS + " ("
-            + KEY_FEED + ")";
+            + INDEX_NAME_FEEDITEMS_FEED + " ON " + TABLE_NAME_FEED_ITEMS + " ("
+            + KEY_FEED + ", " + KEY_PUBDATE + ", " + KEY_READ + ")";
 
     static final String CREATE_INDEX_FEEDITEMS_PUBDATE = "CREATE INDEX "
             + TABLE_NAME_FEED_ITEMS + "_" + KEY_PUBDATE + " ON " + TABLE_NAME_FEED_ITEMS + " ("
             + KEY_PUBDATE + ")";
 
+    static final String INDEX_NAME_FEEDITEMS_READ = TABLE_NAME_FEED_ITEMS + "_" + KEY_READ;
     static final String CREATE_INDEX_FEEDITEMS_READ = "CREATE INDEX "
-            + TABLE_NAME_FEED_ITEMS + "_" + KEY_READ + " ON " + TABLE_NAME_FEED_ITEMS + " ("
-            + KEY_READ + ")";
+            + INDEX_NAME_FEEDITEMS_READ + " ON " + TABLE_NAME_FEED_ITEMS + " ("
+            + KEY_READ + ", " + KEY_PUBDATE + ", " + KEY_FEED + ")";
 
     static final String CREATE_INDEX_QUEUE_FEEDITEM = "CREATE INDEX "
             + TABLE_NAME_QUEUE + "_" + KEY_FEEDITEM + " ON " + TABLE_NAME_QUEUE + " ("
             + KEY_FEEDITEM + ")";
 
+    static final String INDEX_NAME_FEEDMEDIA_FEEDITEM = TABLE_NAME_FEED_MEDIA + "_" + KEY_FEEDITEM;
     static final String CREATE_INDEX_FEEDMEDIA_FEEDITEM = "CREATE INDEX "
-            + TABLE_NAME_FEED_MEDIA + "_" + KEY_FEEDITEM + " ON " + TABLE_NAME_FEED_MEDIA + " ("
-            + KEY_FEEDITEM + ")";
+            + INDEX_NAME_FEEDMEDIA_FEEDITEM + " ON " + TABLE_NAME_FEED_MEDIA + " ("
+            + KEY_FEEDITEM + ", " + KEY_DOWNLOAD_DATE + ")";
 
     static final String CREATE_INDEX_SIMPLECHAPTERS_FEEDITEM = "CREATE INDEX "
             + TABLE_NAME_SIMPLECHAPTERS + "_" + KEY_FEEDITEM + " ON " + TABLE_NAME_SIMPLECHAPTERS + " ("


### PR DESCRIPTION
### Description

Replace the three single-column indexes on `FeedItems` and `FeedMedia` with composite versions that keep the existing leading column, so all existing access paths keep working. Common filter and sort queries like the Inbox, the navigation drawer counters and the downloaded filter can then be answered directly from the index instead of scanning nearly all episodes.

On the real-world library from #8679 (`~66,000` episodes, `~33,000` of them new, `220 MB` database), this drops the Inbox count from `473 ms` to `84 ms`, the counters from `910 ms` to `108 ms` and the downloaded filter from `761 ms` to `179 ms`, measured on-device.

Storage cost is `+684 KiB` (`+0.29%`) and download writes stay in the `1-5 ms` range, so the extra index maintenance is not noticeable in normal use.

Existing installations are migrated in a single upgrade step (database version ~`3120000`~ `3130000`) that rebuilds the three indexes.

Closes: #8679

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] ~If it is a core feature, I have added automated tests~
