### PR TITLE
Add option to remove episodes that are no longer in the feed

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/screen/feed/preferences/FeedSettingsPreferenceFragment.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.provider.Settings;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -17,6 +18,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.core.content.ContextCompat;
 import androidx.preference.ListPreference;
@@ -71,6 +73,9 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
     private static final String PREF_TAGS = "tags";
     private static final String PREF_EDIT_FEED_URL = "editFeedUrl";
     private static final String PREF_RECONNECT_LOCAL_FOLDER = "reconnectLocalFolder";
+    private static final String PREF_REMOVE_UNLISTED_EPISODES = "removeUnlistedEpisodes";
+    private static final String PREF_CLEANUP_UNLISTED_EPISODES = "cleanupUnlistedEpisodes";
+    private static final int CONFIRMATION_COUNTDOWN_MS = 15000;
 
     private Feed feed;
     private Disposable disposable;
@@ -148,6 +153,8 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
                         findPreference(PREF_AUTODOWNLOAD).setVisible(false);
                         findPreference(PREF_EPISODE_FILTER).setVisible(false);
                         findPreference(PREF_EDIT_FEED_URL).setVisible(false);
+                        findPreference(PREF_REMOVE_UNLISTED_EPISODES).setVisible(false);
+                        findPreference(PREF_CLEANUP_UNLISTED_EPISODES).setVisible(false);
                     }
 
                     findPreference(PREF_SCREEN).setVisible(true);
@@ -306,6 +313,51 @@ public class FeedSettingsPreferenceFragment extends PreferenceFragmentCompat {
             alert.show();
             return true;
         });
+        SwitchPreferenceCompat removeUnlisted = findPreference(PREF_REMOVE_UNLISTED_EPISODES);
+        removeUnlisted.setChecked(feedPreferences.getRemoveUnlistedEpisodes());
+        removeUnlisted.setOnPreferenceChangeListener((preference, newValue) -> {
+            boolean checked = Boolean.TRUE.equals(newValue);
+            if (!checked) {
+                feedPreferences.setRemoveUnlistedEpisodes(false);
+                DBWriter.setFeedPreferences(feedPreferences);
+                removeUnlisted.setChecked(false);
+                return false;
+            }
+            showRemoveUnlistedConfirmation(() -> {
+                feedPreferences.setRemoveUnlistedEpisodes(true);
+                DBWriter.setFeedPreferences(feedPreferences);
+                removeUnlisted.setChecked(true);
+            });
+            return false;
+        });
+        findPreference(PREF_CLEANUP_UNLISTED_EPISODES).setOnPreferenceClickListener(preference -> {
+            showRemoveUnlistedConfirmation(() ->
+                    FeedUpdateManager.getInstance().runOnce(getContext(), feed, false, true));
+            return true;
+        });
+    }
+
+    private void showRemoveUnlistedConfirmation(Runnable onConfirmed) {
+        AlertDialog dialog = new MaterialAlertDialogBuilder(getContext())
+                .setTitle(R.string.remove_unlisted_episodes)
+                .setMessage(R.string.remove_unlisted_episodes_confirmation_msg)
+                .setPositiveButton(android.R.string.ok, (d, which) -> onConfirmed.run())
+                .setNegativeButton(R.string.cancel_label, null)
+                .show();
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+        new CountDownTimer(CONFIRMATION_COUNTDOWN_MS, 1000) {
+            @Override
+            public void onTick(long millisUntilFinished) {
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setText(String.format(Locale.getDefault(), "%s (%d)",
+                        getString(android.R.string.ok), millisUntilFinished / 1000 + 1));
+            }
+
+            @Override
+            public void onFinish() {
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setText(android.R.string.ok);
+            }
+        }.start();
     }
 
     private void updateAutoDeleteSummary() {

--- a/app/src/main/res/xml/feed_settings.xml
+++ b/app/src/main/res/xml/feed_settings.xml
@@ -90,6 +90,18 @@
             android:summary="@string/episode_filters_description"
             android:title="@string/episode_filters_label" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:icon="@drawable/ic_delete"
+            android:key="removeUnlistedEpisodes"
+            android:summary="@string/remove_unlisted_episodes_summary"
+            android:title="@string/remove_unlisted_episodes" />
+
+        <Preference
+            android:key="cleanupUnlistedEpisodes"
+            android:summary="@string/cleanup_unlisted_episodes_summary"
+            android:title="@string/cleanup_unlisted_episodes" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
+++ b/model/src/main/java/de/danoeh/antennapod/model/feed/FeedPreferences.java
@@ -122,6 +122,7 @@ public class FeedPreferences implements Serializable {
     private int feedSkipEnding;
     private SkipSilence feedSkipSilence;
     private boolean showEpisodeNotification;
+    private boolean removeUnlistedEpisodes;
     private final Set<String> tags = new HashSet<>();
 
     public FeedPreferences(long feedID, AutoDownloadSetting autoDownload, AutoDeleteAction autoDeleteAction,
@@ -129,7 +130,7 @@ public class FeedPreferences implements Serializable {
                            String username, String password) {
         this(feedID, autoDownload, true, autoDeleteAction, volumeAdaptionSetting, username, password,
                 new FeedFilter(), SPEED_USE_GLOBAL, 0, 0, SkipSilence.GLOBAL,
-                false, newEpisodesAction, new HashSet<>());
+                false, newEpisodesAction, new HashSet<>(), false);
     }
 
     public FeedPreferences(long feedID, AutoDownloadSetting autoDownload, boolean keepUpdated,
@@ -137,7 +138,7 @@ public class FeedPreferences implements Serializable {
                             String username, String password, @NonNull FeedFilter filter,
                             float feedPlaybackSpeed, int feedSkipIntro, int feedSkipEnding, SkipSilence feedSkipSilence,
                             boolean showEpisodeNotification, NewEpisodesAction newEpisodesAction,
-                            Set<String> tags) {
+                            Set<String> tags, boolean removeUnlistedEpisodes) {
         this.feedID = feedID;
         this.autoDownload = autoDownload;
         this.keepUpdated = keepUpdated;
@@ -153,6 +154,7 @@ public class FeedPreferences implements Serializable {
         this.showEpisodeNotification = showEpisodeNotification;
         this.newEpisodesAction = newEpisodesAction;
         this.tags.addAll(tags);
+        this.removeUnlistedEpisodes = removeUnlistedEpisodes;
     }
 
     /**
@@ -176,6 +178,17 @@ public class FeedPreferences implements Serializable {
 
     public void setKeepUpdated(boolean keepUpdated) {
         this.keepUpdated = keepUpdated;
+    }
+
+    /**
+     * @return true if episodes that are no longer listed in the feed should be deleted when refreshing.
+     */
+    public boolean getRemoveUnlistedEpisodes() {
+        return removeUnlistedEpisodes;
+    }
+
+    public void setRemoveUnlistedEpisodes(boolean removeUnlistedEpisodes) {
+        this.removeUnlistedEpisodes = removeUnlistedEpisodes;
     }
 
     /**

--- a/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/FeedUpdateManager.java
+++ b/net/download/service-interface/src/main/java/de/danoeh/antennapod/net/download/serviceinterface/FeedUpdateManager.java
@@ -24,6 +24,8 @@ public abstract class FeedUpdateManager {
 
     public abstract void runOnce(Context context, Feed feed, boolean nextPage);
 
+    public abstract void runOnce(Context context, Feed feed, boolean nextPage, boolean removeUnlistedItems);
+
     public abstract void runOnceOrAsk(@NonNull Context context);
 
     public abstract void runOnceOrAsk(@NonNull Context context, @Nullable Feed feed);

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateManagerImpl.java
@@ -31,6 +31,7 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
     private static final String WORK_ID_FEED_UPDATE_MANUAL = "feedUpdateManual";
     public static final String EXTRA_FEED_ID = "feed_id";
     public static final String EXTRA_NEXT_PAGE = "next_page";
+    public static final String EXTRA_REMOVE_UNLISTED_ITEMS = "remove_unlisted_items";
     public static final String EXTRA_EVEN_ON_MOBILE = "even_on_mobile";
     public static final String EXTRA_MANUAL = "manual";
     private static final String TAG = "AutoUpdateManager";
@@ -67,6 +68,10 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
     }
 
     public void runOnce(Context context, Feed feed, boolean nextPage) {
+        runOnce(context, feed, nextPage, false);
+    }
+
+    public void runOnce(Context context, Feed feed, boolean nextPage, boolean removeUnlistedItems) {
         lastManualRefreshTime = System.currentTimeMillis();
         lastManualRefreshFeedId = feed != null ? feed.getId() : -1;
         OneTimeWorkRequest.Builder workRequest = new OneTimeWorkRequest.Builder(FeedUpdateWorker.class)
@@ -83,6 +88,7 @@ public class FeedUpdateManagerImpl extends FeedUpdateManager {
         if (feed != null) {
             builder.putLong(EXTRA_FEED_ID, feed.getId());
             builder.putBoolean(EXTRA_NEXT_PAGE, nextPage);
+            builder.putBoolean(EXTRA_REMOVE_UNLISTED_ITEMS, removeUnlistedItems);
         }
         workRequest.setInputData(builder.build());
         WorkManager.getInstance(context).enqueueUniqueWork(WORK_ID_FEED_UPDATE_MANUAL,

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/feed/FeedUpdateWorker.java
@@ -238,7 +238,12 @@ public class FeedUpdateWorker extends Worker {
             return null;
         }
         feedHandlerResult.feed.setLastRefreshAttempt(System.currentTimeMillis());
-        Feed savedFeed = FeedDatabaseWriter.updateFeed(getApplicationContext(), feedHandlerResult.feed, false);
+        boolean forceRemoveUnlisted = getInputData()
+                .getBoolean(FeedUpdateManagerImpl.EXTRA_REMOVE_UNLISTED_ITEMS, false);
+        boolean removeUnlistedItems = (forceRemoveUnlisted || feed.getPreferences().getRemoveUnlistedEpisodes())
+                && !nextPage && !feed.isPaged();
+        Feed savedFeed = FeedDatabaseWriter.updateFeed(
+                getApplicationContext(), feedHandlerResult.feed, removeUnlistedItems);
 
         if (request.getFeedfileId() == 0) {
             return savedFeed; // No download logs for new subscriptions

--- a/storage/database/README.md
+++ b/storage/database/README.md
@@ -2,3 +2,9 @@
 
 AntennaPod's main database, containing subscriptions and playback state (but not user settings).
 Uses raw SQLite via `PodDBAdapter` (not Room); writes go through async `DBWriter`; reads use cursor-to-object mappers in the `mapper/` package.
+
+Adding a `FeedPreferences` field requires touching five places: the model class in `:model`, then in `PodDBAdapter` the `KEY_` constant, `CREATE_TABLE_FEEDS`, the `KEYS_FEED` select list and `setFeedPreferences()`, then `mapper/FeedPreferencesCursor`, a new `oldVersion <` block in `DBUpgrader` and a bump of `PodDBAdapter.VERSION`.
+Omitting the `KEYS_FEED` select list makes `FeedPreferencesCursor` throw at runtime, because it resolves every column with `getColumnIndexOrThrow`.
+
+`FeedDatabaseWriter.updateFeed(context, feed, removeUnlistedItems)` deletes stored items that are absent from the parsed feed, except downloaded ones of remote feeds.
+Callers must only pass `true` when the parsed item list is exhaustive, so never for a single page of a paged feed.

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/DBUpgrader.java
@@ -355,6 +355,10 @@ class DBUpgrader {
             db.execSQL("DELETE FROM " + PodDBAdapter.TABLE_NAME_FAVORITES + " WHERE " + PodDBAdapter.KEY_FEEDITEM
                     + " NOT IN (SELECT " + PodDBAdapter.KEY_ID + " FROM " + PodDBAdapter.TABLE_NAME_FEED_ITEMS + ")");
         }
+        if (oldVersion < 3120000) {
+            db.execSQL("ALTER TABLE " + PodDBAdapter.TABLE_NAME_FEEDS
+                    + " ADD COLUMN " + PodDBAdapter.KEY_REMOVE_UNLISTED_EPISODES + " INTEGER DEFAULT 0");
+        }
     }
 
 }

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriter.java
@@ -188,6 +188,10 @@ public abstract class FeedDatabaseWriter {
                 Iterator<FeedItem> it = savedFeed.getItems().iterator();
                 while (it.hasNext()) {
                     FeedItem feedItem = it.next();
+                    if (!savedFeed.isLocalFeed() && feedItem.getMedia() != null
+                            && feedItem.getMedia().isDownloaded()) {
+                        continue;
+                    }
                     if (newFeedDuplicateGuesser.findById(feedItem) == null) {
                         unlistedItems.add(feedItem);
                         it.remove();

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/PodDBAdapter.java
@@ -55,7 +55,7 @@ public class PodDBAdapter {
 
     private static final String TAG = "PodDBAdapter";
     public static final String DATABASE_NAME = "Antennapod.db";
-    public static final int VERSION = 3110000;
+    public static final int VERSION = 3120000;
 
     /**
      * Maximum number of arguments for IN-operator.
@@ -123,6 +123,7 @@ public class PodDBAdapter {
     public static final String KEY_FEED_TAGS = "tags";
     public static final String KEY_EPISODE_NOTIFICATION = "episode_notification";
     public static final String KEY_NEW_EPISODES_ACTION = "new_episodes_action";
+    public static final String KEY_REMOVE_UNLISTED_EPISODES = "remove_unlisted_episodes";
     public static final String KEY_PODCASTINDEX_CHAPTER_URL = "podcastindex_chapter_url";
     public static final String KEY_SOCIAL_INTERACT_URL = "social_interact_url";
     public static final String KEY_STATE = "state";
@@ -179,7 +180,8 @@ public class PodDBAdapter {
             + KEY_FEED_SKIP_ENDING + " INTEGER DEFAULT 0,"
             + KEY_EPISODE_NOTIFICATION + " INTEGER DEFAULT 0,"
             + KEY_STATE + " INTEGER DEFAULT " + Feed.STATE_SUBSCRIBED + ","
-            + KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0)";
+            + KEY_NEW_EPISODES_ACTION + " INTEGER DEFAULT 0,"
+            + KEY_REMOVE_UNLISTED_EPISODES + " INTEGER DEFAULT 0)";
 
     private static final String CREATE_TABLE_FEED_ITEMS = "CREATE TABLE "
             + TABLE_NAME_FEED_ITEMS + " (" + TABLE_PRIMARY_KEY
@@ -344,7 +346,8 @@ public class PodDBAdapter {
             + TABLE_NAME_FEEDS + "." + KEY_FEED_SKIP_ENDING + ", "
             + TABLE_NAME_FEEDS + "." + KEY_EPISODE_NOTIFICATION + ", "
             + TABLE_NAME_FEEDS + "." + KEY_STATE + ", "
-            + TABLE_NAME_FEEDS + "." + KEY_NEW_EPISODES_ACTION;
+            + TABLE_NAME_FEEDS + "." + KEY_NEW_EPISODES_ACTION + ", "
+            + TABLE_NAME_FEEDS + "." + KEY_REMOVE_UNLISTED_EPISODES;
 
     private static final String JOIN_FEED_ITEM_AND_MEDIA = " LEFT JOIN " + TABLE_NAME_FEED_MEDIA
             + " ON " + TABLE_NAME_FEED_ITEMS + "." + KEY_ID + "=" + TABLE_NAME_FEED_MEDIA + "." + KEY_FEEDITEM + " ";
@@ -511,6 +514,7 @@ public class PodDBAdapter {
         values.put(KEY_FEED_SKIP_ENDING, prefs.getFeedSkipEnding());
         values.put(KEY_EPISODE_NOTIFICATION, prefs.getShowEpisodeNotification());
         values.put(KEY_NEW_EPISODES_ACTION, prefs.getNewEpisodesAction().code);
+        values.put(KEY_REMOVE_UNLISTED_EPISODES, prefs.getRemoveUnlistedEpisodes());
         db.update(TABLE_NAME_FEEDS, values, KEY_ID + "=?", new String[]{String.valueOf(prefs.getFeedID())});
     }
 

--- a/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedPreferencesCursor.java
+++ b/storage/database/src/main/java/de/danoeh/antennapod/storage/database/mapper/FeedPreferencesCursor.java
@@ -33,6 +33,7 @@ public class FeedPreferencesCursor extends CursorWrapper {
     private final int indexEpisodeNotification;
     private final int indexNewEpisodesAction;
     private final int indexTags;
+    private final int indexRemoveUnlistedEpisodes;
 
     public FeedPreferencesCursor(Cursor cursor) {
         super(cursor);
@@ -53,6 +54,7 @@ public class FeedPreferencesCursor extends CursorWrapper {
         indexEpisodeNotification = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_EPISODE_NOTIFICATION);
         indexNewEpisodesAction = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_NEW_EPISODES_ACTION);
         indexTags = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_FEED_TAGS);
+        indexRemoveUnlistedEpisodes = cursor.getColumnIndexOrThrow(PodDBAdapter.KEY_REMOVE_UNLISTED_EPISODES);
     }
 
     /**
@@ -80,6 +82,7 @@ public class FeedPreferencesCursor extends CursorWrapper {
                 FeedPreferences.SkipSilence.fromCode(getInt(indexFeedSkipSilence)),
                 getInt(indexEpisodeNotification) > 0,
                 FeedPreferences.NewEpisodesAction.fromCode(getInt(indexNewEpisodesAction)),
-                new HashSet<>(Arrays.asList(tagsString.split(FeedPreferences.TAG_SEPARATOR))));
+                new HashSet<>(Arrays.asList(tagsString.split(FeedPreferences.TAG_SEPARATOR))),
+                getInt(indexRemoveUnlistedEpisodes) > 0);
     }
 }

--- a/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriterTest.java
+++ b/storage/database/src/test/java/de/danoeh/antennapod/storage/database/FeedDatabaseWriterTest.java
@@ -263,6 +263,30 @@ public class FeedDatabaseWriterTest {
     }
 
     @Test
+    public void testUpdateFeedRemoveUnlistedItemsKeepsDownloaded() {
+        final Feed feed = createFeed();
+        for (int i = 0; i < 10; i++) {
+            feed.getItems().add(
+                    new FeedItem(0, "item " + i, "id " + i, "link " + i, new Date(i), FeedItem.PLAYED, feed));
+        }
+        FeedItem downloaded = feed.getItemAtIndex(0);
+        downloaded.setMedia(new FeedMedia(downloaded, "download url 0", 123, "media/mp3"));
+        downloaded.getMedia().setDownloaded(true, System.currentTimeMillis());
+        PodDBAdapter adapter = PodDBAdapter.getInstance();
+        adapter.open();
+        adapter.setCompleteFeed(feed);
+        adapter.close();
+
+        // remove the downloaded item and one other item from the feed
+        feed.getItems().subList(0, 2).clear();
+        Feed newFeed = FeedDatabaseWriter.updateFeed(context, feed, true);
+        assertEquals(9, newFeed.getItems().size()); // the downloaded item is kept
+
+        Feed feedFromDB = DBReader.getFeed(newFeed.getId(), false, 0, Integer.MAX_VALUE);
+        assertEquals(9, feedFromDB.getItems().size());
+    }
+
+    @Test
     public void testUpdateFeedSetDuplicate() {
         final Feed feed = createFeed();
         for (int i = 0; i < 10; i++) {

--- a/ui/i18n/src/main/res/values/strings.xml
+++ b/ui/i18n/src/main/res/values/strings.xml
@@ -844,6 +844,11 @@
     <string name="exclude_episodes_shorter_than">Exclude episodes shorter than</string>
     <string name="keep_updated">Keep updated</string>
     <string name="keep_updated_summary">Include this podcast when (auto-)refreshing all podcasts</string>
+    <string name="remove_unlisted_episodes">Remove unlisted episodes</string>
+    <string name="remove_unlisted_episodes_summary">Delete episodes that are no longer in the feed when refreshing this podcast</string>
+    <string name="cleanup_unlisted_episodes">Remove unlisted episodes now</string>
+    <string name="cleanup_unlisted_episodes_summary">Refresh this podcast and delete all episodes that are no longer in the feed</string>
+    <string name="remove_unlisted_episodes_confirmation_msg">Episodes that are no longer in the feed will be permanently deleted, including their playback history and statistics. Downloaded episodes are kept. This cannot be undone.</string>
     <plurals name="statistics_episodes_started">
         <item quantity="one">started</item>
         <item quantity="other">started</item>


### PR DESCRIPTION
### Description

Adds an opt-in per-podcast setting "Remove unlisted episodes" that deletes episodes which are no longer in the RSS feed when the podcast is refreshed, plus a one-shot "Remove unlisted episodes now" action for a manual cleanup. Both are off by default and ask for confirmation with a 15-second countdown, like changing a feed URL. Downloaded episodes are never removed, and nothing is removed for paged feeds or when loading an additional page. The removal itself reuses the existing `removeUnlistedItems` path in `FeedDatabaseWriter.updateFeed`, which so far was only used by local feeds.

This issue is still labelled "Needs: Decision", so please treat this as a concrete proposal rather than an agreed design. I went for the opt-in destructive variant described in the issue; happy to rework it into the non-destructive alternative (mark the episodes and hide them behind a filter) if the team prefers that.

Closes: #4426

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
