### PR TITLE
Fix sleep timer auto-enabling and not disengaging

### DIFF
--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/Media3PlaybackService.java
@@ -151,7 +151,8 @@ public class Media3PlaybackService extends MediaLibraryService {
                     return;
                 }
 
-                if (currentPlayable != null && !getPlayWhenReady()) {
+                boolean wasPlaying = getPlayWhenReady();
+                if (currentPlayable != null && !wasPlaying) {
                     long savedPosition = getCurrentPosition();
                     long startPosition = RewindAfterPauseUtils.calculatePositionWithRewind(
                             (int) savedPosition, currentPlayable.getLastPlayedTimeStatistics());
@@ -160,6 +161,15 @@ public class Media3PlaybackService extends MediaLibraryService {
                     }
                 }
                 super.play();
+                if (!wasPlaying && sleepTimer == null && SleepTimerPreferences.autoEnable()) {
+                    int currentHour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
+                    if (SleepTimerPreferences.isInTimeRange(
+                            SleepTimerPreferences.autoEnableFrom(),
+                            SleepTimerPreferences.autoEnableTo(),
+                            currentHour)) {
+                        startSleepTimer(SleepTimerPreferences.timerMillisOrEpisodes());
+                    }
+                }
             }
 
             @Override

--- a/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ClockSleepTimer.java
+++ b/playback/service/src/main/java/de/danoeh/antennapod/playback/service/internal/ClockSleepTimer.java
@@ -110,6 +110,7 @@ public class ClockSleepTimer implements SleepTimer {
 
     @Override
     public void stop() {
+        isRunning = false;
         timeLeft = 0;
         EventBus.getDefault().unregister(this);
 


### PR DESCRIPTION
### Description
Closes: #8712

Move the auto-enable sleep timer check from `onIsPlayingChanged` to `ForwardingPlayer.play()`. Previously, `onIsPlayingChanged` was triggered on various playback and session state updates while audio was playing, which immediately re-engaged the sleep timer right after the user disabled it. In addition, `ClockSleepTimer.stop()` now resets its running state.

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests