### PR TITLE
Restructure m4a reader to be extensible

### DIFF
--- a/parser/media/src/main/java/de/danoeh/antennapod/parser/media/m4a/M4AChapterReader.java
+++ b/parser/media/src/main/java/de/danoeh/antennapod/parser/media/m4a/M4AChapterReader.java
@@ -2,8 +2,6 @@ package de.danoeh.antennapod.parser.media.m4a;
 
 import android.util.Log;
 
-import org.apache.commons.io.IOUtils;
-
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -15,14 +13,14 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class M4AChapterReader {
+public class M4AChapterReader extends M4AReader {
     private static final String TAG = "M4AChapterReader";
+    private static final String ATOM_NERO_CHAPTERS = "moov.udta.chpl";
+
     private final List<Chapter> chapters = new ArrayList<>();
-    private final InputStream inputStream;
-    private static final int FTYP_CODE = 0x66747970; // "ftyp"
 
     public M4AChapterReader(InputStream input) {
-        inputStream = input;
+        super(input, ATOM_NERO_CHAPTERS);
     }
 
     /**
@@ -30,88 +28,20 @@ public class M4AChapterReader {
      */
     public void readInputStream() {
         try {
-            isM4A(inputStream);
-            int dataSize = this.findAtom("moov.udta.chpl");
-            if (dataSize == -1) {
-                Log.d(TAG, "Nero Chapter Atom not found");
-            } else {
-                Log.d(TAG, "Nero Chapter Atom found. Data Size: " + dataSize);
-                this.parseNeroChapterAtom(dataSize);
-            }
+            readAtoms();
         } catch (Exception e) {
             Log.d(TAG, "ERROR: " + e.getMessage());
         }
     }
 
-    /**
-     * Find the atom with the given name in the M4A file
-     *
-     * @param name the name of the atom to find, separated by dots
-     * @return the size of the atom (minus the 8-byte header) if found
-     * @throws IOException if an I/O error occurs or the atom is not found
-     */
-    public int findAtom(String name) throws IOException {
-        // Split the name into parts encoded as UTF-8
-        String[] parts = name.split("\\.");
-        int partIndex = 0;
-        // Initialize remaining size to track the current part's size and check if it is exceeded
-        int remainingSize = -1;
-
-        // Read the M4A file atom by atom
-        ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
-        while (true) {
-            // Read the atom header
-            IOUtils.readFully(inputStream, buffer.array());
-            // Get the size of the current atom
-            int chunkSize = buffer.getInt();
-            int dataSize = chunkSize - 8;
-
-            // Get the atom type
-            String atomType = StandardCharsets.UTF_8.decode(buffer).toString();
-
-            // Reset the buffer for reading the atom data
-            buffer.clear();
-
-            // Check if the current atom matches the current part of the name
-            if (atomType.equals(parts[partIndex])) {
-                if (partIndex == parts.length - 1) {
-                    // If the current atom is the last part of the name return its size
-                    return dataSize;
-                } else {
-                    // Else move to the next part of the name
-                    partIndex++;
-                    // Update the remaining size
-                    remainingSize = dataSize;
-                }
-            } else {
-                // Do not check the remaining size of top-level atoms
-                if (partIndex > 0) {
-                    // Update the remaining size
-                    remainingSize -= dataSize;
-                    // If the remaining size is exhausted, throw an exception
-                    if (remainingSize <= 0) {
-                        throw new IOException("Part size exceeded for part \"" + parts[partIndex - 1]
-                                + "\" while searching atom. Remaining Size: " + remainingSize);
-                    }
-                }
-                // Skip the rest of the atom
-                IOUtils.skipFully(inputStream, dataSize);
-            }
+    @Override
+    protected void onAtom(String path, long chunkSize) throws IOException {
+        if (!ATOM_NERO_CHAPTERS.equals(path)) {
+            throw new IllegalArgumentException("Received atom that is not chapter");
         }
-    }
-
-    /**
-     * Parse the Nero Chapter Atom in the M4A file
-     * Assumes that the current position is at the start of the Nero Chapter Atom
-     *
-     * @param chunkSize the size of the Nero Chapter Atom
-     * @throws IOException if an I/O error occurs
-     * @see <a href="https://github.com/Zeugma440/atldotnet/wiki/Focus-on-Chapter-metadata#nero-chapters">Nero Chapter</a>
-     */
-    private void parseNeroChapterAtom(long chunkSize) throws IOException {
-        // Read the Nero Chapter Atom data into a buffer
+        Log.d(TAG, "Nero Chapter Atom found. Data Size: " + chunkSize);
         ByteBuffer byteBuffer = ByteBuffer.allocate((int) chunkSize).order(ByteOrder.BIG_ENDIAN);
-        IOUtils.readFully(inputStream, byteBuffer.array());
+        readFully(byteBuffer.array());
         // Skip the 5-byte header
         // Nero Chapter Atom consists of a 5-byte header followed by chapter data
         // The first 4 bytes are the version and flags, the 5th byte is reserved
@@ -140,22 +70,5 @@ public class M4AChapterReader {
 
     public List<Chapter> getChapters() {
         return chapters;
-    }
-
-    /**
-     * Assert that the input stream is an M4A file by checking the signature
-     *
-     * @param inputStream the input stream to check
-     * @throws IOException if an I/O error occurs
-     */
-    public static void isM4A(InputStream inputStream) throws IOException {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
-        IOUtils.readFully(inputStream, byteBuffer.array());
-
-        int ftypSize = byteBuffer.getInt();
-        if (byteBuffer.getInt() != FTYP_CODE) {
-            throw new IOException("Not an M4A file");
-        }
-        IOUtils.skipFully(inputStream, ftypSize - 8);
     }
 }

--- a/parser/media/src/main/java/de/danoeh/antennapod/parser/media/m4a/M4AReader.java
+++ b/parser/media/src/main/java/de/danoeh/antennapod/parser/media/m4a/M4AReader.java
@@ -1,0 +1,134 @@
+package de.danoeh.antennapod.parser.media.m4a;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.CountingInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Reads the atom tree of an M4A file. Implementations declare the paths of the atoms they
+ * need, such as "moov.udta.chpl". Only the atoms on the way to those paths are read, and
+ * reading stops as soon as all of them have been found or turned out to be missing.
+ */
+public abstract class M4AReader {
+    private static final int FTYP_CODE = 0x66747970; // "ftyp"
+    private static final int HEADER_LENGTH = 8;
+    private static final int LARGE_SIZE_LENGTH = 8;
+    private static final int SIZE_UNTIL_END_OF_PARENT = 0;
+    private static final int SIZE_IS_LARGE = 1;
+
+    private final CountingInputStream inputStream;
+    private final Set<String> pendingPaths = new HashSet<>();
+
+    public M4AReader(InputStream input, String... atomPaths) {
+        inputStream = new CountingInputStream(input);
+        pendingPaths.addAll(Arrays.asList(atomPaths));
+    }
+
+    /**
+     * Is called for every declared atom path that the file contains,
+     * so that the implementation can read the payload of the atom.
+     */
+    protected abstract void onAtom(String path, long payloadLength) throws IOException;
+
+    protected void readAtoms() throws IOException {
+        assertM4A();
+        try {
+            readAtoms("", Long.MAX_VALUE);
+        } catch (EOFException e) {
+            // The file does not contain any further atoms
+        }
+    }
+
+    private void readAtoms(String parentPath, long available) throws IOException {
+        ByteBuffer header = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
+        while (available >= HEADER_LENGTH && !pendingPaths.isEmpty()) {
+            header.clear();
+            IOUtils.readFully(inputStream, header.array());
+            long size = header.getInt() & 0xffffffffL;
+            String type = StandardCharsets.ISO_8859_1.decode(header).toString();
+            long headerLength = HEADER_LENGTH;
+            if (size == SIZE_IS_LARGE) {
+                size = readLargeSize();
+                headerLength += LARGE_SIZE_LENGTH;
+            } else if (size == SIZE_UNTIL_END_OF_PARENT) {
+                size = available;
+            }
+            if (size < headerLength) {
+                throw new IOException("Atom \"" + type + "\" has invalid size " + size);
+            }
+
+            String path = parentPath.isEmpty() ? type : parentPath + "." + type;
+            long payloadLength = size - headerLength;
+            long bytesReadBefore = inputStream.getByteCount();
+            if (pendingPaths.remove(path)) {
+                onAtom(path, payloadLength);
+            } else if (hasPendingChildren(path)) {
+                readAtoms(path, payloadLength);
+                // Whatever is not inside this atom cannot be anywhere else in the file
+                removePendingChildren(path);
+            }
+            if (pendingPaths.isEmpty()) {
+                return;
+            }
+            // Skip what the handler did not read, so the next atom starts at the right position
+            skipBytes(payloadLength - (inputStream.getByteCount() - bytesReadBefore));
+            available -= size;
+        }
+    }
+
+    private boolean hasPendingChildren(String path) {
+        for (String pending : pendingPaths) {
+            if (pending.startsWith(path + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void removePendingChildren(String path) {
+        Iterator<String> iterator = pendingPaths.iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().startsWith(path + ".")) {
+                iterator.remove();
+            }
+        }
+    }
+
+    protected final void readFully(byte[] buffer) throws IOException {
+        IOUtils.readFully(inputStream, buffer);
+    }
+
+    protected final void skipBytes(long number) throws IOException {
+        IOUtils.skipFully(inputStream, number);
+    }
+
+    private long readLargeSize() throws IOException {
+        byte[] buffer = new byte[LARGE_SIZE_LENGTH];
+        IOUtils.readFully(inputStream, buffer);
+        return ByteBuffer.wrap(buffer).order(ByteOrder.BIG_ENDIAN).getLong();
+    }
+
+    /**
+     * Assert that the input stream is an M4A file by checking the signature
+     */
+    private void assertM4A() throws IOException {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
+        IOUtils.readFully(inputStream, byteBuffer.array());
+
+        int ftypSize = byteBuffer.getInt();
+        if (byteBuffer.getInt() != FTYP_CODE) {
+            throw new IOException("Not an M4A file");
+        }
+        skipBytes(ftypSize - HEADER_LENGTH);
+    }
+}


### PR DESCRIPTION
### Description

Restructure m4a reader to be extensible. The old reader supported only one specific atom.

### Checklist
<!-- 
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests
