### PR TITLE
Support legacy iTunes podcast namespace

### DIFF
--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/SyndHandler.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/SyndHandler.java
@@ -93,7 +93,7 @@ public class SyndHandler extends DefaultHandler {
                     && prefix.equals(Content.NSTAG)) {
                 state.namespaces.put(uri, new Content());
                 Log.d(TAG, "Recognized Content namespace");
-            } else if (uri.equals(Itunes.NSURI)
+            } else if ((uri.equals(Itunes.NSURI) || uri.equals(Itunes.NSURI_LEGACY))
                     && prefix.equals(Itunes.NSTAG)) {
                 state.namespaces.put(uri, new Itunes());
                 Log.d(TAG, "Recognized ITunes namespace");

--- a/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Itunes.java
+++ b/parser/feed/src/main/java/de/danoeh/antennapod/parser/feed/namespace/Itunes.java
@@ -15,6 +15,7 @@ public class Itunes extends Namespace {
 
     public static final String NSTAG = "itunes";
     public static final String NSURI = "http://www.itunes.com/dtds/podcast-1.0.dtd";
+    public static final String NSURI_LEGACY = "http://www.itunes.com/DTDs/Podcast-1.0.dtd";
 
     private static final String IMAGE = "image";
     private static final String IMAGE_HREF = "href";

--- a/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
+++ b/parser/feed/src/test/java/de/danoeh/antennapod/parser/feed/element/namespace/RssParserTest.java
@@ -69,6 +69,13 @@ public class RssParserTest {
     }
 
     @Test
+    public void testLegacyItunesNamespace() throws Exception {
+        File feedFile = FeedParserTestHelper.getFeedFile("feed-rss-testLegacyItunesNamespace.xml");
+        Feed feed = FeedParserTestHelper.runFeedParser(feedFile);
+        assertEquals("https://example.com/image.png", feed.getImageUrl());
+    }
+
+    @Test
     public void testMediaContentMime() throws Exception {
         File feedFile = FeedParserTestHelper.getFeedFile("feed-rss-testMediaContentMime.xml");
         Feed feed = FeedParserTestHelper.runFeedParser(feedFile);

--- a/parser/feed/src/test/resources/feed-rss-testLegacyItunesNamespace.xml
+++ b/parser/feed/src/test/resources/feed-rss-testLegacyItunesNamespace.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
+    <channel>
+        <title>title</title>
+        <description>description</description>
+        <link>https://example.com</link>
+        <itunes:image href="https://example.com/image.png" />
+    </channel>
+</rss>


### PR DESCRIPTION
### Description

`SyndHandler` matches the iTunes namespace URI with `String.equals` against
`http://www.itunes.com/dtds/podcast-1.0.dtd`, so feeds declaring the namespace with Apple's
original capitalisation (`http://www.itunes.com/DTDs/Podcast-1.0.dtd`) are not recognised and
all of their `itunes:` elements are silently dropped. Feeds that supply their artwork only
through `<itunes:image>` therefore end up with no cover at all. This adds the legacy URI as a
second accepted spelling for the same namespace, plus a parser regression test and fixture.

Verified against the affected feed
(`https://minicast.imbc.com/PodCast/pod.aspx?code=1000671100000100000`), whose artwork now
loads in a local debug build.

- https://patents.google.com/patent/US8346762B2/en
- https://www.w3.org/2005/07/media-and-rss.html
- https://github.com/Podcastindex-org/podcast-namespace/blob/main/existing-namespaces.txt
- https://sources.debian.org/src/podcastparser/0.6.5-1/podcastparser.py

Closes: #8721

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
