### PR TITLE
Suppress BuildConfig lint on Java 25

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -46,6 +46,9 @@ android {
             "-Xlint:all,-deprecation,-serial,-this-escape,-unchecked,-processing,-classfile",
             "-Werror",
         ])
+        if (JavaVersion.current() >= JavaVersion.VERSION_22) {
+            options.compilerArgs.add("-Xlint:-dangling-doc-comments")
+        }
     }
 
     testOptions {


### PR DESCRIPTION
### Description

Suppress lint rule complaining about BuildConfig comments when compiling with JDK 25
Closes #8729

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
